### PR TITLE
ci: consolidate Dependabot into ecosystem-based update PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,11 @@
 # Dependabot v2 configuration for signal-fish-client
 #
-# Keeps Cargo dependencies and GitHub Actions up to date via automated PRs.
-# PRs target the default branch (main) and trigger the full CI check suite.
+# Goal: prefer fewer, larger "area" PRs over many tiny PRs.
 #
-# Grouping strategy:
-#   - Cargo patch/minor updates are batched into a single PR to reduce noise.
-#   - GitHub Actions patch/minor updates are batched into a single PR.
-#   - Major version bumps (Cargo and Actions) get individual PRs for careful review.
+# Strategy:
+#   - One broad Cargo PR that batches ALL version updates (major/minor/patch).
+#   - One broad GitHub Actions PR that batches ALL version updates.
+#   - Low open PR limits so Dependabot focuses on consolidated batches.
 #
 # See: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
@@ -23,13 +22,14 @@ updates:
     labels:
       - dependencies
       - security
-    open-pull-requests-limit: 10
-    # Group patch and minor updates together to reduce PR churn.
-    # Major updates are left ungrouped so each gets its own PR for
-    # individual review (breaking changes require attention).
+    # Keep this low to strongly prefer a single, broad dependency batch.
+    open-pull-requests-limit: 2
     groups:
-      cargo-patch-minor:
+      cargo-all-dependencies:
+        patterns:
+          - "*"
         update-types:
+          - major
           - minor
           - patch
     commit-message:
@@ -46,13 +46,14 @@ updates:
     labels:
       - dependencies
       - security
-    open-pull-requests-limit: 10
-    # Group patch and minor Actions updates together to reduce PR churn.
-    # Major updates are left ungrouped so each gets its own PR for
-    # individual review (breaking changes require attention).
+    # Keep this low to strongly prefer a single, broad dependency batch.
+    open-pull-requests-limit: 2
     groups:
-      github-actions-patch-minor:
+      github-actions-all:
+        patterns:
+          - "*"
         update-types:
+          - major
           - minor
           - patch
     commit-message:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,13 @@
 # Dependabot v2 configuration for signal-fish-client
 #
-# Goal: prefer fewer, larger "area" PRs over many tiny PRs.
+# Goal: prefer fewer, larger ecosystem-based PRs over many tiny per-package PRs.
 #
 # Strategy:
 #   - One broad Cargo PR that batches ALL version updates (major/minor/patch).
 #   - One broad GitHub Actions PR that batches ALL version updates.
-#   - Low open PR limits so Dependabot focuses on consolidated batches.
+#   - open-pull-requests-limit: 1 per ecosystem so Dependabot can only open
+#     one consolidated batch PR at a time; once that batch is merged a fresh
+#     one is opened for any remaining pending updates.
 #
 # See: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
@@ -22,8 +24,8 @@ updates:
     labels:
       - dependencies
       - security
-    # Keep this low to strongly prefer a single, broad dependency batch.
-    open-pull-requests-limit: 2
+    # Limit to 1 so Dependabot can only open one consolidated batch PR at a time.
+    open-pull-requests-limit: 1
     groups:
       cargo-all-dependencies:
         patterns:
@@ -46,8 +48,8 @@ updates:
     labels:
       - dependencies
       - security
-    # Keep this low to strongly prefer a single, broad dependency batch.
-    open-pull-requests-limit: 2
+    # Limit to 1 so Dependabot can only open one consolidated batch PR at a time.
+    open-pull-requests-limit: 1
     groups:
       github-actions-all:
         patterns:

--- a/.llm/skills/ci-configuration.md
+++ b/.llm/skills/ci-configuration.md
@@ -137,6 +137,7 @@ Keep comments in CI shell scripts behaviorally exact:
 - Remember `grep` is line-based; validate multi-line attributes with staged checks.
 - Avoid broad patterns (`grep -q '#\[allow('`) when you intend a specific lint.
 - For string-literal detection heuristics (e.g., "odd number of unescaped quotes"), strip escaped quotes before counting: `unescaped="${var//\\\"/}"`. A comment saying "unescaped quotes" while the code counts ALL quotes (including `\"`) is a comment/behavior mismatch that hides bugs.
+- **Dependabot config:** keep inline comments in `.github/dependabot.yml` synchronized with field values. A comment saying "single consolidated PR" while `open-pull-requests-limit: 2` is set is incorrect — set the limit to `1` or change the comment. Enforced by three tests in `tests/ci_config_tests.rs` (`dependency_policy` module): each ecosystem sets `open-pull-requests-limit: 1`, all values are consistent, and every ecosystem has a wildcard catchall group (`- "*"`).
 
 ### check-no-panics.sh: Compound cfg(test) attributes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Dependabot: corrected `open-pull-requests-limit` from 2 to 1 for both the
+  `cargo` and `github-actions` ecosystems, aligning the config value with the
+  documented "single consolidated batch PR" intent. Updated header comment from
+  "area PRs" to "ecosystem-based PRs" for clarity.
+- CI policy tests: added three new tests in `ci_config_tests.rs` to enforce
+  Dependabot structural invariants — each ecosystem must set
+  `open-pull-requests-limit: 1`, all ecosystem limits must be consistent, and
+  every ecosystem must declare a wildcard catchall group.
+
 ## [0.4.1] - 2026-03-15
 
 ### Changed

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -2030,6 +2030,114 @@ mod dependency_policy {
         );
     }
 
+    /// Splits `.github/dependabot.yml` into per-ecosystem sections.
+    ///
+    /// Each section starts at a `- package-ecosystem:` list item and runs until
+    /// the next one (or EOF). Returns `(ecosystem_name, section_text)` pairs in
+    /// declaration order.
+    fn dependabot_ecosystem_sections(contents: &str) -> Vec<(String, String)> {
+        let mut sections: Vec<(String, String)> = Vec::new();
+        let mut current_ecosystem: Option<String> = None;
+        let mut current_body = String::new();
+
+        for line in contents.lines() {
+            let trimmed = line.trim();
+            if let Some(rest) = trimmed.strip_prefix("- package-ecosystem:") {
+                if let Some(eco) = current_ecosystem.take() {
+                    sections.push((eco, std::mem::take(&mut current_body)));
+                }
+                current_ecosystem = Some(rest.trim().to_string());
+                current_body.clear();
+            } else if current_ecosystem.is_some() {
+                current_body.push_str(line);
+                current_body.push('\n');
+            }
+        }
+        if let Some(eco) = current_ecosystem {
+            sections.push((eco, current_body));
+        }
+        sections
+    }
+
+    #[test]
+    fn dependabot_each_ecosystem_sets_open_prs_limit_to_one() {
+        // Each ecosystem block must set open-pull-requests-limit: 1 so that
+        // Dependabot is forced into a single consolidated batch PR rather than
+        // scattering updates across multiple open PRs.
+        let contents = read_project_file(".github/dependabot.yml");
+        let sections = dependabot_ecosystem_sections(&contents);
+        assert!(
+            !sections.is_empty(),
+            "dependabot.yml has no 'updates' entries. \
+             Expected at least one '- package-ecosystem:' block."
+        );
+        for (ecosystem, body) in &sections {
+            assert!(
+                body.lines()
+                    .any(|l| l.trim() == "open-pull-requests-limit: 1"),
+                "dependabot.yml ecosystem '{ecosystem}' does not set \
+                 `open-pull-requests-limit: 1`. \
+                 The project policy requires exactly 1 to enforce a single \
+                 consolidated batch PR per ecosystem. \
+                 Either update the limit to 1 or revise the consolidation policy \
+                 and update this test."
+            );
+        }
+    }
+
+    #[test]
+    fn dependabot_open_prs_limits_are_all_consistent() {
+        // All open-pull-requests-limit values must be identical across ecosystems
+        // so the consolidation strategy is applied uniformly.
+        let contents = read_project_file(".github/dependabot.yml");
+        let limits: Vec<&str> = contents
+            .lines()
+            .filter_map(|l| {
+                let trimmed = l.trim();
+                trimmed
+                    .strip_prefix("open-pull-requests-limit:")
+                    .map(str::trim)
+            })
+            .collect();
+        assert!(
+            !limits.is_empty(),
+            "dependabot.yml sets no 'open-pull-requests-limit' values. \
+             Each ecosystem block must specify one."
+        );
+        let first = limits[0];
+        for (i, &limit) in limits.iter().enumerate().skip(1) {
+            assert_eq!(
+                first, limit,
+                "dependabot.yml has inconsistent open-pull-requests-limit values: \
+                 entry 0 is '{first}' but entry {i} is '{limit}'. \
+                 All ecosystems must use the same limit to apply the consolidation \
+                 policy uniformly."
+            );
+        }
+    }
+
+    #[test]
+    fn dependabot_each_ecosystem_has_wildcard_catchall_group() {
+        // Each ecosystem block must define at least one group that includes the
+        // `- "*"` wildcard pattern so all packages are batched together.
+        let contents = read_project_file(".github/dependabot.yml");
+        let sections = dependabot_ecosystem_sections(&contents);
+        assert!(
+            !sections.is_empty(),
+            "dependabot.yml has no 'updates' entries."
+        );
+        for (ecosystem, body) in &sections {
+            assert!(
+                body.lines().any(|l| l.trim() == r#"- "*""#),
+                "dependabot.yml ecosystem '{ecosystem}' does not define a group \
+                 with a wildcard `- \"*\"` pattern. \
+                 The project policy requires a catchall group so all packages are \
+                 consolidated into a single batch PR rather than triggering \
+                 individual per-package PRs."
+            );
+        }
+    }
+
     #[test]
     fn uuid_dependency_enables_v4_and_serde_features() {
         let parsed = cargo_toml();


### PR DESCRIPTION
### Motivation
- Reduce Dependabot churn by preferring fewer, larger, ecosystem-grouped PRs that batch many version updates together.
- Make Cargo and GitHub Actions updates appear as consolidated, reviewable batches rather than many single-package PRs.
- Align the repository's Dependabot behavior with the requested high-consolidation strategy used elsewhere in the org.

### Description
- Rewrote `.github/dependabot.yml` to create a single Cargo group `cargo-all-dependencies` with `patterns: ["*"]` and `update-types` set to `major`, `minor`, and `patch`.
- Added a single GitHub Actions group `github-actions-all` with `patterns: ["*"]` and `update-types` set to `major`, `minor`, and `patch`.
- Set `open-pull-requests-limit: 1` for both ecosystems so Dependabot can only open one consolidated batch PR at a time; once merged, a fresh batch is opened for any remaining pending updates.
- Updated header comment from "area PRs" to "ecosystem-based PRs" to accurately describe the grouping strategy.
- Updated inline comments to precisely match the enforced single-PR behavior.
- Added three structural policy tests in `tests/ci_config_tests.rs` (`dependency_policy` module) to prevent future comment/value drift:
  - `dependabot_each_ecosystem_sets_open_prs_limit_to_one` — every ecosystem block must set the limit to exactly `1`.
  - `dependabot_open_prs_limits_are_all_consistent` — all `open-pull-requests-limit` values must be identical across ecosystems.
  - `dependabot_each_ecosystem_has_wildcard_catchall_group` — every ecosystem must declare a `- "*"` catchall pattern.
- Updated `.llm/skills/ci-configuration.md` with a note documenting the Dependabot comment/value consistency rule and pointing at the enforcement tests.

### Testing
- Ran `cargo fmt` and it completed successfully.
- Ran `cargo clippy --all-targets --all-features -- -D warnings` and it completed successfully with no warnings.
- Ran `cargo test --all-features --test ci_config_tests` which produced `165 passed; 0 failed`, including all three new Dependabot policy tests.
- Validated the YAML structure of `.github/dependabot.yml` with `ruby -ryaml` which succeeded.