### PR TITLE
ci: enforce concurrency and cancel-in-progress on all workflows

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,21 @@
+name: Dependabot auto-merge
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    name: Enable auto-merge for Dependabot PRs
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Enable auto-merge
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -9,7 +9,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.event.action }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -8,10 +8,15 @@ permissions:
   contents: write
   pull-requests: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.event.action }}
+  cancel-in-progress: true
+
 jobs:
   dependabot:
     name: Enable auto-merge for Dependabot PRs
     runs-on: ubuntu-latest
+    timeout-minutes: 2
     if: github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
       - name: Enable auto-merge

--- a/scripts/check-workflows.sh
+++ b/scripts/check-workflows.sh
@@ -331,11 +331,12 @@ echo ""
 # ── Phase 8: concurrency block policy — prevent redundant CI runs ─────
 echo -e "${YELLOW}Phase 8: Checking workflow concurrency block policy...${NC}"
 
-for workflow_path in .github/workflows/*.yml; do
+while IFS= read -r workflow_path; do
+    workflow_path="${workflow_path//$'\r'/}"
     if ! grep -q "concurrency:" "$workflow_path"; then
         echo "  $workflow_path: missing 'concurrency:' block" >>"$TMP_CONCURRENCY_VIOLATIONS"
     fi
-done
+done < <(find .github/workflows -maxdepth 1 -name "*.yml" -type f | sort)
 
 if [ -s "$TMP_CONCURRENCY_VIOLATIONS" ]; then
     echo -e "${RED}Phase 8: FAIL${NC}"

--- a/scripts/check-workflows.sh
+++ b/scripts/check-workflows.sh
@@ -333,14 +333,18 @@ echo -e "${YELLOW}Phase 8: Checking workflow concurrency block policy...${NC}"
 
 while IFS= read -r workflow_path; do
     workflow_path="${workflow_path//$'\r'/}"
-    if ! grep -q "concurrency:" "$workflow_path"; then
+    # Use anchored grep (-E) to match only real YAML keys, not comment lines.
+    if ! grep -Eq '^[[:space:]]*concurrency:' "$workflow_path"; then
         echo "  $workflow_path: missing 'concurrency:' block" >>"$TMP_CONCURRENCY_VIOLATIONS"
+    fi
+    if ! grep -Eq '^[[:space:]]*cancel-in-progress:' "$workflow_path"; then
+        echo "  $workflow_path: missing 'cancel-in-progress:' in concurrency block" >>"$TMP_CONCURRENCY_VIOLATIONS"
     fi
 done < <(find .github/workflows -maxdepth 1 -name "*.yml" -type f | sort)
 
 if [ -s "$TMP_CONCURRENCY_VIOLATIONS" ]; then
     echo -e "${RED}Phase 8: FAIL${NC}"
-    echo "The following workflows are missing a 'concurrency:' block:"
+    echo "The following workflows are missing required concurrency settings:"
     cat "$TMP_CONCURRENCY_VIOLATIONS"
     VIOLATIONS=$((VIOLATIONS + 1))
 else

--- a/scripts/check-workflows.sh
+++ b/scripts/check-workflows.sh
@@ -26,6 +26,7 @@ TMP_TOOLCHAIN_VIOLATIONS="$(mktemp -t signal-fish-toolchain-violations.XXXXXX)"
 TMP_STEP_NAME_VIOLATIONS="$(mktemp -t signal-fish-step-name-violations.XXXXXX)"
 TMP_ACTION_REF_VIOLATIONS="$(mktemp -t signal-fish-action-ref-violations.XXXXXX)"
 TMP_MAJOR_ONLY_VIOLATIONS="$(mktemp -t signal-fish-major-only-violations.XXXXXX)"
+TMP_CONCURRENCY_VIOLATIONS="$(mktemp -t signal-fish-concurrency-violations.XXXXXX)"
 
 # shellcheck disable=SC2317  # trap handler invoked indirectly
 cleanup() {
@@ -33,6 +34,7 @@ cleanup() {
     rm -f "$TMP_STEP_NAME_VIOLATIONS"
     rm -f "$TMP_ACTION_REF_VIOLATIONS"
     rm -f "$TMP_MAJOR_ONLY_VIOLATIONS"
+    rm -f "$TMP_CONCURRENCY_VIOLATIONS"
 }
 
 trap cleanup EXIT
@@ -323,6 +325,25 @@ if [ -s "$TMP_MAJOR_ONLY_VIOLATIONS" ]; then
     echo -e "${YELLOW}Phase 7: WARNING (informational — not blocking)${NC}"
 else
     echo -e "${GREEN}Phase 7: PASS${NC}"
+fi
+echo ""
+
+# ── Phase 8: concurrency block policy — prevent redundant CI runs ─────
+echo -e "${YELLOW}Phase 8: Checking workflow concurrency block policy...${NC}"
+
+for workflow_path in .github/workflows/*.yml; do
+    if ! grep -q "concurrency:" "$workflow_path"; then
+        echo "  $workflow_path: missing 'concurrency:' block" >>"$TMP_CONCURRENCY_VIOLATIONS"
+    fi
+done
+
+if [ -s "$TMP_CONCURRENCY_VIOLATIONS" ]; then
+    echo -e "${RED}Phase 8: FAIL${NC}"
+    echo "The following workflows are missing a 'concurrency:' block:"
+    cat "$TMP_CONCURRENCY_VIOLATIONS"
+    VIOLATIONS=$((VIOLATIONS + 1))
+else
+    echo -e "${GREEN}Phase 8: PASS${NC}"
 fi
 echo ""
 

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -222,6 +222,7 @@ const REQUIRED_WORKFLOW_PATHS: &[&str] = &[
     ".github/workflows/unused-deps.yml",
     ".github/workflows/wasm.yml",
     ".github/workflows/workflow-lint.yml",
+    ".github/workflows/dependabot-auto-merge.yml",
 ];
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1668,6 +1669,25 @@ mod workflow_security {
         }
     }
 
+    #[test]
+    fn all_workflows_have_concurrency() {
+        for workflow_path in REQUIRED_WORKFLOW_PATHS {
+            let contents = read_project_file(workflow_path);
+            assert!(
+                contents.contains("concurrency:"),
+                "Workflow '{workflow_path}' is missing a 'concurrency:' block. \
+                 Every workflow must define a concurrency group to prevent redundant \
+                 runs from consuming CI resources when new commits are pushed rapidly."
+            );
+            assert!(
+                contents.contains("cancel-in-progress:"),
+                "Workflow '{workflow_path}' is missing 'cancel-in-progress:' in its \
+                 concurrency block. Without this setting, superseded workflow runs \
+                 will continue consuming CI capacity instead of being cancelled."
+            );
+        }
+    }
+
     // Verifies that action `uses:` references are version tags (v-prefixed)
     // rather than commit hashes.
     //
@@ -1935,6 +1955,29 @@ mod workflow_security {
             contents.contains("informational"),
             "scripts/check-workflows.sh Phase 7 must be marked as informational \
              to confirm it is a non-blocking warning rather than a hard failure."
+        );
+    }
+
+    #[test]
+    fn check_workflows_script_detects_missing_concurrency() {
+        let contents = read_project_file("scripts/check-workflows.sh");
+
+        assert!(
+            contents.contains("signal-fish-concurrency-violations"),
+            "scripts/check-workflows.sh must create a temp file for concurrency \
+             block violations (signal-fish-concurrency-violations)."
+        );
+
+        assert!(
+            contents.contains("concurrency:"),
+            "scripts/check-workflows.sh must scan for 'concurrency:' to detect \
+             workflows missing a concurrency block."
+        );
+
+        assert!(
+            contents.contains("Phase 8"),
+            "scripts/check-workflows.sh must include Phase 8 for concurrency \
+             block enforcement."
         );
     }
 }

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -222,6 +222,7 @@ const REQUIRED_WORKFLOW_PATHS: &[&str] = &[
     ".github/workflows/unused-deps.yml",
     ".github/workflows/wasm.yml",
     ".github/workflows/workflow-lint.yml",
+    ".github/workflows/publish.yml",
     ".github/workflows/dependabot-auto-merge.yml",
 ];
 

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -1672,19 +1672,66 @@ mod workflow_security {
 
     #[test]
     fn all_workflows_have_concurrency() {
+        // Scan line-by-line to avoid false positives from comment lines or
+        // string values that happen to contain the keyword. A valid match is a
+        // non-comment line whose code portion (before any `#`) starts with the
+        // keyword after stripping leading whitespace.
+        //
+        // Additionally, `cancel-in-progress:` must appear *after* `concurrency:`
+        // in the file, confirming it is nested inside the concurrency block
+        // rather than somewhere unrelated.
         for workflow_path in REQUIRED_WORKFLOW_PATHS {
             let contents = read_project_file(workflow_path);
+
+            let mut concurrency_line: Option<usize> = None;
+            let mut cancel_in_progress_line: Option<usize> = None;
+
+            for (line_num, line) in contents.lines().enumerate() {
+                let trimmed = line.trim_start();
+
+                // Skip full-line comments — no code tokens here.
+                if trimmed.starts_with('#') {
+                    continue;
+                }
+
+                // Strip any inline trailing comment before matching.
+                let code_part = trimmed.split('#').next().unwrap_or("").trim_end();
+
+                if code_part.starts_with("concurrency:") && concurrency_line.is_none() {
+                    concurrency_line = Some(line_num);
+                }
+                if code_part.starts_with("cancel-in-progress:") && cancel_in_progress_line.is_none()
+                {
+                    cancel_in_progress_line = Some(line_num);
+                }
+            }
+
             assert!(
-                contents.contains("concurrency:"),
+                concurrency_line.is_some(),
                 "Workflow '{workflow_path}' is missing a 'concurrency:' block. \
                  Every workflow must define a concurrency group to prevent redundant \
                  runs from consuming CI resources when new commits are pushed rapidly."
             );
+
             assert!(
-                contents.contains("cancel-in-progress:"),
+                cancel_in_progress_line.is_some(),
                 "Workflow '{workflow_path}' is missing 'cancel-in-progress:' in its \
                  concurrency block. Without this setting, superseded workflow runs \
                  will continue consuming CI capacity instead of being cancelled."
+            );
+
+            // Verify cancel-in-progress appears after concurrency: in the file.
+            let concurrency_pos =
+                concurrency_line.expect("concurrency_line verified as Some by preceding assert");
+            let cancel_pos = cancel_in_progress_line
+                .expect("cancel_in_progress_line verified as Some by preceding assert");
+            assert!(
+                cancel_pos > concurrency_pos,
+                "Workflow '{workflow_path}': 'cancel-in-progress:' (line {}) appears \
+                 before 'concurrency:' (line {}). It must be nested inside the \
+                 concurrency block.",
+                cancel_pos + 1,
+                concurrency_pos + 1,
             );
         }
     }
@@ -1970,15 +2017,32 @@ mod workflow_security {
         );
 
         assert!(
-            contents.contains("concurrency:"),
-            "scripts/check-workflows.sh must scan for 'concurrency:' to detect \
-             workflows missing a concurrency block."
-        );
-
-        assert!(
             contents.contains("Phase 8"),
             "scripts/check-workflows.sh must include Phase 8 for concurrency \
              block enforcement."
+        );
+
+        // The grep pattern must be anchored with -E so that matches inside YAML
+        // comments (e.g. `# concurrency:`) do not suppress a real violation.
+        assert!(
+            contents.contains("grep -Eq"),
+            "scripts/check-workflows.sh Phase 8 must use 'grep -Eq' (extended \
+             regex with anchoring) to detect workflow concurrency keys accurately, \
+             avoiding false passes from comment-only matches."
+        );
+
+        assert!(
+            contents.contains("^[[:space:]]*concurrency:"),
+            "scripts/check-workflows.sh must use the anchored pattern \
+             '^[[:space:]]*concurrency:' to match only real YAML concurrency \
+             keys, not occurrences inside comments or string values."
+        );
+
+        assert!(
+            contents.contains("^[[:space:]]*cancel-in-progress:"),
+            "scripts/check-workflows.sh must enforce the presence of \
+             'cancel-in-progress:' using an anchored pattern so workflows that \
+             define an empty or comment-only concurrency block are still flagged."
         );
     }
 }


### PR DESCRIPTION
`dependabot-auto-merge.yml` was missing `concurrency` and `timeout-minutes`, and no automation enforced these properties across all workflows.

## Workflow fix
- Added `concurrency` keyed by `workflow + PR number` (not action type — including `github.event.action` creates per-event groups, defeating `cancel-in-progress`)
- Added `timeout-minutes: 2`

## Enforcement — Rust tests (`workflow_security`)
- Added `dependabot-auto-merge.yml` and `publish.yml` (pre-existing gap) to `REQUIRED_WORKFLOW_PATHS`
- `all_workflows_have_concurrency()`: line-by-line scan skipping comment lines and stripping inline `#` before matching; verifies `cancel-in-progress:` appears *after* `concurrency:` in the file to confirm correct nesting — not just substring presence
- `check_workflows_script_detects_missing_concurrency()`: asserts `grep -Eq`, anchored `^[[:space:]]*concurrency:`, and anchored `^[[:space:]]*cancel-in-progress:` patterns are present in the script

## Enforcement — `scripts/check-workflows.sh` (Phase 8)
Replaced unanchored `grep -q "concurrency:"` with two anchored checks:
```bash
grep -Eq '^[[:space:]]*concurrency:'       # won't match `# concurrency:` in comments
grep -Eq '^[[:space:]]*cancel-in-progress:' # enforces the setting, not just the block
```
Uses `find` (consistent with Phase 7) so new workflow files are covered automatically, even before being added to `REQUIRED_WORKFLOW_PATHS`.