### PR TITLE
fix!: no-silent-loss reliability overhaul — lossless events, bounded sends, driving contract (v0.6.0)

### DIFF
--- a/.llm/context.md
+++ b/.llm/context.md
@@ -5,7 +5,7 @@
 - **Company:** Ambiguous Interactive
 - **Product:** Signal Fish Client SDK
 - **Crate:** `signal-fish-client`
-- **Version:** 0.5.0
+- **Version:** 0.6.0
 - **Edition:** 2021
 - **MSRV:** 1.85.0
 - **License:** MIT
@@ -29,10 +29,10 @@ Run this before every commit. All three steps must pass with zero warnings.
 
 Use version tags in workflow `uses:` references, not commit hashes.
 
-- Prefer: `owner/action@vN.N.N` (patch-level pin — immutable tag)
-- Acceptable: `owner/action@vN` (major-only pin — mutable, flagged by Phase 7 warning)
-- Exception: `dtolnay/rust-toolchain@stable|nightly|beta`
-- Exception: `mymindstorm/setup-emsdk@vN` (no patch releases available)
+- Prefer: `owner/action@vN.N.N` (immutable tag); `owner/action@vN` acceptable
+  (mutable major pin, flagged by Phase 7 warning)
+- Exceptions: `dtolnay/rust-toolchain@stable|nightly|beta`,
+  `mymindstorm/setup-emsdk@vN` (no patch releases available)
 - Avoid commit-SHA refs unless a workflow has an explicit unavoidable requirement
 
 ## Changelog Policy
@@ -102,7 +102,6 @@ async fn main() -> Result<(), signal_fish_client::SignalFishError> {
             _ => {}
         }
     }
-
     // 5. Shut down gracefully
     client.shutdown().await;
     Ok(())
@@ -121,12 +120,14 @@ pub struct SignalFishConfig {
     pub sdk_version: Option<String>,          // defaults to crate version
     pub platform: Option<String>,             // e.g. "unity", "godot", "rust"
     pub game_data_format: Option<GameDataEncoding>,
-    pub event_channel_capacity: usize,        // defaults to 256
+    pub event_channel_capacity: usize,        // defaults to 256 (buffer before backpressure)
+    pub command_channel_capacity: usize,      // defaults to 1024 (bounded send queue)
     pub shutdown_timeout: std::time::Duration, // defaults to 1 second
 }
 
 let config = SignalFishConfig::new("mb_app_abc123")
     .with_event_channel_capacity(512)
+    .with_command_channel_capacity(2048)
     .with_shutdown_timeout(std::time::Duration::from_secs(5));
 ```
 
@@ -144,12 +145,13 @@ client.join_room(params)?;
 
 ### Key Client Methods
 
-All methods except `shutdown` are synchronous (they queue a message, no round-trip):
+All methods except `shutdown` and the `*_reliable` sends are synchronous (they queue a message on the bounded command channel, no round-trip):
 
 ```rust,ignore
 client.join_room(params: JoinRoomParams) -> Result<()>
 client.leave_room() -> Result<()>
 client.send_game_data(data: serde_json::Value) -> Result<()>
+client.send_game_data_reliable(data).await   // waits for queue space (pacing)
 client.set_ready() -> Result<()>
 client.start_game() -> Result<()>           // protocol v2: explicit game start
 client.request_authority(become_authority: bool) -> Result<()>
@@ -158,11 +160,18 @@ client.reconnect(player_id, room_id, auth_token) -> Result<()>
 client.join_as_spectator(game_name, room_code, spectator_name) -> Result<()>
 client.leave_spectator() -> Result<()>
 client.ping() -> Result<()>
+client.send_signal_reliable(to, signal).await // v3 only; waiting send_signal
+client.send_capacity() / client.max_send_capacity() -> usize // queue diagnostics
+client.stats() -> ClientStats  // cumulative game_data_sent/received counters
 client.shutdown().await      // async, graceful
 ```
 
-All `Result<()>` methods return `Err(SignalFishError::NotConnected)` when the
-transport is closed.
+Sync sends return `SignalFishError::NotConnected` when the transport is closed
+and `SignalFishError::SendBufferFull { capacity }` when the bounded queue is
+full (message refused, never silently dropped). Events are also never dropped:
+a full event channel pauses the transport loop (backpressure); events are
+missed only on receiver drop or shutdown-timeout abort.
+`SignalFishPollingClient` shares the queue bound, capacity accessors, and `stats()`.
 
 ## Feature Flags
 
@@ -191,10 +200,7 @@ transport is closed.
 
 ### Dev
 
-| Crate | Purpose |
-|-------|---------|
-| `tokio` (full) | Full runtime for tests |
-| `tracing-subscriber` | Log output during tests |
+`tokio` (full features, for tests) and `tracing-subscriber` (test log output).
 
 ## Key Design Decisions
 
@@ -220,9 +226,8 @@ breaking change.
 
 ### No Heavy Dependencies
 
-- No `chrono` — timestamps remain `String` from the server
-- No `bytes` — binary payloads are `Vec<u8>` with `serde_bytes`
-- No `reqwest` — HTTP is out of scope
+No `chrono` (timestamps remain `String` from the server), no `bytes` (binary
+payloads are `Vec<u8>` with `serde_bytes`), no `reqwest` (HTTP is out of scope).
 
 ### UUID Convention
 
@@ -261,10 +266,8 @@ for the v2/v3 deltas.
 ## `.llm/` Structure
 
 - `.llm/context.md` -- this file (canonical source of truth)
-- `.llm/skills/index.md` -- auto-regenerated skill index (do not edit)
+- `.llm/skills/index.md` -- auto-regenerated skill index (do not edit); summarizes each skill
 - `.llm/skills/*.md` -- focused reference guides for common tasks
-
-See `skills/index.md` for a summary of each skill.
 
 ## Documentation Rendering (MkDocs)
 
@@ -285,15 +288,13 @@ A pre-commit hook enforces:
 4. `cargo clippy --all-targets --all-features -- -D warnings` passes
 5. Workflow guard checks pass (`scripts/check-workflows.sh`), including explicit step names (`- name: ...`) in workflow steps and MSRV/toolchain policy validation
 6. Fenced YAML workflow snippets keep step-key alignment (`name`/`uses`/`with`/`run`) to prevent malformed docs examples
-7. FFI safety check passes (`scripts/check-ffi-safety.sh`)
-8. FFI safety script tests pass (`scripts/test_check_ffi_safety.sh`)
-9. Test quality check passes (`scripts/check-test-quality.sh`) — catches `&mut <literal>` temporaries
-10. Devcontainer compatibility check passes (`scripts/check-devcontainer-compat.sh`) — catches non-portable host lifecycle commands and required host-home credential bind mounts
-11. Devcontainer compatibility script tests pass (`scripts/test_check_devcontainer_compat.sh`)
-12. Devcontainer Dockerfile static check passes when Docker buildx is available (`docker buildx build --check -f .devcontainer/Dockerfile .`)
-13. MkDocs admonition/details titles are well-formed (`scripts/check-admonitions.py`, self-tested by `scripts/test_check_admonitions.py`) — no embedded double quotes that silently break title rendering
+7. FFI safety check and its script tests pass (`scripts/check-ffi-safety.sh`, `scripts/test_check_ffi_safety.sh`)
+8. Test quality check passes (`scripts/check-test-quality.sh`) — catches `&mut <literal>` temporaries
+9. Devcontainer compatibility check and its script tests pass (`scripts/check-devcontainer-compat.sh`, `scripts/test_check_devcontainer_compat.sh`) — catches non-portable host lifecycle commands and required host-home credential bind mounts
+10. Devcontainer Dockerfile static check passes when Docker buildx is available (`docker buildx build --check -f .devcontainer/Dockerfile .`)
+11. MkDocs admonition/details titles are well-formed (`scripts/check-admonitions.py`, self-tested by `scripts/test_check_admonitions.py`) — no embedded double quotes that silently break title rendering
 
-`cargo test` is part of the mandatory workflow but runs on push, not every commit
-(too slow for a blocking hook). Run it manually before opening a PR.
+`cargo test` runs on push, not every commit (too slow for a blocking hook) —
+run it manually before opening a PR.
 
 Install hooks with: `bash scripts/install-hooks.sh`

--- a/.llm/context.md
+++ b/.llm/context.md
@@ -286,13 +286,11 @@ A pre-commit hook enforces:
 2. `skills/index.md` is auto-regenerated from skill file headings
 3. `cargo fmt --all -- --check` passes
 4. `cargo clippy --all-targets --all-features -- -D warnings` passes
-5. Workflow guard checks pass (`scripts/check-workflows.sh`), including explicit step names (`- name: ...`) in workflow steps and MSRV/toolchain policy validation
-6. Fenced YAML workflow snippets keep step-key alignment (`name`/`uses`/`with`/`run`) to prevent malformed docs examples
-7. FFI safety check and its script tests pass (`scripts/check-ffi-safety.sh`, `scripts/test_check_ffi_safety.sh`)
-8. Test quality check passes (`scripts/check-test-quality.sh`) — catches `&mut <literal>` temporaries
-9. Devcontainer compatibility check and its script tests pass (`scripts/check-devcontainer-compat.sh`, `scripts/test_check_devcontainer_compat.sh`) — catches non-portable host lifecycle commands and required host-home credential bind mounts
-10. Devcontainer Dockerfile static check passes when Docker buildx is available (`docker buildx build --check -f .devcontainer/Dockerfile .`)
-11. MkDocs admonition/details titles are well-formed (`scripts/check-admonitions.py`, self-tested by `scripts/test_check_admonitions.py`) — no embedded double quotes that silently break title rendering
+5. Workflow guard checks pass (`scripts/check-workflows.sh`): explicit step names, MSRV/toolchain policy, fenced-YAML step-key alignment
+6. FFI safety check and its script tests pass (`scripts/check-ffi-safety.sh`)
+7. Test quality check passes (`scripts/check-test-quality.sh`) — catches `&mut <literal>` temporaries
+8. Devcontainer compatibility checks pass (`scripts/check-devcontainer-compat.sh`, plus a Dockerfile `docker buildx build --check` when buildx is available)
+9. MkDocs admonition/details titles are well-formed (`scripts/check-admonitions.py`) — no embedded double quotes
 
 `cargo test` runs on push, not every commit (too slow for a blocking hook) —
 run it manually before opening a PR.

--- a/.llm/context.md
+++ b/.llm/context.md
@@ -244,8 +244,8 @@ strings to match server expectations.
    is ready (`SignalFishClient`: at the start of the transport loop;
    `SignalFishPollingClient`: once `Transport::is_ready()` returns `true`).
    `SignalFishEvent::Disconnected` is emitted when the transport closes
-   (best-effort; delivery may be missed if the receiver is dropped or shutdown
-   times out).
+   (best-effort; missed only if the receiver is dropped, shutdown times out,
+   or the handle is dropped without `shutdown()`).
 
 ## Protocol Overview
 

--- a/.llm/context.md
+++ b/.llm/context.md
@@ -170,7 +170,8 @@ Sync sends return `SignalFishError::NotConnected` when the transport is closed
 and `SignalFishError::SendBufferFull { capacity }` when the bounded queue is
 full (message refused, never silently dropped). Events are also never dropped:
 a full event channel pauses the transport loop (backpressure); events are
-missed only on receiver drop or shutdown-timeout abort.
+missed only on receiver drop, shutdown-timeout abort, or handle drop without
+`shutdown()`.
 `SignalFishPollingClient` shares the queue bound, capacity accessors, and `stats()`.
 
 ## Feature Flags

--- a/.llm/skills/async-rust-patterns.md
+++ b/.llm/skills/async-rust-patterns.md
@@ -139,6 +139,11 @@ tx.try_send(event)?;         // non-blocking, returns Err if full
 while let Some(event) = rx.recv().await { /* ... */ }
 ```
 
+The event channel uses `send().await` exclusively: events are **never
+dropped** — a full channel pauses the transport loop and backpressure
+propagates to the server. Never introduce a `try_send`-and-drop path for
+events.
+
 ### oneshot — single message
 
 ```rust
@@ -149,13 +154,33 @@ tokio::spawn(async move { tx.send(()).ok(); });
 rx.await?; // RecvError if sender dropped
 ```
 
-### unbounded — for command channels
+### Bounded command channel — fail fast or wait, never drop
+
+`SignalFishClient` uses a *bounded* channel for client→transport commands
+(default 1024, `SignalFishConfig::command_channel_capacity`). Sync methods
+fail fast; the `*_reliable` async variants wait for capacity:
 
 ```rust
-// SignalFishClient uses unbounded for client→transport commands
-let (cmd_tx, mut cmd_rx) = mpsc::unbounded_channel::<ClientMessage>();
-cmd_tx.send(msg).ok(); // never blocks — used in sync client methods
+let (cmd_tx, mut cmd_rx) = mpsc::channel::<ClientMessage>(1024);
+
+// Sync client methods (send_game_data, join_room, …): refuse, don't drop.
+match cmd_tx.try_send(msg) {
+    Ok(()) => Ok(()),
+    Err(mpsc::error::TrySendError::Full(_)) => Err(SignalFishError::SendBufferFull {
+        capacity: cmd_tx.max_capacity(),
+    }),
+    Err(mpsc::error::TrySendError::Closed(_)) => Err(SignalFishError::NotConnected),
+}
+
+// `*_reliable` variants (send_game_data_reliable, send_signal_reliable):
+// wait for a slot — paces the caller to transport throughput.
+cmd_tx.send(msg).await.map_err(|_| SignalFishError::NotConnected)?;
 ```
+
+Congestion must always surface (`SendBufferFull` or waiting) — never an
+unbounded backlog and never a silent drop. `send_capacity()` /
+`max_send_capacity()` expose `cmd_tx.capacity()` / `max_capacity()` for
+diagnostics.
 
 ## Timeouts
 

--- a/.llm/skills/crate-publishing.md
+++ b/.llm/skills/crate-publishing.md
@@ -7,7 +7,7 @@ Reference for Cargo.toml metadata, docs.rs configuration, deny.toml, cargo-deny,
 ```toml
 [package]
 name = "signal-fish-client"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 rust-version = "1.85.0"          # MSRV — enforced by cargo
 license = "MIT"                   # SPDX identifier

--- a/.llm/skills/doc-accuracy-guarantees.md
+++ b/.llm/skills/doc-accuracy-guarantees.md
@@ -30,8 +30,8 @@ cancellation, channel drops, etc.
    - BAD: "Events are always delivered regardless of capacity."
    - GOOD: "Events are never dropped on overflow — a full channel pauses the
      transport loop and backpressure propagates to the server — but an event
-     may be missed if the receiver is dropped or if shutdown times out and
-     aborts the transport task."
+     may be missed if the receiver is dropped, shutdown times out and aborts
+     the transport task, or the handle is dropped without shutdown."
 
 3. **Document timeout/abort consequences** — If a function has a timeout that
    aborts work, document what events or side effects may be skipped when the

--- a/.llm/skills/doc-accuracy-guarantees.md
+++ b/.llm/skills/doc-accuracy-guarantees.md
@@ -19,15 +19,19 @@ cancellation, channel drops, etc.
    - Receiver dropped — `send().await` returns `Err`
    - Task aborted (timeout, cancellation) — code after the abort point never
      runs
-   - Channel full — `try_send` drops the message
+   - Channel full — a `try_send` path refuses or drops the message. (This
+     SDK's event path uses `send().await`, so a full channel *blocks* the
+     transport loop instead of dropping; its command path is bounded and
+     refuses with `SendBufferFull` rather than dropping.)
    - Panic in spawned task — subsequent code in that task is skipped
 
 2. **Qualify delivery semantics** — Describe what the mechanism prevents AND
    what it does not prevent.
-   - BAD: "The Disconnected event is always delivered regardless of capacity."
-   - GOOD: "The Disconnected event uses a blocking send so it will not be
-     dropped due to a full channel, but it may be missed if the receiver is
-     dropped or if shutdown times out and aborts the transport task."
+   - BAD: "Events are always delivered regardless of capacity."
+   - GOOD: "Events are never dropped on overflow — a full channel pauses the
+     transport loop and backpressure propagates to the server — but an event
+     may be missed if the receiver is dropped or if shutdown times out and
+     aborts the transport task."
 
 3. **Document timeout/abort consequences** — If a function has a timeout that
    aborts work, document what events or side effects may be skipped when the
@@ -51,13 +55,14 @@ cancellation, channel drops, etc.
 
 ## Examples from This Codebase
 
-### `emit_disconnected` — Qualified guarantee
+### `emit_event` — Qualified guarantee
 
 ```rust
-/// Uses `send().await` (blocking) instead of `try_send` so that `Disconnected`
-/// is not dropped due to channel backpressure. However, delivery is not
-/// unconditional: the event will be lost if the receiver has been dropped, or
-/// if `shutdown` aborts the transport task before this function completes.
+/// Events are **never dropped**: when the consumer lags, the transport loop
+/// pauses here, which stops reading from the transport and propagates
+/// backpressure to the server (e.g. via TCP receive windows). Delivery only
+/// fails if the receiver has been dropped, or if `shutdown` aborts the
+/// transport task while this send is still waiting.
 ```
 
 ### `shutdown_timeout` — Documenting abort consequences

--- a/.llm/skills/doc-accuracy-guarantees.md
+++ b/.llm/skills/doc-accuracy-guarantees.md
@@ -61,8 +61,9 @@ cancellation, channel drops, etc.
 /// Events are **never dropped**: when the consumer lags, the transport loop
 /// pauses here, which stops reading from the transport and propagates
 /// backpressure to the server (e.g. via TCP receive windows). Delivery only
-/// fails if the receiver has been dropped, or if `shutdown` aborts the
-/// transport task while this send is still waiting.
+/// fails if the receiver has been dropped, or if the transport task is
+/// aborted while this send is still waiting (a `shutdown` timeout, or the
+/// client handle dropped without `shutdown`).
 ```
 
 ### `shutdown_timeout` — Documenting abort consequences

--- a/.llm/skills/error-handling.md
+++ b/.llm/skills/error-handling.md
@@ -32,6 +32,13 @@ pub enum SignalFishError {
     #[error("not connected to server")]
     NotConnected,
 
+    /// The bounded outgoing command queue is full. Fail-fast send-side
+    /// backpressure: the message was refused, not queued, nothing dropped.
+    /// Callers retry, pace via send_game_data_reliable / send_signal_reliable,
+    /// or raise SignalFishConfig::command_channel_capacity.
+    #[error("outgoing command queue full (capacity {capacity}): ...")]
+    SendBufferFull { capacity: usize },
+
     /// Not in a room.
     #[error("not in a room")]
     NotInRoom,
@@ -42,6 +49,11 @@ pub enum SignalFishError {
         message: String,
         error_code: Option<ErrorCode>,
     },
+
+    /// A protocol-v3-only operation attempted before v3 was negotiated.
+    /// mode is "relay-only" (negotiated below v3) or "pre-negotiation".
+    #[error("operation requires a negotiated protocol v3 session ...")]
+    ProtocolUnsupported { mode: &'static str },
 
     /// An operation timed out.
     #[error("operation timed out")]
@@ -98,7 +110,7 @@ async fn do_thing(&mut self) -> Result<(), SignalFishError> {
 
 ## ErrorCode Enum
 
-Defined in `src/error_codes.rs`. This enum is exhaustive. 40 variants:
+Defined in `src/error_codes.rs`. This enum is exhaustive. 48 variants:
 
 ```rust
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -132,6 +144,16 @@ pub enum ErrorCode {
 
     // Server (3)
     InternalError, StorageError, ServiceUnavailable,
+
+    // Game start, protocol v2 (2)
+    GameStartNotReady, GameStartForbidden,
+
+    // Signaling, protocol v3 (5)
+    CrossRoomSignal, UnsupportedTransport, SignalTargetNotFound,
+    SignalRateLimited, SignalTooLarge,
+
+    // Connection lifecycle, protocol v3 (1)
+    ConnectionIdleTimeout,
 }
 ```
 

--- a/.llm/skills/public-api-design.md
+++ b/.llm/skills/public-api-design.md
@@ -248,3 +248,18 @@ let (client, events) = SignalFishClient::start(transport, config);
 - **The mesh surface is feature-gated** behind `mesh` (and the async controller
   additionally behind `tokio-runtime`), keeping the default build minimal. See
   [webrtc-mesh-signaling](webrtc-mesh-signaling.md).
+
+## Send-Path Conventions (0.6.0)
+
+- **Fail-fast / waiting pairs.** The sync send methods queue on a bounded
+  channel and fail fast with `SignalFishError::SendBufferFull { capacity }`
+  when full; each high-rate send has an async waiting counterpart named
+  `*_reliable` (`send_game_data_reliable`, `send_signal_reliable`). Follow
+  this naming and pairing for any future send-style API: congestion must
+  surface as an error or as waiting — never as a silent drop or an unbounded
+  backlog.
+- **Diagnostics are plain accessors.** `send_capacity()`,
+  `max_send_capacity()`, and `stats()` (returning the plain-data
+  `ClientStats`) exist on both clients; keep the two client APIs mirrored.
+- Adding `SendBufferFull` to the exhaustive `SignalFishError` is breaking
+  (MINOR for 0.x) — the `0.5.0 → 0.6.0` bump.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-07-01
+
 ### Added
 
+- `SignalFishClient::send_game_data_reliable(data)` — backpressure-aware
+  counterpart to `send_game_data` that waits for space in the outgoing command
+  queue instead of failing fast, pacing the caller to actual transport
+  throughput; the recommended way to stream high-rate payloads such as
+  rollback input packets (#47).
+- `SignalFishClient::send_signal_reliable(to, signal)` — waiting counterpart
+  to `send_signal` for WebRTC signaling (protocol v3 only), so congestion
+  never loses an offer/answer/ICE candidate (#47).
+- `SignalFishConfig::command_channel_capacity` field (default `1024`, values
+  below 1 clamped to 1) and the
+  `SignalFishConfig::with_command_channel_capacity(n)` builder for tuning the
+  bounded outgoing command queue (#47).
+- `SignalFishError::SendBufferFull { capacity }` — returned by the fail-fast
+  send methods when the outgoing command queue is full; the message is not
+  queued and nothing is silently dropped (#47).
+- `send_capacity()` / `max_send_capacity()` on `SignalFishClient` and
+  `SignalFishPollingClient` — remaining/configured command-queue capacity for
+  send pacing and congestion diagnostics (#47).
+- `ClientStats` (re-exported at the crate root) with cumulative
+  `game_data_sent` / `game_data_received` counters, returned by `stats()` on
+  both clients. The counters survive disconnection and make relay-path loss
+  observable: the client itself never drops game data, so a cross-peer
+  sent-vs-received deficit points at the relay path or a peer, not at this
+  client (#47).
 - Optional low-latency mesh pump: `WebRtcDriver::set_ready_waker` (default no-op)
   hands the driver a `MeshWaker` it can `wake()` when it has output ready, so
   trickled ICE candidates and inbound data surface immediately instead of waiting
@@ -21,6 +47,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Breaking (behavior): events are never dropped.** The transport loop now
+  delivers every event with `send().await`; a lagging consumer pauses the
+  loop and backpressure propagates to the server instead of losing events.
+  Previously a full event channel dropped events with a warning (only
+  `Disconnected` was blocking). `SignalFishConfig::event_channel_capacity`
+  (default 256) now only controls how much buffering the consumer gets before
+  backpressure kicks in, not loss (#47).
+- **Breaking (API): the async client's command channel is now bounded.** All
+  synchronous send methods (`join_room`, `send_game_data`, `send_signal`,
+  `ping`, …) fail fast with the new `SendBufferFull` error variant when the
+  queue is full. Adding a variant to `SignalFishError` is breaking for
+  exhaustive matches (#47).
+- `SignalFishPollingClient` applies the same bound to its command queue
+  (via `command_channel_capacity`); queueing methods return `SendBufferFull`
+  once a stalled transport fills it (#47).
+- `MeshController` now relays driver signals via `send_signal_reliable`, so
+  mesh signals are never dropped under command-queue congestion, and
+  debug-logs transport-status reports the client refuses (#47).
+- Documented the runtime driving contract: `SignalFishClient::start` spawns
+  the transport loop with `tokio::spawn` and works on any *driven* runtime
+  (including `current_thread`), but manually "ticking" a runtime starves it —
+  frame-driven or wasm environments should use `SignalFishPollingClient`
+  (feature `polling-client`) (#47).
 - `MeshSession` and `MeshController` now defensively replay any mesh events a
   server batches into a reconnect's `missed_events` (in addition to handling a
   re-sent live `SessionPlan`), so a mesh session is rebuilt correctly after a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Minimum supported `tokio` is now declared as `1.21` (previously `1`): the
+  new queue-capacity diagnostics use `mpsc::Sender::capacity` (tokio 1.5)
+  and `mpsc::Sender::max_capacity` (tokio 1.21). Any lockfile from the last
+  few years already satisfies this; the requirement is now honest (#47).
 - **Breaking (behavior): events are never dropped.** The transport loop now
   delivers every event with `send().await`; a lagging consumer pauses the
   loop and backpressure propagates to the server instead of losing events.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   queue is full. Adding a variant to `SignalFishError` is breaking for
   exhaustive matches (#47).
 - `SignalFishPollingClient` applies the same bound to its command queue
-  (via `command_channel_capacity`); queueing methods return `SendBufferFull`
+  (via `command_channel_capacity`); queuing methods return `SendBufferFull`
   once a stalled transport fills it (#47).
 - `MeshController` no longer drops a driver signal the command queue refuses:
   the signal is buffered in the controller and retried (in order, ahead of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,8 +64,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   once a stalled transport fills it (#47).
 - `MeshController` no longer drops a driver signal the command queue refuses:
   the signal is buffered in the controller and retried (in order, ahead of
-  further driver output) until the queue accepts it or the connection ends,
-  and `recv()` is
+  further driver output) until the queue accepts it — or discarded if the
+  connection ends or the target peer's handshake is torn down first (a
+  stale signal is never relayed) — and `recv()` is
   documented cancel-safe — a buffered signal survives cancellation. Refused
   transport-status reports are now debug-logged instead of silently
   discarded (#47).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   once a stalled transport fills it (#47).
 - `MeshController` no longer drops a driver signal the command queue refuses:
   the signal is buffered in the controller and retried (in order, ahead of
-  further driver output) until the queue accepts it, and `recv()` is
+  further driver output) until the queue accepts it or the connection ends,
+  and `recv()` is
   documented cancel-safe — a buffered signal survives cancellation. Refused
   transport-status reports are now debug-logged instead of silently
   discarded (#47).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,9 +62,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `SignalFishPollingClient` applies the same bound to its command queue
   (via `command_channel_capacity`); queueing methods return `SendBufferFull`
   once a stalled transport fills it (#47).
-- `MeshController` now relays driver signals via `send_signal_reliable`, so
-  mesh signals are never dropped under command-queue congestion, and
-  debug-logs transport-status reports the client refuses (#47).
+- `MeshController` no longer drops a driver signal the command queue refuses:
+  the signal is buffered in the controller and retried (in order, ahead of
+  further driver output) until the queue accepts it, and `recv()` is
+  documented cancel-safe — a buffered signal survives cancellation. Refused
+  transport-status reports are now debug-logged instead of silently
+  discarded (#47).
 - Documented the runtime driving contract: `SignalFishClient::start` spawns
   the transport loop with `tokio::spawn` and works on any *driven* runtime
   (including `current_thread`), but manually "ticking" a runtime starves it —

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signal-fish-client"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 license = "MIT"
 authors = ["Ambiguous Interactive <eli@theambiguous.co>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,10 @@ mesh = []
 
 [dependencies]
 # Async
-tokio = { version = "1", features = ["sync", "macros"] }
+# 1.21 is the true minimum: Sender::max_capacity() (1.21) and
+# Sender::capacity() (1.5) back send_capacity()/max_send_capacity()
+# and the SendBufferFull capacity report.
+tokio = { version = "1.21", features = ["sync", "macros"] }
 async-trait = "0.1"
 
 # Serialization
@@ -64,7 +67,7 @@ futures-util = { version = "0.3", optional = true, features = ["sink"] }
 uuid = { version = "1", features = ["v4", "serde", "js"] }
 
 [dev-dependencies]
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1.21", features = ["full"] }
 futures-util = "0.3"
 serde_json = "1.0"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/README.md
+++ b/README.md
@@ -46,25 +46,26 @@ Transport-agnostic async Rust client for the **Signal Fish** multiplayer signali
 - **Protocol support: v2 relay + v3 mesh** — v3 (opt-in, backward-compatible) adds WebRTC mesh signaling; a default client stays byte-identical to v2 (the "relay-floor guarantee"). Enable with `SignalFishConfig::enable_mesh()`.
 - **Feature-gated WebSocket transport** — the default `transport-websocket` feature provides a ready-to-use `WebSocketTransport`
 - **Event-driven** — receive typed `SignalFishEvent`s via a Tokio MPSC channel
-- **Structured errors** — `SignalFishError` (10 variants) and `ErrorCode` (48 variants) for precise error handling
+- **Structured errors** — `SignalFishError` (11 variants) and `ErrorCode` (48 variants) for precise error handling
 - **Full protocol coverage** — 14 client message types, 28 server message types, 30 event variants
-- **Configurable** — tune event channel capacity, shutdown timeout, and more via `SignalFishConfig` builder methods
+- **No silent loss** — events are delivered with backpressure (never dropped), and the bounded send queue surfaces congestion as `SignalFishError::SendBufferFull` instead of buffering without bound; `send_game_data_reliable` / `send_signal_reliable` wait for capacity, and `stats()` counters make relay-path loss observable
+- **Configurable** — tune event channel capacity, command queue capacity, shutdown timeout, and more via `SignalFishConfig` builder methods
 - **WebAssembly ready** — compiles to `wasm32-unknown-unknown` and `wasm32-unknown-emscripten` with zero unsafe panics
 - **Emscripten WebSocket transport** — the `transport-websocket-emscripten` feature provides `EmscriptenWebSocketTransport` with raw FFI to Emscripten's C API
-- **Polling client** — `SignalFishPollingClient` drives the protocol from a game loop without an async runtime, ideal for Godot 4.5 web exports
+- **Polling client** — `SignalFishPollingClient` drives the protocol from a game loop without an async runtime, ideal for frame-driven engines and wasm targets (e.g. Godot 4.5 web exports)
 
 ## Installation
 
 ```toml
 [dependencies]
-signal-fish-client = "0.5.0"
+signal-fish-client = "0.6.0"
 ```
 
 Without the built-in WebSocket transport (bring your own):
 
 ```toml
 [dependencies]
-signal-fish-client = { version = "0.5.0", default-features = false }
+signal-fish-client = { version = "0.6.0", default-features = false }
 ```
 
 ## Quick Start
@@ -124,7 +125,7 @@ async fn main() -> Result<(), signal_fish_client::SignalFishError> {
 | `client`      | `SignalFishClient` handle, `SignalFishConfig`, `JoinRoomParams`   |
 | `event`       | `SignalFishEvent` enum (28 server + 2 synthetic variants)         |
 | `protocol`    | Wire-compatible `ClientMessage` (14) / `ServerMessage` (28) types |
-| `error`       | `SignalFishError` unified error type (10 variants)                |
+| `error`       | `SignalFishError` unified error type (11 variants)                |
 | `error_codes` | `ErrorCode` enum (48 server error code variants)                  |
 | `transport`   | `Transport` trait for pluggable backends                          |
 | `transports`  | Built-in transport implementations (`WebSocketTransport`)         |
@@ -205,6 +206,8 @@ The SDK supports two WASM targets:
 | --- | --- | --- | --- |
 | `wasm32-unknown-unknown` | Browser apps (wasm-pack, wasm-bindgen) | Bring your own | `SignalFishPollingClient` (with `polling-client` feature) |
 | `wasm32-unknown-emscripten` | Godot 4.5 web exports (gdext) | `EmscriptenWebSocketTransport` | `SignalFishPollingClient` |
+
+The async `SignalFishClient` needs a *driven* tokio runtime (its transport loop runs under `tokio::spawn`); manually "ticking" a runtime once per frame starves it. Frame-driven or single-threaded environments — game loops on native as well as wasm — should use `SignalFishPollingClient` (feature `polling-client`), a synchronous pump you call once per frame.
 
 ### Emscripten Quick Start
 

--- a/docs/client.md
+++ b/docs/client.md
@@ -30,7 +30,8 @@ let config = SignalFishConfig::new("mb_app_abc123");
 | `sdk_version` | `Option<String>` | Crate version at compile time | SDK version string sent during authentication. |
 | `platform` | `Option<String>` | `None` | Platform identifier (e.g. `"unity"`, `"godot"`, `"rust"`). |
 | `game_data_format` | `Option<GameDataEncoding>` | `None` | Preferred game data encoding format (`Json`, `MessagePack`, or `Rkyv`). |
-| `event_channel_capacity` | `usize` | `256` | Capacity of the bounded event channel. Values below 1 are clamped to 1. |
+| `event_channel_capacity` | `usize` | `256` | Capacity of the bounded event channel. Events are never dropped — a full channel pauses the transport loop (backpressure), so this only controls buffering before backpressure kicks in. Values below 1 are clamped to 1. |
+| `command_channel_capacity` | `usize` | `1024` | Capacity of the bounded outgoing command queue. When full, the synchronous send methods fail fast with [`SignalFishError::SendBufferFull`](errors.md#handling-sendbufferfull); the `*_reliable` variants wait for a slot instead. Values below 1 are clamped to 1. |
 | `shutdown_timeout` | `Duration` | `1 second` | Timeout for graceful shutdown of the background transport loop. A zero timeout aborts the loop immediately. |
 
 ### Builder Methods
@@ -40,6 +41,7 @@ All builder methods are `#[must_use]` — you must chain or assign the return va
 | Method | Parameter Type | Description |
 |---|---|---|
 | `.with_event_channel_capacity(n)` | `usize` | Set the bounded event channel capacity (default 256). |
+| `.with_command_channel_capacity(n)` | `usize` | Set the bounded outgoing command queue capacity (default 1024). |
 | `.with_shutdown_timeout(d)` | `Duration` | Set the graceful shutdown timeout (default 1 second). |
 
 ### Full Example
@@ -50,6 +52,7 @@ use std::time::Duration;
 
 let config = SignalFishConfig::new("mb_app_abc123")
     .with_event_channel_capacity(512)
+    .with_command_channel_capacity(2048)
     .with_shutdown_timeout(Duration::from_secs(5));
 ```
 
@@ -60,7 +63,7 @@ use signal_fish_client::{SignalFishConfig, protocol::GameDataEncoding};
 
 let config = SignalFishConfig {
     app_id: "mb_app_abc123".into(),
-    sdk_version: Some("0.5.0".into()),
+    sdk_version: Some("0.6.0".into()),
     platform: Some("rust".into()),
     game_data_format: Some(GameDataEncoding::Json),
     ..SignalFishConfig::new("mb_app_abc123")
@@ -113,12 +116,19 @@ Async client handle for the Signal Fish signaling protocol. Created via
 and returns this handle together with an event receiver.
 
 All command methods serialize a `ClientMessage` and queue it to the transport
-loop over an unbounded channel — they return immediately without awaiting a
-round-trip.
+loop over a **bounded** channel (default 1024, via
+[`SignalFishConfig::command_channel_capacity`](#fields)) — they return
+immediately without awaiting a round-trip.
 
 !!! info "Error convention"
-    All `Result<()>` methods return `Err(SignalFishError::NotConnected)` when the
-    transport is closed.
+    All synchronous `Result<()>` methods return
+    `Err(SignalFishError::NotConnected)` when the transport is closed, and
+    `Err(SignalFishError::SendBufferFull { capacity })` when the outgoing
+    command queue is full (the message is **not** queued; nothing is silently
+    dropped). The async `*_reliable` variants
+    ([`send_game_data_reliable`](#send_game_data_reliable),
+    [`send_signal_reliable`](mesh-guide.md)) wait for queue capacity instead
+    of failing fast.
 
 !!! info "ID types"
     `PlayerId` and `RoomId` are both type aliases for `uuid::Uuid`.
@@ -273,6 +283,73 @@ client.send_game_data(serde_json::json!({
 
 The data is forwarded to all other players (and spectators) in the room.
 
+`send_game_data` returns as soon as the message is queued; when the bounded
+command queue is full it fails fast with
+`SignalFishError::SendBufferFull` — the message is not queued.
+
+---
+
+#### `send_game_data_reliable`
+
+Send arbitrary JSON game data, waiting for space in the outgoing command
+queue when it is full.
+
+```rust,ignore
+async fn send_game_data_reliable(&self, data: serde_json::Value) -> Result<()>
+```
+
+```rust,ignore
+client.send_game_data_reliable(serde_json::json!({
+    "input": { "frame": 1042, "buttons": 0b0110 },
+})).await?;
+```
+
+The backpressure-aware counterpart to [`send_game_data`](#send_game_data):
+instead of failing fast with `SendBufferFull`, it pauses until the transport
+drains a slot, pacing the caller to actual transport throughput. This is the
+recommended way to stream high-rate payloads (rollback input packets, state
+sync) without guessing at sleep durations. It only errors with
+`NotConnected` when the transport has closed.
+
+The WebRTC-signaling counterpart is `send_signal_reliable(to, signal)`
+(protocol v3 only — see the [Mesh Guide](mesh-guide.md)); a lost
+offer/answer/ICE candidate stalls a handshake, so waiting beats failing when
+the queue is congested.
+
+---
+
+### Send Queue & Traffic Stats
+
+Synchronous diagnostics for the outgoing command queue and game-data traffic:
+
+| Method | Signature | Description |
+|---|---|---|
+| `send_capacity()` | `fn send_capacity(&self) -> usize` | Messages that can currently be queued before the fail-fast sends return `SendBufferFull`. A shrinking value is the congestion signal; `0` means the next fail-fast send is refused. |
+| `max_send_capacity()` | `fn max_send_capacity(&self) -> usize` | Configured capacity of the outgoing command queue (`command_channel_capacity`). |
+| `stats()` | `fn stats(&self) -> ClientStats` | Cumulative game-data traffic counters. |
+
+`ClientStats` (re-exported at the crate root) carries `game_data_sent` (
+`GameData` messages written to the transport) and `game_data_received`
+(`GameData`/`GameDataBinary` events received). The counters are cumulative
+for the lifetime of the client — they survive room changes and disconnects.
+
+Because the client itself never drops game data (events are delivered with
+backpressure; refused sends return `SendBufferFull`), these counters make
+loss *elsewhere* observable: exchange or log them across peers, and a
+persistent sent-vs-received deficit points at the relay path or a peer — not
+at this client.
+
+```rust,ignore
+let stats = client.stats();
+println!(
+    "sent {} / received {} (queue {}/{} free)",
+    stats.game_data_sent,
+    stats.game_data_received,
+    client.send_capacity(),
+    client.max_send_capacity(),
+);
+```
+
 ---
 
 ### Authority
@@ -424,6 +501,13 @@ Originally created for WebAssembly targets (specifically
 `wasm32-unknown-emscripten` and Godot 4.5 web exports via gdext), but usable
 in any single-threaded context with any `Transport` implementation.
 
+This is the right client whenever your application is **frame-driven** —
+native game loops as much as wasm. The async `SignalFishClient` only makes
+progress while its tokio runtime is being driven; manually "ticking" a
+runtime once per frame starves its transport loop (see
+[Driving the Client](concepts.md#driving-the-client-runtime-contract)). The
+polling client has no background task and no runtime — you pump it yourself.
+
 !!! note "Feature gate"
     `SignalFishPollingClient` requires the `polling-client` feature.
     This feature is automatically enabled by `transport-websocket-emscripten`.
@@ -510,6 +594,13 @@ for event in events {
 All command methods are synchronous. They queue an outgoing message that is
 flushed on the next `poll()` call. All return `Result<(), SignalFishError>`.
 
+The outgoing queue is bounded by the same
+[`SignalFishConfig::command_channel_capacity`](#fields) (default 1024): if
+the transport stalls long enough for the queue to fill, further queueing
+methods return `SignalFishError::SendBufferFull` (the message is not
+queued). `send_capacity()` / `max_send_capacity()` report the remaining and
+configured capacity.
+
 | Method | Description |
 |---|---|
 | `join_room(params: JoinRoomParams)` | Join or create a room. |
@@ -539,6 +630,9 @@ All accessors are **synchronous** (no async, no mutex):
 | `current_player_id()` | `Option<PlayerId>` | Current player ID, if assigned. |
 | `current_room_id()` | `Option<RoomId>` | Current room ID, if in a room. |
 | `current_room_code()` | `Option<&str>` | Current room code, if in a room. |
+| `send_capacity()` | `usize` | Messages that can still be queued before `SendBufferFull`. |
+| `max_send_capacity()` | `usize` | Configured command-queue capacity. |
+| `stats()` | `ClientStats` | Cumulative `game_data_sent` / `game_data_received` counters (see [Send Queue & Traffic Stats](#send-queue--traffic-stats)). |
 
 !!! note "No async accessors"
     Unlike `SignalFishClient`, all `SignalFishPollingClient` accessors are

--- a/docs/client.md
+++ b/docs/client.md
@@ -311,6 +311,15 @@ recommended way to stream high-rate payloads (rollback input packets, state
 sync) without guessing at sleep durations. It only errors with
 `NotConnected` when the transport has closed.
 
+!!! warning "Keep draining events"
+    The command queue only drains while the transport loop runs, and the
+    loop pauses whenever the *event* channel is full (events are never
+    dropped). A task that awaits this method while it is also the only
+    consumer of the event receiver can deadlock under simultaneous
+    send + receive pressure — drain events from a separate task rather than
+    strictly sequentially. (Do **not** race this send against the event
+    receiver in a `tokio::select!`: a cancelled send discards its payload.)
+
 The WebRTC-signaling counterpart is `send_signal_reliable(to, signal)`
 (protocol v3 only — see the [Mesh Guide](mesh-guide.md)); a lost
 offer/answer/ICE candidate stalls a handshake, so waiting beats failing when
@@ -632,7 +641,7 @@ All accessors are **synchronous** (no async, no mutex):
 | `current_room_code()` | `Option<&str>` | Current room code, if in a room. |
 | `send_capacity()` | `usize` | Messages that can still be queued before `SendBufferFull`. |
 | `max_send_capacity()` | `usize` | Configured command-queue capacity. |
-| `stats()` | `ClientStats` | Cumulative `game_data_sent` / `game_data_received` counters (see [Send Queue & Traffic Stats](#send-queue--traffic-stats)). |
+| `stats()` | `ClientStats` | Cumulative `game_data_sent` / `game_data_received` counters (see [Send Queue & Traffic Stats](#send-queue-traffic-stats)). |
 
 !!! note "No async accessors"
     Unlike `SignalFishClient`, all `SignalFishPollingClient` accessors are

--- a/docs/client.md
+++ b/docs/client.md
@@ -337,10 +337,14 @@ Synchronous diagnostics for the outgoing command queue and game-data traffic:
 | `max_send_capacity()` | `fn max_send_capacity(&self) -> usize` | Configured capacity of the outgoing command queue (`command_channel_capacity`). |
 | `stats()` | `fn stats(&self) -> ClientStats` | Cumulative game-data traffic counters. |
 
-`ClientStats` (re-exported at the crate root) carries `game_data_sent` (
-`GameData` messages written to the transport) and `game_data_received`
-(`GameData`/`GameDataBinary` events received). The counters are cumulative
-for the lifetime of the client — they survive room changes and disconnects.
+`ClientStats` (re-exported at the crate root) carries `game_data_sent`
+(`GameData` messages written to the transport) and `game_data_received`
+(`GameData`/`GameDataBinary` messages read off the transport and parsed —
+counted at **receipt**, not at delivery to your event loop, so a consumer
+that stops draining events cannot masquerade as relay loss; in steady state
+the two are identical because events are never dropped). The counters are
+cumulative for the lifetime of the client — they survive room changes and
+disconnects.
 
 Because the client itself never drops game data (events are delivered with
 backpressure; refused sends return `SendBufferFull`), these counters make

--- a/docs/client.md
+++ b/docs/client.md
@@ -327,7 +327,7 @@ the queue is congested.
 
 ---
 
-### Send Queue & Traffic Stats
+### Send Queue and Traffic Stats
 
 Synchronous diagnostics for the outgoing command queue and game-data traffic:
 
@@ -605,7 +605,7 @@ flushed on the next `poll()` call. All return `Result<(), SignalFishError>`.
 
 The outgoing queue is bounded by the same
 [`SignalFishConfig::command_channel_capacity`](#fields) (default 1024): if
-the transport stalls long enough for the queue to fill, further queueing
+the transport stalls long enough for the queue to fill, further queuing
 methods return `SignalFishError::SendBufferFull` (the message is not
 queued). `send_capacity()` / `max_send_capacity()` report the remaining and
 configured capacity.
@@ -641,7 +641,7 @@ All accessors are **synchronous** (no async, no mutex):
 | `current_room_code()` | `Option<&str>` | Current room code, if in a room. |
 | `send_capacity()` | `usize` | Messages that can still be queued before `SendBufferFull`. |
 | `max_send_capacity()` | `usize` | Configured command-queue capacity. |
-| `stats()` | `ClientStats` | Cumulative `game_data_sent` / `game_data_received` counters (see [Send Queue & Traffic Stats](#send-queue-traffic-stats)). |
+| `stats()` | `ClientStats` | Cumulative `game_data_sent` / `game_data_received` counters (see [Send Queue and Traffic Stats](#send-queue-and-traffic-stats)). |
 
 !!! note "No async accessors"
     Unlike `SignalFishClient`, all `SignalFishPollingClient` accessors are

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -185,8 +185,9 @@ generated locally by the transport layer:
     transport until the channel has room, so backpressure propagates to the
     server instead of losing events. The capacity only controls how much
     buffering the consumer gets before that backpressure kicks in. An event
-    can only be missed if the receiver is dropped or a shutdown timeout
-    aborts the transport task (see [Events](events.md)). A responsive event
+    can only be missed if the receiver is dropped, a shutdown timeout aborts
+    the transport task, or the client handle is dropped without calling
+    `shutdown()` (see [Events](events.md)). A responsive event
     loop keeps the connection flowing; a stalled one stalls the transport.
 
 ---

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -178,15 +178,16 @@ generated locally by the transport layer:
 | `SignalFishEvent::Connected` | Emitted when the transport opens, before any server message. |
 | `SignalFishEvent::Disconnected { reason }` | Emitted when the transport closes or errors. Last event (best-effort). |
 
-!!! warning "Channel capacity"
-    The event channel has a default capacity of **256** (configurable via
-    `SignalFishConfig::event_channel_capacity`). If your consumer falls behind,
-    events are **dropped** (with a warning logged) to avoid blocking the
-    transport loop. The `Disconnected` event is the exception — it uses a
-    blocking send so it will not be dropped due to backpressure, but it may be
-    missed if the receiver is dropped or shutdown times out (see
-    [Events](events.md)). Design your event loop to stay responsive to avoid
-    losing events.
+!!! note "Lossless delivery with backpressure"
+    Events are **never dropped**. The event channel has a default capacity of
+    **256** (configurable via `SignalFishConfig::event_channel_capacity`); if
+    your consumer falls behind, the transport loop pauses reading from the
+    transport until the channel has room, so backpressure propagates to the
+    server instead of losing events. The capacity only controls how much
+    buffering the consumer gets before that backpressure kicks in. An event
+    can only be missed if the receiver is dropped or a shutdown timeout
+    aborts the transport task (see [Events](events.md)). A responsive event
+    loop keeps the connection flowing; a stalled one stalls the transport.
 
 ---
 
@@ -195,8 +196,10 @@ generated locally by the transport layer:
 All client command methods — `join_room`, `leave_room`, `send_game_data`,
 `set_ready`, `request_authority`, `provide_connection_info`, `reconnect`,
 `join_as_spectator`, `leave_spectator`, `ping` — are **synchronous**. They
-serialize a `ClientMessage`, queue it on an internal unbounded channel, and
-return `Result<()>` immediately. There is no `.await`.
+serialize a `ClientMessage`, queue it on an internal **bounded** channel
+(default capacity **1024**, configurable via
+`SignalFishConfig::command_channel_capacity`), and return `Result<()>`
+immediately. There is no `.await`.
 
 ```rust,ignore
 // These return instantly — no network round-trip
@@ -210,11 +213,66 @@ client.send_game_data(serde_json::json!({ "action": "move", "x": 10 }))?;
 client.set_ready()?;
 ```
 
-Besides the state accessors, the **only** async method on the client is `shutdown()`:
+When the queue is full — the caller is producing faster than the transport
+can drain — these methods **fail fast** with
+[`SignalFishError::SendBufferFull`](errors.md): the message is *not* queued,
+and nothing is silently dropped. For high-rate payloads, use the
+backpressure-aware async variants instead, which wait for a free slot rather
+than failing:
+
+```rust,ignore
+// Waits for queue capacity — paces the caller to actual transport throughput.
+client.send_game_data_reliable(serde_json::json!({ "input": frame_input })).await?;
+
+// Same for WebRTC signals (protocol v3 only) — a lost signal stalls a handshake.
+client.send_signal_reliable(peer_id, PeerSignal::Offer(sdp)).await?;
+```
+
+`send_capacity()` (remaining slots) and `max_send_capacity()` (configured
+capacity) expose the queue state for pacing and diagnostics.
+
+Besides the state accessors and the `*_reliable` sends, the only other async
+method on the client is `shutdown()`:
 
 ```rust,ignore
 client.shutdown().await;
 ```
+
+### Reliability & Flow Control
+
+Putting the two halves together, the client **never silently drops data** in
+either direction:
+
+- **Inbound:** events are delivered with backpressure — a lagging consumer
+  pauses the transport loop; nothing is lost.
+- **Outbound:** the command queue is bounded — congestion surfaces as
+  `SendBufferFull` (fail-fast methods) or as waiting (`*_reliable` methods),
+  never as an unbounded backlog or a silent drop.
+
+Because the client is lossless, loss elsewhere becomes observable. `stats()`
+returns [`ClientStats`](client.md) with cumulative `game_data_sent` /
+`game_data_received` counters (they survive disconnects): exchange or log
+them across peers, and a persistent sent-vs-received deficit points at the
+relay path or a peer — not at this client. Pace high-rate streams with
+`send_game_data_reliable` instead of guessing at sleep durations.
+
+---
+
+## Driving the Client (Runtime Contract)
+
+`SignalFishClient::start` spawns the background transport loop with
+`tokio::spawn`. That loop only makes progress while the tokio runtime is
+**driven** — some task is being awaited (`#[tokio::main]`, `block_on`, worker
+threads). Both multi-thread and `current_thread` runtimes work, as long as
+the runtime is actually running.
+
+What does **not** work is "ticking" a runtime manually — e.g. calling one
+`yield_now().await` per game frame: the transport loop starves and messages
+appear to vanish. For frame-driven or single-threaded environments (game
+engines, `wasm32` targets), use `SignalFishPollingClient` (feature
+`polling-client`) instead: a synchronous pump you call once per frame, with
+no background task and no runtime at all. See the
+[WebAssembly Guide](wasm.md) and [Client API](client.md#signalfishpollingclient).
 
 ### State Accessors
 
@@ -311,6 +369,7 @@ directly from client methods as `Result<(), SignalFishError>`.
 | `TransportClosed` | The transport connection closed unexpectedly. |
 | `Serialization(serde_json::Error)` | JSON serialization / deserialization failed. |
 | `NotConnected` | Attempted an operation without an active connection. |
+| `SendBufferFull { capacity }` | The bounded outgoing command queue is full; the message was refused, not queued. See [Non-Blocking Command Sending](#non-blocking-command-sending). |
 | `NotInRoom` | Attempted a room operation without being in a room. |
 | `ServerError { message, error_code }` | The server returned an error; `error_code` is `Option<ErrorCode>` and may be absent. |
 | `ProtocolUnsupported { mode }` | A protocol-v3-only send was attempted before v3 was negotiated. See [Protocol versioning & topology](#protocol-versioning--topology). |

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -245,18 +245,37 @@ either direction:
 
 - **Inbound:** events are delivered with backpressure — a lagging consumer
   pauses the transport loop; nothing is lost.
-- **Outbound:** the command queue is bounded — congestion surfaces as
+- **Outbound:** queue admission is never silent — congestion surfaces as
   `SendBufferFull` (fail-fast methods) or as waiting (`*_reliable` methods),
-  never as an unbounded backlog or a silent drop.
+  never as an unbounded backlog. Note that *queued* is not *delivered*:
+  commands still in the queue when the connection ends are discarded with
+  it, surfaced by the `Disconnected` event.
 
 Because the client is lossless, loss elsewhere becomes observable. `stats()`
 returns [`ClientStats`](client.md) with cumulative `game_data_sent` /
 `game_data_received` counters (they survive disconnects): exchange or log
 them across peers, and a persistent sent-vs-received deficit points at the
 relay path or a peer — not at this client. Pace high-rate streams with
-`send_game_data_reliable` instead of guessing at sleep durations.
+`send_game_data_reliable` instead of guessing at sleep durations — but drain
+events from a separate task while awaiting it: the queue only drains while
+the transport loop runs, and the loop pauses when the event channel is full,
+so a lone task doing both strictly sequentially can deadlock under
+simultaneous send + receive pressure.
 
 ---
+
+### State Accessors
+
+| Accessor | Async? | Returns |
+|----------|--------|---------|
+| `is_connected()` | No | `bool` |
+| `is_authenticated()` | No | `bool` |
+| `current_player_id()` | Yes (`async`) | `Option<PlayerId>` |
+| `current_room_id()` | Yes (`async`) | `Option<RoomId>` |
+| `current_room_code()` | Yes (`async`) | `Option<String>` |
+
+The synchronous accessors use `AtomicBool` internally. The async accessors use
+a `tokio::sync::Mutex` because they guard heap-allocated optional state.
 
 ## Driving the Client (Runtime Contract)
 
@@ -273,19 +292,6 @@ engines, `wasm32` targets), use `SignalFishPollingClient` (feature
 `polling-client`) instead: a synchronous pump you call once per frame, with
 no background task and no runtime at all. See the
 [WebAssembly Guide](wasm.md) and [Client API](client.md#signalfishpollingclient).
-
-### State Accessors
-
-| Accessor | Async? | Returns |
-|----------|--------|---------|
-| `is_connected()` | No | `bool` |
-| `is_authenticated()` | No | `bool` |
-| `current_player_id()` | Yes (`async`) | `Option<PlayerId>` |
-| `current_room_id()` | Yes (`async`) | `Option<RoomId>` |
-| `current_room_code()` | Yes (`async`) | `Option<String>` |
-
-The synchronous accessors use `AtomicBool` internally. The async accessors use
-a `tokio::sync::Mutex` because they guard heap-allocated optional state.
 
 ---
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -239,7 +239,7 @@ method on the client is `shutdown()`:
 client.shutdown().await;
 ```
 
-### Reliability & Flow Control
+### Reliability and Flow Control
 
 Putting the two halves together, the client **never silently drops data** in
 either direction:

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -19,7 +19,7 @@ All fallible client methods return `Result<T>`, which is an alias for
 pub type Result<T> = std::result::Result<T, SignalFishError>;
 ```
 
-`SignalFishError` derives `Debug` and `Error` (via `thiserror`). It has **10
+`SignalFishError` derives `Debug` and `Error` (via `thiserror`). It has **11
 variants**:
 
 | Variant | Fields | When it occurs |
@@ -29,6 +29,7 @@ variants**:
 | `TransportClosed` | — | The transport connection was closed unexpectedly. |
 | `Serialization` | `serde_json::Error` | Failed to serialize or deserialize a protocol message. Implements `From<serde_json::Error>`. |
 | `NotConnected` | — | Attempted an operation requiring an active connection but the client is not connected. |
+| `SendBufferFull` | `capacity: usize` | The bounded outgoing command queue is full — the caller is producing messages faster than the transport can drain them. The message was refused, **not** queued; nothing is silently dropped. See [Handling `SendBufferFull`](#handling-sendbufferfull). |
 | `NotInRoom` | — | Attempted a room operation but the client is not in a room. |
 | `ServerError` | `message: String`, `error_code: Option<ErrorCode>` | The server returned an error message. |
 | `ProtocolUnsupported` | `mode: &'static str` | A protocol-v3-only send (e.g. `send_signal`, `report_transport_status`) was attempted before v3 was negotiated. `mode` is `"pre-negotiation"` (no `ProtocolInfo` yet — negotiation still in flight) or `"relay-only"` (a `ProtocolInfo` arrived but negotiated v2, the terminal relay floor). See [Protocol Versioning](protocol-versioning.md). |
@@ -283,6 +284,44 @@ async fn handle_event(event: SignalFishEvent) {
     The `RateLimitInfo` provided in the `Authenticated` event tells you the
     per-minute, per-hour, and per-day limits for your application. Proactively
     throttling requests avoids `RateLimitExceeded` errors entirely.
+
+### Handling `SendBufferFull`
+
+The synchronous send methods (`send_game_data`, `send_signal`, `join_room`, …)
+fail fast with `SignalFishError::SendBufferFull` when the bounded outgoing
+command queue (default **1024**, set via
+`SignalFishConfig::command_channel_capacity`) is full. The message is refused,
+not queued — congestion is surfaced, never hidden. Three remedies, in order of
+preference:
+
+1. **Pace with the waiting variants.** `send_game_data_reliable` /
+   `send_signal_reliable` are async and wait for a free slot instead of
+   failing — the right tool for high-rate streams (rollback inputs, state
+   sync).
+2. **Retry later.** Treat the error as "try again next frame"; watch
+   `send_capacity()` to see the queue drain.
+3. **Raise the capacity.** `SignalFishConfig::with_command_channel_capacity(n)`
+   buys more burst headroom, at the cost of more queued latency when the
+   transport truly cannot keep up.
+
+```rust,ignore
+use signal_fish_client::{SignalFishClient, SignalFishError};
+
+async fn stream_input(client: &SignalFishClient, input: serde_json::Value) {
+    match client.send_game_data(input.clone()) {
+        Ok(()) => {}
+        Err(SignalFishError::SendBufferFull { capacity }) => {
+            // Transport can't keep up with our send rate (queue of `capacity`
+            // is full). Switch to the pacing variant instead of dropping.
+            eprintln!("send queue full ({capacity}); pacing");
+            if let Err(e) = client.send_game_data_reliable(input).await {
+                eprintln!("send failed: {e}");
+            }
+        }
+        Err(e) => eprintln!("send failed: {e}"),
+    }
+}
+```
 
 ### Distinguishing transport errors from server errors
 

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -323,6 +323,15 @@ async fn stream_input(client: &SignalFishClient, input: serde_json::Value) {
 }
 ```
 
+!!! warning "Keep draining events while awaiting a reliable send"
+    The command queue only drains while the transport loop runs, and the
+    loop pauses whenever the *event* channel is full (events are never
+    dropped). A task that awaits `send_game_data_reliable` while it is also
+    the only consumer of the event receiver can deadlock under simultaneous
+    send + receive pressure — drain events from a separate task. See the
+    [`send_game_data_reliable` rustdoc](https://docs.rs/signal-fish-client)
+    for details.
+
 ### Distinguishing transport errors from server errors
 
 Transport errors are returned by client methods via `SignalFishError`, while

--- a/docs/events.md
+++ b/docs/events.md
@@ -24,9 +24,11 @@ descriptions and usage examples.
     (default **256**, via `SignalFishConfig::event_channel_capacity`), and a
     consumer that falls behind pauses the transport loop until the channel
     has room — backpressure propagates to the server instead of losing
-    events. There are exactly two ways an event can be missed: the event
-    receiver is dropped, or a [`shutdown()`](client.md#shutdown) timeout
-    aborts the transport task.
+    events. There are exactly three ways an event can be missed — each one
+    stops delivery entirely; there is never selective loss: the event
+    receiver is dropped, a [`shutdown()`](client.md#shutdown) timeout aborts
+    the transport task, or the client handle is dropped without calling
+    `shutdown()` (which aborts the loop immediately).
 
 ---
 

--- a/docs/events.md
+++ b/docs/events.md
@@ -45,8 +45,9 @@ Use these to track the raw connection lifecycle.
 !!! note "Best-effort delivery on shutdown"
     Like every event, `Disconnected` is never dropped due to channel
     backpressure. It is delivered best-effort only in the sense that it may
-    be missed if the event receiver is dropped or if
-    [`shutdown()`](client.md#shutdown) times out and aborts the transport task.
+    be missed if the event receiver is dropped, if
+    [`shutdown()`](client.md#shutdown) times out and aborts the transport
+    task, or if the client handle is dropped without calling `shutdown()`.
 
 ```rust,ignore
 match event {

--- a/docs/events.md
+++ b/docs/events.md
@@ -19,6 +19,15 @@ descriptions and usage examples.
     `PlayerId` is an alias for `uuid::Uuid`.
     `RoomId` is an alias for `uuid::Uuid`.
 
+!!! note "Lossless delivery"
+    Events are **never dropped on overflow**. The event channel is bounded
+    (default **256**, via `SignalFishConfig::event_channel_capacity`), and a
+    consumer that falls behind pauses the transport loop until the channel
+    has room — backpressure propagates to the server instead of losing
+    events. There are exactly two ways an event can be missed: the event
+    receiver is dropped, or a [`shutdown()`](client.md#shutdown) timeout
+    aborts the transport task.
+
 ---
 
 ## Connection Events
@@ -31,9 +40,10 @@ Use these to track the raw connection lifecycle.
 | `Connected` | — | The transport handshake is complete and the client is ready to communicate. Synthetic — see [Connection timing](wasm.md#connection-timing) for details. |
 | `Disconnected` | `reason: Option<String>` | The transport connection was closed or errored. |
 
-!!! note "Best-effort delivery"
-    `Disconnected` uses a blocking send so it will not be dropped due to channel
-    backpressure, but it may be missed if the event receiver is dropped or if
+!!! note "Best-effort delivery on shutdown"
+    Like every event, `Disconnected` is never dropped due to channel
+    backpressure. It is delivered best-effort only in the sense that it may
+    be missed if the event receiver is dropped or if
     [`shutdown()`](client.md#shutdown) times out and aborts the transport task.
 
 ```rust,ignore

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -536,7 +536,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 godot = "0.3"
-signal-fish-client = { version = "0.5.0", default-features = false, features = ["transport-websocket-emscripten"] }
+signal-fish-client = { version = "0.6.0", default-features = false, features = ["transport-websocket-emscripten"] }
 serde_json = "1.0"  # Required for send_game_data(serde_json::Value)
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -31,14 +31,14 @@ cargo add signal-fish-client
 
 ```toml
 [dependencies]
-signal-fish-client = "0.5.0"
+signal-fish-client = "0.6.0"
 ```
 
 #### Without default features (bring your own transport)
 
 ```toml
 [dependencies]
-signal-fish-client = { version = "0.5.0", default-features = false }
+signal-fish-client = { version = "0.6.0", default-features = false }
 ```
 
 !!! tip
@@ -48,7 +48,7 @@ signal-fish-client = { version = "0.5.0", default-features = false }
 
 ```toml
 [dependencies]
-signal-fish-client = { version = "0.5.0", default-features = false, features = ["transport-websocket-emscripten"] }
+signal-fish-client = { version = "0.6.0", default-features = false, features = ["transport-websocket-emscripten"] }
 ```
 
 !!! tip
@@ -120,7 +120,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 !!! note
     `WebSocketTransport` requires the `transport-websocket` feature, which is enabled by default. If you disabled default features you will need to re-enable it explicitly:
     ```toml
-    signal-fish-client = { version = "0.5.0", default-features = false, features = ["transport-websocket"] }
+    signal-fish-client = { version = "0.6.0", default-features = false, features = ["transport-websocket"] }
     ```
 
 ## What Happens Under the Hood
@@ -131,17 +131,17 @@ When you call `SignalFishClient::start`, the SDK:
 2. **Auto-authenticates** by immediately sending an `Authenticate` message with the App ID from your `SignalFishConfig`.
 3. **Emits typed events** on a bounded `tokio::sync::mpsc` channel (default capacity **256**, configurable via [`SignalFishConfig::event_channel_capacity`](client.md#signalfishconfig)). Your application consumes these via the `event_rx` receiver returned from `start`.
 
-You interact with the server by calling methods on the `SignalFishClient` handle (e.g., `join_room`, `send_game_data`). These enqueue outgoing messages that the background task sends over the transport.
+You interact with the server by calling methods on the `SignalFishClient` handle (e.g., `join_room`, `send_game_data`). These enqueue outgoing messages on a bounded queue that the background task drains over the transport; if you outpace the transport, sends fail fast with `SendBufferFull` instead of silently dropping (see [Core Concepts](concepts.md#non-blocking-command-sending)).
 
-!!! warning
-    If your event-processing loop cannot keep up with the server, events will be
-    **dropped** (with a warning logged) to avoid blocking the transport loop. The
-    `Disconnected` event uses a blocking send so it will not be dropped due to
-    backpressure, but it may be missed if the receiver is dropped or
-    [`shutdown()`](client.md#shutdown) times out. Design your handler to stay
-    responsive.
-    You can increase the buffer by setting `event_channel_capacity` on your
-    `SignalFishConfig`.
+!!! note
+    Events are **never dropped**. If your event-processing loop cannot keep up
+    with the server, the transport loop pauses until the channel has room —
+    backpressure propagates to the server instead of losing events. An event
+    can only be missed if the receiver is dropped or
+    [`shutdown()`](client.md#shutdown) times out. Keep your handler responsive
+    so the connection keeps flowing; `event_channel_capacity` on your
+    `SignalFishConfig` controls how much buffering you get before
+    backpressure kicks in.
 
 ## Next Steps
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -137,7 +137,8 @@ You interact with the server by calling methods on the `SignalFishClient` handle
     Events are **never dropped**. If your event-processing loop cannot keep up
     with the server, the transport loop pauses until the channel has room —
     backpressure propagates to the server instead of losing events. An event
-    can only be missed if the receiver is dropped or
+    can only be missed if the receiver is dropped, the client handle is
+    dropped without calling `shutdown()`, or
     [`shutdown()`](client.md#shutdown) times out. Keep your handler responsive
     so the connection keeps flowing; `event_channel_capacity` on your
     `SignalFishConfig` controls how much buffering you get before

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,7 @@ description: "Signal Fish Client SDK — A transport-agnostic Rust client SDK fo
 - :material-web: **WebSocket Built-In** — `WebSocketTransport` ships out of the box (enabled by default via the `transport-websocket` feature) so you can connect in one line.
 - :material-refresh: **Reconnection Support** — Gracefully handle disconnects and reconnect to your session without losing context.
 - :material-eye: **Spectator Mode** — Join rooms as a spectator to observe game state without participating.
-- :material-shield-check: **No Silent Loss** — Events are delivered with backpressure (never dropped), and the bounded send queue surfaces congestion explicitly. See [Core Concepts](concepts.md#reliability-flow-control).
+- :material-shield-check: **No Silent Loss** — Events are delivered with backpressure (never dropped), and the bounded send queue surfaces congestion explicitly. See [Core Concepts](concepts.md#reliability-and-flow-control).
 - :material-tune-variant: **Configurable** — Tune event channel capacity, command queue capacity, shutdown timeout, and more via `SignalFishConfig` builder methods.
 
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,13 +20,13 @@ description: "Signal Fish Client SDK — A transport-agnostic Rust client SDK fo
 ## Key Features
 
 - :material-swap-horizontal: **Transport-Agnostic** — Plug in any transport that implements the `Transport` trait; swap WebSocket for TCP, QUIC, or a test loopback without changing your game code.
-- :material-lightning-bolt: **Async / Await** — Built on Tokio with a fully non-blocking API. Command methods return immediately; events arrive on an async channel.
+- :material-lightning-bolt: **Async / Await** — Built on Tokio with a fully non-blocking API. Command methods return immediately (failing fast with `SendBufferFull` under congestion); events arrive on an async channel.
 - :material-message-flash: **Event-Driven Architecture** — All server responses are delivered as strongly-typed `SignalFishEvent` variants on a bounded `mpsc` channel — just `match` in a loop.
 - :material-lan: **Protocol v2 relay + v3 mesh** — v3 WebRTC mesh signaling is opt-in and backward-compatible; a default client stays byte-identical to v2. See [Protocol Versioning](protocol-versioning.md) and the [Mesh Guide](mesh-guide.md).
 - :material-web: **WebSocket Built-In** — `WebSocketTransport` ships out of the box (enabled by default via the `transport-websocket` feature) so you can connect in one line.
 - :material-refresh: **Reconnection Support** — Gracefully handle disconnects and reconnect to your session without losing context.
 - :material-eye: **Spectator Mode** — Join rooms as a spectator to observe game state without participating.
-- :material-shield-check: **No Silent Loss** — Events are delivered with backpressure (never dropped), and the bounded send queue surfaces congestion explicitly. See [Core Concepts](concepts.md#reliability--flow-control).
+- :material-shield-check: **No Silent Loss** — Events are delivered with backpressure (never dropped), and the bounded send queue surfaces congestion explicitly. See [Core Concepts](concepts.md#reliability-flow-control).
 - :material-tune-variant: **Configurable** — Tune event channel capacity, command queue capacity, shutdown timeout, and more via `SignalFishConfig` builder methods.
 
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,8 @@ description: "Signal Fish Client SDK — A transport-agnostic Rust client SDK fo
 - :material-web: **WebSocket Built-In** — `WebSocketTransport` ships out of the box (enabled by default via the `transport-websocket` feature) so you can connect in one line.
 - :material-refresh: **Reconnection Support** — Gracefully handle disconnects and reconnect to your session without losing context.
 - :material-eye: **Spectator Mode** — Join rooms as a spectator to observe game state without participating.
-- :material-tune-variant: **Configurable** — Tune event channel capacity, shutdown timeout, and more via `SignalFishConfig` builder methods.
+- :material-shield-check: **No Silent Loss** — Events are delivered with backpressure (never dropped), and the bounded send queue surfaces congestion explicitly. See [Core Concepts](concepts.md#reliability--flow-control).
+- :material-tune-variant: **Configurable** — Tune event channel capacity, command queue capacity, shutdown timeout, and more via `SignalFishConfig` builder methods.
 
 ---
 
@@ -74,7 +75,7 @@ async fn main() -> Result<(), signal_fish_client::SignalFishError> {
 !!! tip "Feature flag"
     `WebSocketTransport` requires the **`transport-websocket`** feature, which is enabled by default. If you disabled default features, re-enable it explicitly:
     ```toml
-    signal-fish-client = { version = "0.5.0", features = ["transport-websocket"] }
+    signal-fish-client = { version = "0.6.0", features = ["transport-websocket"] }
     ```
 
 ---

--- a/docs/mesh-guide.md
+++ b/docs/mesh-guide.md
@@ -146,9 +146,10 @@ timer.
 a `SignalFishClient`. On `SessionPlan`/`NewPeer` it calls `connect(peer,
 initiate)` and `set_ice_servers`; on a received signal it feeds `on_signal`; it
 relays the driver's outbound signals via the client (a signal the command
-queue refuses is buffered and retried, in order, until the queue accepts it
-or the connection ends — congestion never drops a signal, and a buffered
-signal survives `recv()` cancellation), reports `TransportStatus` on the 0↔1 connected boundary, tears
+queue refuses is buffered and retried, in order, until the queue accepts it —
+congestion never drops a signal, and a buffered signal survives `recv()`
+cancellation; it is discarded only if the connection ends or its target
+peer's handshake is torn down first, so nothing stale is relayed), reports `TransportStatus` on the 0↔1 connected boundary, tears
 down peers on re-election / `PlayerLeft` / `RoomLeft` / `Disconnected`, and
 surfaces a clean `MeshEvent` stream.
 

--- a/docs/mesh-guide.md
+++ b/docs/mesh-guide.md
@@ -146,9 +146,9 @@ timer.
 a `SignalFishClient`. On `SessionPlan`/`NewPeer` it calls `connect(peer,
 initiate)` and `set_ice_servers`; on a received signal it feeds `on_signal`; it
 relays the driver's outbound signals via the client (a signal the command
-queue refuses is buffered and retried, in order, until the queue accepts it —
-congestion never drops a signal, and a buffered signal survives `recv()`
-cancellation), reports `TransportStatus` on the 0↔1 connected boundary, tears
+queue refuses is buffered and retried, in order, until the queue accepts it
+or the connection ends — congestion never drops a signal, and a buffered
+signal survives `recv()` cancellation), reports `TransportStatus` on the 0↔1 connected boundary, tears
 down peers on re-election / `PlayerLeft` / `RoomLeft` / `Disconnected`, and
 surfaces a clean `MeshEvent` stream.
 

--- a/docs/mesh-guide.md
+++ b/docs/mesh-guide.md
@@ -145,9 +145,10 @@ timer.
 `MeshController` drives the **entire** v3 handshake against your driver on top of
 a `SignalFishClient`. On `SessionPlan`/`NewPeer` it calls `connect(peer,
 initiate)` and `set_ice_servers`; on a received signal it feeds `on_signal`; it
-relays the driver's outbound signals via the client (using
-`send_signal_reliable`, so signals are never dropped under command-queue
-congestion), reports `TransportStatus` on the 0↔1 connected boundary, tears
+relays the driver's outbound signals via the client (a signal the command
+queue refuses is buffered and retried, in order, until the queue accepts it —
+congestion never drops a signal, and a buffered signal survives `recv()`
+cancellation), reports `TransportStatus` on the 0↔1 connected boundary, tears
 down peers on re-election / `PlayerLeft` / `RoomLeft` / `Disconnected`, and
 surfaces a clean `MeshEvent` stream.
 

--- a/docs/mesh-guide.md
+++ b/docs/mesh-guide.md
@@ -11,7 +11,7 @@ drive the whole handshake for you.
     `tokio-runtime` feature.
 
     ```toml
-    signal-fish-client = { version = "0.5.0", features = ["mesh"] }
+    signal-fish-client = { version = "0.6.0", features = ["mesh"] }
     ```
 
 ---
@@ -145,9 +145,11 @@ timer.
 `MeshController` drives the **entire** v3 handshake against your driver on top of
 a `SignalFishClient`. On `SessionPlan`/`NewPeer` it calls `connect(peer,
 initiate)` and `set_ice_servers`; on a received signal it feeds `on_signal`; it
-relays the driver's outbound signals via the client, reports `TransportStatus` on
-the 0↔1 connected boundary, tears down peers on re-election / `PlayerLeft` /
-`RoomLeft` / `Disconnected`, and surfaces a clean `MeshEvent` stream.
+relays the driver's outbound signals via the client (using
+`send_signal_reliable`, so signals are never dropped under command-queue
+congestion), reports `TransportStatus` on the 0↔1 connected boundary, tears
+down peers on re-election / `PlayerLeft` / `RoomLeft` / `Disconnected`, and
+surfaces a clean `MeshEvent` stream.
 
 ```rust,ignore
 use signal_fish_client::webrtc::{MeshController, MeshEvent};

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -649,7 +649,7 @@ Every message on the wire is a JSON object with two top-level keys:
         "type": "Authenticate",
         "data": {
             "app_id": "mb_app_abc123",
-            "sdk_version": "0.5.0"
+            "sdk_version": "0.6.0"
         }
     }
     ```

--- a/docs/wasm.md
+++ b/docs/wasm.md
@@ -113,7 +113,7 @@ Enable the `transport-websocket-emscripten` feature to access
 
 ```toml
 [dependencies]
-signal-fish-client = { version = "0.5.0", default-features = false, features = ["transport-websocket-emscripten"] }
+signal-fish-client = { version = "0.6.0", default-features = false, features = ["transport-websocket-emscripten"] }
 ```
 
 ### Building
@@ -232,6 +232,17 @@ A synchronous, polling-based alternative to `SignalFishClient`. It does **not**
 spawn a background task or require an async runtime. Instead, the caller drives
 the client by calling `poll()` once per frame from the game loop.
 
+!!! tip "Not just for wasm"
+    The polling client is the right choice for **any frame-driven
+    environment**, native game loops included. `SignalFishClient::start`
+    spawns its transport loop with `tokio::spawn`, so it needs a *driven*
+    tokio runtime (`#[tokio::main]`, `block_on`, worker threads — a
+    `current_thread` runtime is fine as long as it is actually running).
+    Manually "ticking" a runtime once per frame starves the loop and makes
+    messages appear to vanish. If you cannot keep a runtime driven, pump
+    `SignalFishPollingClient` instead — see
+    [Driving the Client](concepts.md#driving-the-client-runtime-contract).
+
 ### Construction
 
 ```rust,ignore
@@ -345,7 +356,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 godot = "0.3"
-signal-fish-client = { version = "0.5.0", default-features = false, features = ["transport-websocket-emscripten"] }
+signal-fish-client = { version = "0.6.0", default-features = false, features = ["transport-websocket-emscripten"] }
 serde_json = "1.0"  # Required for send_game_data(serde_json::Value)
 ```
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -478,6 +478,13 @@ impl SignalFishClient {
     /// The transport loop immediately sends an [`Authenticate`](ClientMessage::Authenticate)
     /// message using the provided [`SignalFishConfig`].
     ///
+    /// The loop is spawned with [`tokio::spawn`] and therefore only makes
+    /// progress while the tokio runtime is driven — see
+    /// [the driving contract](self#driving-the-client-runtime-contract). For
+    /// frame-driven or runtime-less environments use
+    /// [`SignalFishPollingClient`](crate::polling_client::SignalFishPollingClient)
+    /// instead.
+    ///
     /// # Arguments
     ///
     /// * `transport` — A connected [`Transport`] implementation.
@@ -1742,6 +1749,48 @@ mod tests {
             seqs, expected,
             "GameData must be delivered losslessly and in order"
         );
+
+        client.shutdown().await;
+    }
+
+    /// Issue #47, item 3 (driving contract): a `current_thread` runtime is
+    /// fully supported as long as it is actually *driven* — every await here
+    /// yields to the runtime, which is what lets the spawned transport loop
+    /// progress. No sleeps and no multi-thread runtime are required for a
+    /// complete authenticate → send → receive round-trip.
+    #[tokio::test(flavor = "current_thread")]
+    async fn current_thread_runtime_completes_round_trip() {
+        let game_data_json = serde_json::to_string(&ServerMessage::GameData {
+            from_player: uuid::Uuid::from_u128(9),
+            data: serde_json::json!({ "seq": 0 }),
+        })
+        .unwrap();
+        let (transport, sent, _closed) = MockTransport::new(vec![
+            Some(Ok(authenticated_json())),
+            Some(Ok(game_data_json)),
+        ]);
+
+        let config = SignalFishConfig::new("mb_test");
+        let (mut client, mut events) = SignalFishClient::start(transport, config);
+
+        let event = events.recv().await.unwrap();
+        assert!(matches!(event, SignalFishEvent::Connected));
+        let event = events.recv().await.unwrap();
+        assert!(matches!(event, SignalFishEvent::Authenticated { .. }));
+
+        for seq in 0..3 {
+            client
+                .send_game_data_reliable(serde_json::json!({ "seq": seq }))
+                .await
+                .unwrap();
+        }
+
+        let event = events.recv().await.unwrap();
+        assert!(matches!(event, SignalFishEvent::GameData { .. }));
+
+        // Authenticate + 3 GameData all reach the wire on a single thread.
+        wait_for_sent_len(&sent, 4).await;
+        wait_until(|| client.stats().game_data_sent == 3).await;
 
         client.shutdown().await;
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -1851,6 +1851,7 @@ mod tests {
     }
 
     impl GatedSendTransport {
+        #[allow(clippy::type_complexity)]
         fn new(
             initial_permits: usize,
         ) -> (
@@ -1959,7 +1960,7 @@ mod tests {
         let (transport, entered_send, permits, sent) = GatedSendTransport::new(0);
 
         let config = SignalFishConfig::new("mb_test").with_command_channel_capacity(1);
-        let (mut client, mut events) = SignalFishClient::start(transport, config);
+        let (client, mut events) = SignalFishClient::start(transport, config);
 
         let _ = events.recv().await; // Connected
         wait_until(|| entered_send.load(Ordering::Acquire)).await;

--- a/src/client.rs
+++ b/src/client.rs
@@ -54,7 +54,7 @@
 //! }
 //! ```
 
-use std::sync::atomic::{AtomicBool, AtomicU16, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU16, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -364,6 +364,30 @@ impl JoinRoomParams {
     }
 }
 
+// ── Traffic statistics ──────────────────────────────────────────────
+
+/// Snapshot of a client's game-data traffic counters.
+///
+/// Returned by [`SignalFishClient::stats`] and
+/// [`SignalFishPollingClient::stats`](crate::polling_client::SignalFishPollingClient::stats).
+///
+/// The client itself never drops game data (events are delivered with
+/// backpressure and refused sends return
+/// [`SendBufferFull`](crate::SignalFishError::SendBufferFull)), so these
+/// counters make loss *elsewhere* observable: exchange or log them across
+/// peers, and a persistent sent-vs-received deficit points at the relay
+/// path or a peer — not at this client.
+///
+/// Counters are cumulative for the lifetime of the client (they survive
+/// room changes and disconnection).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ClientStats {
+    /// `GameData` messages successfully written to the transport.
+    pub game_data_sent: u64,
+    /// `GameData`/`GameDataBinary` events received from the server.
+    pub game_data_received: u64,
+}
+
 // ── Shared state ────────────────────────────────────────────────────
 
 /// Internal shared state between the client handle and the transport loop.
@@ -382,6 +406,12 @@ struct ClientState {
     player_id: Mutex<Option<PlayerId>>,
     room_id: Mutex<Option<RoomId>>,
     room_code: Mutex<Option<String>>,
+    /// `GameData` messages successfully written to the transport.
+    /// Cumulative — intentionally not reset by `clear_session_state`.
+    game_data_sent: AtomicU64,
+    /// `GameData`/`GameDataBinary` events received from the server.
+    /// Cumulative — intentionally not reset by `clear_session_state`.
+    game_data_received: AtomicU64,
 }
 
 #[cfg_attr(not(feature = "tokio-runtime"), allow(dead_code))]
@@ -395,6 +425,8 @@ impl ClientState {
             player_id: Mutex::new(None),
             room_id: Mutex::new(None),
             room_code: Mutex::new(None),
+            game_data_sent: AtomicU64::new(0),
+            game_data_received: AtomicU64::new(0),
         }
     }
 
@@ -914,6 +946,14 @@ impl SignalFishClient {
         self.cmd_tx.max_capacity()
     }
 
+    /// Cumulative game-data traffic counters (see [`ClientStats`]).
+    pub fn stats(&self) -> ClientStats {
+        ClientStats {
+            game_data_sent: self.state.game_data_sent.load(Ordering::Relaxed),
+            game_data_received: self.state.game_data_received.load(Ordering::Relaxed),
+        }
+    }
+
     // ── Internal helpers ────────────────────────────────────────────
 
     /// Guard for protocol-v3-only operations: returns an error unless the
@@ -1035,6 +1075,9 @@ async fn transport_loop(
                                         Some(format!("transport send error: {e}")),
                                     ).await;
                                     break;
+                                }
+                                if matches!(msg, ClientMessage::GameData { .. }) {
+                                    state.game_data_sent.fetch_add(1, Ordering::Relaxed);
                                 }
                             }
                             Err(e) => {
@@ -1177,6 +1220,9 @@ async fn update_state(state: &ClientState, msg: &ServerMessage) {
             *state.room_id.lock().await = None;
             *state.room_code.lock().await = None;
             debug!("state: left spectator mode");
+        }
+        ServerMessage::GameData { .. } | ServerMessage::GameDataBinary { .. } => {
+            state.game_data_received.fetch_add(1, Ordering::Relaxed);
         }
         _ => {}
     }
@@ -1695,6 +1741,51 @@ mod tests {
         assert_eq!(
             seqs, expected,
             "GameData must be delivered losslessly and in order"
+        );
+
+        client.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn stats_count_game_data_sent_and_received() {
+        let game_data_json = |seq: u64| {
+            serde_json::to_string(&ServerMessage::GameData {
+                from_player: uuid::Uuid::from_u128(9),
+                data: serde_json::json!({ "seq": seq }),
+            })
+            .unwrap()
+        };
+        let (transport, sent, _closed) = MockTransport::new(vec![
+            Some(Ok(authenticated_json())),
+            Some(Ok(game_data_json(0))),
+            Some(Ok(game_data_json(1))),
+        ]);
+
+        let config = SignalFishConfig::new("mb_test");
+        let (mut client, mut events) = SignalFishClient::start(transport, config);
+
+        assert_eq!(client.stats(), ClientStats::default());
+
+        let _ = events.recv().await; // Connected
+        let _ = events.recv().await; // Authenticated
+        let _ = events.recv().await; // GameData 0
+        let _ = events.recv().await; // GameData 1
+
+        for seq in 0..3 {
+            client
+                .send_game_data(serde_json::json!({ "seq": seq }))
+                .unwrap();
+        }
+        // Authenticate + 3 GameData on the wire; only GameData is counted.
+        wait_for_sent_len(&sent, 4).await;
+        wait_until(|| client.stats().game_data_sent == 3).await;
+
+        assert_eq!(
+            client.stats(),
+            ClientStats {
+                game_data_sent: 3,
+                game_data_received: 2,
+            }
         );
 
         client.shutdown().await;

--- a/src/client.rs
+++ b/src/client.rs
@@ -1278,8 +1278,10 @@ async fn emit_event(event_tx: &mpsc::Sender<SignalFishEvent>, event: SignalFishE
 /// Emit a [`Disconnected`](SignalFishEvent::Disconnected) event and update state.
 ///
 /// Like every event, `Disconnected` is delivered with backpressure (see
-/// [`emit_event`]); it can only be missed if the receiver has been dropped or
-/// if [`SignalFishClient::shutdown`] aborts the transport task first.
+/// [`emit_event`]); it can only be missed if the receiver has been dropped
+/// or if the transport task is aborted first (a
+/// [`SignalFishClient::shutdown`] timeout, or the client handle dropped
+/// without `shutdown`).
 #[cfg(feature = "tokio-runtime")]
 async fn emit_disconnected(
     event_tx: &mpsc::Sender<SignalFishEvent>,

--- a/src/client.rs
+++ b/src/client.rs
@@ -115,11 +115,13 @@ pub struct SignalFishConfig {
     pub supported_topologies: Option<Vec<Topology>>,
     /// Capacity of the bounded event channel.
     ///
-    /// When the consumer cannot keep up with incoming server messages, events
-    /// are dropped (with a warning logged) to avoid blocking the transport loop.
-    /// The `Disconnected` event uses a blocking send so it will not be dropped
-    /// due to a full channel, but it may be missed if the receiver is dropped
-    /// or if [`SignalFishClient::shutdown`] times out and aborts the transport task.
+    /// Events are **never dropped**. When the consumer cannot keep up with
+    /// incoming server messages, the transport loop pauses until the consumer
+    /// drains the channel, propagating backpressure to the server instead of
+    /// losing data. The capacity only controls how much buffering the consumer
+    /// gets before that backpressure kicks in. An event can only be missed if
+    /// the receiver is dropped or if [`SignalFishClient::shutdown`] times out
+    /// and aborts the transport task.
     ///
     /// Defaults to **256**. Values below 1 are clamped to 1.
     pub event_channel_capacity: usize,
@@ -1012,31 +1014,26 @@ async fn update_state(state: &ClientState, msg: &ServerMessage) {
     }
 }
 
-/// Emit an event to the event channel. If the channel is full, log a warning
-/// and drop the event to avoid blocking the transport loop.
+/// Emit an event to the event channel, waiting for capacity if it is full.
+///
+/// Events are **never dropped**: when the consumer lags, the transport loop
+/// pauses here, which stops reading from the transport and propagates
+/// backpressure to the server (e.g. via TCP receive windows). Delivery only
+/// fails if the receiver has been dropped, or if
+/// [`SignalFishClient::shutdown`] aborts the transport task while this send
+/// is still waiting.
 #[cfg(feature = "tokio-runtime")]
 async fn emit_event(event_tx: &mpsc::Sender<SignalFishEvent>, event: SignalFishEvent) {
-    match event_tx.try_send(event) {
-        Ok(()) => {}
-        Err(mpsc::error::TrySendError::Full(dropped)) => {
-            warn!(
-                "event channel full, dropping event: {:?}",
-                std::mem::discriminant(&dropped)
-            );
-        }
-        Err(mpsc::error::TrySendError::Closed(_)) => {
-            debug!("event channel closed, receiver dropped");
-        }
+    if event_tx.send(event).await.is_err() {
+        debug!("event channel closed, receiver dropped");
     }
 }
 
 /// Emit a [`Disconnected`](SignalFishEvent::Disconnected) event and update state.
 ///
-/// Uses `send().await` (blocking) instead of `try_send` so that `Disconnected`
-/// is not dropped due to channel backpressure. However, delivery is not
-/// unconditional: the event will be lost if the receiver has been dropped, or
-/// if [`SignalFishClient::shutdown`] aborts the transport task before this
-/// function completes.
+/// Like every event, `Disconnected` is delivered with backpressure (see
+/// [`emit_event`]); it can only be missed if the receiver has been dropped or
+/// if [`SignalFishClient::shutdown`] aborts the transport task first.
 #[cfg(feature = "tokio-runtime")]
 async fn emit_disconnected(
     event_tx: &mpsc::Sender<SignalFishEvent>,
@@ -1045,10 +1042,7 @@ async fn emit_disconnected(
 ) {
     state.connected.store(false, Ordering::Release);
     state.clear_session_state().await;
-    let event = SignalFishEvent::Disconnected { reason };
-    if event_tx.send(event).await.is_err() {
-        debug!("event channel closed, receiver dropped");
-    }
+    emit_event(event_tx, SignalFishEvent::Disconnected { reason }).await;
 }
 
 // ── Tests ───────────────────────────────────────────────────────────
@@ -1452,8 +1446,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn small_event_channel_capacity_triggers_backpressure() {
-        // Use a capacity of 1 and send multiple messages — events should be dropped.
+    async fn small_event_channel_capacity_delivers_all_events_losslessly() {
+        // Capacity 1 forces maximum backpressure: the transport loop must wait
+        // for the consumer on every event instead of dropping any.
         let mut incoming: Vec<Option<std::result::Result<String, SignalFishError>>> = Vec::new();
         incoming.push(Some(Ok(authenticated_json())));
         let pong_json = serde_json::to_string(&ServerMessage::Pong).unwrap();
@@ -1467,23 +1462,62 @@ mod tests {
         let config = SignalFishConfig::new("mb_test").with_event_channel_capacity(1);
         let (mut client, mut events) = SignalFishClient::start(transport, config);
 
-        // Let the channel fill up and events get dropped.
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        // Give the transport loop time to run ahead; it must block, not drop.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
-        let mut count = 0;
-        while let Some(_event) = events.recv().await {
-            count += 1;
+        let mut received = Vec::new();
+        while let Some(event) = events.recv().await {
+            received.push(event);
         }
-        // With capacity 1, we should receive fewer events than were sent.
-        // At minimum we get Connected (first try_send succeeds) and Disconnected
-        // (delivered via blocking send, not dropped due to backpressure).
-        // Authenticated and Pong events may be dropped when the single-slot
-        // channel is full.
-        assert!(count >= 2, "expected at least 2 events, got {count}");
-        // But fewer than the total sent (2 synthetic + 1 auth + 20 pongs = 23 possible).
-        assert!(
-            count < 23,
-            "expected backpressure to drop some events, but got all {count}"
+        // Connected + Authenticated + 20 Pongs + Disconnected — nothing dropped.
+        assert_eq!(
+            received.len(),
+            23,
+            "every event must be delivered, got {}",
+            received.len()
+        );
+        assert!(matches!(received[0], SignalFishEvent::Connected));
+        assert!(matches!(received[1], SignalFishEvent::Authenticated { .. }));
+        assert!(matches!(
+            received.last(),
+            Some(SignalFishEvent::Disconnected { .. })
+        ));
+
+        client.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn game_data_events_are_never_dropped_and_stay_ordered() {
+        // Data-driven regression for issue #47: a burst of sequenced GameData
+        // far larger than the event buffer must arrive complete and in order.
+        const MESSAGES: u64 = 500;
+        let mut incoming: Vec<Option<std::result::Result<String, SignalFishError>>> = Vec::new();
+        incoming.push(Some(Ok(authenticated_json())));
+        for seq in 0..MESSAGES {
+            let msg = ServerMessage::GameData {
+                from_player: uuid::Uuid::from_u128(7),
+                data: serde_json::json!({ "seq": seq }),
+            };
+            incoming.push(Some(Ok(serde_json::to_string(&msg).unwrap())));
+        }
+        incoming.push(None);
+
+        let (transport, _sent, _closed) = MockTransport::new(incoming);
+
+        // Tiny event buffer: correctness must not depend on channel capacity.
+        let config = SignalFishConfig::new("mb_test").with_event_channel_capacity(2);
+        let (mut client, mut events) = SignalFishClient::start(transport, config);
+
+        let mut seqs = Vec::new();
+        while let Some(event) = events.recv().await {
+            if let SignalFishEvent::GameData { data, .. } = event {
+                seqs.push(data["seq"].as_u64().unwrap());
+            }
+        }
+        let expected: Vec<u64> = (0..MESSAGES).collect();
+        assert_eq!(
+            seqs, expected,
+            "GameData must be delivered losslessly and in order"
         );
 
         client.shutdown().await;
@@ -1737,13 +1771,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn event_channel_backpressure_does_not_block() {
+    async fn event_channel_overflow_backpressures_without_loss() {
         // Create a transport with more messages than the event channel capacity.
         let mut incoming: Vec<Option<std::result::Result<String, SignalFishError>>> = Vec::new();
         incoming.push(Some(Ok(authenticated_json())));
         // Fill more than DEFAULT_EVENT_CHANNEL_CAPACITY pong messages.
+        let pongs = DEFAULT_EVENT_CHANNEL_CAPACITY + 50;
         let pong_json = serde_json::to_string(&ServerMessage::Pong).unwrap();
-        for _ in 0..(DEFAULT_EVENT_CHANNEL_CAPACITY + 50) {
+        for _ in 0..pongs {
             incoming.push(Some(Ok(pong_json.clone())));
         }
         // End with a clean close.
@@ -1754,17 +1789,21 @@ mod tests {
         let config = SignalFishConfig::new("mb_test");
         let (mut client, mut events) = SignalFishClient::start(transport, config);
 
-        // Don't read events immediately — let the channel fill up.
+        // Don't read events immediately — let the channel fill up. The
+        // transport loop must pause on the full channel, not drop events.
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
-        // Now drain events. The loop should have completed (possibly
-        // dropping some events due to backpressure) without blocking.
+        // Now drain events: every single one must have survived the overflow.
         let mut count = 0;
         while let Some(_event) = events.recv().await {
             count += 1;
         }
-        // We should have received at least some events.
-        assert!(count > 0, "expected to receive at least some events");
+        // Connected + Authenticated + pongs + Disconnected.
+        assert_eq!(
+            count,
+            pongs + 3,
+            "backpressure must preserve every event, got {count}"
+        );
 
         client.shutdown().await;
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -2028,7 +2028,7 @@ mod tests {
             .expect("task must not panic");
         assert!(result.is_ok(), "reliable send should succeed: {result:?}");
 
-        // All three messages reach the wire: Authenticate + both game datas.
+        // All three messages reach the wire: Authenticate + both game data payloads.
         wait_for_sent_len(&sent, 3).await;
 
         let mut client = Arc::into_inner(client).expect("all clones dropped");

--- a/src/client.rs
+++ b/src/client.rs
@@ -821,9 +821,9 @@ impl SignalFishClient {
     /// a lost offer/answer/ICE candidate stalls a WebRTC handshake, so waiting
     /// beats failing when the queue is congested (e.g. by game-data bursts).
     ///
-    /// The same caveat as
-    /// [`send_game_data_reliable`](Self::send_game_data_reliable#keep-draining-events)
-    /// applies: keep draining events from another task while awaiting this.
+    /// The "Keep draining events" caveat on
+    /// [`send_game_data_reliable`](Self::send_game_data_reliable)
+    /// applies here too: drain events from another task while awaiting this.
     ///
     /// # Errors
     ///

--- a/src/client.rs
+++ b/src/client.rs
@@ -393,7 +393,14 @@ impl JoinRoomParams {
 pub struct ClientStats {
     /// `GameData` messages successfully written to the transport.
     pub game_data_sent: u64,
-    /// `GameData`/`GameDataBinary` events received from the server.
+    /// `GameData`/`GameDataBinary` messages received from the server.
+    ///
+    /// Counted at **receipt** (when the message is read off the transport
+    /// and parsed), not at delivery to your event loop. That is the number
+    /// the relay-path deficit diagnostic needs — it measures the wire, so a
+    /// consumer that stops draining events (or a terminal abort racing the
+    /// last deliveries) cannot masquerade as relay loss. In steady state
+    /// receipt and delivery are identical because events are never dropped.
     pub game_data_received: u64,
 }
 
@@ -418,7 +425,8 @@ struct ClientState {
     /// `GameData` messages successfully written to the transport.
     /// Cumulative — intentionally not reset by `clear_session_state`.
     game_data_sent: AtomicU64,
-    /// `GameData`/`GameDataBinary` events received from the server.
+    /// `GameData`/`GameDataBinary` messages received from the server,
+    /// counted at receipt (see [`ClientStats::game_data_received`]).
     /// Cumulative — intentionally not reset by `clear_session_state`.
     game_data_received: AtomicU64,
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,9 +1,37 @@
 //! Async client for the Signal Fish signaling protocol.
 //!
 //! [`SignalFishClient`] is a thin handle that communicates with a background
-//! transport loop task via an unbounded MPSC channel. Events are emitted on a
-//! bounded channel ([`tokio::sync::mpsc::Receiver<SignalFishEvent>`]) returned
-//! from [`SignalFishClient::start`].
+//! transport loop task via a bounded MPSC command channel. Events are emitted
+//! on a bounded channel ([`tokio::sync::mpsc::Receiver<SignalFishEvent>`])
+//! returned from [`SignalFishClient::start`].
+//!
+//! # Delivery guarantees
+//!
+//! Neither direction silently drops data:
+//!
+//! - **Events** are delivered with backpressure. If the consumer lags, the
+//!   transport loop pauses reading from the transport until the event channel
+//!   has room — backpressure propagates to the server instead of losing
+//!   events. An event can only be missed if the receiver is dropped or a
+//!   [`shutdown`](SignalFishClient::shutdown) timeout aborts the loop.
+//! - **Commands** go through a bounded queue. The synchronous send methods
+//!   fail fast with [`SignalFishError::SendBufferFull`] when it is full; the
+//!   `*_reliable` async variants wait for capacity instead. Congestion is
+//!   always surfaced, never buffered without bound.
+//!
+//! # Driving the client (runtime contract)
+//!
+//! [`SignalFishClient::start`] spawns the transport loop with
+//! [`tokio::spawn`], so the loop only makes progress while the tokio runtime
+//! is **driven** — i.e. some task is being awaited (`block_on`, `#[tokio::main]`,
+//! worker threads). Both multi-thread and `current_thread` runtimes work, as
+//! long as the runtime is actually running. What does *not* work is "ticking"
+//! a runtime manually (e.g. one `yield_now().await` per game frame): the loop
+//! starves and messages appear to vanish. For frame-driven or single-threaded
+//! environments (game engines, `wasm32`), use
+//! [`SignalFishPollingClient`](crate::polling_client::SignalFishPollingClient)
+//! (feature `polling-client`), which is a synchronous pump you call once per
+//! frame and needs no runtime at all.
 //!
 //! # Example
 //!
@@ -57,6 +85,9 @@ use crate::transport::Transport;
 
 /// Default capacity of the bounded event channel.
 const DEFAULT_EVENT_CHANNEL_CAPACITY: usize = 256;
+
+/// Default capacity of the bounded outgoing command queue.
+const DEFAULT_COMMAND_CHANNEL_CAPACITY: usize = 1024;
 
 /// Default timeout for the graceful shutdown.
 const DEFAULT_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(1);
@@ -125,6 +156,18 @@ pub struct SignalFishConfig {
     ///
     /// Defaults to **256**. Values below 1 are clamped to 1.
     pub event_channel_capacity: usize,
+    /// Capacity of the bounded outgoing command queue.
+    ///
+    /// Commands (including game data) are **never silently dropped**. When the
+    /// queue is full, the synchronous send methods fail fast with
+    /// [`SignalFishError::SendBufferFull`](crate::SignalFishError::SendBufferFull),
+    /// and the waiting variants (e.g.
+    /// [`SignalFishClient::send_game_data_reliable`]) pause until the
+    /// transport drains a slot. Either way the caller gets a deterministic
+    /// congestion signal instead of an unbounded backlog.
+    ///
+    /// Defaults to **1024**. Values below 1 are clamped to 1.
+    pub command_channel_capacity: usize,
     /// Timeout for the graceful shutdown.
     ///
     /// When [`SignalFishClient::shutdown`] is called, the background transport
@@ -150,6 +193,7 @@ impl SignalFishConfig {
             supported_transports: None,
             supported_topologies: None,
             event_channel_capacity: DEFAULT_EVENT_CHANNEL_CAPACITY,
+            command_channel_capacity: DEFAULT_COMMAND_CHANNEL_CAPACITY,
             shutdown_timeout: DEFAULT_SHUTDOWN_TIMEOUT,
         }
     }
@@ -160,6 +204,18 @@ impl SignalFishConfig {
     #[must_use]
     pub fn with_event_channel_capacity(mut self, capacity: usize) -> Self {
         self.event_channel_capacity = capacity.max(1);
+        self
+    }
+
+    /// Set the capacity of the bounded outgoing command queue.
+    ///
+    /// See [`command_channel_capacity`](Self::command_channel_capacity) for
+    /// the backpressure semantics.
+    ///
+    /// Defaults to **1024**. Values below 1 are clamped to 1.
+    #[must_use]
+    pub fn with_command_channel_capacity(mut self, capacity: usize) -> Self {
+        self.command_channel_capacity = capacity.max(1);
         self
     }
 
@@ -359,13 +415,17 @@ impl ClientState {
 /// Created via [`SignalFishClient::start`], which spawns a background transport
 /// loop and returns this handle together with an event receiver.
 ///
-/// All public methods serialize a [`ClientMessage`] and send it to the
-/// transport loop over an unbounded channel. They return immediately once the
-/// message is queued (no round-trip await).
+/// All synchronous public methods serialize a [`ClientMessage`] and queue it
+/// to the transport loop over a **bounded** channel, returning immediately
+/// once the message is queued (no round-trip await). When the queue is full
+/// they fail fast with [`SignalFishError::SendBufferFull`]; the waiting
+/// variants ([`send_game_data_reliable`](Self::send_game_data_reliable),
+/// [`send_signal_reliable`](Self::send_signal_reliable)) instead await
+/// capacity, pacing the caller to actual transport throughput.
 #[cfg_attr(not(feature = "tokio-runtime"), allow(dead_code))]
 pub struct SignalFishClient {
-    /// Sender half of the command channel to the transport loop.
-    cmd_tx: mpsc::UnboundedSender<ClientMessage>,
+    /// Sender half of the bounded command channel to the transport loop.
+    cmd_tx: mpsc::Sender<ClientMessage>,
     /// Shared state updated by the transport loop.
     state: Arc<ClientState>,
     /// Handle to the background transport loop task.
@@ -400,8 +460,9 @@ impl SignalFishClient {
         transport: impl Transport,
         config: SignalFishConfig,
     ) -> (Self, mpsc::Receiver<SignalFishEvent>) {
-        let (cmd_tx, cmd_rx) = mpsc::unbounded_channel::<ClientMessage>();
-        // Clamp capacity to at least 1 (tokio panics on 0).
+        // Clamp capacities to at least 1 (tokio panics on 0).
+        let cmd_capacity = config.command_channel_capacity.max(1);
+        let (cmd_tx, cmd_rx) = mpsc::channel::<ClientMessage>(cmd_capacity);
         let capacity = config.event_channel_capacity.max(1);
         let (event_tx, event_rx) = mpsc::channel::<SignalFishEvent>(capacity);
         let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
@@ -420,8 +481,9 @@ impl SignalFishClient {
             supported_transports: config.supported_transports,
             supported_topologies: config.supported_topologies,
         };
-        // This cannot fail because we just created the channel.
-        let _ = cmd_tx.send(auth_msg);
+        // This cannot fail: the channel was just created empty and its
+        // capacity is clamped to at least 1.
+        let _ = cmd_tx.try_send(auth_msg);
 
         let task = tokio::spawn(transport_loop(
             transport,
@@ -488,7 +550,9 @@ impl SignalFishClient {
     ///
     /// # Errors
     ///
-    /// Returns [`SignalFishError::NotConnected`] if the transport has closed.
+    /// Returns [`SignalFishError::NotConnected`] if the transport has closed,
+    /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
+    /// is full (the message is **not** queued; nothing is silently dropped).
     pub fn join_room(&self, params: JoinRoomParams) -> Result<()> {
         self.send(ClientMessage::JoinRoom {
             game_name: params.game_name,
@@ -504,25 +568,53 @@ impl SignalFishClient {
     ///
     /// # Errors
     ///
-    /// Returns [`SignalFishError::NotConnected`] if the transport has closed.
+    /// Returns [`SignalFishError::NotConnected`] if the transport has closed,
+    /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
+    /// is full (the message is **not** queued; nothing is silently dropped).
     pub fn leave_room(&self) -> Result<()> {
         self.send(ClientMessage::LeaveRoom)
     }
 
     /// Send arbitrary JSON game data to other players in the room.
     ///
+    /// Returns as soon as the message is queued. For high-rate payloads
+    /// (e.g. per-frame input packets), prefer
+    /// [`send_game_data_reliable`](Self::send_game_data_reliable), which
+    /// waits for queue capacity instead of failing fast under congestion.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SignalFishError::NotConnected`] if the transport has closed,
+    /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
+    /// is full (the message is **not** queued; nothing is silently dropped).
+    pub fn send_game_data(&self, data: serde_json::Value) -> Result<()> {
+        self.send(ClientMessage::GameData { data })
+    }
+
+    /// Send arbitrary JSON game data, waiting for space in the outgoing
+    /// command queue when it is full.
+    ///
+    /// This is the backpressure-aware counterpart to
+    /// [`send_game_data`](Self::send_game_data): instead of failing fast with
+    /// [`SignalFishError::SendBufferFull`], it pauses until the transport
+    /// drains a slot, pacing the caller to actual transport throughput. This
+    /// is the recommended way to stream high-rate payloads (rollback input
+    /// packets, state sync) without guessing at sleep durations.
+    ///
     /// # Errors
     ///
     /// Returns [`SignalFishError::NotConnected`] if the transport has closed.
-    pub fn send_game_data(&self, data: serde_json::Value) -> Result<()> {
-        self.send(ClientMessage::GameData { data })
+    pub async fn send_game_data_reliable(&self, data: serde_json::Value) -> Result<()> {
+        self.send_reliable(ClientMessage::GameData { data }).await
     }
 
     /// Signal readiness to start the game in the lobby.
     ///
     /// # Errors
     ///
-    /// Returns [`SignalFishError::NotConnected`] if the transport has closed.
+    /// Returns [`SignalFishError::NotConnected`] if the transport has closed,
+    /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
+    /// is full (the message is **not** queued; nothing is silently dropped).
     pub fn set_ready(&self) -> Result<()> {
         self.send(ClientMessage::PlayerReady)
     }
@@ -531,7 +623,9 @@ impl SignalFishClient {
     ///
     /// # Errors
     ///
-    /// Returns [`SignalFishError::NotConnected`] if the transport has closed.
+    /// Returns [`SignalFishError::NotConnected`] if the transport has closed,
+    /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
+    /// is full (the message is **not** queued; nothing is silently dropped).
     pub fn request_authority(&self, become_authority: bool) -> Result<()> {
         self.send(ClientMessage::AuthorityRequest { become_authority })
     }
@@ -540,7 +634,9 @@ impl SignalFishClient {
     ///
     /// # Errors
     ///
-    /// Returns [`SignalFishError::NotConnected`] if the transport has closed.
+    /// Returns [`SignalFishError::NotConnected`] if the transport has closed,
+    /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
+    /// is full (the message is **not** queued; nothing is silently dropped).
     pub fn provide_connection_info(&self, connection_info: ConnectionInfo) -> Result<()> {
         self.send(ClientMessage::ProvideConnectionInfo { connection_info })
     }
@@ -549,7 +645,9 @@ impl SignalFishClient {
     ///
     /// # Errors
     ///
-    /// Returns [`SignalFishError::NotConnected`] if the transport has closed.
+    /// Returns [`SignalFishError::NotConnected`] if the transport has closed,
+    /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
+    /// is full (the message is **not** queued; nothing is silently dropped).
     pub fn reconnect(
         &self,
         player_id: PlayerId,
@@ -567,7 +665,9 @@ impl SignalFishClient {
     ///
     /// # Errors
     ///
-    /// Returns [`SignalFishError::NotConnected`] if the transport has closed.
+    /// Returns [`SignalFishError::NotConnected`] if the transport has closed,
+    /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
+    /// is full (the message is **not** queued; nothing is silently dropped).
     pub fn join_as_spectator(
         &self,
         game_name: String,
@@ -585,7 +685,9 @@ impl SignalFishClient {
     ///
     /// # Errors
     ///
-    /// Returns [`SignalFishError::NotConnected`] if the transport has closed.
+    /// Returns [`SignalFishError::NotConnected`] if the transport has closed,
+    /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
+    /// is full (the message is **not** queued; nothing is silently dropped).
     pub fn leave_spectator(&self) -> Result<()> {
         self.send(ClientMessage::LeaveSpectator)
     }
@@ -594,7 +696,9 @@ impl SignalFishClient {
     ///
     /// # Errors
     ///
-    /// Returns [`SignalFishError::NotConnected`] if the transport has closed.
+    /// Returns [`SignalFishError::NotConnected`] if the transport has closed,
+    /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
+    /// is full (the message is **not** queued; nothing is silently dropped).
     pub fn ping(&self) -> Result<()> {
         self.send(ClientMessage::Ping)
     }
@@ -615,7 +719,9 @@ impl SignalFishClient {
     ///
     /// # Errors
     ///
-    /// Returns [`SignalFishError::NotConnected`] if the transport has closed.
+    /// Returns [`SignalFishError::NotConnected`] if the transport has closed,
+    /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
+    /// is full (the message is **not** queued; nothing is silently dropped).
     pub fn start_game(&self) -> Result<()> {
         self.send(ClientMessage::StartGame)
     }
@@ -637,13 +743,41 @@ impl SignalFishClient {
     ///
     /// Returns [`SignalFishError::ProtocolUnsupported`] if the connection has not
     /// negotiated protocol v3 (fail-fast — the server would otherwise reject it),
-    /// or [`SignalFishError::NotConnected`] if the transport has closed.
+    /// [`SignalFishError::NotConnected`] if the transport has closed, or
+    /// [`SignalFishError::SendBufferFull`] if the outgoing command queue is
+    /// full (see [`send_signal_reliable`](Self::send_signal_reliable) for a
+    /// waiting variant).
     pub fn send_signal(&self, to: PlayerId, signal: impl Into<PeerSignal>) -> Result<()> {
         self.ensure_v3()?;
         self.send(ClientMessage::Signal {
             to,
             signal: signal.into().into(),
         })
+    }
+
+    /// Send a typed WebRTC signal, waiting for space in the outgoing command
+    /// queue when it is full. **Protocol v3 only.**
+    ///
+    /// The backpressure-aware counterpart to [`send_signal`](Self::send_signal):
+    /// a lost offer/answer/ICE candidate stalls a WebRTC handshake, so waiting
+    /// beats failing when the queue is congested (e.g. by game-data bursts).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SignalFishError::ProtocolUnsupported`] if the connection has
+    /// not negotiated protocol v3, or [`SignalFishError::NotConnected`] if the
+    /// transport has closed.
+    pub async fn send_signal_reliable(
+        &self,
+        to: PlayerId,
+        signal: impl Into<PeerSignal>,
+    ) -> Result<()> {
+        self.ensure_v3()?;
+        self.send_reliable(ClientMessage::Signal {
+            to,
+            signal: signal.into().into(),
+        })
+        .await
     }
 
     /// Send an SDP offer to a peer. **Protocol v3 only.**
@@ -701,8 +835,9 @@ impl SignalFishClient {
     /// # Errors
     ///
     /// Returns [`SignalFishError::ProtocolUnsupported`] if the connection has not
-    /// negotiated protocol v3, or [`SignalFishError::NotConnected`] if the
-    /// transport has closed.
+    /// negotiated protocol v3, [`SignalFishError::NotConnected`] if the
+    /// transport has closed, or [`SignalFishError::SendBufferFull`] if the
+    /// outgoing command queue is full.
     pub fn report_transport_status(&self, transport: TransportKind, connected: bool) -> Result<()> {
         self.ensure_v3()?;
         self.send(ClientMessage::TransportStatus {
@@ -763,6 +898,22 @@ impl SignalFishClient {
         self.state.room_code.lock().await.clone()
     }
 
+    /// Number of messages that can currently be queued before the synchronous
+    /// send methods return [`SignalFishError::SendBufferFull`].
+    ///
+    /// A shrinking value is the congestion signal: the caller is producing
+    /// faster than the transport drains. `0` means the next fail-fast send
+    /// will be refused.
+    pub fn send_capacity(&self) -> usize {
+        self.cmd_tx.capacity()
+    }
+
+    /// Configured capacity of the outgoing command queue
+    /// (see [`SignalFishConfig::command_channel_capacity`]).
+    pub fn max_send_capacity(&self) -> usize {
+        self.cmd_tx.max_capacity()
+    }
+
     // ── Internal helpers ────────────────────────────────────────────
 
     /// Guard for protocol-v3-only operations: returns an error unless the
@@ -791,13 +942,30 @@ impl SignalFishClient {
         Err(SignalFishError::ProtocolUnsupported { mode })
     }
 
-    /// Queue a `ClientMessage` to the transport loop.
+    /// Queue a `ClientMessage` to the transport loop, failing fast when the
+    /// bounded command queue is full.
     fn send(&self, msg: ClientMessage) -> Result<()> {
+        if !self.state.connected.load(Ordering::Acquire) {
+            return Err(SignalFishError::NotConnected);
+        }
+        match self.cmd_tx.try_send(msg) {
+            Ok(()) => Ok(()),
+            Err(mpsc::error::TrySendError::Full(_)) => Err(SignalFishError::SendBufferFull {
+                capacity: self.cmd_tx.max_capacity(),
+            }),
+            Err(mpsc::error::TrySendError::Closed(_)) => Err(SignalFishError::NotConnected),
+        }
+    }
+
+    /// Queue a `ClientMessage` to the transport loop, waiting for capacity
+    /// when the bounded command queue is full.
+    async fn send_reliable(&self, msg: ClientMessage) -> Result<()> {
         if !self.state.connected.load(Ordering::Acquire) {
             return Err(SignalFishError::NotConnected);
         }
         self.cmd_tx
             .send(msg)
+            .await
             .map_err(|_| SignalFishError::NotConnected)
     }
 }
@@ -840,7 +1008,7 @@ impl Drop for SignalFishClient {
 #[cfg(feature = "tokio-runtime")]
 async fn transport_loop(
     mut transport: impl Transport,
-    mut cmd_rx: mpsc::UnboundedReceiver<ClientMessage>,
+    mut cmd_rx: mpsc::Receiver<ClientMessage>,
     event_tx: mpsc::Sender<SignalFishEvent>,
     state: Arc<ClientState>,
     mut shutdown_rx: tokio::sync::oneshot::Receiver<()>,
@@ -1380,6 +1548,7 @@ mod tests {
         assert!(config.supported_transports.is_none());
         assert!(config.supported_topologies.is_none());
         assert_eq!(config.event_channel_capacity, 256);
+        assert_eq!(config.command_channel_capacity, 1024);
         assert_eq!(config.shutdown_timeout, std::time::Duration::from_secs(1));
     }
 
@@ -1387,8 +1556,10 @@ mod tests {
     async fn config_builder_methods() {
         let config = SignalFishConfig::new("mb_test")
             .with_event_channel_capacity(512)
+            .with_command_channel_capacity(64)
             .with_shutdown_timeout(std::time::Duration::from_secs(5));
         assert_eq!(config.event_channel_capacity, 512);
+        assert_eq!(config.command_channel_capacity, 64);
         assert_eq!(config.shutdown_timeout, std::time::Duration::from_secs(5));
     }
 
@@ -1427,6 +1598,12 @@ mod tests {
     async fn event_channel_capacity_is_clamped_to_one() {
         let config = SignalFishConfig::new("mb_test").with_event_channel_capacity(0);
         assert_eq!(config.event_channel_capacity, 1);
+    }
+
+    #[tokio::test]
+    async fn command_channel_capacity_is_clamped_to_one() {
+        let config = SignalFishConfig::new("mb_test").with_command_channel_capacity(0);
+        assert_eq!(config.command_channel_capacity, 1);
     }
 
     #[tokio::test]
@@ -1520,6 +1697,168 @@ mod tests {
             "GameData must be delivered losslessly and in order"
         );
 
+        client.shutdown().await;
+    }
+
+    // ── Send-side backpressure (issue #47, item 2) ──────────────────
+
+    /// Transport whose `send()` requires a semaphore permit per message, so
+    /// tests can stall the outgoing path deterministically.
+    struct GatedSendTransport {
+        entered_send: Arc<AtomicBool>,
+        permits: Arc<tokio::sync::Semaphore>,
+        sent: Arc<StdMutex<Vec<String>>>,
+    }
+
+    impl GatedSendTransport {
+        fn new(
+            initial_permits: usize,
+        ) -> (
+            Self,
+            Arc<AtomicBool>,
+            Arc<tokio::sync::Semaphore>,
+            Arc<StdMutex<Vec<String>>>,
+        ) {
+            let entered_send = Arc::new(AtomicBool::new(false));
+            let permits = Arc::new(tokio::sync::Semaphore::new(initial_permits));
+            let sent = Arc::new(StdMutex::new(Vec::new()));
+            (
+                Self {
+                    entered_send: Arc::clone(&entered_send),
+                    permits: Arc::clone(&permits),
+                    sent: Arc::clone(&sent),
+                },
+                entered_send,
+                permits,
+                sent,
+            )
+        }
+    }
+
+    #[async_trait]
+    impl Transport for GatedSendTransport {
+        async fn send(&mut self, message: String) -> std::result::Result<(), SignalFishError> {
+            self.entered_send.store(true, Ordering::Release);
+            let permit = self
+                .permits
+                .acquire()
+                .await
+                .map_err(|_| SignalFishError::TransportClosed)?;
+            permit.forget();
+            self.sent.lock().unwrap().push(message);
+            Ok(())
+        }
+
+        async fn recv(&mut self) -> Option<std::result::Result<String, SignalFishError>> {
+            // No scripted messages — pending() never completes, keeping the
+            // transport loop alive until shutdown aborts it.
+            std::future::pending().await
+        }
+
+        async fn close(&mut self) -> std::result::Result<(), SignalFishError> {
+            Ok(())
+        }
+    }
+
+    async fn wait_until(condition: impl Fn() -> bool) {
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while !condition() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap_or_else(|_| panic!("timed out waiting for condition"));
+    }
+
+    #[tokio::test]
+    async fn sync_send_fails_fast_when_command_queue_is_full() {
+        // No permits: the transport loop stalls inside send(Authenticate),
+        // leaving exactly `capacity` free slots in the command channel.
+        let (transport, entered_send, permits, sent) = GatedSendTransport::new(0);
+
+        let config = SignalFishConfig::new("mb_test").with_command_channel_capacity(2);
+        let (mut client, mut events) = SignalFishClient::start(transport, config);
+
+        let _ = events.recv().await; // Connected
+
+        // Wait until the loop has pulled Authenticate and stalled in send().
+        wait_until(|| entered_send.load(Ordering::Acquire)).await;
+        assert_eq!(client.max_send_capacity(), 2);
+
+        // Fill the queue to capacity, then observe the loud refusal.
+        client
+            .send_game_data(serde_json::json!({ "seq": 0 }))
+            .unwrap();
+        client
+            .send_game_data(serde_json::json!({ "seq": 1 }))
+            .unwrap();
+        assert_eq!(client.send_capacity(), 0);
+        let err = client
+            .send_game_data(serde_json::json!({ "seq": 2 }))
+            .unwrap_err();
+        assert!(
+            matches!(err, SignalFishError::SendBufferFull { capacity: 2 }),
+            "expected SendBufferFull, got {err:?}"
+        );
+
+        // Unblock the transport: the queue drains and sends succeed again.
+        permits.add_permits(16);
+        wait_for_sent_len(&sent, 3).await;
+        wait_until(|| client.send_capacity() > 0).await;
+        client
+            .send_game_data(serde_json::json!({ "seq": 3 }))
+            .unwrap();
+
+        client.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn send_game_data_reliable_waits_for_capacity_instead_of_failing() {
+        // No permits: Authenticate stalls in send(), then one queued message
+        // saturates the capacity-1 command channel.
+        let (transport, entered_send, permits, sent) = GatedSendTransport::new(0);
+
+        let config = SignalFishConfig::new("mb_test").with_command_channel_capacity(1);
+        let (mut client, mut events) = SignalFishClient::start(transport, config);
+
+        let _ = events.recv().await; // Connected
+        wait_until(|| entered_send.load(Ordering::Acquire)).await;
+
+        client
+            .send_game_data(serde_json::json!({ "seq": 0 }))
+            .unwrap();
+        assert!(matches!(
+            client.send_game_data(serde_json::json!({ "nope": true })),
+            Err(SignalFishError::SendBufferFull { .. })
+        ));
+
+        // The reliable variant must wait (not fail) while the queue is full…
+        let client = Arc::new(client);
+        let sender = Arc::clone(&client);
+        let mut reliable = tokio::spawn(async move {
+            sender
+                .send_game_data_reliable(serde_json::json!({ "seq": 1 }))
+                .await
+        });
+        let still_waiting =
+            tokio::time::timeout(std::time::Duration::from_millis(50), &mut reliable).await;
+        assert!(
+            still_waiting.is_err(),
+            "reliable send must wait while the queue is full"
+        );
+
+        // …and complete once the transport drains the queue.
+        permits.add_permits(16);
+        let result = tokio::time::timeout(std::time::Duration::from_secs(1), reliable)
+            .await
+            .expect("reliable send should complete once capacity frees")
+            .expect("task must not panic");
+        assert!(result.is_ok(), "reliable send should succeed: {result:?}");
+
+        // All three messages reach the wire: Authenticate + both game datas.
+        wait_for_sent_len(&sent, 3).await;
+
+        let mut client = Arc::into_inner(client).expect("all clones dropped");
         client.shutdown().await;
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -640,6 +640,16 @@ impl SignalFishClient {
     /// is the recommended way to stream high-rate payloads (rollback input
     /// packets, state sync) without guessing at sleep durations.
     ///
+    /// # Keep draining events
+    ///
+    /// The command queue only drains while the transport loop runs, and the
+    /// transport loop pauses whenever the **event** channel is full (events
+    /// are never dropped). A task that awaits this method while it is also
+    /// the only consumer of the event receiver can therefore deadlock under
+    /// simultaneous send + receive pressure. Drain events concurrently (a
+    /// separate task, or `tokio::select!` over the event receiver and this
+    /// send) rather than strictly sequentially.
+    ///
     /// # Errors
     ///
     /// Returns [`SignalFishError::NotConnected`] if the transport has closed.

--- a/src/client.rs
+++ b/src/client.rs
@@ -12,12 +12,19 @@
 //! - **Events** are delivered with backpressure. If the consumer lags, the
 //!   transport loop pauses reading from the transport until the event channel
 //!   has room — backpressure propagates to the server instead of losing
-//!   events. An event can only be missed if the receiver is dropped or a
-//!   [`shutdown`](SignalFishClient::shutdown) timeout aborts the loop.
-//! - **Commands** go through a bounded queue. The synchronous send methods
-//!   fail fast with [`SignalFishError::SendBufferFull`] when it is full; the
+//!   events. An event can only be missed when the loop stops delivering
+//!   entirely: the receiver was dropped, a
+//!   [`shutdown`](SignalFishClient::shutdown) timeout aborted the loop, or
+//!   the client handle was dropped without calling `shutdown` (which aborts
+//!   immediately).
+//! - **Commands** go through a bounded queue and queue admission is never
+//!   silent: the synchronous send methods fail fast with
+//!   [`SignalFishError::SendBufferFull`] when it is full, and the
 //!   `*_reliable` async variants wait for capacity instead. Congestion is
-//!   always surfaced, never buffered without bound.
+//!   always surfaced, never buffered without bound. Note that *queued* is
+//!   not *delivered*: commands still in the queue when the connection ends
+//!   (transport error, shutdown, handle drop) are discarded with the
+//!   connection, which is surfaced by the `Disconnected` event.
 //!
 //! # Driving the client (runtime contract)
 //!
@@ -150,21 +157,23 @@ pub struct SignalFishConfig {
     /// incoming server messages, the transport loop pauses until the consumer
     /// drains the channel, propagating backpressure to the server instead of
     /// losing data. The capacity only controls how much buffering the consumer
-    /// gets before that backpressure kicks in. An event can only be missed if
-    /// the receiver is dropped or if [`SignalFishClient::shutdown`] times out
-    /// and aborts the transport task.
+    /// gets before that backpressure kicks in. An event can only be missed
+    /// when delivery stops entirely: the receiver is dropped,
+    /// [`SignalFishClient::shutdown`] times out and aborts the transport
+    /// task, or the client handle is dropped without calling `shutdown`.
     ///
     /// Defaults to **256**. Values below 1 are clamped to 1.
     pub event_channel_capacity: usize,
     /// Capacity of the bounded outgoing command queue.
     ///
-    /// Commands (including game data) are **never silently dropped**. When the
-    /// queue is full, the synchronous send methods fail fast with
-    /// [`SignalFishError::SendBufferFull`](crate::SignalFishError::SendBufferFull),
-    /// and the waiting variants (e.g.
+    /// Queue admission is **never silent**. When the queue is full, the
+    /// synchronous send methods fail fast with
+    /// [`SignalFishError::SendBufferFull`], and the waiting variants (e.g.
     /// [`SignalFishClient::send_game_data_reliable`]) pause until the
     /// transport drains a slot. Either way the caller gets a deterministic
-    /// congestion signal instead of an unbounded backlog.
+    /// congestion signal instead of an unbounded backlog. Commands still
+    /// queued when the connection ends are discarded with it (surfaced by
+    /// the `Disconnected` event); *queued* is not *delivered*.
     ///
     /// Defaults to **1024**. Values below 1 are clamped to 1.
     pub command_channel_capacity: usize,
@@ -646,9 +655,10 @@ impl SignalFishClient {
     /// transport loop pauses whenever the **event** channel is full (events
     /// are never dropped). A task that awaits this method while it is also
     /// the only consumer of the event receiver can therefore deadlock under
-    /// simultaneous send + receive pressure. Drain events concurrently (a
-    /// separate task, or `tokio::select!` over the event receiver and this
-    /// send) rather than strictly sequentially.
+    /// simultaneous send + receive pressure. Drain events from a separate
+    /// task rather than strictly sequentially. (Do **not** race this send
+    /// against the event receiver in a `tokio::select!`: if the event arm
+    /// wins, the cancelled send future discards the payload.)
     ///
     /// # Errors
     ///
@@ -810,6 +820,10 @@ impl SignalFishClient {
     /// The backpressure-aware counterpart to [`send_signal`](Self::send_signal):
     /// a lost offer/answer/ICE candidate stalls a WebRTC handshake, so waiting
     /// beats failing when the queue is congested (e.g. by game-data bursts).
+    ///
+    /// The same caveat as
+    /// [`send_game_data_reliable`](Self::send_game_data_reliable#keep-draining-events)
+    /// applies: keep draining events from another task while awaiting this.
     ///
     /// # Errors
     ///
@@ -1250,9 +1264,10 @@ async fn update_state(state: &ClientState, msg: &ServerMessage) {
 /// Events are **never dropped**: when the consumer lags, the transport loop
 /// pauses here, which stops reading from the transport and propagates
 /// backpressure to the server (e.g. via TCP receive windows). Delivery only
-/// fails if the receiver has been dropped, or if
-/// [`SignalFishClient::shutdown`] aborts the transport task while this send
-/// is still waiting.
+/// fails if the receiver has been dropped, or if the transport task is
+/// aborted while this send is still waiting (a
+/// [`SignalFishClient::shutdown`] timeout, or the client handle dropped
+/// without `shutdown`).
 #[cfg(feature = "tokio-runtime")]
 async fn emit_event(event_tx: &mpsc::Sender<SignalFishEvent>, event: SignalFishEvent) {
     if event_tx.send(event).await.is_err() {
@@ -1350,7 +1365,7 @@ mod tests {
     // ── Helper ──────────────────────────────────────────────────────
 
     async fn wait_for_sent_len(sent: &Arc<StdMutex<Vec<String>>>, expected_len: usize) {
-        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
             loop {
                 if sent.lock().unwrap().len() >= expected_len {
                     break;
@@ -1574,6 +1589,11 @@ mod tests {
         client.shutdown().await;
 
         let result = client.ping();
+        assert!(matches!(result, Err(SignalFishError::NotConnected)));
+        // The waiting variant refuses just the same after shutdown.
+        let result = client
+            .send_game_data_reliable(serde_json::json!({ "seq": 0 }))
+            .await;
         assert!(matches!(result, Err(SignalFishError::NotConnected)));
     }
 
@@ -1912,7 +1932,7 @@ mod tests {
     }
 
     async fn wait_until(condition: impl Fn() -> bool) {
-        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
             while !condition() {
                 tokio::task::yield_now().await;
             }
@@ -2010,6 +2030,93 @@ mod tests {
         wait_for_sent_len(&sent, 3).await;
 
         let mut client = Arc::into_inner(client).expect("all clones dropped");
+        client.shutdown().await;
+    }
+
+    fn protocol_info_v3_json() -> String {
+        use crate::protocol::ProtocolInfoPayload;
+        serde_json::to_string(&ServerMessage::ProtocolInfo(ProtocolInfoPayload {
+            platform: None,
+            sdk_version: None,
+            minimum_version: None,
+            recommended_version: None,
+            capabilities: vec![],
+            notes: None,
+            game_data_formats: vec![],
+            player_name_rules: None,
+            protocol_version: Some(3),
+            min_protocol_version: Some(2),
+            max_protocol_version: Some(3),
+        }))
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn send_signal_reliable_fails_fast_pre_negotiation_even_when_queue_full() {
+        // Saturate the capacity-1 command queue behind a stalled transport.
+        let (transport, entered_send, permits, _sent) = GatedSendTransport::new(0);
+        let config = SignalFishConfig::new("mb_test").with_command_channel_capacity(1);
+        let (mut client, mut events) = SignalFishClient::start(transport, config);
+
+        let _ = events.recv().await; // Connected
+        wait_until(|| entered_send.load(Ordering::Acquire)).await;
+        client
+            .send_game_data(serde_json::json!({ "seq": 0 }))
+            .unwrap();
+        assert_eq!(client.send_capacity(), 0);
+
+        // The v3 guard must be evaluated BEFORE waiting for queue capacity:
+        // pre-negotiation, this returns immediately (nothing is queued)
+        // instead of blocking on the full queue.
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            client.send_signal_reliable(uuid::Uuid::from_u128(5), PeerSignal::Offer("sdp".into())),
+        )
+        .await
+        .expect("guard must fail fast, not wait for capacity");
+        assert!(
+            matches!(
+                result,
+                Err(SignalFishError::ProtocolUnsupported {
+                    mode: "pre-negotiation"
+                })
+            ),
+            "expected ProtocolUnsupported, got {result:?}"
+        );
+
+        permits.add_permits(16);
+        client.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn send_signal_reliable_reaches_wire_after_v3() {
+        let (transport, sent, _closed) = MockTransport::new(vec![
+            Some(Ok(authenticated_json())),
+            Some(Ok(protocol_info_v3_json())),
+        ]);
+
+        let config = SignalFishConfig::new("mb_test").enable_mesh();
+        let (mut client, mut events) = SignalFishClient::start(transport, config);
+
+        let _ = events.recv().await; // Connected
+        let _ = events.recv().await; // Authenticated
+        let _ = events.recv().await; // ProtocolInfo (negotiates v3)
+
+        client
+            .send_signal_reliable(uuid::Uuid::from_u128(5), PeerSignal::Offer("sdp".into()))
+            .await
+            .unwrap();
+
+        wait_for_sent_len(&sent, 2).await;
+        {
+            let messages = sent.lock().unwrap();
+            let last: ClientMessage = serde_json::from_str(messages.last().unwrap()).unwrap();
+            assert!(
+                matches!(last, ClientMessage::Signal { .. }),
+                "expected Signal on the wire, got {last:?}"
+            );
+        }
+
         client.shutdown().await;
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -26,6 +26,24 @@ pub enum SignalFishError {
     #[error("not connected to server")]
     NotConnected,
 
+    /// The bounded outgoing command queue is full — the caller is producing
+    /// messages faster than the transport can drain them.
+    ///
+    /// This is the client's send-side backpressure signal: nothing was lost,
+    /// the message was simply refused. Either retry later, pace high-rate
+    /// payloads with the waiting variant
+    /// [`SignalFishClient::send_game_data_reliable`](crate::SignalFishClient::send_game_data_reliable),
+    /// or raise
+    /// [`SignalFishConfig::command_channel_capacity`](crate::SignalFishConfig::command_channel_capacity).
+    #[error(
+        "outgoing command queue full (capacity {capacity}): the transport cannot keep up; \
+         pace sends (e.g. send_game_data_reliable) or increase command_channel_capacity"
+    )]
+    SendBufferFull {
+        /// Configured capacity of the outgoing command queue.
+        capacity: usize,
+    },
+
     /// Attempted a room operation but the client is not in a room.
     #[error("not in a room")]
     NotInRoom,

--- a/src/error.rs
+++ b/src/error.rs
@@ -30,14 +30,16 @@ pub enum SignalFishError {
     /// messages faster than the transport can drain them.
     ///
     /// This is the client's send-side backpressure signal: nothing was lost,
-    /// the message was simply refused. Either retry later, pace high-rate
-    /// payloads with the waiting variant
-    /// [`SignalFishClient::send_game_data_reliable`](crate::SignalFishClient::send_game_data_reliable),
+    /// the message was simply refused. Either retry later (e.g. next frame),
+    /// pace high-rate payloads with a waiting `*_reliable` variant
+    /// ([`SignalFishClient::send_game_data_reliable`](crate::SignalFishClient::send_game_data_reliable),
+    /// [`SignalFishClient::send_signal_reliable`](crate::SignalFishClient::send_signal_reliable)),
     /// or raise
     /// [`SignalFishConfig::command_channel_capacity`](crate::SignalFishConfig::command_channel_capacity).
     #[error(
         "outgoing command queue full (capacity {capacity}): the transport cannot keep up; \
-         pace sends (e.g. send_game_data_reliable) or increase command_channel_capacity"
+         retry later, pace high-rate sends with a waiting *_reliable variant, or increase \
+         command_channel_capacity"
     )]
     SendBufferFull {
         /// Configured capacity of the outgoing command queue.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,26 @@
 //!   stays byte-identical to v2 (see [Protocol versions](#protocol-versions))
 //! - **WebSocket built-in** — default `transport-websocket` feature provides `WebSocketTransport`
 //! - **Event-driven** — receive typed `SignalFishEvent`s via a channel
+//! - **No silent loss** — events are delivered with backpressure and sends are
+//!   bounded with explicit congestion signals (see
+//!   [Delivery guarantees](client#delivery-guarantees))
+//!
+//! ## Choosing a client
+//!
+//! The crate ships two clients with identical protocol behavior; pick by how
+//! your application is driven:
+//!
+//! - [`SignalFishClient`] (async) — spawns a background transport loop with
+//!   [`tokio::spawn`]. Use it when a tokio runtime is *running* (a
+//!   `#[tokio::main]`/`block_on` application, multi-thread or
+//!   `current_thread`). It only makes progress while the runtime is driven —
+//!   manually "ticking" a runtime once per frame starves it (see
+//!   [the driving contract](client#driving-the-client-runtime-contract)).
+//! - [`SignalFishPollingClient`](polling_client::SignalFishPollingClient)
+//!   (sync, feature `polling-client`) — no background task, no runtime. You
+//!   call [`poll()`](polling_client::SignalFishPollingClient::poll) once per
+//!   frame from a game loop. This is the right client for frame-driven
+//!   engines (Godot, Bevy without tokio, Unity via FFI) and `wasm32` targets.
 //!
 //! ## Protocol versions
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,8 +28,8 @@
 //!   `current_thread`). It only makes progress while the runtime is driven —
 //!   manually "ticking" a runtime once per frame starves it (see
 //!   [the driving contract](client#driving-the-client-runtime-contract)).
-//! - [`SignalFishPollingClient`](polling_client::SignalFishPollingClient)
-//!   (sync, feature `polling-client`) — no background task, no runtime. You
+//! - [`SignalFishPollingClient`] (sync, feature `polling-client`) — no
+//!   background task, no runtime. You
 //!   call [`poll()`](polling_client::SignalFishPollingClient::poll) once per
 //!   frame from a game loop. This is the right client for frame-driven
 //!   engines (Godot, Bevy without tokio, Unity via FFI) and `wasm32` targets.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,7 @@ pub mod transports;
 pub const PROTOCOL_VERSION: u16 = 3;
 
 // Re-export primary types for ergonomic imports.
-pub use client::{JoinRoomParams, SignalFishClient, SignalFishConfig};
+pub use client::{ClientStats, JoinRoomParams, SignalFishClient, SignalFishConfig};
 pub use error::SignalFishError;
 pub use error_codes::ErrorCode;
 pub use event::SignalFishEvent;

--- a/src/polling_client.rs
+++ b/src/polling_client.rs
@@ -1,9 +1,20 @@
 //! Synchronous, polling-based client for the Signal Fish signaling protocol.
 //!
-//! [`SignalFishPollingClient`] is designed for environments without an async
-//! runtime (e.g., Godot web builds via gdext on `wasm32-unknown-emscripten`).
-//! The caller drives the client by calling [`poll()`](SignalFishPollingClient::poll)
-//! once per frame from the game loop.
+//! [`SignalFishPollingClient`] is designed for environments without a
+//! continuously driven async runtime: frame-driven game engines (Godot,
+//! Unity via FFI, Bevy without tokio), `wasm32` targets (e.g. Godot web
+//! builds via gdext on `wasm32-unknown-emscripten`), and any application
+//! that would otherwise "tick" a tokio runtime once per frame — a pattern
+//! that starves [`SignalFishClient`](crate::SignalFishClient)'s spawned
+//! transport loop. The caller drives the client by calling
+//! [`poll()`](SignalFishPollingClient::poll) once per frame from the game
+//! loop; no background task or runtime is required.
+//!
+//! Delivery guarantees match the async client: incoming events are returned
+//! from `poll()` without loss, and outgoing commands go through a bounded
+//! queue that fails fast with
+//! [`SendBufferFull`](crate::error::SignalFishError::SendBufferFull) instead
+//! of growing without bound when the transport is congested.
 
 use std::collections::VecDeque;
 

--- a/src/polling_client.rs
+++ b/src/polling_client.rs
@@ -35,6 +35,12 @@ struct PollingClientState {
     player_id: Option<PlayerId>,
     room_id: Option<RoomId>,
     room_code: Option<String>,
+    /// `GameData` messages successfully written to the transport.
+    /// Cumulative — intentionally not reset by `clear_session`.
+    game_data_sent: u64,
+    /// `GameData`/`GameDataBinary` events received from the server.
+    /// Cumulative — intentionally not reset by `clear_session`.
+    game_data_received: u64,
 }
 
 impl PollingClientState {
@@ -49,6 +55,8 @@ impl PollingClientState {
             player_id: None,
             room_id: None,
             room_code: None,
+            game_data_sent: 0,
+            game_data_received: 0,
         }
     }
 
@@ -208,7 +216,11 @@ impl<T: Transport> SignalFishPollingClient<T> {
             };
 
             match send_result {
-                std::task::Poll::Ready(Ok(())) => {}
+                std::task::Poll::Ready(Ok(())) => {
+                    if matches!(msg, ClientMessage::GameData { .. }) {
+                        self.state.game_data_sent += 1;
+                    }
+                }
                 std::task::Poll::Ready(Err(e)) => {
                     error!("transport send error: {e}");
                     self.handle_disconnect(&mut events, Some(format!("transport send error: {e}")));
@@ -572,6 +584,15 @@ impl<T: Transport> SignalFishPollingClient<T> {
         self.command_capacity
     }
 
+    /// Cumulative game-data traffic counters
+    /// (see [`ClientStats`](crate::client::ClientStats)).
+    pub fn stats(&self) -> crate::client::ClientStats {
+        crate::client::ClientStats {
+            game_data_sent: self.state.game_data_sent,
+            game_data_received: self.state.game_data_received,
+        }
+    }
+
     // ── Close ───────────────────────────────────────────────────────
 
     /// Close the transport and mark the client as disconnected.
@@ -692,6 +713,9 @@ impl<T: Transport> SignalFishPollingClient<T> {
             ServerMessage::SpectatorLeft { .. } => {
                 self.state.room_id = None;
                 self.state.room_code = None;
+            }
+            ServerMessage::GameData { .. } | ServerMessage::GameDataBinary { .. } => {
+                self.state.game_data_received += 1;
             }
             _ => {}
         }
@@ -1268,6 +1292,41 @@ mod tests {
 
     fn authenticated_json_str() -> &'static str {
         r#"{"type":"Authenticated","data":{"app_name":"test","rate_limits":{"per_minute":60,"per_hour":1000,"per_day":10000}}}"#
+    }
+
+    #[test]
+    fn stats_count_game_data_sent_and_received() {
+        let game_data_json = |seq: u64| {
+            serde_json::to_string(&ServerMessage::GameData {
+                from_player: uuid::Uuid::from_u128(9),
+                data: serde_json::json!({ "seq": seq }),
+            })
+            .expect("GameData serializes")
+        };
+        let transport = MockTransport::new().with_incoming(vec![
+            Some(Ok(authenticated_json_str().to_string())),
+            Some(Ok(game_data_json(0))),
+            Some(Ok(game_data_json(1))),
+        ]);
+        let mut client = SignalFishPollingClient::new(transport, default_config());
+
+        assert_eq!(client.stats(), crate::client::ClientStats::default());
+
+        for seq in 0..3 {
+            client
+                .send_game_data(serde_json::json!({ "seq": seq }))
+                .unwrap();
+        }
+        let _ = client.poll();
+
+        // Authenticate + 3 GameData flushed; only GameData counts as sent.
+        assert_eq!(
+            client.stats(),
+            crate::client::ClientStats {
+                game_data_sent: 3,
+                game_data_received: 2,
+            }
+        );
     }
 
     #[test]

--- a/src/polling_client.rs
+++ b/src/polling_client.rs
@@ -112,6 +112,10 @@ impl PollingClientState {
 pub struct SignalFishPollingClient<T: Transport> {
     transport: T,
     cmd_queue: VecDeque<ClientMessage>,
+    /// Maximum number of queued commands before sends fail fast with
+    /// [`SignalFishError::SendBufferFull`]. Mirrors the async client's
+    /// bounded command channel.
+    command_capacity: usize,
     state: PollingClientState,
     started: bool,
 }
@@ -141,6 +145,7 @@ impl<T: Transport> SignalFishPollingClient<T> {
         Self {
             transport,
             cmd_queue,
+            command_capacity: config.command_channel_capacity.max(1),
             state: PollingClientState::new(),
             started: false,
         }
@@ -278,7 +283,9 @@ impl<T: Transport> SignalFishPollingClient<T> {
     ///
     /// # Errors
     ///
-    /// Returns [`SignalFishError::NotConnected`] if the transport has closed.
+    /// Returns [`SignalFishError::NotConnected`] if the transport has closed,
+    /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
+    /// is full (the message is **not** queued; nothing is silently dropped).
     pub fn join_room(&mut self, params: JoinRoomParams) -> Result<()> {
         self.queue_cmd(ClientMessage::JoinRoom {
             game_name: params.game_name,
@@ -294,7 +301,9 @@ impl<T: Transport> SignalFishPollingClient<T> {
     ///
     /// # Errors
     ///
-    /// Returns [`SignalFishError::NotConnected`] if the transport has closed.
+    /// Returns [`SignalFishError::NotConnected`] if the transport has closed,
+    /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
+    /// is full (the message is **not** queued; nothing is silently dropped).
     pub fn leave_room(&mut self) -> Result<()> {
         self.queue_cmd(ClientMessage::LeaveRoom)
     }
@@ -303,7 +312,9 @@ impl<T: Transport> SignalFishPollingClient<T> {
     ///
     /// # Errors
     ///
-    /// Returns [`SignalFishError::NotConnected`] if the transport has closed.
+    /// Returns [`SignalFishError::NotConnected`] if the transport has closed,
+    /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
+    /// is full (the message is **not** queued; nothing is silently dropped).
     pub fn send_game_data(&mut self, data: serde_json::Value) -> Result<()> {
         self.queue_cmd(ClientMessage::GameData { data })
     }
@@ -312,7 +323,9 @@ impl<T: Transport> SignalFishPollingClient<T> {
     ///
     /// # Errors
     ///
-    /// Returns [`SignalFishError::NotConnected`] if the transport has closed.
+    /// Returns [`SignalFishError::NotConnected`] if the transport has closed,
+    /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
+    /// is full (the message is **not** queued; nothing is silently dropped).
     pub fn set_ready(&mut self) -> Result<()> {
         self.queue_cmd(ClientMessage::PlayerReady)
     }
@@ -321,7 +334,9 @@ impl<T: Transport> SignalFishPollingClient<T> {
     ///
     /// # Errors
     ///
-    /// Returns [`SignalFishError::NotConnected`] if the transport has closed.
+    /// Returns [`SignalFishError::NotConnected`] if the transport has closed,
+    /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
+    /// is full (the message is **not** queued; nothing is silently dropped).
     pub fn request_authority(&mut self, become_authority: bool) -> Result<()> {
         self.queue_cmd(ClientMessage::AuthorityRequest { become_authority })
     }
@@ -330,7 +345,9 @@ impl<T: Transport> SignalFishPollingClient<T> {
     ///
     /// # Errors
     ///
-    /// Returns [`SignalFishError::NotConnected`] if the transport has closed.
+    /// Returns [`SignalFishError::NotConnected`] if the transport has closed,
+    /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
+    /// is full (the message is **not** queued; nothing is silently dropped).
     pub fn provide_connection_info(&mut self, connection_info: ConnectionInfo) -> Result<()> {
         self.queue_cmd(ClientMessage::ProvideConnectionInfo { connection_info })
     }
@@ -339,7 +356,9 @@ impl<T: Transport> SignalFishPollingClient<T> {
     ///
     /// # Errors
     ///
-    /// Returns [`SignalFishError::NotConnected`] if the transport has closed.
+    /// Returns [`SignalFishError::NotConnected`] if the transport has closed,
+    /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
+    /// is full (the message is **not** queued; nothing is silently dropped).
     pub fn reconnect(
         &mut self,
         player_id: PlayerId,
@@ -357,7 +376,9 @@ impl<T: Transport> SignalFishPollingClient<T> {
     ///
     /// # Errors
     ///
-    /// Returns [`SignalFishError::NotConnected`] if the transport has closed.
+    /// Returns [`SignalFishError::NotConnected`] if the transport has closed,
+    /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
+    /// is full (the message is **not** queued; nothing is silently dropped).
     pub fn join_as_spectator(
         &mut self,
         game_name: String,
@@ -375,7 +396,9 @@ impl<T: Transport> SignalFishPollingClient<T> {
     ///
     /// # Errors
     ///
-    /// Returns [`SignalFishError::NotConnected`] if the transport has closed.
+    /// Returns [`SignalFishError::NotConnected`] if the transport has closed,
+    /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
+    /// is full (the message is **not** queued; nothing is silently dropped).
     pub fn leave_spectator(&mut self) -> Result<()> {
         self.queue_cmd(ClientMessage::LeaveSpectator)
     }
@@ -384,7 +407,9 @@ impl<T: Transport> SignalFishPollingClient<T> {
     ///
     /// # Errors
     ///
-    /// Returns [`SignalFishError::NotConnected`] if the transport has closed.
+    /// Returns [`SignalFishError::NotConnected`] if the transport has closed,
+    /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
+    /// is full (the message is **not** queued; nothing is silently dropped).
     pub fn ping(&mut self) -> Result<()> {
         self.queue_cmd(ClientMessage::Ping)
     }
@@ -399,7 +424,9 @@ impl<T: Transport> SignalFishPollingClient<T> {
     ///
     /// # Errors
     ///
-    /// Returns [`SignalFishError::NotConnected`] if the transport has closed.
+    /// Returns [`SignalFishError::NotConnected`] if the transport has closed,
+    /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
+    /// is full (the message is **not** queued; nothing is silently dropped).
     pub fn start_game(&mut self) -> Result<()> {
         self.queue_cmd(ClientMessage::StartGame)
     }
@@ -415,8 +442,9 @@ impl<T: Transport> SignalFishPollingClient<T> {
     /// # Errors
     ///
     /// Returns [`SignalFishError::ProtocolUnsupported`] if the connection has not
-    /// negotiated protocol v3, or [`SignalFishError::NotConnected`] if the
-    /// transport has closed.
+    /// negotiated protocol v3, [`SignalFishError::NotConnected`] if the
+    /// transport has closed, or [`SignalFishError::SendBufferFull`] if the
+    /// outgoing command queue is full.
     pub fn send_signal(&mut self, to: PlayerId, signal: impl Into<PeerSignal>) -> Result<()> {
         self.ensure_v3()?;
         self.queue_cmd(ClientMessage::Signal {
@@ -472,8 +500,9 @@ impl<T: Transport> SignalFishPollingClient<T> {
     /// # Errors
     ///
     /// Returns [`SignalFishError::ProtocolUnsupported`] if the connection has not
-    /// negotiated protocol v3, or [`SignalFishError::NotConnected`] if the
-    /// transport has closed.
+    /// negotiated protocol v3, [`SignalFishError::NotConnected`] if the
+    /// transport has closed, or [`SignalFishError::SendBufferFull`] if the
+    /// outgoing command queue is full.
     pub fn report_transport_status(
         &mut self,
         transport: TransportKind,
@@ -526,6 +555,21 @@ impl<T: Transport> SignalFishPollingClient<T> {
     /// The current room code, set after joining a room.
     pub fn current_room_code(&self) -> Option<&str> {
         self.state.room_code.as_deref()
+    }
+
+    /// Number of messages that can currently be queued before send methods
+    /// return [`SignalFishError::SendBufferFull`].
+    ///
+    /// The queue drains on every [`poll()`](Self::poll) while the transport
+    /// accepts writes, so a shrinking value means the transport is congested.
+    pub fn send_capacity(&self) -> usize {
+        self.command_capacity.saturating_sub(self.cmd_queue.len())
+    }
+
+    /// Configured capacity of the outgoing command queue
+    /// (see [`SignalFishConfig::command_channel_capacity`]).
+    pub fn max_send_capacity(&self) -> usize {
+        self.command_capacity
     }
 
     // ── Close ───────────────────────────────────────────────────────
@@ -581,6 +625,15 @@ impl<T: Transport> SignalFishPollingClient<T> {
     fn queue_cmd(&mut self, msg: ClientMessage) -> Result<()> {
         if !self.state.connected {
             return Err(SignalFishError::NotConnected);
+        }
+        // The queue only backs up while the transport reports Pending across
+        // polls; refusing (rather than growing without bound) surfaces the
+        // congestion to the caller, mirroring the async client's bounded
+        // command channel.
+        if self.cmd_queue.len() >= self.command_capacity {
+            return Err(SignalFishError::SendBufferFull {
+                capacity: self.command_capacity,
+            });
         }
         self.cmd_queue.push_back(msg);
         Ok(())
@@ -2477,6 +2530,81 @@ mod tests {
             );
         }
         assert!(!client.is_connected());
+    }
+
+    /// Transport whose `send()` stays `Pending` until `allow` is set, so tests
+    /// can saturate and then drain the bounded command queue deterministically.
+    struct TogglePendingSendTransport {
+        allow: std::sync::Arc<std::sync::atomic::AtomicBool>,
+        sent: Vec<String>,
+    }
+
+    #[async_trait]
+    impl Transport for TogglePendingSendTransport {
+        async fn send(&mut self, message: String) -> std::result::Result<(), SignalFishError> {
+            if !self.allow.load(std::sync::atomic::Ordering::Acquire) {
+                // Simulates a congested transport: pending() never completes,
+                // so the single noop-waker poll observes Pending and requeues.
+                std::future::pending::<()>().await;
+            }
+            self.sent.push(message);
+            Ok(())
+        }
+
+        async fn recv(&mut self) -> Option<std::result::Result<String, SignalFishError>> {
+            // No scripted messages — pending() never completes; the noop-waker
+            // poll observes Pending and stops the recv drain for this frame.
+            std::future::pending().await
+        }
+
+        async fn close(&mut self) -> std::result::Result<(), SignalFishError> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn queue_cmd_fails_fast_when_command_queue_is_full() {
+        let allow = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let transport = TogglePendingSendTransport {
+            allow: std::sync::Arc::clone(&allow),
+            sent: Vec::new(),
+        };
+        let config = default_config().with_command_channel_capacity(3);
+        let mut client = SignalFishPollingClient::new(transport, config);
+
+        // Authenticate occupies one of the three slots.
+        assert_eq!(client.max_send_capacity(), 3);
+        assert_eq!(client.send_capacity(), 2);
+
+        client
+            .send_game_data(serde_json::json!({ "seq": 0 }))
+            .unwrap();
+        client
+            .send_game_data(serde_json::json!({ "seq": 1 }))
+            .unwrap();
+        assert_eq!(client.send_capacity(), 0);
+        let err = client
+            .send_game_data(serde_json::json!({ "seq": 2 }))
+            .unwrap_err();
+        assert!(
+            matches!(err, SignalFishError::SendBufferFull { capacity: 3 }),
+            "expected SendBufferFull, got {err:?}"
+        );
+
+        // A stalled transport keeps the queue full across polls — nothing is
+        // lost and nothing grows without bound.
+        let _ = client.poll();
+        assert_eq!(client.send_capacity(), 0);
+        assert!(client.is_connected());
+
+        // Once the transport accepts writes again, one poll drains everything.
+        allow.store(true, std::sync::atomic::Ordering::Release);
+        let _ = client.poll();
+        assert_eq!(client.send_capacity(), 3);
+        assert_eq!(client.transport.sent.len(), 3);
+        client
+            .send_game_data(serde_json::json!({ "seq": 3 }))
+            .unwrap();
     }
 
     #[test]

--- a/src/polling_client.rs
+++ b/src/polling_client.rs
@@ -49,7 +49,9 @@ struct PollingClientState {
     /// `GameData` messages successfully written to the transport.
     /// Cumulative — intentionally not reset by `clear_session`.
     game_data_sent: u64,
-    /// `GameData`/`GameDataBinary` events received from the server.
+    /// `GameData`/`GameDataBinary` messages received from the server,
+    /// counted at receipt (see
+    /// [`ClientStats::game_data_received`](crate::client::ClientStats)).
     /// Cumulative — intentionally not reset by `clear_session`.
     game_data_received: u64,
 }

--- a/src/webrtc.rs
+++ b/src/webrtc.rs
@@ -278,7 +278,7 @@ mod controller {
             loop {
                 // Surface any pending driver output first (relaying signals /
                 // reporting status as side effects).
-                if let Some(event) = self.drain_driver() {
+                if let Some(event) = self.drain_driver().await {
                     return Some(event);
                 }
 
@@ -451,12 +451,15 @@ mod controller {
 
         /// Drain one surfacing driver output, performing the signaling side
         /// effects (relay signal / report status) for non-surfacing outputs.
-        fn drain_driver(&mut self) -> Option<MeshEvent> {
+        async fn drain_driver(&mut self) -> Option<MeshEvent> {
             while let Some(driver_event) = self.driver.poll() {
                 match driver_event {
                     DriverEvent::Signal { peer, signal } => {
                         // Relay the offer/answer/ICE to the peer via the server.
-                        if let Err(e) = self.client.send_signal(peer, signal) {
+                        // Reliably: a lost signal stalls the WebRTC handshake, so
+                        // wait for command-queue capacity instead of dropping when
+                        // the queue is congested (e.g. by game-data bursts).
+                        if let Err(e) = self.client.send_signal_reliable(peer, signal).await {
                             debug!("could not relay signal to {peer}: {e}");
                         }
                     }
@@ -483,10 +486,15 @@ mod controller {
             let was_empty = self.connected_peers.is_empty();
             self.connected_peers.push(peer);
             if was_empty {
-                // First live P2P channel: tell the server WebRTC is up.
-                let _ = self
+                // First live P2P channel: tell the server WebRTC is up. The
+                // report is informational and idempotent, so a refusal (e.g.
+                // NotConnected during teardown) is logged, not retried.
+                if let Err(e) = self
                     .client
-                    .report_transport_status(TransportKind::WebRtc, true);
+                    .report_transport_status(TransportKind::WebRtc, true)
+                {
+                    debug!("could not report WebRTC transport up: {e}");
+                }
             }
         }
 
@@ -495,9 +503,13 @@ mod controller {
             self.connected_peers.retain(|p| *p != peer);
             if self.connected_peers.is_empty() && before > 0 {
                 // Last live P2P channel closed: we are back on the relay floor.
-                let _ = self
+                // Informational and idempotent — a refusal is logged, not retried.
+                if let Err(e) = self
                     .client
-                    .report_transport_status(TransportKind::WebRtc, false);
+                    .report_transport_status(TransportKind::WebRtc, false)
+                {
+                    debug!("could not report WebRTC transport down: {e}");
+                }
             }
         }
 

--- a/src/webrtc.rs
+++ b/src/webrtc.rs
@@ -513,9 +513,7 @@ mod controller {
                 if !self.relay_pending_signal() {
                     return None;
                 }
-                let Some(driver_event) = self.driver.poll() else {
-                    return None;
-                };
+                let driver_event = self.driver.poll()?;
                 match driver_event {
                     DriverEvent::Signal { peer, signal } => {
                         // Buffer, then immediately attempt the relay on the

--- a/src/webrtc.rs
+++ b/src/webrtc.rs
@@ -219,6 +219,12 @@ mod controller {
         /// Signaled by the driver (via its [`MeshWaker`]) when it has output
         /// ready, so `recv` pumps on demand instead of waiting for the timer.
         ready: std::sync::Arc<tokio::sync::Notify>,
+        /// An outbound signal the command queue refused (`SendBufferFull`),
+        /// held for retry so congestion never drops it. Driver output is not
+        /// popped past a pending signal, preserving signal order, and `recv`
+        /// stays cancel-safe because the signal lives here rather than in a
+        /// cancellable future.
+        pending_signal: Option<(PlayerId, PeerSignal)>,
     }
 
     impl<D: WebRtcDriver> MeshController<D> {
@@ -250,6 +256,7 @@ mod controller {
                 connected_peers: Vec::new(),
                 pump_interval: DEFAULT_PUMP_INTERVAL,
                 ready,
+                pending_signal: None,
             }
         }
 
@@ -274,11 +281,26 @@ mod controller {
 
         /// Receive the next high-level mesh event. Returns `None` once the
         /// underlying transport closes.
+        ///
+        /// # Cancel safety
+        ///
+        /// This method is cancel-safe: it never holds a popped driver output
+        /// across an await point. An outbound signal the command queue cannot
+        /// accept yet is buffered in the controller and relayed on a later
+        /// iteration (or a later `recv` call), so cancelling `recv` — e.g.
+        /// with `tokio::time::timeout` in a frame-budgeted game loop — never
+        /// loses a signal.
         pub async fn recv(&mut self) -> Option<MeshEvent> {
             loop {
                 // Surface any pending driver output first (relaying signals /
-                // reporting status as side effects).
-                if let Some(event) = self.drain_driver().await {
+                // reporting status as side effects). This is deliberately
+                // synchronous: it must not await while the controller — the
+                // sole consumer of `self.events` — is not draining events,
+                // or a full command queue + full event channel would
+                // deadlock. A refused signal stays buffered; draining events
+                // below is exactly what lets the transport loop make
+                // progress and free queue capacity for the retry.
+                if let Some(event) = self.drain_driver() {
                     return Some(event);
                 }
 
@@ -449,19 +471,56 @@ mod controller {
             }
         }
 
+        /// Attempt to relay the buffered outbound signal, if any.
+        ///
+        /// Returns `true` when the buffer is clear — the signal was relayed,
+        /// there was nothing to relay, or the refusal was terminal
+        /// (`NotConnected` / `ProtocolUnsupported`, logged and discarded
+        /// because retrying cannot succeed). Returns `false` when the
+        /// command queue is full and the signal must be retried later: a
+        /// lost offer/answer/ICE candidate stalls the WebRTC handshake, so
+        /// congestion buffers the signal instead of dropping it.
+        fn relay_pending_signal(&mut self) -> bool {
+            let Some((peer, signal)) = self.pending_signal.take() else {
+                return true;
+            };
+            match self.client.send_signal(peer, signal.clone()) {
+                Ok(()) => true,
+                Err(crate::error::SignalFishError::SendBufferFull { .. }) => {
+                    self.pending_signal = Some((peer, signal));
+                    false
+                }
+                Err(e) => {
+                    debug!("could not relay signal to {peer}: {e}");
+                    true
+                }
+            }
+        }
+
         /// Drain one surfacing driver output, performing the signaling side
         /// effects (relay signal / report status) for non-surfacing outputs.
-        async fn drain_driver(&mut self) -> Option<MeshEvent> {
-            while let Some(driver_event) = self.driver.poll() {
+        ///
+        /// Synchronous by design (see [`recv`](Self::recv)): a signal the
+        /// command queue refuses is buffered in `pending_signal` — and driver
+        /// output is not popped past it, preserving signal order — rather
+        /// than awaited on, so this never blocks event draining and never
+        /// holds a popped signal across a cancellation point.
+        fn drain_driver(&mut self) -> Option<MeshEvent> {
+            loop {
+                // A buffered signal must go out before any further driver
+                // output is popped; if the queue is still full, return to
+                // the select loop and retry on the next wake.
+                if !self.relay_pending_signal() {
+                    return None;
+                }
+                let Some(driver_event) = self.driver.poll() else {
+                    return None;
+                };
                 match driver_event {
                     DriverEvent::Signal { peer, signal } => {
-                        // Relay the offer/answer/ICE to the peer via the server.
-                        // Reliably: a lost signal stalls the WebRTC handshake, so
-                        // wait for command-queue capacity instead of dropping when
-                        // the queue is congested (e.g. by game-data bursts).
-                        if let Err(e) = self.client.send_signal_reliable(peer, signal).await {
-                            debug!("could not relay signal to {peer}: {e}");
-                        }
+                        // Buffer, then immediately attempt the relay on the
+                        // next loop iteration.
+                        self.pending_signal = Some((peer, signal));
                     }
                     DriverEvent::Connected { peer } => {
                         self.mark_connected(peer);
@@ -476,7 +535,6 @@ mod controller {
                     }
                 }
             }
-            None
         }
 
         fn mark_connected(&mut self, peer: PlayerId) {
@@ -931,6 +989,126 @@ mod tests {
                 return Some(p);
             }
         }
+    }
+
+    /// Transport whose sends each require a semaphore permit, so a test can
+    /// hold the client's bounded command queue full deterministically.
+    struct GatedTransport {
+        incoming: VecDeque<Option<Result<String, crate::error::SignalFishError>>>,
+        sent: Arc<Mutex<Vec<String>>>,
+        permits: Arc<tokio::sync::Semaphore>,
+        entered: Arc<std::sync::atomic::AtomicUsize>,
+    }
+
+    #[async_trait::async_trait]
+    impl Transport for GatedTransport {
+        async fn send(&mut self, message: String) -> Result<(), crate::error::SignalFishError> {
+            self.entered
+                .fetch_add(1, std::sync::atomic::Ordering::AcqRel);
+            let permit = self
+                .permits
+                .acquire()
+                .await
+                .map_err(|_| crate::error::SignalFishError::TransportClosed)?;
+            permit.forget();
+            self.sent.lock().unwrap().push(message);
+            Ok(())
+        }
+        async fn recv(&mut self) -> Option<Result<String, crate::error::SignalFishError>> {
+            if let Some(item) = self.incoming.pop_front() {
+                item
+            } else {
+                // No scripted messages remain — pending() never completes,
+                // keeping the transport loop alive until shutdown aborts it.
+                std::future::pending().await
+            }
+        }
+        async fn close(&mut self) -> Result<(), crate::error::SignalFishError> {
+            Ok(())
+        }
+    }
+
+    /// Regression test for the two #47-class hazards in the controller's
+    /// signal relay: a driver signal refused by a full command queue must be
+    /// buffered (not dropped), survive `recv()` cancellation, and go out
+    /// exactly once when the congestion clears.
+    #[tokio::test]
+    async fn congestion_buffers_driver_signal_and_relays_exactly_once() {
+        let peer = uuid(9);
+        // One permit: exactly the Authenticate send is allowed through.
+        let permits = Arc::new(tokio::sync::Semaphore::new(1));
+        let entered = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let sent = Arc::new(Mutex::new(Vec::new()));
+        let transport = GatedTransport {
+            incoming: VecDeque::from(vec![
+                Some(Ok(authed())),
+                Some(Ok(protocol_info_v3())),
+                Some(Ok(session_plan(peer, true))),
+            ]),
+            sent: Arc::clone(&sent),
+            permits: Arc::clone(&permits),
+            entered: Arc::clone(&entered),
+        };
+        let driver = SharedDriver::default();
+        let config = SignalFishConfig::new("app").with_command_channel_capacity(1);
+        let mut mesh = MeshController::start(transport, config, driver.clone());
+
+        // Pump until the SessionPlan is folded: the driver has been told to
+        // connect and holds an Offer ready to relay (not yet drained).
+        assert!(
+            pump_until(&mut mesh, &driver, |calls| calls
+                .iter()
+                .any(|c| matches!(c, DriverCall::Connect(p, true) if *p == peer)))
+            .await,
+            "driver never told to connect"
+        );
+
+        // Saturate the capacity-1 command queue: the first filler is pulled
+        // by the loop, which then parks inside the permit-less transport
+        // send; the second filler occupies the queue's single slot.
+        mesh.client()
+            .send_game_data(serde_json::json!({ "filler": 1 }))
+            .unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            while entered.load(std::sync::atomic::Ordering::Acquire) < 2 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("transport loop never parked in the gated send");
+        mesh.client()
+            .send_game_data(serde_json::json!({ "filler": 2 }))
+            .unwrap();
+
+        // Pump once (cancelled by timeout): the Offer is popped, refused by
+        // the full queue, and buffered — cancellation must not lose it.
+        let _ = tokio::time::timeout(std::time::Duration::from_millis(80), mesh.recv()).await;
+        assert_eq!(
+            sent_count(&sent, &[r#""type":"Signal""#]),
+            0,
+            "signal must not reach the wire while the queue is congested"
+        );
+
+        // Clear the congestion: the buffered signal must be relayed.
+        permits.add_permits(64);
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            while sent_count(&sent, &[r#""type":"Signal""#]) == 0 {
+                let _ =
+                    tokio::time::timeout(std::time::Duration::from_millis(40), mesh.recv()).await;
+            }
+        })
+        .await
+        .expect("buffered signal was never relayed after congestion cleared");
+
+        // A few extra pumps must not re-relay it.
+        drain(&mut mesh, 3).await;
+        assert_eq!(
+            sent_count(&sent, &[r#""type":"Signal""#]),
+            1,
+            "the buffered signal must be relayed exactly once"
+        );
+
+        mesh.shutdown().await;
     }
 
     #[tokio::test]

--- a/src/webrtc.rs
+++ b/src/webrtc.rs
@@ -223,7 +223,9 @@ mod controller {
         /// held for retry so congestion never drops it. Driver output is not
         /// popped past a pending signal, preserving signal order, and `recv`
         /// stays cancel-safe because the signal lives here rather than in a
-        /// cancellable future.
+        /// cancellable future. Cleared when the controller tears down the
+        /// target peer (see `disconnect_peer`) — an abandoned handshake's
+        /// signal must not be relayed stale.
         pending_signal: Option<(PlayerId, PeerSignal)>,
     }
 
@@ -355,8 +357,7 @@ mod controller {
                         .filter(|id| !new_ids.contains(id))
                         .collect();
                     for old in dropped {
-                        self.driver.disconnect(old);
-                        self.mark_disconnected(old);
+                        self.disconnect_peer(old);
                     }
                     self.known_peers.retain(|k| new_ids.contains(&k.id));
                     // Connect peers newly named by this plan; a survivor whose
@@ -379,8 +380,7 @@ mod controller {
                     }
                 }
                 SignalFishEvent::PlayerLeft { player_id } => {
-                    self.driver.disconnect(*player_id);
-                    self.mark_disconnected(*player_id);
+                    self.disconnect_peer(*player_id);
                     self.known_peers.retain(|k| k.id != *player_id);
                 }
                 // The session ended: tear down every peer connection. Route each
@@ -391,8 +391,7 @@ mod controller {
                 // `mark_disconnected` empties `connected_peers` as it goes.
                 SignalFishEvent::RoomLeft | SignalFishEvent::Disconnected { .. } => {
                     for peer in std::mem::take(&mut self.known_peers) {
-                        self.driver.disconnect(peer.id);
-                        self.mark_disconnected(peer.id);
+                        self.disconnect_peer(peer.id);
                     }
                 }
                 SignalFishEvent::RoomJoined { ice_servers, .. } if !ice_servers.is_empty() => {
@@ -429,6 +428,25 @@ mod controller {
             }
         }
 
+        /// Tear down `peer`'s driver connection, dropping any buffered
+        /// outbound signal addressed to it: the signal belongs to the
+        /// handshake being abandoned and would be stale (wrong role, or a
+        /// peer no longer in the session) if relayed later. Used for every
+        /// controller-initiated teardown; a driver-reported channel drop
+        /// (`DriverEvent::Disconnected`) does not clear the buffer, because
+        /// the handshake context is still live there.
+        fn disconnect_peer(&mut self, peer: PlayerId) {
+            self.driver.disconnect(peer);
+            if self
+                .pending_signal
+                .as_ref()
+                .is_some_and(|(to, _)| *to == peer)
+            {
+                self.pending_signal = None;
+            }
+            self.mark_disconnected(peer);
+        }
+
         /// Ensure the driver holds the server's current offerer role for `peer`.
         ///
         /// A peer the controller has not connected yet is connected fresh. A
@@ -460,8 +478,7 @@ mod controller {
                         initiate,
                         "server reassigned the offerer role; restarting handshake"
                     );
-                    self.driver.disconnect(peer);
-                    self.mark_disconnected(peer);
+                    self.disconnect_peer(peer);
                     self.driver.connect(peer, initiate);
                     if let Some(k) = self.known_peers.iter_mut().find(|k| k.id == peer) {
                         k.initiate = initiate;
@@ -812,6 +829,7 @@ mod tests {
         }
     }
 
+    use crate::event::SignalFishEvent;
     use crate::protocol::ServerMessage;
     use crate::transport::Transport;
 
@@ -1104,6 +1122,96 @@ mod tests {
             sent_count(&sent, &[r#""type":"Signal""#]),
             1,
             "the buffered signal must be relayed exactly once"
+        );
+
+        mesh.shutdown().await;
+    }
+
+    /// A buffered signal whose target peer is torn down (here: `PlayerLeft`
+    /// while the command queue is congested) must be discarded, not relayed
+    /// stale after the congestion clears.
+    #[tokio::test]
+    async fn peer_teardown_discards_buffered_signal_for_that_peer() {
+        let peer = uuid(9);
+        let player_left = serde_json::to_string(&ServerMessage::PlayerLeft { player_id: peer })
+            .expect("PlayerLeft serializes");
+        // One permit: exactly the Authenticate send is allowed through.
+        let permits = Arc::new(tokio::sync::Semaphore::new(1));
+        let entered = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let sent = Arc::new(Mutex::new(Vec::new()));
+        let transport = GatedTransport {
+            incoming: VecDeque::from(vec![
+                Some(Ok(authed())),
+                Some(Ok(protocol_info_v3())),
+                Some(Ok(session_plan(peer, true))),
+                // Queued in the event channel behind the SessionPlan; the
+                // controller folds it while the Offer sits buffered below.
+                Some(Ok(player_left)),
+            ]),
+            sent: Arc::clone(&sent),
+            permits: Arc::clone(&permits),
+            entered: Arc::clone(&entered),
+        };
+        let driver = SharedDriver::default();
+        let config = SignalFishConfig::new("app").with_command_channel_capacity(1);
+        let mut mesh = MeshController::start(transport, config, driver.clone());
+
+        // Fold the SessionPlan (driver told to connect; Offer queued in the
+        // driver, not yet drained). The PlayerLeft event is still undelivered.
+        assert!(
+            pump_until(&mut mesh, &driver, |calls| calls
+                .iter()
+                .any(|c| matches!(c, DriverCall::Connect(p, true) if *p == peer)))
+            .await,
+            "driver never told to connect"
+        );
+
+        // Saturate the capacity-1 command queue (loop parks in the gated
+        // send; the second filler occupies the queue slot).
+        mesh.client()
+            .send_game_data(serde_json::json!({ "filler": 1 }))
+            .unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            while entered.load(std::sync::atomic::Ordering::Acquire) < 2 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("transport loop never parked in the gated send");
+        mesh.client()
+            .send_game_data(serde_json::json!({ "filler": 2 }))
+            .unwrap();
+
+        // Pump: the Offer is popped, refused (queue full), and buffered; the
+        // select then delivers PlayerLeft, whose teardown must clear the
+        // buffered signal for that peer.
+        let saw_player_left = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            loop {
+                if let Some(MeshEvent::Signaling(ev)) = mesh.recv().await {
+                    if matches!(*ev, SignalFishEvent::PlayerLeft { .. }) {
+                        break;
+                    }
+                }
+            }
+        })
+        .await;
+        assert!(saw_player_left.is_ok(), "never surfaced PlayerLeft");
+        assert!(
+            driver
+                .calls()
+                .iter()
+                .any(|c| matches!(c, DriverCall::Disconnect(p) if *p == peer)),
+            "driver never told to disconnect the departed peer"
+        );
+
+        // Clear the congestion and keep pumping: the stale Offer must never
+        // reach the wire.
+        permits.add_permits(64);
+        drain(&mut mesh, 5).await;
+        assert_eq!(
+            sent_count(&sent, &[r#""type":"Signal""#]),
+            0,
+            "a buffered signal for a torn-down peer must be discarded, not relayed"
         );
 
         mesh.shutdown().await;

--- a/tests/protocol_tests.rs
+++ b/tests/protocol_tests.rs
@@ -1214,7 +1214,7 @@ fn authenticate_relay_floor_omits_v3_fields() {
     // to v2 — none of the negotiation keys appear.
     let msg = ClientMessage::Authenticate {
         app_id: "mb_app".into(),
-        sdk_version: Some("0.5.0".into()),
+        sdk_version: Some("0.6.0".into()),
         platform: None,
         game_data_format: None,
         protocol_version: None,


### PR DESCRIPTION
# fix!: no-silent-loss reliability overhaul — lossless events, bounded sends, driving contract (v0.6.0)

Closes #47.

## Summary

Real-game usage (relaying `fortress-rollback` input packets) surfaced three reliability/ergonomics gaps that made high-rate `GameData` unreliable and nearly impossible to diagnose. This PR removes the entire class: **the client never silently drops data in either direction**, congestion is always surfaced deterministically, and the runtime driving contract is documented with a supported pump alternative. Version bumped to **0.6.0** (breaking).

## The three defects (issue #47) and their fixes

### 1. Events were silently dropped on overflow → lossless delivery with backpressure

`emit_event` used `try_send` and dropped events (including `GameData`, which an application can never reconstruct) whenever the consumer lagged — with only a `warn!` as evidence. Now **every** event is delivered with `send().await`: a lagging consumer pauses the transport loop and backpressure propagates to the server (TCP receive window) instead of losing data. The `Disconnected` special case is gone — delivery semantics are uniform. `event_channel_capacity` now only tunes buffering, not loss.

An event can be missed only when delivery stops entirely (receiver dropped, `shutdown()` timeout abort, or handle dropped without `shutdown()`) — never selectively.

### 2. Unbounded command channel → bounded queue with fail-fast + waiting sends

`send_game_data` enqueued onto an unbounded channel with no congestion signal; the only workaround was guessing at `sleep` durations. Now:

- The command channel is **bounded** (`SignalFishConfig::command_channel_capacity`, default 1024, `with_command_channel_capacity`).
- Synchronous send methods fail fast with the new **`SignalFishError::SendBufferFull { capacity }`** — the message is *not* queued; nothing is silently dropped.
- New waiting variants **`send_game_data_reliable().await`** / **`send_signal_reliable().await`** pace the caller to actual transport throughput — the pit-of-success API for rollback inputs and other high-rate payloads.
- **`send_capacity()` / `max_send_capacity()`** expose queue headroom for deterministic pacing.
- `SignalFishPollingClient`'s `VecDeque` command queue gets the same bound and accessors (same-class sweep).

### 3. Undocumented driving model → documented contract + first-class pump client

The transport loop is a `tokio::spawn`ed task and only progresses while the runtime is driven. "Ticking" a runtime once per frame starves it — the source of the sleep-dependent behavior in the report. Now documented at every level (crate docs "Choosing a client", client module docs "Driving the client (runtime contract)", docs site, README), with **`SignalFishPollingClient`** positioned as the supported synchronous `poll()`-per-frame pump for frame-driven engines and `wasm32` — exactly the `pump`/`step` API the issue requested. A new `current_thread`-flavor test proves a full authenticate → send → receive round-trip works single-threaded with no sleeps.

## Diagnostics for the relay-path deficit

The reported constant ~298-packet deficit was *below* the client (relay path). Since the client is now provably lossless, loss elsewhere becomes observable: **`ClientStats { game_data_sent, game_data_received }`** (via `stats()` on both clients, cumulative across disconnects) lets applications compare counters across peers — a persistent deficit now provably points at the relay/server, not the SDK.

## Same-class sweep

- `MeshController` relayed driver signals through the same congested path and could soft-drop them; a refused signal is now **buffered and retried in order** (never dropped under congestion), and `recv()` is documented **cancel-safe** — a buffered signal survives `tokio::time::timeout` cancellation. Refused transport-status reports are debug-logged instead of silently discarded.
- Polling client queue bound (above) closes the "stalled transport grows the queue without bound" variant.

## Breaking changes (0.5.0 → 0.6.0)

- New `SignalFishError::SendBufferFull` variant (exhaustive enum).
- New public `SignalFishConfig::command_channel_capacity` field.
- Behavior: events are never dropped (backpressure instead); sync sends can now return `SendBufferFull`.

## Testing

- Red-green: the two tests that asserted drop behavior now assert lossless delivery; a data-driven regression pushes 500 sequenced `GameData` through a capacity-2 channel and asserts complete, ordered arrival.
- Deterministic-by-construction backpressure tests via a semaphore-gated transport (fail-fast at capacity, reliable-send waits then completes, v3 guard fails fast even when the queue is full).
- Mesh regression test pins buffer-retry-exactly-once + cancellation survival under congestion.
- Adversarially reviewed in three rounds by independent reviewers (concurrency, docs-consistency, test-quality lenses); full suite run 70+ times (debug + release) with zero flakes.

## Docs

Every surface updated and consistency-checked: rustdoc, docs site (concepts/client/events/errors/wasm/mesh-guide/index/getting-started), README, CHANGELOG (Keep-a-Changelog, breaking changes flagged), `.llm/` context + skills. Version literals bumped across all test-pinned locations (`ci_config_tests` green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking changes to core async client behavior (event backpressure, send failures) and the exhaustive `SignalFishError` enum affect all integrators; scope is well-tested and documented but mis-handling `SendBufferFull` or event-loop deadlock warnings could still bite high-rate games.
> 
> **Overview**
> **v0.6.0** overhauls client reliability so congestion and lag are visible instead of silently losing traffic (#47).
> 
> **Inbound:** The transport loop now emits events with `send().await` only—no `try_send` drops. A full event channel stalls reads and pushes backpressure to the server; `event_channel_capacity` is buffering before stall, not a loss budget.
> 
> **Outbound:** Commands use a **bounded** queue (`command_channel_capacity`, default 1024). Sync APIs fail fast with **`SignalFishError::SendBufferFull`**; **`send_game_data_reliable`** / **`send_signal_reliable`** wait for slots. **`send_capacity`**, **`max_send_capacity`**, and **`ClientStats`** (`game_data_sent` / `game_data_received` via **`stats()`**) support pacing and relay-path deficit checks. **`SignalFishPollingClient`** mirrors the same bound and accessors.
> 
> **Mesh:** **`MeshController`** buffers driver signals when the queue refuses them, retries in order, drops stale signals on peer teardown, and documents cancel-safe **`recv()`**.
> 
> **Ergonomics:** Crate/docs/README spell out that **`SignalFishClient`** needs a driven Tokio runtime; frame-driven / wasm paths should use **`SignalFishPollingClient`**. Minimum **`tokio`** is **1.21** for queue capacity APIs.
> 
> Breaking: new error variant, new config field, and changed event/send behavior—exhaustive matches on **`SignalFishError`** must be updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e1aa90d23bf210c458a3e7d6a7695225bc2e6f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->