### PR TITLE
feat!: loud receive path, eviction attribution, wedge-proof shutdown + measured delivery contract (0.7.0)

### DIFF
--- a/.github/workflows/protocol-sync.yml
+++ b/.github/workflows/protocol-sync.yml
@@ -58,3 +58,18 @@ jobs:
             exit 1
           fi
           echo "Vendored wire samples are in sync with upstream."
+
+      - name: Compare vendored AsyncAPI spec to upstream and fail on drift
+        run: |
+          set -euo pipefail
+          url="https://raw.githubusercontent.com/Ambiguous-Interactive/signal-fish-server/main/spec/signal-fish-protocol.asyncapi.yaml"
+          curl -fsS "$url" -o /tmp/signal-fish-protocol.asyncapi.yaml
+          if ! diff -q tests/server-spec/signal-fish-protocol.asyncapi.yaml /tmp/signal-fish-protocol.asyncapi.yaml >/dev/null 2>&1; then
+            echo "::error::server AsyncAPI spec drift detected — upstream changed (new error codes or messages?)"
+            diff tests/server-spec/signal-fish-protocol.asyncapi.yaml /tmp/signal-fish-protocol.asyncapi.yaml || true
+            echo "Refresh per .llm/skills/protocol-wire-conformance.md: re-vendor the spec, update"
+            echo "tests/server-spec/PROVENANCE.toml, and run cargo test --test error_code_conformance_tests"
+            echo "to surface any ErrorCode variants the client must add."
+            exit 1
+          fi
+          echo "Vendored AsyncAPI spec is in sync with upstream."

--- a/.llm/context.md
+++ b/.llm/context.md
@@ -168,10 +168,10 @@ client.shutdown().await      // async, graceful
 
 Sync sends return `SignalFishError::NotConnected` when the transport is closed
 and `SignalFishError::SendBufferFull { capacity }` when the bounded queue is
-full (message refused, never silently dropped). Events are also never dropped:
-a full event channel pauses the transport loop (backpressure); events are
-missed only on receiver drop, shutdown-timeout abort, or handle drop without
-`shutdown()`.
+full (message refused, never silently dropped). Events are never dropped either:
+a full event channel pauses the transport loop (backpressure); undecodable
+frames surface as `DecodeFailed` events; events are missed only on receiver
+drop, handle drop without `shutdown()`, or shutdown (abandons ≤1 in-flight).
 `SignalFishPollingClient` shares the queue bound, capacity accessors, and `stats()`.
 
 ## Feature Flags

--- a/.llm/context.md
+++ b/.llm/context.md
@@ -5,7 +5,7 @@
 - **Company:** Ambiguous Interactive
 - **Product:** Signal Fish Client SDK
 - **Crate:** `signal-fish-client`
-- **Version:** 0.6.0
+- **Version:** 0.7.0
 - **Edition:** 2021
 - **MSRV:** 1.85.0
 - **License:** MIT

--- a/.llm/context.md
+++ b/.llm/context.md
@@ -49,7 +49,7 @@ Only add `CHANGELOG.md` entries for user-visible changes.
 | `src/transport.rs` | `Transport` trait — async bidirectional text messages |
 | `src/protocol.rs` | Wire-compatible protocol types (`ClientMessage`, `ServerMessage`, v3 `Topology`/`TransportKind`/`SessionPlanPayload`) |
 | `src/signal.rs` | `PeerSignal` — typed, matchbox-compatible WebRTC signal (protocol v3) |
-| `src/error_codes.rs` | `ErrorCode` enum — 48 variants from server |
+| `src/error_codes.rs` | `ErrorCode` enum — 50 variants from server |
 | `src/error.rs` | `SignalFishError` error type |
 | `src/event.rs` | `SignalFishEvent` high-level event stream |
 | `src/client.rs` | `SignalFishClient` async client + `SignalFishConfig` + `JoinRoomParams` |

--- a/.llm/skills/crate-publishing.md
+++ b/.llm/skills/crate-publishing.md
@@ -218,7 +218,7 @@ Follow [Keep a Changelog](https://keepachangelog.com/):
 - Initial release
 - `SignalFishClient` with WebSocket transport
 - 26-variant `SignalFishEvent` enum
-- 40-variant `ErrorCode` enum
+- 50-variant `ErrorCode` enum
 
 [Unreleased]: https://github.com/Ambiguous-Interactive/signal-fish-client-rust/compare/v0.2.0...HEAD
 [0.2.0]: https://github.com/Ambiguous-Interactive/signal-fish-client-rust/compare/v0.1.0...v0.2.0

--- a/.llm/skills/crate-publishing.md
+++ b/.llm/skills/crate-publishing.md
@@ -7,7 +7,7 @@ Reference for Cargo.toml metadata, docs.rs configuration, deny.toml, cargo-deny,
 ```toml
 [package]
 name = "signal-fish-client"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 rust-version = "1.85.0"          # MSRV — enforced by cargo
 license = "MIT"                   # SPDX identifier

--- a/.llm/skills/doc-accuracy-guarantees.md
+++ b/.llm/skills/doc-accuracy-guarantees.md
@@ -30,8 +30,9 @@ cancellation, channel drops, etc.
    - BAD: "Events are always delivered regardless of capacity."
    - GOOD: "Events are never dropped on overflow — a full channel pauses the
      transport loop and backpressure propagates to the server — but an event
-     may be missed if the receiver is dropped, shutdown times out and aborts
-     the transport task, or the handle is dropped without shutdown."
+     may be missed if the receiver is dropped, on shutdown (which abandons at
+     most one in-flight event and delivers the terminal `Disconnected`
+     best-effort), or if the handle is dropped without shutdown."
 
 3. **Document timeout/abort consequences** — If a function has a timeout that
    aborts work, document what events or side effects may be skipped when the
@@ -55,15 +56,16 @@ cancellation, channel drops, etc.
 
 ## Examples from This Codebase
 
-### `emit_event` — Qualified guarantee
+### `emit_event_or_shutdown` — Qualified guarantee
+
+The transport loop delivers events with backpressure but lets a shutdown
+request preempt a blocked delivery, so the guarantee is scoped precisely:
 
 ```rust
-/// Events are **never dropped**: when the consumer lags, the transport loop
-/// pauses here, which stops reading from the transport and propagates
-/// backpressure to the server (e.g. via TCP receive windows). Delivery only
-/// fails if the receiver has been dropped, or if the transport task is
-/// aborted while this send is still waiting (a `shutdown` timeout, or the
-/// client handle dropped without `shutdown`).
+/// Emit an event with backpressure, but let a shutdown request preempt the
+/// wait. `biased` polls the delivery arm first, so when both are ready the
+/// event is still delivered; only a genuinely blocked delivery (consumer not
+/// draining) lets shutdown win, abandoning that one in-flight event.
 ```
 
 ### `shutdown_timeout` — Documenting abort consequences

--- a/.llm/skills/error-handling.md
+++ b/.llm/skills/error-handling.md
@@ -110,7 +110,7 @@ async fn do_thing(&mut self) -> Result<(), SignalFishError> {
 
 ## ErrorCode Enum
 
-Defined in `src/error_codes.rs`. This enum is exhaustive. 48 variants:
+Defined in `src/error_codes.rs`. This enum is exhaustive. 50 variants:
 
 ```rust
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -154,6 +154,9 @@ pub enum ErrorCode {
 
     // Connection lifecycle, protocol v3 (1)
     ConnectionIdleTimeout,
+
+    // Delivery & liveness (2)
+    SlowConsumer, ActivityTimeout,
 }
 ```
 

--- a/.llm/skills/error-handling.md
+++ b/.llm/skills/error-handling.md
@@ -248,7 +248,7 @@ async fn test_transport_receive_error() {
     let _ = events.recv().await; // Connected
     let event = events.recv().await.unwrap();
     // Transport errors emit Disconnected with the error message as reason
-    if let SignalFishEvent::Disconnected { reason } = event {
+    if let SignalFishEvent::Disconnected { reason, .. } = event {
         assert!(reason.unwrap().contains("boom"));
     }
     client.shutdown().await;

--- a/.llm/skills/protocol-wire-conformance.md
+++ b/.llm/skills/protocol-wire-conformance.md
@@ -20,6 +20,14 @@ vendored verbatim into `tests/wire-samples/` and consumed by
 `tests/wire-samples/PROVENANCE.toml` records the upstream commit, the protocol
 version range, the sync date, and a SHA-256 per file.
 
+The server's machine-readable AsyncAPI spec
+(`spec/signal-fish-protocol.asyncapi.yaml`) is vendored the same way into
+`tests/server-spec/` (own `PROVENANCE.toml`) and consumed by
+`tests/error_code_conformance_tests.rs`, which asserts the client `ErrorCode`
+enum covers the spec's error-code token space in both directions. This closes
+the blind spot where a server-side error-code addition passes the wire-sample
+golden tests (they pin message *shapes*, not the error-code value space).
+
 ## The Refresh Procedure
 
 When the server protocol changes, refresh the vendored corpus:
@@ -35,6 +43,13 @@ When the server protocol changes, refresh the vendored corpus:
    if a pre-existing v2 field changed). Bump the version per
    [crate-publishing](crate-publishing.md).
 
+For the AsyncAPI spec the procedure is the same shape: copy
+`spec/signal-fish-protocol.asyncapi.yaml` into `tests/server-spec/`, update that
+directory's `PROVENANCE.toml` (commit, `synced`, SHA-256), then run
+`cargo test --test error_code_conformance_tests` — if red, add the missing
+variants to `src/error_codes.rs` (never edit the spec to pass) and document the
+new codes in `CHANGELOG.md` (a guard test enforces this).
+
 ## Guard Tests
 
 In `tests/ci_config_tests.rs` (`protocol_wire_conformance_policy`):
@@ -46,11 +61,14 @@ In `tests/ci_config_tests.rs` (`protocol_wire_conformance_policy`):
   sample cannot be edited without updating the marker (keeps provenance honest).
 - `no_protocol_type_uses_deny_unknown_fields` — protocol types must stay
   forward-compatible with additive server fields.
+- `server_spec_files_exist_and_are_non_empty`, `server_spec_provenance_marker_is_valid`,
+  `server_spec_provenance_checksum_matches_vendored_file` — the same discipline
+  for the vendored AsyncAPI spec in `tests/server-spec/`.
 
 ## Drift Detection
 
 `.github/workflows/protocol-sync.yml` runs weekly: it re-fetches the upstream
-samples and **fails loudly** if the vendored copies have drifted from the recorded
+samples **and the AsyncAPI spec** and **fails loudly** if the vendored copies have drifted from the recorded
 commit (fail-closed, no auto-PR). When it fails, follow the refresh procedure
 above. This catches the "upstream changed but nobody refreshed us" case that the
 offline checksum test cannot.

--- a/.llm/skills/public-api-design.md
+++ b/.llm/skills/public-api-design.md
@@ -23,7 +23,7 @@ for newly added variants:
 ```rust
 match event {
     SignalFishEvent::RoomJoined { room_code, .. } => { /* ... */ }
-    SignalFishEvent::Disconnected { reason } => { /* ... */ }
+    SignalFishEvent::Disconnected { reason, .. } => { /* ... */ }
     // Avoid wildcard arms in enum matches so missing variants are compile
     // errors during upgrades.
     SignalFishEvent::Connected => {}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   overhaul (server 851c446). Before this release an `Error` frame carrying
   either code failed to deserialize and was **silently discarded**, so a
   slow-consumer eviction looked like a bare disconnect with no reason.
+- `SignalFishEvent::DecodeFailed { message_type, error, raw_prefix }` — an
+  inbound frame that fails to decode into a `ServerMessage` (unknown message
+  type, unknown error-code string, malformed JSON) now surfaces as a typed
+  event instead of a log-only silent drop. The raw frame text is preserved
+  up to `DECODE_FAILED_RAW_PREFIX_MAX` (512) bytes. Emitted by both
+  `SignalFishClient` and `SignalFishPollingClient` with identical fields.
+- `ClientStats::messages_undecodable` — cumulative count of inbound frames
+  that failed to decode, on both clients.
+- `SignalFishEvent::Disconnected` now carries
+  `last_server_error: Option<ServerErrorInfo>` — the most recent
+  `Error`/`AuthenticationError` received on the connection — so a
+  disconnect that follows a server farewell (e.g. the best-effort
+  `SLOW_CONSUMER` eviction notice) can be attributed programmatically.
+- `Transport::close_reason()` (defaulted, non-breaking for implementors):
+  transports can expose a close explanation; `WebSocketTransport` now
+  captures the peer's Close frame text, and both clients include it in
+  `Disconnected::reason` as `"closed by server: …"`.
 - Error-code-space conformance suite
   (`tests/error_code_conformance_tests.rs`): the server's AsyncAPI spec is
   vendored under `tests/server-spec/` with SHA-pinned provenance, and tests
@@ -30,6 +47,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Breaking:** `ErrorCode` gained the two variants above; exhaustive
   `match`es over `ErrorCode` must add arms.
+- **Breaking:** `SignalFishEvent` gained the `DecodeFailed` variant and
+  `Disconnected` gained the `last_server_error` field; exhaustive matches
+  and struct patterns must be updated (`Disconnected { reason, .. }`).
+- **Breaking:** `ClientStats` gained `messages_undecodable`; struct-literal
+  construction must add the field.
+- Graceful [`shutdown`] now preempts a transport loop wedged on a full event
+  channel (a consumer that stopped draining): the loop abandons at most the
+  one in-flight event delivery, **closes the transport cleanly** (previously
+  the abort left the connection dangling), and delivers the terminal
+  `Disconnected` best-effort. The event channel closing remains the
+  authoritative end-of-stream signal.
 
 ## [0.6.0] - 2026-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.7.0] - 2026-07-02
 
+### Added
+
+- `ErrorCode::SlowConsumer` (wire `"SLOW_CONSUMER"`) and
+  `ErrorCode::ActivityTimeout` (wire `"ACTIVITY_TIMEOUT"`) — the delivery &
+  liveness codes the server introduced with its no-silent-drop relay
+  overhaul (server 851c446). Before this release an `Error` frame carrying
+  either code failed to deserialize and was **silently discarded**, so a
+  slow-consumer eviction looked like a bare disconnect with no reason.
+- Error-code-space conformance suite
+  (`tests/error_code_conformance_tests.rs`): the server's AsyncAPI spec is
+  vendored under `tests/server-spec/` with SHA-pinned provenance, and tests
+  assert every server error-code token deserializes into a client
+  `ErrorCode` variant (and vice versa). The weekly `protocol-sync` workflow
+  now also diffs the vendored spec against the server's `main`, closing the
+  drift blind spot where new server codes passed the wire-sample golden
+  tests unnoticed.
+
+### Changed
+
+- **Breaking:** `ErrorCode` gained the two variants above; exhaustive
+  `match`es over `ErrorCode` must add arms.
+
 ## [0.6.0] - 2026-07-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   now also diffs the vendored spec against the server's `main`, closing the
   drift blind spot where new server codes passed the wire-sample golden
   tests unnoticed.
+- `examples/load_lab.rs` — a CSV-emitting measurement harness (ping /
+  throughput / slow-consumer / control-starvation modes) for running
+  controlled relay experiments against a local server, plus
+  `tests/real_server_e2e.rs`, env-gated end-to-end tests against a real
+  server binary (ignored by default).
+- New docs page **Delivery Contract & Backpressure** (`docs/delivery.md`)
+  documenting the end-to-end delivery pipeline with measured numbers: what
+  a slow-consumer eviction looks like from the client, the reconnect
+  contract (no token is obtainable today), relay capacity, and the
+  wedged-consumer hazard.
+
+### Fixed
+
+- README no longer overclaims byte-exact wire parity (the protocol is
+  conformance-tested; undecodable frames surface as `DecodeFailed`), and
+  `GameDataEncoding::Rkyv` docs now state the server never negotiates rkyv
+  today (silent JSON downgrade) instead of recommending it for
+  performance.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,11 +71,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Breaking:** `ClientStats` gained `messages_undecodable`; struct-literal
   construction must add the field.
 - Graceful [`shutdown`] now preempts a transport loop wedged on a full event
-  channel (a consumer that stopped draining): the loop abandons at most the
-  one in-flight event delivery, **closes the transport cleanly** (previously
-  the abort left the connection dangling), and delivers the terminal
-  `Disconnected` best-effort. The event channel closing remains the
-  authoritative end-of-stream signal.
+  channel (a consumer that stopped draining) on **every** path — the
+  per-message event path *and* the terminal `Disconnected` emitted on a
+  transport error, a clean server close, or a dropped handle. Each path races
+  the shutdown signal, so `shutdown()` completes promptly and **closes the
+  transport cleanly** instead of stalling until the timeout aborts the task
+  (which previously left the connection dangling). The terminal `Disconnected`
+  is delivered best-effort (it may be dropped if the channel is full at that
+  instant); the event channel closing remains the authoritative
+  end-of-stream signal.
 
 ## [0.6.0] - 2026-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-07-02
+
 ## [0.6.0] - 2026-07-01
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signal-fish-client"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 license = "MIT"
 authors = ["Ambiguous Interactive <eli@theambiguous.co>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,10 @@ required-features = ["tokio-runtime"]
 name = "mesh_session"
 required-features = ["mesh", "tokio-runtime"]
 
+[[example]]
+name = "load_lab"
+required-features = ["transport-websocket"]
+
 [package.metadata.cargo-machete]
 ignored = ["serde_bytes"]
 

--- a/README.md
+++ b/README.md
@@ -42,12 +42,12 @@ Transport-agnostic async Rust client for the **Signal Fish** multiplayer signali
 ## Features
 
 - **Transport-agnostic** — implement the `Transport` trait for any backend (WebSocket, TCP, QUIC, WebRTC data channels, etc.)
-- **Wire-compatible** — all protocol types match the Signal Fish server's JSON format exactly
+- **Wire-compatible** — protocol types are conformance-tested against the server's published wire samples and error-code registry; undecodable frames surface as a typed `DecodeFailed` event
 - **Protocol support: v2 relay + v3 mesh** — v3 (opt-in, backward-compatible) adds WebRTC mesh signaling; a default client stays byte-identical to v2 (the "relay-floor guarantee"). Enable with `SignalFishConfig::enable_mesh()`.
 - **Feature-gated WebSocket transport** — the default `transport-websocket` feature provides a ready-to-use `WebSocketTransport`
 - **Event-driven** — receive typed `SignalFishEvent`s via a Tokio MPSC channel
 - **Structured errors** — `SignalFishError` (11 variants) and `ErrorCode` (50 variants) for precise error handling
-- **Full protocol coverage** — 14 client message types, 28 server message types, 30 event variants
+- **Full protocol coverage** — 14 client message types, 28 server message types, 31 event variants
 - **No silent loss** — events are delivered with backpressure (never dropped), and the bounded send queue surfaces congestion as `SignalFishError::SendBufferFull` instead of buffering without bound; `send_game_data_reliable` / `send_signal_reliable` wait for capacity, and `stats()` counters make relay-path loss observable
 - **Configurable** — tune event channel capacity, command queue capacity, shutdown timeout, and more via `SignalFishConfig` builder methods
 - **WebAssembly ready** — compiles to `wasm32-unknown-unknown` and `wasm32-unknown-emscripten` with zero unsafe panics

--- a/README.md
+++ b/README.md
@@ -58,14 +58,14 @@ Transport-agnostic async Rust client for the **Signal Fish** multiplayer signali
 
 ```toml
 [dependencies]
-signal-fish-client = "0.6.0"
+signal-fish-client = "0.7.0"
 ```
 
 Without the built-in WebSocket transport (bring your own):
 
 ```toml
 [dependencies]
-signal-fish-client = { version = "0.6.0", default-features = false }
+signal-fish-client = { version = "0.7.0", default-features = false }
 ```
 
 ## Quick Start

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Transport-agnostic async Rust client for the **Signal Fish** multiplayer signali
 - **Protocol support: v2 relay + v3 mesh** — v3 (opt-in, backward-compatible) adds WebRTC mesh signaling; a default client stays byte-identical to v2 (the "relay-floor guarantee"). Enable with `SignalFishConfig::enable_mesh()`.
 - **Feature-gated WebSocket transport** — the default `transport-websocket` feature provides a ready-to-use `WebSocketTransport`
 - **Event-driven** — receive typed `SignalFishEvent`s via a Tokio MPSC channel
-- **Structured errors** — `SignalFishError` (11 variants) and `ErrorCode` (48 variants) for precise error handling
+- **Structured errors** — `SignalFishError` (11 variants) and `ErrorCode` (50 variants) for precise error handling
 - **Full protocol coverage** — 14 client message types, 28 server message types, 30 event variants
 - **No silent loss** — events are delivered with backpressure (never dropped), and the bounded send queue surfaces congestion as `SignalFishError::SendBufferFull` instead of buffering without bound; `send_game_data_reliable` / `send_signal_reliable` wait for capacity, and `stats()` counters make relay-path loss observable
 - **Configurable** — tune event channel capacity, command queue capacity, shutdown timeout, and more via `SignalFishConfig` builder methods
@@ -126,7 +126,7 @@ async fn main() -> Result<(), signal_fish_client::SignalFishError> {
 | `event`       | `SignalFishEvent` enum (28 server + 2 synthetic variants)         |
 | `protocol`    | Wire-compatible `ClientMessage` (14) / `ServerMessage` (28) types |
 | `error`       | `SignalFishError` unified error type (11 variants)                |
-| `error_codes` | `ErrorCode` enum (48 server error code variants)                  |
+| `error_codes` | `ErrorCode` enum (50 server error code variants)                  |
 | `transport`   | `Transport` trait for pluggable backends                          |
 | `transports`  | Built-in transport implementations (`WebSocketTransport`)         |
 | `polling_client` | `SignalFishPollingClient` — synchronous, game-loop-driven client |

--- a/docs/client.md
+++ b/docs/client.md
@@ -30,7 +30,7 @@ let config = SignalFishConfig::new("mb_app_abc123");
 | `sdk_version` | `Option<String>` | Crate version at compile time | SDK version string sent during authentication. |
 | `platform` | `Option<String>` | `None` | Platform identifier (e.g. `"unity"`, `"godot"`, `"rust"`). |
 | `game_data_format` | `Option<GameDataEncoding>` | `None` | Preferred game data encoding format (`Json`, `MessagePack`, or `Rkyv`). |
-| `event_channel_capacity` | `usize` | `256` | Capacity of the bounded event channel. Events are never dropped — a full channel pauses the transport loop (backpressure), so this only controls buffering before backpressure kicks in. Values below 1 are clamped to 1. |
+| `event_channel_capacity` | `usize` | `256` | Capacity of the bounded event channel. Events are never dropped on overflow — a full channel pauses the transport loop (backpressure), so this only controls buffering before backpressure kicks in. Values below 1 are clamped to 1. |
 | `command_channel_capacity` | `usize` | `1024` | Capacity of the bounded outgoing command queue. When full, the synchronous send methods fail fast with [`SignalFishError::SendBufferFull`](errors.md#handling-sendbufferfull); the `*_reliable` variants wait for a slot instead. Values below 1 are clamped to 1. |
 | `shutdown_timeout` | `Duration` | `1 second` | Timeout for graceful shutdown of the background transport loop. A zero timeout aborts the loop immediately. |
 
@@ -342,7 +342,7 @@ Synchronous diagnostics for the outgoing command queue and game-data traffic:
 (`GameData`/`GameDataBinary` messages read off the transport and parsed —
 counted at **receipt**, not at delivery to your event loop, so a consumer
 that stops draining events cannot masquerade as relay loss; in steady state
-the two are identical because events are never dropped), and
+the two are identical because events are not dropped on overflow), and
 `messages_undecodable` (inbound frames that failed to decode — each also
 surfaces as a [`DecodeFailed`](events.md#decodefailed) event; steady growth
 means protocol drift or a corrupting middlebox). The counters are

--- a/docs/client.md
+++ b/docs/client.md
@@ -338,11 +338,14 @@ Synchronous diagnostics for the outgoing command queue and game-data traffic:
 | `stats()` | `fn stats(&self) -> ClientStats` | Cumulative game-data traffic counters. |
 
 `ClientStats` (re-exported at the crate root) carries `game_data_sent`
-(`GameData` messages written to the transport) and `game_data_received`
+(`GameData` messages written to the transport), `game_data_received`
 (`GameData`/`GameDataBinary` messages read off the transport and parsed —
 counted at **receipt**, not at delivery to your event loop, so a consumer
 that stops draining events cannot masquerade as relay loss; in steady state
-the two are identical because events are never dropped). The counters are
+the two are identical because events are never dropped), and
+`messages_undecodable` (inbound frames that failed to decode — each also
+surfaces as a [`DecodeFailed`](events.md#decodefailed) event; steady growth
+means protocol drift or a corrupting middlebox). The counters are
 cumulative for the lifetime of the client — they survive room changes and
 disconnects.
 
@@ -645,7 +648,7 @@ All accessors are **synchronous** (no async, no mutex):
 | `current_room_code()` | `Option<&str>` | Current room code, if in a room. |
 | `send_capacity()` | `usize` | Messages that can still be queued before `SendBufferFull`. |
 | `max_send_capacity()` | `usize` | Configured command-queue capacity. |
-| `stats()` | `ClientStats` | Cumulative `game_data_sent` / `game_data_received` counters (see [Send Queue and Traffic Stats](#send-queue-and-traffic-stats)). |
+| `stats()` | `ClientStats` | Cumulative `game_data_sent` / `game_data_received` / `messages_undecodable` counters (see [Send Queue and Traffic Stats](#send-queue-and-traffic-stats)). |
 
 !!! note "No async accessors"
     Unlike `SignalFishClient`, all `SignalFishPollingClient` accessors are

--- a/docs/client.md
+++ b/docs/client.md
@@ -63,7 +63,7 @@ use signal_fish_client::{SignalFishConfig, protocol::GameDataEncoding};
 
 let config = SignalFishConfig {
     app_id: "mb_app_abc123".into(),
-    sdk_version: Some("0.6.0".into()),
+    sdk_version: Some("0.7.0".into()),
     platform: Some("rust".into()),
     game_data_format: Some(GameDataEncoding::Json),
     ..SignalFishConfig::new("mb_app_abc123")

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -159,7 +159,7 @@ while let Some(event) = events.recv().await {
         SignalFishEvent::RoomJoined { room_code, current_players, .. } => {
             println!("Joined room {room_code} with {} players", current_players.len());
         }
-        SignalFishEvent::Disconnected { reason } => {
+        SignalFishEvent::Disconnected { reason, .. } => {
             println!("Disconnected: {reason:?}");
             break;
         }
@@ -170,13 +170,14 @@ while let Some(event) = events.recv().await {
 
 ### Synthetic vs. Server Events
 
-Most events correspond 1:1 to a server message. Two **synthetic** events are
-generated locally by the transport layer:
+Most events correspond 1:1 to a server message. Three **synthetic** events
+are generated locally by the transport layer:
 
 | Event | Origin |
 |-------|--------|
 | `SignalFishEvent::Connected` | Emitted when the transport opens, before any server message. |
-| `SignalFishEvent::Disconnected { reason }` | Emitted when the transport closes or errors. Last event (best-effort). |
+| `SignalFishEvent::Disconnected { reason, .. }` | Emitted when the transport closes or errors. Last event (best-effort). |
+| `SignalFishEvent::DecodeFailed { .. }` | Emitted when an inbound frame fails to decode; the connection stays open. See [Events](events.md#decodefailed). |
 
 !!! note "Lossless delivery with backpressure"
     Events are **never dropped**. The event channel has a default capacity of

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -385,7 +385,7 @@ directly from client methods as `Result<(), SignalFishError>`.
 
 ### Server-Side: `ErrorCode`
 
-`ErrorCode` is a 48-variant enum that arrives inside events. The server sends
+`ErrorCode` is a 50-variant enum that arrives inside events. The server sends
 these as `SCREAMING_SNAKE_CASE` strings (e.g., `"ROOM_NOT_FOUND"`).
 
 ```rust,ignore

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -180,7 +180,7 @@ are generated locally by the transport layer:
 | `SignalFishEvent::DecodeFailed { .. }` | Emitted when an inbound frame fails to decode; the connection stays open. See [Events](events.md#decodefailed). |
 
 !!! note "Lossless delivery with backpressure"
-    Events are **never dropped**. The event channel has a default capacity of
+    Events are **never dropped on overflow**. The event channel has a default capacity of
     **256** (configurable via `SignalFishConfig::event_channel_capacity`); if
     your consumer falls behind, the transport loop pauses reading from the
     transport until the channel has room, so backpressure propagates to the
@@ -263,7 +263,8 @@ guarantee, backpressure toward senders, slow-consumer eviction, and the
 measured capacity envelope — is documented in
 [Delivery Contract & Backpressure](delivery.md).
 
-Because the client is lossless, loss elsewhere becomes observable. `stats()`
+Because the client applies backpressure instead of dropping events on
+overflow, loss elsewhere becomes observable. `stats()`
 returns [`ClientStats`](client.md) with cumulative `game_data_sent` /
 `game_data_received` / `messages_undecodable` counters (they survive
 disconnects): exchange or log them across peers, and a persistent

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -186,10 +186,12 @@ are generated locally by the transport layer:
     transport until the channel has room, so backpressure propagates to the
     server instead of losing events. The capacity only controls how much
     buffering the consumer gets before that backpressure kicks in. An event
-    can only be missed if the receiver is dropped, a shutdown timeout aborts
-    the transport task, or the client handle is dropped without calling
-    `shutdown()` (see [Events](events.md)). A responsive event
-    loop keeps the connection flowing; a stalled one stalls the transport.
+    can only be missed if the receiver is dropped, if the client handle is
+    dropped without calling `shutdown()`, or on `shutdown()` — which delivers
+    the terminal `Disconnected` best-effort and may drop it if the channel is
+    full (see [Events](events.md); the channel closing is the guaranteed
+    end-of-stream signal). A responsive event loop keeps the connection
+    flowing; a stalled one stalls the transport.
 
 ---
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -245,18 +245,27 @@ Putting the two halves together, the client **never silently drops data** in
 either direction:
 
 - **Inbound:** events are delivered with backpressure — a lagging consumer
-  pauses the transport loop; nothing is lost.
+  pauses the transport loop; nothing is lost. Frames that fail to decode
+  (an unknown message type or error code from a newer server, malformed
+  JSON) surface as [`DecodeFailed`](events.md#decodefailed) events instead
+  of being skipped.
 - **Outbound:** queue admission is never silent — congestion surfaces as
   `SendBufferFull` (fail-fast methods) or as waiting (`*_reliable` methods),
   never as an unbounded backlog. Note that *queued* is not *delivered*:
   commands still in the queue when the connection ends are discarded with
   it, surfaced by the `Disconnected` event.
 
+The server's half of the story — the relay's reliable-and-ordered
+guarantee, backpressure toward senders, slow-consumer eviction, and the
+measured capacity envelope — is documented in
+[Delivery Contract & Backpressure](delivery.md).
+
 Because the client is lossless, loss elsewhere becomes observable. `stats()`
 returns [`ClientStats`](client.md) with cumulative `game_data_sent` /
-`game_data_received` counters (they survive disconnects): exchange or log
-them across peers, and a persistent sent-vs-received deficit points at the
-relay path or a peer — not at this client. Pace high-rate streams with
+`game_data_received` / `messages_undecodable` counters (they survive
+disconnects): exchange or log them across peers, and a persistent
+sent-vs-received deficit points at the relay path or a peer — not at this
+client. Pace high-rate streams with
 `send_game_data_reliable` instead of guessing at sleep durations — but drain
 events from a separate task while awaiting it: the queue only drains while
 the transport loop runs, and the loop pauses when the event channel is full,

--- a/docs/delivery.md
+++ b/docs/delivery.md
@@ -138,4 +138,4 @@ including the eviction farewell) arrive, followed by `Disconnected`.
 | Knob | Default | Raise it when… |
 |------|---------|----------------|
 | `event_channel_capacity` | 256 | your consumer has bursty frame times (GC pauses, loading screens) and you want more absorption before socket-read backpressure engages. Capacity does not fix a consumer that is *sustainably* slower than the room's send rate — nothing client-side can. |
-| `command_channel_capacity` | 1024 | you emit large synchronized bursts and prefer queueing to `SendBufferFull` refusals. The queue only drains at socket speed; deeper queues mean staler data, not more throughput. |
+| `command_channel_capacity` | 1024 | you emit large synchronized bursts and prefer queuing to `SendBufferFull` refusals. The queue only drains at socket speed; deeper queues mean staler data, not more throughput. |

--- a/docs/delivery.md
+++ b/docs/delivery.md
@@ -1,0 +1,141 @@
+# Delivery Contract & Backpressure
+
+What actually happens to a message between `send_game_data(...)` on one
+client and the event receiver on another — including what happens when a
+consumer falls behind. This page documents the **end-to-end** contract
+(client + server), not just this SDK's half of it.
+
+Numbers on this page were measured against a local signal-fish-server
+built from commit `851c446` (the "never silently drop relayed messages"
+delivery rework) with the repository's
+[`load_lab`](examples.md#load-lab-measurement-harness) example. Localhost figures are lower bounds —
+real networks add RTT — but the *shapes* (where queues form, who waits,
+who gets evicted) are configuration-driven and transfer directly.
+
+## The pipeline
+
+```text
+your code ──► bounded command queue (1024) ──► WebSocket ──► server
+                                                             │ per-recipient
+                                                             │ FIFO queue (1024)
+                                                             ▼
+your code ◄── bounded event channel (256) ◄── WebSocket ◄── batcher (10 / 16 ms)
+```
+
+Every hop is bounded, and no hop drops silently:
+
+- **Send side (this SDK):** `send_game_data` fails fast with
+  [`SendBufferFull`](errors.md#handling-sendbufferfull) when the command
+  queue is full; `send_game_data_reliable` waits for space. *Queued is not
+  delivered* — commands still in the queue when the connection ends are
+  discarded with it (surfaced by `Disconnected`).
+- **Relay (server):** relayed messages are delivered **reliably and in
+  order per connection**. A recipient whose queue is full applies
+  backpressure to senders; a recipient that cannot absorb a single message
+  for the whole `slow_consumer_timeout_ms` grace window (default **5000**)
+  is disconnected with a best-effort `SLOW_CONSUMER` error frame. The
+  server never drops a relayed message except together with the connection
+  itself.
+- **Receive side (this SDK):** events are delivered losslessly with
+  backpressure; a consumer that stops draining stops the socket being read
+  (the server then sees *you* as the slow consumer). Undecodable frames
+  surface as [`DecodeFailed`](events.md#decodefailed) events.
+
+## What a slow-consumer eviction looks like from here
+
+When the server evicts this client, it writes a best-effort
+`Error { error_code: SlowConsumer }` farewell and then closes the socket
+**bare** — no WebSocket close code. Measured outcomes (queue=8,
+timeout=500ms, 8 KiB payloads; wedged consumer resumed after eviction):
+
+| Signal | Observed |
+|--------|----------|
+| `Error { SlowConsumer }` event | **Arrived** — the farewell sat in the kernel receive buffer and surfaced once draining resumed. It may be lost when buffers are truly full; treat it as best-effort. |
+| `Disconnected.last_server_error` | Carried the farewell (`SlowConsumer` + message) whenever the farewell arrived. |
+| `Disconnected.reason` | `None` — the server sends no close code today, so a bare stream end is all the transport sees. |
+
+Handle it like this:
+
+```rust,ignore
+SignalFishEvent::Disconnected { reason, last_server_error } => {
+    if let Some(info) = &last_server_error {
+        if info.error_code == Some(ErrorCode::SlowConsumer) {
+            // We weren't draining events fast enough and got evicted.
+            // Slow down consumption work, raise event_channel_capacity,
+            // or move heavy per-event work off the draining task —
+            // then reconnect and rejoin.
+        }
+    }
+}
+```
+
+## Reconnect: what survives, what doesn't
+
+The server keeps a reconnection record (room membership snapshot) for
+`reconnection_window` (default 300 s) after an unexpected disconnect —
+**but no wire message ever carries the reconnection token**, so
+`reconnect(player_id, room_id, token)` cannot legitimately succeed today
+(measured: an empty token is rejected with `RECONNECTION_TOKEN_INVALID`),
+and `Reconnected.missed_events` is always empty on this server. Treat a
+disconnect as a fresh session: connect, authenticate, `join_room` with the
+same room code, and resynchronize state at the application level.
+
+## Capacity: what the relay sustains (measured)
+
+Localhost, 1 sender → 3 recipients, all draining promptly, default server
+config. `load_lab throughput` sweep; latency is send-timestamp →
+receive-drain on one clock:
+
+| Payload | Offered rate | Delivered | p50 | p99 |
+|---------|--------------|-----------|-----|-----|
+| 256 B | 50–1600 msg/s | **100% at every rate** | 5–10 ms | 16–49 ms |
+| 1 KiB | 50–1600 msg/s | 100% | 15–45 ms | 63–107 ms |
+| 16 KiB | 50–800 msg/s | 100% | 10–26 ms | 22–91 ms |
+| 16 KiB | 1600 msg/s (~78 MB/s fan-out) | ~99.9% accepted, delivered completely | 5.7 ms | 167 ms |
+
+The latency floor is dominated by the server's write batching
+(`batch_size` 10 / `batch_interval_ms` 16). **Healthy rooms are not the
+hazard — slow consumers are:**
+
+| Scenario (measured) | Result |
+|---------------------|--------|
+| One peer drains at 10 msg/s in a 120 msg/s room (default queue 1024, 25 s) | The slow peer's data ages to **22.9 s stale**; it is **never evicted** (eviction requires drain < 1 message per 5 s); nobody is notified. |
+| Same, `send_queue_capacity=64`, 4 KiB payloads, 30 s | The **healthy** peers' latency climbs to **p95 5.4 s / p99 6.6 s** — a room broadcast waits on its slowest recipient, so one slow member paces everyone. |
+| Backlogged recipient sends Pings during a flood | **1 of 15 Pongs arrived in 15 s** (the pre-backlog one, 3.8 ms; baseline p50 3.6 ms). Control messages share the single per-connection FIFO with game data. |
+
+Practical guidance:
+
+- **Drain events on a dedicated task** and keep per-event work minimal —
+  the [wedged-consumer hazard](#the-wedged-consumer-hazard) below is the
+  single most damaging client-side failure mode.
+- Pace bulk sends with `send_game_data_reliable` and watch
+  [`send_capacity()`](client.md) shrink as the congestion signal.
+- Compare [`stats()`](client.md#send-queue-and-traffic-stats) counters across peers to detect
+  relay-path anomalies; watch `messages_undecodable` for protocol drift.
+- For loss-tolerant, latency-critical traffic (rollback-netcode inputs,
+  position streams), the relay's reliable-and-ordered semantics work
+  against you: a slow recipient converts your freshest packets into a
+  backlog of stale ones. Prefer the [v3 mesh](mesh-guide.md) and WebRTC
+  unreliable data channels for that traffic — the relay is the control
+  plane and universal fallback. Note that `send_game_data` **always** uses
+  the relay, even when a mesh session is established; mesh traffic goes
+  through your `WebRtcDriver`'s data channels (`MeshController::send_to`).
+
+## The wedged-consumer hazard
+
+If your event consumer stops draining **forever**, the transport loop
+blocks delivering the next event, stops reading the socket, and the server
+eventually evicts you (`SLOW_CONSUMER`) — but the wedged client cannot
+observe the eviction (it is not reading), so from the inside the session
+just goes quiet. As of 0.7.0, [`shutdown()`](client.md#shutdown) preempts
+the wedge: it abandons at most the one in-flight event delivery, closes
+the transport cleanly, and completes without waiting for the timeout
+abort. If draining ever resumes instead, the buffered events (often
+including the eviction farewell) arrive, followed by `Disconnected`.
+
+## Sizing the channels
+
+| Knob | Default | Raise it when… |
+|------|---------|----------------|
+| `event_channel_capacity` | 256 | your consumer has bursty frame times (GC pauses, loading screens) and you want more absorption before socket-read backpressure engages. Capacity does not fix a consumer that is *sustainably* slower than the room's send rate — nothing client-side can. |
+| `command_channel_capacity` | 1024 | you emit large synchronized bursts and prefer queueing to `SendBufferFull` refusals. The queue only drains at socket speed; deeper queues mean staler data, not more throughput. |

--- a/docs/delivery.md
+++ b/docs/delivery.md
@@ -36,10 +36,11 @@ Every hop is bounded, and no hop drops silently:
   is disconnected with a best-effort `SLOW_CONSUMER` error frame. The
   server never drops a relayed message except together with the connection
   itself.
-- **Receive side (this SDK):** events are delivered losslessly with
-  backpressure; a consumer that stops draining stops the socket being read
-  (the server then sees *you* as the slow consumer). Undecodable frames
-  surface as [`DecodeFailed`](events.md#decodefailed) events.
+- **Receive side (this SDK):** events are delivered with backpressure (never
+  dropped merely because the consumer is behind); a consumer that stops
+  draining stops the socket being read (the server then sees *you* as the slow
+  consumer). Undecodable frames surface as
+  [`DecodeFailed`](events.md#decodefailed) events.
 
 ## What a slow-consumer eviction looks like from here
 

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -72,7 +72,7 @@ fn try_join(client: &SignalFishClient) {
 
 ## `ErrorCode`
 
-`ErrorCode` is a protocol-level enum with **48 variants** representing
+`ErrorCode` is a protocol-level enum with **50 variants** representing
 structured error codes returned by the Signal Fish server. It derives `Debug`,
 `Clone`, `PartialEq`, `Eq`, `Serialize`, and `Deserialize`.
 
@@ -198,6 +198,13 @@ that the server could not honor. See the [Mesh Guide](mesh-guide.md).
 | Variant | Description |
 |---------|-------------|
 | `ConnectionIdleTimeout` | The connection was closed by the server after being idle for too long. |
+
+### Delivery & Liveness (2)
+
+| Variant | Description |
+|---------|-------------|
+| `SlowConsumer` | The server evicted this connection because its outbound queue stayed full past the slow-consumer grace window (5 s by default): the client was not draining messages fast enough. The farewell frame carrying this code is written best-effort into an already-congested socket, so it may never arrive — a bare disconnect can be the only observable signal. |
+| `ActivityTimeout` | The server closed the connection after prolonged protocol inactivity. Send periodic pings to keep the connection alive. |
 
 !!! note "The six new v3 *server* codes vs. `SignalFishError::ProtocolUnsupported`"
     The five `Signal*` codes plus `ConnectionIdleTimeout` are **server-sent**

--- a/docs/events.md
+++ b/docs/events.md
@@ -55,13 +55,17 @@ Use these to track the raw connection lifecycle.
 | `reason` | `Option<String>` | Human-readable close explanation. When the transport captured a WebSocket Close frame with a reason, it appears as `"closed by server: …"`. The current server closes bare, so this is usually `None` for server-initiated closes. |
 | `last_server_error` | `Option<ServerErrorInfo>` | The most recent `Error`/`AuthenticationError` received on this connection — a correlation aid for attributing the disconnect. A server that evicts a slow consumer writes a best-effort `Error { error_code: SlowConsumer }` farewell before closing; when that frame arrives, it shows up here. See the [Delivery Contract](delivery.md). |
 
-!!! note "Best-effort delivery on shutdown"
-    Like every event, `Disconnected` is never dropped due to channel
-    backpressure. It is delivered best-effort only in the sense that it may
-    be missed if the event receiver is dropped, if the client handle is
-    dropped without calling `shutdown()`, or if the event channel happens to
-    be full at the instant an explicit [`shutdown()`](client.md#shutdown)
-    completes — the channel closing then signals the end of the stream.
+!!! note "Delivery of the terminal `Disconnected`"
+    During normal operation `Disconnected` is delivered with backpressure
+    like every other event — it is not dropped merely because the consumer
+    is briefly behind. When the connection ends while a
+    [`shutdown()`](client.md#shutdown) is pending (or the handle is dropped),
+    the terminal `Disconnected` is delivered **best-effort**: the transport
+    loop races the shutdown signal so it can exit promptly, and if the event
+    channel is full at that moment the event **may be dropped** (it is sent
+    with a non-blocking `try_send`). The event channel closing (`recv()`
+    returns `None`) is the guaranteed end-of-stream signal — rely on it, not
+    on always observing a final `Disconnected`.
 
 ### `DecodeFailed`
 

--- a/docs/events.md
+++ b/docs/events.md
@@ -1,17 +1,17 @@
 # Events Reference
 
-Every message from the Signal Fish server — plus two synthetic transport-layer
-signals — is delivered as a [`SignalFishEvent`] variant through the event
-receiver returned by [`SignalFishClient::start`].
+Every message from the Signal Fish server — plus three synthetic
+transport-layer signals — is delivered as a [`SignalFishEvent`] variant
+through the event receiver returned by [`SignalFishClient::start`].
 
-This page documents all **30 variants** grouped by category, with field
+This page documents all **31 variants** grouped by category, with field
 descriptions and usage examples.
 
 !!! info "Protocol v2 relay + v3 mesh"
     Four variants — [`SessionPlan`](#mesh-events-protocol-v3),
     `NewPeer`, `SignalReceived`, and `PeerTransportStatus` — only arrive on a
     **v3-negotiated** connection (opt in with `SignalFishConfig::enable_mesh()`).
-    The other 26 are available on every connection, including the v2 relay floor.
+    The other 27 are available on every connection, including the v2 relay floor.
     See [Protocol Versioning](protocol-versioning.md) and the
     [Mesh Guide](mesh-guide.md).
 
@@ -24,11 +24,16 @@ descriptions and usage examples.
     (default **256**, via `SignalFishConfig::event_channel_capacity`), and a
     consumer that falls behind pauses the transport loop until the channel
     has room — backpressure propagates to the server instead of losing
-    events. There are exactly three ways an event can be missed — each one
-    stops delivery entirely; there is never selective loss: the event
-    receiver is dropped, a [`shutdown()`](client.md#shutdown) timeout aborts
-    the transport task, or the client handle is dropped without calling
-    `shutdown()` (which aborts the loop immediately).
+    events. Inbound frames that fail to decode surface as
+    [`DecodeFailed`](#decodefailed) events rather than being skipped. There
+    are exactly three ways an event can be missed — each one stops delivery
+    entirely; there is never selective loss: the event receiver is dropped,
+    the client handle is dropped without calling
+    [`shutdown()`](client.md#shutdown) (which aborts the loop immediately),
+    or `shutdown()` is invoked — a shutdown abandons at most the one event
+    delivery it interrupted, closes the transport gracefully, and delivers
+    the terminal `Disconnected` best-effort (the event channel closing is
+    the authoritative end-of-stream signal).
 
 ---
 
@@ -40,22 +45,54 @@ Use these to track the raw connection lifecycle.
 | Variant | Fields | Description |
 |---------|--------|-------------|
 | `Connected` | — | The transport handshake is complete and the client is ready to communicate. Synthetic — see [Connection timing](wasm.md#connection-timing) for details. |
-| `Disconnected` | `reason: Option<String>` | The transport connection was closed or errored. |
+| `Disconnected` | `reason: Option<String>`, `last_server_error: Option<ServerErrorInfo>` | The transport connection was closed or errored. |
+| `DecodeFailed` | `message_type: Option<String>`, `error: String`, `raw_prefix: String` | An inbound frame could not be decoded into a `ServerMessage`; the connection stays open. |
+
+### `Disconnected`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `reason` | `Option<String>` | Human-readable close explanation. When the transport captured a WebSocket Close frame with a reason, it appears as `"closed by server: …"`. The current server closes bare, so this is usually `None` for server-initiated closes. |
+| `last_server_error` | `Option<ServerErrorInfo>` | The most recent `Error`/`AuthenticationError` received on this connection — a correlation aid for attributing the disconnect. A server that evicts a slow consumer writes a best-effort `Error { error_code: SlowConsumer }` farewell before closing; when that frame arrives, it shows up here. See the [Delivery Contract](delivery.md). |
 
 !!! note "Best-effort delivery on shutdown"
     Like every event, `Disconnected` is never dropped due to channel
     backpressure. It is delivered best-effort only in the sense that it may
-    be missed if the event receiver is dropped, if
-    [`shutdown()`](client.md#shutdown) times out and aborts the transport
-    task, or if the client handle is dropped without calling `shutdown()`.
+    be missed if the event receiver is dropped, if the client handle is
+    dropped without calling `shutdown()`, or if the event channel happens to
+    be full at the instant an explicit [`shutdown()`](client.md#shutdown)
+    completes — the channel closing then signals the end of the stream.
+
+### `DecodeFailed`
+
+Emitted when an inbound frame fails to deserialize — an unknown message
+`type` from a newer server, an unknown `error_code` string inside a known
+message, a proxy injecting non-protocol frames, or corruption. The
+connection stays open and later frames are unaffected; each occurrence also
+increments [`ClientStats::messages_undecodable`](client.md#send-queue-and-traffic-stats).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `message_type` | `Option<String>` | The wire `type` tag when the frame was valid JSON. `Some("Error")` plus a decode failure strongly implies an unknown `error_code`; `None` means the frame was not valid JSON at all. |
+| `error` | `String` | The deserialization error text. |
+| `raw_prefix` | `String` | The raw frame, truncated to `DECODE_FAILED_RAW_PREFIX_MAX` (512) bytes on a UTF-8 boundary. |
+
+Steady growth of `messages_undecodable` means protocol drift (upgrade this
+SDK) or a corrupting middlebox — log `DecodeFailed` in production builds.
 
 ```rust,ignore
 match event {
     SignalFishEvent::Connected => {
         println!("Transport connected — waiting for authentication…");
     }
-    SignalFishEvent::Disconnected { reason } => {
-        println!("Disconnected: {}", reason.as_deref().unwrap_or("unknown"));
+    SignalFishEvent::Disconnected { reason, last_server_error } => {
+        println!(
+            "Disconnected: {} (last server error: {last_server_error:?})",
+            reason.as_deref().unwrap_or("unknown"),
+        );
+    }
+    SignalFishEvent::DecodeFailed { message_type, error, .. } => {
+        eprintln!("undecodable frame (type {message_type:?}): {error}");
     }
     _ => {}
 }

--- a/docs/events.md
+++ b/docs/events.md
@@ -623,7 +623,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
 
             // ── Disconnection ───────────────────────────────────
-            SignalFishEvent::Disconnected { reason } => {
+            SignalFishEvent::Disconnected { reason, .. } => {
                 println!("Disconnected: {}",
                     reason.as_deref().unwrap_or("unknown"));
                 break;

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -102,7 +102,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     SignalFishEvent::Error { message, error_code } => {
                         tracing::error!("Server error [{error_code:?}]: {message}");
                     }
-                    SignalFishEvent::Disconnected { reason } => {
+                    SignalFishEvent::Disconnected { reason, .. } => {
                         tracing::warn!("Disconnected: {}", reason.as_deref().unwrap_or("unknown"));
                         break;
                     }
@@ -285,7 +285,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             SignalFishEvent::Authenticated { app_name, .. } => {
                 println!("Event: Authenticated — app_name={app_name}");
             }
-            SignalFishEvent::Disconnected { reason } => {
+            SignalFishEvent::Disconnected { reason, .. } => {
                 println!("Event: Disconnected — {}", reason.as_deref().unwrap_or("clean"));
                 break;
             }
@@ -597,7 +597,7 @@ impl INode for SignalFishNode {
                 SignalFishEvent::GameData { data, from_player, .. } => {
                     godot_print!("Game data from {}: {}", from_player, data);
                 }
-                SignalFishEvent::Disconnected { reason } => {
+                SignalFishEvent::Disconnected { reason, .. } => {
                     godot_print!(
                         "Disconnected: {}",
                         reason.as_deref().unwrap_or("unknown")

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -670,3 +670,34 @@ cargo +nightly build -Zbuild-std \
 ```
 
 The resulting `.wasm` file is used by Godot's HTML5 export template.
+
+---
+
+## Load Lab (measurement harness)
+
+[`examples/load_lab.rs`](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/blob/main/examples/load_lab.rs)
+is a CSV-emitting measurement harness for running controlled relay
+experiments against a **local** Signal Fish server — the tool behind the
+numbers in [Delivery Contract & Backpressure](delivery.md).
+
+```sh
+# Run a local server in open lab mode first:
+#   SIGNAL_FISH__SECURITY__REQUIRE_WEBSOCKET_AUTH=false \
+#   SIGNAL_FISH__SECURITY__REQUIRE_METRICS_AUTH=false \
+#   SIGNAL_FISH__PROTOCOL__SDK_COMPATIBILITY__ENFORCE=false \
+#   signal-fish-server
+
+cargo run --example load_lab --features transport-websocket -- ping
+cargo run --example load_lab --features transport-websocket -- \
+    throughput rates=50,100,200,400 payload=1024 recipients=3
+cargo run --example load_lab --features transport-websocket -- \
+    slow-consumer rate=120 drain_ms=100
+cargo run --example load_lab --features transport-websocket -- \
+    control-starvation drain_ms=5
+```
+
+Four modes: `ping` (baseline RTT), `throughput` (offered-rate sweep with
+latency percentiles), `slow-consumer` (one slow-draining room member —
+measures how much it paces the sender and the healthy recipients), and
+`control-starvation` (Pong RTT at a backlogged recipient). Never point it
+at a production deployment you don't own.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -536,7 +536,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 godot = "0.3"
-signal-fish-client = { version = "0.6.0", default-features = false, features = ["transport-websocket-emscripten"] }
+signal-fish-client = { version = "0.7.0", default-features = false, features = ["transport-websocket-emscripten"] }
 serde_json = "1.0"  # Required for send_game_data(serde_json::Value)
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -31,14 +31,14 @@ cargo add signal-fish-client
 
 ```toml
 [dependencies]
-signal-fish-client = "0.6.0"
+signal-fish-client = "0.7.0"
 ```
 
 #### Without default features (bring your own transport)
 
 ```toml
 [dependencies]
-signal-fish-client = { version = "0.6.0", default-features = false }
+signal-fish-client = { version = "0.7.0", default-features = false }
 ```
 
 !!! tip
@@ -48,7 +48,7 @@ signal-fish-client = { version = "0.6.0", default-features = false }
 
 ```toml
 [dependencies]
-signal-fish-client = { version = "0.6.0", default-features = false, features = ["transport-websocket-emscripten"] }
+signal-fish-client = { version = "0.7.0", default-features = false, features = ["transport-websocket-emscripten"] }
 ```
 
 !!! tip
@@ -120,7 +120,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 !!! note
     `WebSocketTransport` requires the `transport-websocket` feature, which is enabled by default. If you disabled default features you will need to re-enable it explicitly:
     ```toml
-    signal-fish-client = { version = "0.6.0", default-features = false, features = ["transport-websocket"] }
+    signal-fish-client = { version = "0.7.0", default-features = false, features = ["transport-websocket"] }
     ```
 
 ## What Happens Under the Hood

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -134,15 +134,16 @@ When you call `SignalFishClient::start`, the SDK:
 You interact with the server by calling methods on the `SignalFishClient` handle (e.g., `join_room`, `send_game_data`). These enqueue outgoing messages on a bounded queue that the background task drains over the transport; if you outpace the transport, sends fail fast with `SendBufferFull` instead of silently dropping (see [Core Concepts](concepts.md#non-blocking-command-sending)).
 
 !!! note
-    Events are **never dropped**. If your event-processing loop cannot keep up
-    with the server, the transport loop pauses until the channel has room —
-    backpressure propagates to the server instead of losing events. An event
-    can only be missed if the receiver is dropped, the client handle is
-    dropped without calling `shutdown()`, or
-    [`shutdown()`](client.md#shutdown) times out. Keep your handler responsive
-    so the connection keeps flowing; `event_channel_capacity` on your
-    `SignalFishConfig` controls how much buffering you get before
-    backpressure kicks in.
+    Events are **never dropped on overflow**. If your event-processing loop
+    cannot keep up with the server, the transport loop pauses until the channel
+    has room — backpressure propagates to the server instead of losing events.
+    An event can only be missed if the receiver is dropped, the client handle
+    is dropped without calling `shutdown()`, or on
+    [`shutdown()`](client.md#shutdown) — which delivers the terminal
+    `Disconnected` best-effort and may drop at most one in-flight event. Keep
+    your handler responsive so the connection keeps flowing;
+    `event_channel_capacity` on your `SignalFishConfig` controls how much
+    buffering you get before backpressure kicks in.
 
 ## Next Steps
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -75,7 +75,7 @@ async fn main() -> Result<(), signal_fish_client::SignalFishError> {
 !!! tip "Feature flag"
     `WebSocketTransport` requires the **`transport-websocket`** feature, which is enabled by default. If you disabled default features, re-enable it explicitly:
     ```toml
-    signal-fish-client = { version = "0.6.0", features = ["transport-websocket"] }
+    signal-fish-client = { version = "0.7.0", features = ["transport-websocket"] }
     ```
 
 ---

--- a/docs/mesh-guide.md
+++ b/docs/mesh-guide.md
@@ -11,7 +11,7 @@ drive the whole handshake for you.
     `tokio-runtime` feature.
 
     ```toml
-    signal-fish-client = { version = "0.6.0", features = ["mesh"] }
+    signal-fish-client = { version = "0.7.0", features = ["mesh"] }
     ```
 
 ---

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -82,7 +82,7 @@ pub enum GameDataEncoding {
 |---------|-----------|-------------|
 | `Json` | `"json"` | JSON payloads delivered over text frames (default). |
 | `MessagePack` | `"message_pack"` | MessagePack binary payloads delivered over binary frames. |
-| `Rkyv` | `"rkyv"` | Rkyv zero-copy binary format for maximum performance. |
+| `Rkyv` | `"rkyv"` | Rkyv zero-copy binary format. **Reserved:** the current server never negotiates rkyv — requesting it silently downgrades to JSON. |
 
 ---
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -649,7 +649,7 @@ Every message on the wire is a JSON object with two top-level keys:
         "type": "Authenticate",
         "data": {
             "app_id": "mb_app_abc123",
-            "sdk_version": "0.6.0"
+            "sdk_version": "0.7.0"
         }
     }
     ```

--- a/docs/transport.md
+++ b/docs/transport.md
@@ -8,7 +8,8 @@ of the SDK — and the built-in `WebSocketTransport` that ships with the crate.
 ## The `Transport` Trait
 
 Every transport used by `SignalFishClient` must implement the `Transport` trait.
-It defines three async methods for bidirectional text messaging:
+It defines three async methods for bidirectional text messaging, plus two
+defaulted introspection methods:
 
 ```rust,ignore
 #[async_trait]
@@ -16,6 +17,10 @@ pub trait Transport: Send + 'static {
     async fn send(&mut self, message: String) -> Result<(), SignalFishError>;
     async fn recv(&mut self) -> Option<Result<String, SignalFishError>>;
     async fn close(&mut self) -> Result<(), SignalFishError>;
+
+    // Defaulted — override when your transport can do better.
+    fn is_ready(&self) -> bool { true }
+    fn close_reason(&self) -> Option<String> { None }
 }
 ```
 
@@ -44,6 +49,17 @@ outcomes are:
 
 The client's internal event loop uses `None` to detect a graceful server
 shutdown and emit a `SignalFishEvent::Disconnected` event.
+
+### `close_reason()`
+
+After `recv()` returns `None`, the clients consult
+`close_reason()` to enrich `Disconnected::reason` (as
+`"closed by server: …"`). The default implementation returns `None` —
+correct for transports with no close metadata. `WebSocketTransport`
+overrides it to expose the peer's Close frame text (code + reason) when one
+was received; a bare close (what the Signal Fish server sends today)
+still yields `None`. Custom transports whose protocol carries a close
+explanation should override this so disconnects stay attributable.
 
 ### Cancel Safety
 

--- a/docs/wasm.md
+++ b/docs/wasm.md
@@ -113,7 +113,7 @@ Enable the `transport-websocket-emscripten` feature to access
 
 ```toml
 [dependencies]
-signal-fish-client = { version = "0.6.0", default-features = false, features = ["transport-websocket-emscripten"] }
+signal-fish-client = { version = "0.7.0", default-features = false, features = ["transport-websocket-emscripten"] }
 ```
 
 ### Building
@@ -356,7 +356,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 godot = "0.3"
-signal-fish-client = { version = "0.6.0", default-features = false, features = ["transport-websocket-emscripten"] }
+signal-fish-client = { version = "0.7.0", default-features = false, features = ["transport-websocket-emscripten"] }
 serde_json = "1.0"  # Required for send_game_data(serde_json::Value)
 ```
 

--- a/docs/wasm.md
+++ b/docs/wasm.md
@@ -423,7 +423,7 @@ impl INode for SignalFishNode {
                 SignalFishEvent::GameStarting { peer_connections } => {
                     godot_print!("Game starting with {} peers", peer_connections.len());
                 }
-                SignalFishEvent::Disconnected { reason } => {
+                SignalFishEvent::Disconnected { reason, .. } => {
                     godot_print!(
                         "Disconnected: {}",
                         reason.as_deref().unwrap_or("unknown")

--- a/examples/basic_lobby.rs
+++ b/examples/basic_lobby.rs
@@ -198,7 +198,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     }
 
                     // ── Disconnect ───────────────────────────────────
-                    SignalFishEvent::Disconnected { reason } => {
+                    SignalFishEvent::Disconnected { reason, .. } => {
                         tracing::warn!("Disconnected: {}", reason.as_deref().unwrap_or("unknown"));
                         break;
                     }

--- a/examples/custom_transport.rs
+++ b/examples/custom_transport.rs
@@ -149,7 +149,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             SignalFishEvent::Authenticated { app_name, .. } => {
                 tracing::info!("Event: Authenticated — app_name={app_name}");
             }
-            SignalFishEvent::Disconnected { reason } => {
+            SignalFishEvent::Disconnected { reason, .. } => {
                 tracing::info!(
                     "Event: Disconnected — {}",
                     reason.as_deref().unwrap_or("clean")

--- a/examples/load_lab.rs
+++ b/examples/load_lab.rs
@@ -265,7 +265,7 @@ async fn mode_throughput(opts: &Options) -> Result<(), Box<dyn Error>> {
     );
     for &rate in &opts.rates {
         let suffix = format!("{}-{rate}", std::process::id());
-        let game = format!("lab-thr-{suffix}");
+        let game = format!("lab-throughput-{suffix}");
 
         let (sender, mut sender_events) = connect(opts, "sender", 1024).await?;
         let room_code = join(&sender, &mut sender_events, &game, "sender", None).await?;
@@ -433,7 +433,7 @@ async fn mode_control_starvation(opts: &Options) -> Result<(), Box<dyn Error>> {
     });
 
     // Victim: drains slowly (drain_ms per GameData) and pings periodically.
-    // Pong RTT includes both the server-side queueing behind relayed
+    // Pong RTT includes both the server-side queuing behind relayed
     // GameData and the victim's own backlog — the end-to-end control-plane
     // delay a slow-but-alive client actually experiences.
     let mut pong_rtts: Vec<f64> = Vec::new();

--- a/examples/load_lab.rs
+++ b/examples/load_lab.rs
@@ -1,0 +1,505 @@
+//! Load & latency lab for the Signal Fish relay path.
+//!
+//! A small measurement harness for running controlled experiments against a
+//! **real** Signal Fish server (never run it against a production deployment
+//! you don't own). Produces CSV on stdout for analysis.
+//!
+//! ```text
+//! cargo run --example load_lab --features transport-websocket -- <mode> [key=value ...]
+//!
+//! modes
+//!   ping                 baseline Ping→Pong RTT on an idle connection
+//!   throughput           offered-rate sweep: accepted/delivered rates + latency knee
+//!   slow-consumer        one slow-draining room member; measures how much it
+//!                        paces the sender and the healthy recipients
+//!   control-starvation   Pong RTT at a backlogged recipient vs baseline
+//!
+//! common options (defaults)
+//!   url=ws://127.0.0.1:3536/v2/ws   app=load-lab-app   payload=256   secs=10
+//! throughput options
+//!   rates=50,100,200,400,800,1600   recipients=3
+//! slow-consumer options
+//!   rate=120   drain_ms=100
+//! control-starvation options
+//!   drain_ms=5   ping_every_ms=1000
+//! ```
+//!
+//! The server must accept the app id (run it with
+//! `SIGNAL_FISH__SECURITY__REQUIRE_WEBSOCKET_AUTH=false` and
+//! `SIGNAL_FISH__PROTOCOL__SDK_COMPATIBILITY__ENFORCE=false` for a local lab
+//! instance). Timestamps ride inside the payload, so latency is measured on
+//! one process clock: run all roles from this single binary.
+
+use std::error::Error;
+use std::time::{Duration, Instant};
+
+use signal_fish_client::{
+    JoinRoomParams, SignalFishClient, SignalFishConfig, SignalFishEvent, WebSocketTransport,
+};
+
+// ── Options ─────────────────────────────────────────────────────────
+
+#[derive(Clone)]
+struct Options {
+    mode: String,
+    url: String,
+    app: String,
+    payload: usize,
+    secs: u64,
+    rates: Vec<u32>,
+    recipients: usize,
+    rate: u32,
+    drain_ms: u64,
+    ping_every_ms: u64,
+}
+
+impl Options {
+    fn parse(args: &[String]) -> Result<Self, Box<dyn Error>> {
+        let mode = args.first().cloned().ok_or(
+            "usage: load_lab <ping|throughput|slow-consumer|control-starvation> [key=value ...]",
+        )?;
+        let mut opts = Self {
+            mode,
+            url: "ws://127.0.0.1:3536/v2/ws".to_string(),
+            app: "load-lab-app".to_string(),
+            payload: 256,
+            secs: 10,
+            rates: vec![50, 100, 200, 400, 800, 1600],
+            recipients: 3,
+            rate: 120,
+            drain_ms: 100,
+            ping_every_ms: 1000,
+        };
+        for arg in args.iter().skip(1) {
+            let (key, value) = arg
+                .split_once('=')
+                .ok_or_else(|| format!("expected key=value, got `{arg}`"))?;
+            match key {
+                "url" => opts.url = value.to_string(),
+                "app" => opts.app = value.to_string(),
+                "payload" => opts.payload = value.parse()?,
+                "secs" => opts.secs = value.parse()?,
+                "rates" => {
+                    opts.rates = value
+                        .split(',')
+                        .map(str::parse)
+                        .collect::<Result<Vec<u32>, _>>()?;
+                }
+                "recipients" => opts.recipients = value.parse()?,
+                "rate" => opts.rate = value.parse()?,
+                "drain_ms" => opts.drain_ms = value.parse()?,
+                "ping_every_ms" => opts.ping_every_ms = value.parse()?,
+                other => return Err(format!("unknown option `{other}`").into()),
+            }
+        }
+        Ok(opts)
+    }
+}
+
+// ── Small helpers ───────────────────────────────────────────────────
+
+fn epoch() -> &'static Instant {
+    static EPOCH: std::sync::OnceLock<Instant> = std::sync::OnceLock::new();
+    EPOCH.get_or_init(Instant::now)
+}
+
+fn now_nanos() -> u64 {
+    u64::try_from(epoch().elapsed().as_nanos()).unwrap_or(u64::MAX)
+}
+
+fn payload_with_timestamp(pad: usize) -> serde_json::Value {
+    serde_json::json!({ "t": now_nanos(), "pad": "x".repeat(pad) })
+}
+
+fn latency_ms_from(data: &serde_json::Value) -> Option<f64> {
+    let sent = data.get("t")?.as_u64()?;
+    let now = now_nanos();
+    Some((now.saturating_sub(sent)) as f64 / 1_000_000.0)
+}
+
+fn percentile(sorted: &[f64], p: f64) -> f64 {
+    if sorted.is_empty() {
+        return f64::NAN;
+    }
+    let idx = ((sorted.len() as f64 - 1.0) * p).round() as usize;
+    sorted.get(idx).copied().unwrap_or(f64::NAN)
+}
+
+fn summarize(mut samples: Vec<f64>) -> (usize, f64, f64, f64, f64) {
+    samples.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let n = samples.len();
+    let max = samples.last().copied().unwrap_or(f64::NAN);
+    (
+        n,
+        percentile(&samples, 0.50),
+        percentile(&samples, 0.95),
+        percentile(&samples, 0.99),
+        max,
+    )
+}
+
+async fn connect(
+    opts: &Options,
+    name: &str,
+    event_capacity: usize,
+) -> Result<
+    (
+        SignalFishClient,
+        tokio::sync::mpsc::Receiver<SignalFishEvent>,
+    ),
+    Box<dyn Error>,
+> {
+    let transport = WebSocketTransport::connect(&opts.url).await?;
+    let config =
+        SignalFishConfig::new(opts.app.clone()).with_event_channel_capacity(event_capacity);
+    let (client, mut events) = SignalFishClient::start(transport, config);
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        match tokio::time::timeout(remaining, events.recv()).await {
+            Ok(Some(SignalFishEvent::Authenticated { .. })) => break,
+            Ok(Some(SignalFishEvent::AuthenticationError { error, .. })) => {
+                return Err(format!("{name}: authentication failed: {error}").into());
+            }
+            Ok(Some(_)) => {}
+            _ => return Err(format!("{name}: no Authenticated within 5s").into()),
+        }
+    }
+    Ok((client, events))
+}
+
+async fn join(
+    client: &SignalFishClient,
+    events: &mut tokio::sync::mpsc::Receiver<SignalFishEvent>,
+    game: &str,
+    name: &str,
+    room_code: Option<&str>,
+) -> Result<String, Box<dyn Error>> {
+    let mut params = JoinRoomParams::new(game, name).with_max_players(16);
+    if let Some(code) = room_code {
+        params = params.with_room_code(code);
+    }
+    client.join_room(params)?;
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        match tokio::time::timeout(remaining, events.recv()).await {
+            Ok(Some(SignalFishEvent::RoomJoined { room_code, .. })) => return Ok(room_code),
+            Ok(Some(SignalFishEvent::RoomJoinFailed { reason, .. })) => {
+                return Err(format!("{name}: join failed: {reason}").into());
+            }
+            Ok(Some(_)) => {}
+            _ => return Err(format!("{name}: no RoomJoined within 5s").into()),
+        }
+    }
+}
+
+/// Drain a receiver's GameData latencies for `secs`, sleeping `drain_ms`
+/// after each GameData event (0 = drain at full speed). Returns
+/// (latencies_ms, received_count, saw_disconnect).
+async fn drain_role(
+    mut events: tokio::sync::mpsc::Receiver<SignalFishEvent>,
+    secs: u64,
+    drain_ms: u64,
+) -> (Vec<f64>, u64, bool) {
+    let mut latencies = Vec::new();
+    let mut received = 0u64;
+    let mut disconnected = false;
+    let end = Instant::now() + Duration::from_secs(secs);
+    while Instant::now() < end {
+        let remaining = end.saturating_duration_since(Instant::now());
+        match tokio::time::timeout(remaining, events.recv()).await {
+            Ok(Some(SignalFishEvent::GameData { data, .. })) => {
+                received += 1;
+                if let Some(ms) = latency_ms_from(&data) {
+                    latencies.push(ms);
+                }
+                if drain_ms > 0 {
+                    tokio::time::sleep(Duration::from_millis(drain_ms)).await;
+                }
+            }
+            Ok(Some(SignalFishEvent::Disconnected { .. })) => {
+                disconnected = true;
+                break;
+            }
+            Ok(Some(_)) => {}
+            Ok(None) => {
+                disconnected = true;
+                break;
+            }
+            Err(_) => break,
+        }
+    }
+    (latencies, received, disconnected)
+}
+
+// ── Modes ───────────────────────────────────────────────────────────
+
+async fn mode_ping(opts: &Options) -> Result<(), Box<dyn Error>> {
+    let (client, mut events) = connect(opts, "pinger", 256).await?;
+    let mut rtts = Vec::new();
+    for _ in 0..20 {
+        let sent = Instant::now();
+        client.ping()?;
+        let deadline = Instant::now() + Duration::from_secs(3);
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            match tokio::time::timeout(remaining, events.recv()).await {
+                Ok(Some(SignalFishEvent::Pong)) => break,
+                Ok(Some(_)) => {}
+                _ => return Err("no Pong within 3s".into()),
+            }
+        }
+        rtts.push(sent.elapsed().as_secs_f64() * 1000.0);
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    let (n, p50, p95, p99, max) = summarize(rtts);
+    println!("mode,samples,p50_ms,p95_ms,p99_ms,max_ms");
+    println!("ping,{n},{p50:.2},{p95:.2},{p99:.2},{max:.2}");
+    Ok(())
+}
+
+async fn mode_throughput(opts: &Options) -> Result<(), Box<dyn Error>> {
+    println!(
+        "mode,rate_offered,payload_bytes,accepted_per_s,refused,delivered_per_s_per_recipient,p50_ms,p95_ms,p99_ms,max_ms"
+    );
+    for &rate in &opts.rates {
+        let suffix = format!("{}-{rate}", std::process::id());
+        let game = format!("lab-thr-{suffix}");
+
+        let (sender, mut sender_events) = connect(opts, "sender", 1024).await?;
+        let room_code = join(&sender, &mut sender_events, &game, "sender", None).await?;
+
+        let mut receiver_handles = Vec::new();
+        for i in 0..opts.recipients {
+            let (rx_client, mut rx_events) = connect(opts, "receiver", 4096).await?;
+            join(
+                &rx_client,
+                &mut rx_events,
+                &game,
+                &format!("rx{i}"),
+                Some(&room_code),
+            )
+            .await?;
+            let secs = opts.secs + 2; // outlast the sender to catch stragglers
+            receiver_handles.push((
+                rx_client,
+                tokio::spawn(async move { drain_role(rx_events, secs, 0).await }),
+            ));
+        }
+
+        // Paced sender: fail-fast sends, counting refusals as the
+        // congestion signal.
+        let mut interval = tokio::time::interval(Duration::from_secs_f64(1.0 / f64::from(rate)));
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Burst);
+        let end = Instant::now() + Duration::from_secs(opts.secs);
+        let mut accepted = 0u64;
+        let mut refused = 0u64;
+        while Instant::now() < end {
+            interval.tick().await;
+            match sender.send_game_data(payload_with_timestamp(opts.payload)) {
+                Ok(()) => accepted += 1,
+                Err(_) => refused += 1,
+            }
+            // Keep the sender's own event stream drained.
+            while sender_events.try_recv().is_ok() {}
+        }
+        let accepted_per_s = accepted as f64 / opts.secs as f64;
+
+        let mut all_latencies = Vec::new();
+        let mut delivered_total = 0u64;
+        for (rx_client, handle) in receiver_handles {
+            let (latencies, received, _) = handle.await?;
+            delivered_total += received;
+            all_latencies.extend(latencies);
+            drop(rx_client);
+        }
+        let delivered_per_s =
+            delivered_total as f64 / opts.secs as f64 / std::cmp::max(opts.recipients, 1) as f64;
+        let (_, p50, p95, p99, max) = summarize(all_latencies);
+        println!(
+            "throughput,{rate},{},{accepted_per_s:.1},{refused},{delivered_per_s:.1},{p50:.2},{p95:.2},{p99:.2},{max:.2}",
+            opts.payload
+        );
+        drop(sender);
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+    Ok(())
+}
+
+async fn mode_slow_consumer(opts: &Options) -> Result<(), Box<dyn Error>> {
+    let suffix = std::process::id();
+    let game = format!("lab-slow-{suffix}");
+
+    let (sender, mut sender_events) = connect(opts, "sender", 1024).await?;
+    let room_code = join(&sender, &mut sender_events, &game, "sender", None).await?;
+
+    // Two healthy receivers + one slow one (event capacity 1 so its
+    // backpressure reaches the socket quickly).
+    let mut healthy = Vec::new();
+    for i in 0..2 {
+        let (c, mut e) = connect(opts, "healthy", 4096).await?;
+        join(&c, &mut e, &game, &format!("healthy{i}"), Some(&room_code)).await?;
+        let secs = opts.secs;
+        healthy.push((c, tokio::spawn(async move { drain_role(e, secs, 0).await })));
+    }
+    let (slow_client, mut slow_events) = connect(opts, "slow", 1).await?;
+    join(
+        &slow_client,
+        &mut slow_events,
+        &game,
+        "slow",
+        Some(&room_code),
+    )
+    .await?;
+    let slow_secs = opts.secs;
+    let slow_drain = opts.drain_ms;
+    let slow_handle =
+        tokio::spawn(async move { drain_role(slow_events, slow_secs, slow_drain).await });
+
+    // Sender pushes at the target rate with the waiting (backpressured)
+    // variant: its achieved rate reveals how hard the room paces it.
+    let mut interval = tokio::time::interval(Duration::from_secs_f64(1.0 / f64::from(opts.rate)));
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Burst);
+    let end = Instant::now() + Duration::from_secs(opts.secs);
+    let mut sent = 0u64;
+    while Instant::now() < end {
+        interval.tick().await;
+        sender
+            .send_game_data_reliable(payload_with_timestamp(opts.payload))
+            .await?;
+        sent += 1;
+        while sender_events.try_recv().is_ok() {}
+    }
+    let achieved = sent as f64 / opts.secs as f64;
+
+    println!(
+        "mode,role,offered_per_s,achieved_per_s,received,p50_ms,p95_ms,p99_ms,max_ms,disconnected"
+    );
+    println!("slow-consumer,sender,{},{achieved:.1},,,,,,", opts.rate);
+    for (i, (c, handle)) in healthy.into_iter().enumerate() {
+        let (latencies, received, disconnected) = handle.await?;
+        let (_, p50, p95, p99, max) = summarize(latencies);
+        println!(
+            "slow-consumer,healthy{i},,,{received},{p50:.2},{p95:.2},{p99:.2},{max:.2},{disconnected}"
+        );
+        drop(c);
+    }
+    let (latencies, received, disconnected) = slow_handle.await?;
+    let (_, p50, p95, p99, max) = summarize(latencies);
+    println!(
+        "slow-consumer,slow(drain {}ms),,,{received},{p50:.2},{p95:.2},{p99:.2},{max:.2},{disconnected}",
+        opts.drain_ms
+    );
+    drop(slow_client);
+    Ok(())
+}
+
+async fn mode_control_starvation(opts: &Options) -> Result<(), Box<dyn Error>> {
+    let suffix = std::process::id();
+    let game = format!("lab-ctrl-{suffix}");
+
+    // Victim joins first (owns the room), then the flooder.
+    let (victim, mut victim_events) = connect(opts, "victim", 256).await?;
+    let room_code = join(&victim, &mut victim_events, &game, "victim", None).await?;
+    let (flooder, mut flooder_events) = connect(opts, "flooder", 1024).await?;
+    join(
+        &flooder,
+        &mut flooder_events,
+        &game,
+        "flooder",
+        Some(&room_code),
+    )
+    .await?;
+
+    // Flood task: waiting sends as fast as the relay absorbs them.
+    let payload_size = opts.payload;
+    let flood_secs = opts.secs;
+    let flood = tokio::spawn(async move {
+        let end = Instant::now() + Duration::from_secs(flood_secs);
+        let mut sent = 0u64;
+        while Instant::now() < end {
+            if flooder
+                .send_game_data_reliable(payload_with_timestamp(payload_size))
+                .await
+                .is_err()
+            {
+                break;
+            }
+            sent += 1;
+            while flooder_events.try_recv().is_ok() {}
+        }
+        sent
+    });
+
+    // Victim: drains slowly (drain_ms per GameData) and pings periodically.
+    // Pong RTT includes both the server-side queueing behind relayed
+    // GameData and the victim's own backlog — the end-to-end control-plane
+    // delay a slow-but-alive client actually experiences.
+    let mut pong_rtts: Vec<f64> = Vec::new();
+    let mut game_latencies: Vec<f64> = Vec::new();
+    let mut received = 0u64;
+    let mut ping_outstanding: Option<Instant> = None;
+    let mut next_ping = Instant::now();
+    let end = Instant::now() + Duration::from_secs(opts.secs);
+    while Instant::now() < end {
+        if ping_outstanding.is_none() && Instant::now() >= next_ping {
+            victim.ping()?;
+            ping_outstanding = Some(Instant::now());
+            next_ping = Instant::now() + Duration::from_millis(opts.ping_every_ms);
+        }
+        let remaining = end.saturating_duration_since(Instant::now());
+        match tokio::time::timeout(
+            remaining.min(Duration::from_millis(50)),
+            victim_events.recv(),
+        )
+        .await
+        {
+            Ok(Some(SignalFishEvent::GameData { data, .. })) => {
+                received += 1;
+                if let Some(ms) = latency_ms_from(&data) {
+                    game_latencies.push(ms);
+                }
+                if opts.drain_ms > 0 {
+                    tokio::time::sleep(Duration::from_millis(opts.drain_ms)).await;
+                }
+            }
+            Ok(Some(SignalFishEvent::Pong)) => {
+                if let Some(sent_at) = ping_outstanding.take() {
+                    pong_rtts.push(sent_at.elapsed().as_secs_f64() * 1000.0);
+                }
+            }
+            Ok(Some(SignalFishEvent::Disconnected { .. })) | Ok(None) => break,
+            _ => {}
+        }
+    }
+    let flooded = flood.await?;
+
+    let (n_pong, pong_p50, pong_p95, pong_p99, pong_max) = summarize(pong_rtts);
+    let (_, gd_p50, _, gd_p99, _) = summarize(game_latencies);
+    println!(
+        "mode,flooded_msgs,gamedata_received,gd_p50_ms,gd_p99_ms,pongs,pong_p50_ms,pong_p95_ms,pong_p99_ms,pong_max_ms"
+    );
+    println!(
+        "control-starvation,{flooded},{received},{gd_p50:.2},{gd_p99:.2},{n_pong},{pong_p50:.2},{pong_p95:.2},{pong_p99:.2},{pong_max:.2}"
+    );
+    Ok(())
+}
+
+// ── Entry ───────────────────────────────────────────────────────────
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let opts = Options::parse(&args)?;
+    match opts.mode.as_str() {
+        "ping" => mode_ping(&opts).await,
+        "throughput" => mode_throughput(&opts).await,
+        "slow-consumer" => mode_slow_consumer(&opts).await,
+        "control-starvation" => mode_control_starvation(&opts).await,
+        other => Err(format!(
+            "unknown mode `{other}`; expected ping|throughput|slow-consumer|control-starvation"
+        )
+        .into()),
+    }
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -141,6 +141,7 @@ nav:
       - Errors: errors.md
       - Protocol Types: protocol.md
   - Guides:
+      - Delivery Contract & Backpressure: delivery.md
       - Mesh (v3): mesh-guide.md
       - WebAssembly: wasm.md
   - Examples:

--- a/src/client.rs
+++ b/src/client.rs
@@ -158,14 +158,15 @@ pub struct SignalFishConfig {
     pub supported_topologies: Option<Vec<Topology>>,
     /// Capacity of the bounded event channel.
     ///
-    /// Events are **never dropped**. When the consumer cannot keep up with
-    /// incoming server messages, the transport loop pauses until the consumer
-    /// drains the channel, propagating backpressure to the server instead of
-    /// losing data. The capacity only controls how much buffering the consumer
-    /// gets before that backpressure kicks in. An event can only be missed
-    /// when delivery stops entirely: the receiver is dropped,
-    /// [`SignalFishClient::shutdown`] times out and aborts the transport
-    /// task, or the client handle is dropped without calling `shutdown`.
+    /// Events are **never dropped on overflow**. When the consumer cannot keep
+    /// up with incoming server messages, the transport loop pauses until the
+    /// consumer drains the channel, propagating backpressure to the server
+    /// instead of losing data. The capacity only controls how much buffering
+    /// the consumer gets before that backpressure kicks in. An event can only
+    /// be missed when delivery stops entirely: the receiver is dropped, the
+    /// client handle is dropped without calling [`SignalFishClient::shutdown`],
+    /// or on `shutdown` — which abandons at most one in-flight event and
+    /// delivers the terminal `Disconnected` best-effort.
     ///
     /// Defaults to **256**. Values below 1 are clamped to 1.
     pub event_channel_capacity: usize,
@@ -405,7 +406,8 @@ pub struct ClientStats {
     /// the relay-path deficit diagnostic needs — it measures the wire, so a
     /// consumer that stops draining events (or a terminal abort racing the
     /// last deliveries) cannot masquerade as relay loss. In steady state
-    /// receipt and delivery are identical because events are never dropped.
+    /// receipt and delivery are identical because events are not dropped on
+    /// overflow.
     pub game_data_received: u64,
     /// Inbound frames that failed to decode into a `ServerMessage`.
     ///
@@ -684,7 +686,8 @@ impl SignalFishClient {
     ///
     /// The command queue only drains while the transport loop runs, and the
     /// transport loop pauses whenever the **event** channel is full (events
-    /// are never dropped). A task that awaits this method while it is also
+    /// are never dropped on overflow — the loop pauses instead). A task that
+    /// awaits this method while it is also
     /// the only consumer of the event receiver can therefore deadlock under
     /// simultaneous send + receive pressure. Drain events from a separate
     /// task rather than strictly sequentially. (Do **not** race this send
@@ -1443,12 +1446,12 @@ async fn finish_shutdown(
 /// handshake.
 ///
 /// The break-paths (transport send/receive error, clean server close, dropped
-/// handle) want `Disconnected` delivered losslessly with backpressure — the
-/// normal, never-drop case. But if the consumer has wedged (event channel
+/// handle) want `Disconnected` delivered with backpressure — the normal,
+/// never-drop case. But if the consumer has wedged (event channel
 /// full) *and* a shutdown is pending, a plain blocking send would starve the
 /// shutdown signal and force `shutdown()` down its timeout/abort path (the
 /// same starvation [`emit_event_or_shutdown`] fixes for per-message events).
-/// So this races the lossless send against the shutdown signal, `biased`
+/// So this races the backpressured send against the shutdown signal, `biased`
 /// toward delivery; on preemption it re-sends best-effort via `try_send` so
 /// the event is still likely delivered and the loop exits promptly.
 ///

--- a/src/client.rs
+++ b/src/client.rs
@@ -1144,8 +1144,9 @@ async fn transport_loop(
                             Ok(json) => {
                                 if let Err(e) = transport.send(json).await {
                                     error!("transport send error: {e}");
-                                    emit_disconnected(
+                                    emit_disconnected_or_shutdown(
                                         &event_tx,
+                                        &mut shutdown_rx,
                                         &state,
                                         Some(format!("transport send error: {e}")),
                                         last_server_error.take(),
@@ -1166,8 +1167,9 @@ async fn transport_loop(
                     None => {
                         debug!("command channel closed, shutting down transport loop");
                         let _ = transport.close().await;
-                        emit_disconnected(
+                        emit_disconnected_or_shutdown(
                             &event_tx,
+                            &mut shutdown_rx,
                             &state,
                             Some("client shut down".into()),
                             last_server_error.take(),
@@ -1238,8 +1240,9 @@ async fn transport_loop(
                     }
                     Some(Err(e)) => {
                         error!("transport receive error: {e}");
-                        emit_disconnected(
+                        emit_disconnected_or_shutdown(
                             &event_tx,
+                            &mut shutdown_rx,
                             &state,
                             Some(format!("transport receive error: {e}")),
                             last_server_error.take(),
@@ -1252,7 +1255,13 @@ async fn transport_loop(
                         let reason = transport
                             .close_reason()
                             .map(|r| format!("closed by server: {r}"));
-                        emit_disconnected(&event_tx, &state, reason, last_server_error.take()).await;
+                        emit_disconnected_or_shutdown(
+                            &event_tx,
+                            &mut shutdown_rx,
+                            &state,
+                            reason,
+                            last_server_error.take(),
+                        ).await;
                         break;
                     }
                 }
@@ -1357,22 +1366,6 @@ enum EmitOutcome {
     ShutdownRequested,
 }
 
-/// Emit an event to the event channel, waiting for capacity if it is full.
-///
-/// Events are **never dropped**: when the consumer lags, the transport loop
-/// pauses here, which stops reading from the transport and propagates
-/// backpressure to the server (e.g. via TCP receive windows). Delivery only
-/// fails if the receiver has been dropped, or if the transport task is
-/// aborted while this send is still waiting (a
-/// [`SignalFishClient::shutdown`] timeout, or the client handle dropped
-/// without `shutdown`).
-#[cfg(feature = "tokio-runtime")]
-async fn emit_event(event_tx: &mpsc::Sender<SignalFishEvent>, event: SignalFishEvent) {
-    if event_tx.send(event).await.is_err() {
-        debug!("event channel closed, receiver dropped");
-    }
-}
-
 /// Emit an event with backpressure, but let a shutdown request preempt the
 /// wait.
 ///
@@ -1427,30 +1420,49 @@ async fn finish_shutdown(
     });
 }
 
-/// Emit a [`Disconnected`](SignalFishEvent::Disconnected) event and update state.
+/// Deliver the terminal [`Disconnected`](SignalFishEvent::Disconnected) on a
+/// loop break-path, letting a pending `shutdown()` preempt a blocked delivery.
 ///
-/// Like every event, `Disconnected` is delivered with backpressure (see
-/// [`emit_event`]); it can only be missed if the receiver has been dropped
-/// or if the transport task is aborted first (a
-/// [`SignalFishClient::shutdown`] timeout, or the client handle dropped
-/// without `shutdown`).
+/// The break-paths (transport send/receive error, clean server close, dropped
+/// handle) want `Disconnected` delivered losslessly with backpressure — the
+/// normal, never-drop case. But if the consumer has wedged (event channel
+/// full) *and* a shutdown is pending, a plain blocking send would starve the
+/// shutdown signal and force `shutdown()` down its timeout/abort path (the
+/// same starvation [`emit_event_or_shutdown`] fixes for per-message events).
+/// So this races the lossless send against the shutdown signal, `biased`
+/// toward delivery; on preemption it re-sends best-effort via `try_send` so
+/// the event is still likely delivered and the loop exits promptly.
+///
+/// Terminal: every caller `break`s immediately afterwards, so `shutdown_rx` is
+/// never polled again (a completed `oneshot::Receiver` panics if re-polled).
 #[cfg(feature = "tokio-runtime")]
-async fn emit_disconnected(
+async fn emit_disconnected_or_shutdown(
     event_tx: &mpsc::Sender<SignalFishEvent>,
+    shutdown_rx: &mut tokio::sync::oneshot::Receiver<()>,
     state: &ClientState,
     reason: Option<String>,
     last_server_error: Option<ServerErrorInfo>,
 ) {
     state.connected.store(false, Ordering::Release);
     state.clear_session_state().await;
-    emit_event(
-        event_tx,
-        SignalFishEvent::Disconnected {
-            reason,
-            last_server_error,
-        },
-    )
-    .await;
+    let event = SignalFishEvent::Disconnected {
+        reason,
+        last_server_error,
+    };
+    tokio::select! {
+        biased;
+        res = event_tx.send(event.clone()) => {
+            if res.is_err() {
+                debug!("event channel closed, receiver dropped");
+            }
+        }
+        _ = &mut *shutdown_rx => {
+            // Consumer wedged and a shutdown is pending: preempt the blocked
+            // delivery and re-send best-effort so shutdown() completes promptly
+            // instead of waiting out the abort timeout.
+            let _ = event_tx.try_send(event);
+        }
+    }
 }
 
 // ── Tests ───────────────────────────────────────────────────────────

--- a/src/client.rs
+++ b/src/client.rs
@@ -12,11 +12,16 @@
 //! - **Events** are delivered with backpressure. If the consumer lags, the
 //!   transport loop pauses reading from the transport until the event channel
 //!   has room — backpressure propagates to the server instead of losing
-//!   events. An event can only be missed when the loop stops delivering
-//!   entirely: the receiver was dropped, a
-//!   [`shutdown`](SignalFishClient::shutdown) timeout aborted the loop, or
-//!   the client handle was dropped without calling `shutdown` (which aborts
-//!   immediately).
+//!   events. Inbound frames that fail to decode are surfaced as
+//!   [`DecodeFailed`](SignalFishEvent::DecodeFailed) events (and counted in
+//!   [`ClientStats::messages_undecodable`]) rather than dropped. An event can
+//!   only be missed when the loop stops delivering entirely: the receiver was
+//!   dropped, the client handle was dropped without calling
+//!   [`shutdown`](SignalFishClient::shutdown) (which aborts immediately), or
+//!   `shutdown` was requested — a shutdown abandons at most the one event
+//!   delivery it interrupted, closes the transport gracefully, and delivers
+//!   the terminal `Disconnected` best-effort (a receiver that outlives the
+//!   loop also observes the event channel closing).
 //! - **Commands** go through a bounded queue and queue admission is never
 //!   silent: the synchronous send methods fail fast with
 //!   [`SignalFishError::SendBufferFull`] when it is full, and the
@@ -79,7 +84,7 @@ use tracing::{debug, error, warn};
 
 use crate::error::{Result, SignalFishError};
 #[cfg(feature = "tokio-runtime")]
-use crate::event::SignalFishEvent;
+use crate::event::{ServerErrorInfo, SignalFishEvent};
 #[cfg(feature = "tokio-runtime")]
 use crate::protocol::ServerMessage;
 use crate::protocol::{
@@ -402,6 +407,14 @@ pub struct ClientStats {
     /// last deliveries) cannot masquerade as relay loss. In steady state
     /// receipt and delivery are identical because events are never dropped.
     pub game_data_received: u64,
+    /// Inbound frames that failed to decode into a `ServerMessage`.
+    ///
+    /// Counted when a frame is read off the transport and fails to parse;
+    /// each one also surfaces as a
+    /// [`DecodeFailed`](crate::SignalFishEvent::DecodeFailed) event. Steady
+    /// growth means protocol drift (a server newer than this SDK) or a
+    /// corrupting middlebox.
+    pub messages_undecodable: u64,
 }
 
 // ── Shared state ────────────────────────────────────────────────────
@@ -429,6 +442,10 @@ struct ClientState {
     /// counted at receipt (see [`ClientStats::game_data_received`]).
     /// Cumulative — intentionally not reset by `clear_session_state`.
     game_data_received: AtomicU64,
+    /// Inbound frames that failed to decode into a `ServerMessage`
+    /// (see [`ClientStats::messages_undecodable`]).
+    /// Cumulative — intentionally not reset by `clear_session_state`.
+    messages_undecodable: AtomicU64,
 }
 
 #[cfg_attr(not(feature = "tokio-runtime"), allow(dead_code))]
@@ -444,6 +461,7 @@ impl ClientState {
             room_code: Mutex::new(None),
             game_data_sent: AtomicU64::new(0),
             game_data_received: AtomicU64::new(0),
+            messages_undecodable: AtomicU64::new(0),
         }
     }
 
@@ -562,11 +580,16 @@ impl SignalFishClient {
 
     /// Shut down the client, closing the transport and stopping the background task.
     ///
-    /// The transport loop is given [`shutdown_timeout`](SignalFishConfig::shutdown_timeout)
-    /// to close cleanly and emit a [`Disconnected`](SignalFishEvent::Disconnected)
-    /// event. If the timeout expires, the task is aborted and the `Disconnected`
-    /// event may not be delivered. After shutdown completes, the event receiver
-    /// will yield `None`.
+    /// The shutdown signal preempts even a transport loop blocked on a full
+    /// event channel (a consumer that stopped draining): the loop abandons at
+    /// most the one event delivery it was waiting on, closes the transport
+    /// gracefully, and delivers a terminal
+    /// [`Disconnected`](SignalFishEvent::Disconnected) best-effort. The loop
+    /// is given [`shutdown_timeout`](SignalFishConfig::shutdown_timeout) to
+    /// finish; if the timeout expires (e.g. a transport whose `close()`
+    /// hangs), the task is aborted. After shutdown completes, the event
+    /// receiver yields the remaining buffered events and then `None` — treat
+    /// the channel closing as the authoritative end-of-stream signal.
     pub async fn shutdown(&mut self) {
         debug!("SignalFishClient: shutdown requested");
 
@@ -990,6 +1013,7 @@ impl SignalFishClient {
         ClientStats {
             game_data_sent: self.state.game_data_sent.load(Ordering::Relaxed),
             game_data_received: self.state.game_data_received.load(Ordering::Relaxed),
+            messages_undecodable: self.state.messages_undecodable.load(Ordering::Relaxed),
         }
     }
 
@@ -1094,8 +1118,20 @@ async fn transport_loop(
 ) {
     debug!("transport loop started");
 
+    // The most recent Error/AuthenticationError received on this connection,
+    // remembered so a subsequent disconnect can be attributed (e.g. a
+    // best-effort SLOW_CONSUMER farewell followed by a bare close).
+    let mut last_server_error: Option<ServerErrorInfo> = None;
+
     // Emit the synthetic Connected event before entering the select loop.
-    emit_event(&event_tx, SignalFishEvent::Connected).await;
+    if matches!(
+        emit_event_or_shutdown(&event_tx, &mut shutdown_rx, SignalFishEvent::Connected).await,
+        EmitOutcome::ShutdownRequested
+    ) {
+        finish_shutdown(&mut transport, &event_tx, &state, last_server_error).await;
+        debug!("transport loop exited");
+        return;
+    }
 
     loop {
         tokio::select! {
@@ -1112,6 +1148,7 @@ async fn transport_loop(
                                         &event_tx,
                                         &state,
                                         Some(format!("transport send error: {e}")),
+                                        last_server_error.take(),
                                     ).await;
                                     break;
                                 }
@@ -1129,7 +1166,12 @@ async fn transport_loop(
                     None => {
                         debug!("command channel closed, shutting down transport loop");
                         let _ = transport.close().await;
-                        emit_disconnected(&event_tx, &state, Some("client shut down".into())).await;
+                        emit_disconnected(
+                            &event_tx,
+                            &state,
+                            Some("client shut down".into()),
+                            last_server_error.take(),
+                        ).await;
                         break;
                     }
                 }
@@ -1138,8 +1180,7 @@ async fn transport_loop(
             // Branch 2: shutdown signal
             _ = &mut shutdown_rx => {
                 debug!("shutdown signal received");
-                let _ = transport.close().await;
-                emit_disconnected(&event_tx, &state, Some("client shut down".into())).await;
+                finish_shutdown(&mut transport, &event_tx, &state, last_server_error.take()).await;
                 break;
             }
 
@@ -1149,15 +1190,49 @@ async fn transport_loop(
                     Some(Ok(text)) => {
                         match serde_json::from_str::<ServerMessage>(&text) {
                             Ok(server_msg) => {
+                                // Remember server errors for disconnect attribution.
+                                match &server_msg {
+                                    ServerMessage::Error { message, error_code } => {
+                                        last_server_error = Some(ServerErrorInfo {
+                                            message: message.clone(),
+                                            error_code: error_code.clone(),
+                                        });
+                                    }
+                                    ServerMessage::AuthenticationError { error, error_code } => {
+                                        last_server_error = Some(ServerErrorInfo {
+                                            message: error.clone(),
+                                            error_code: Some(error_code.clone()),
+                                        });
+                                    }
+                                    _ => {}
+                                }
+
                                 // Update shared state based on the message.
                                 update_state(&state, &server_msg).await;
 
                                 // Convert to event and forward to the event channel.
                                 let event = SignalFishEvent::from(server_msg);
-                                emit_event(&event_tx, event).await;
+                                if matches!(
+                                    emit_event_or_shutdown(&event_tx, &mut shutdown_rx, event).await,
+                                    EmitOutcome::ShutdownRequested
+                                ) {
+                                    finish_shutdown(&mut transport, &event_tx, &state, last_server_error).await;
+                                    break;
+                                }
                             }
                             Err(e) => {
+                                // Never a silent drop: surface the frame as a
+                                // typed DecodeFailed event and count it.
                                 warn!("failed to deserialize server message: {e} — raw: {text}");
+                                state.messages_undecodable.fetch_add(1, Ordering::Relaxed);
+                                let event = SignalFishEvent::decode_failed(&text, &e);
+                                if matches!(
+                                    emit_event_or_shutdown(&event_tx, &mut shutdown_rx, event).await,
+                                    EmitOutcome::ShutdownRequested
+                                ) {
+                                    finish_shutdown(&mut transport, &event_tx, &state, last_server_error).await;
+                                    break;
+                                }
                             }
                         }
                     }
@@ -1167,13 +1242,17 @@ async fn transport_loop(
                             &event_tx,
                             &state,
                             Some(format!("transport receive error: {e}")),
+                            last_server_error.take(),
                         ).await;
                         break;
                     }
                     // Transport closed cleanly.
                     None => {
                         debug!("transport closed by server");
-                        emit_disconnected(&event_tx, &state, None).await;
+                        let reason = transport
+                            .close_reason()
+                            .map(|r| format!("closed by server: {r}"));
+                        emit_disconnected(&event_tx, &state, reason, last_server_error.take()).await;
                         break;
                     }
                 }
@@ -1267,6 +1346,17 @@ async fn update_state(state: &ClientState, msg: &ServerMessage) {
     }
 }
 
+/// Result of racing an event delivery against the shutdown signal.
+#[cfg(feature = "tokio-runtime")]
+enum EmitOutcome {
+    /// The event was handed to the channel (or the receiver is gone — the
+    /// loop keeps running either way, matching pre-0.7.0 behavior).
+    Delivered,
+    /// The shutdown signal fired while the delivery was still waiting for
+    /// channel capacity; the in-flight event is abandoned.
+    ShutdownRequested,
+}
+
 /// Emit an event to the event channel, waiting for capacity if it is full.
 ///
 /// Events are **never dropped**: when the consumer lags, the transport loop
@@ -1283,6 +1373,60 @@ async fn emit_event(event_tx: &mpsc::Sender<SignalFishEvent>, event: SignalFishE
     }
 }
 
+/// Emit an event with backpressure, but let a shutdown request preempt the
+/// wait.
+///
+/// `biased` polls the delivery arm first, so when both are ready the event is
+/// still delivered; only a genuinely blocked delivery (consumer not draining)
+/// lets shutdown win. On [`EmitOutcome::ShutdownRequested`] exactly the one
+/// in-flight event is abandoned — the caller must then run
+/// [`finish_shutdown`] and exit the loop **without polling `shutdown_rx`
+/// again** (a completed `oneshot::Receiver` panics if re-polled).
+#[cfg(feature = "tokio-runtime")]
+async fn emit_event_or_shutdown(
+    event_tx: &mpsc::Sender<SignalFishEvent>,
+    shutdown_rx: &mut tokio::sync::oneshot::Receiver<()>,
+    event: SignalFishEvent,
+) -> EmitOutcome {
+    tokio::select! {
+        biased;
+        res = event_tx.send(event) => {
+            if res.is_err() {
+                debug!("event channel closed, receiver dropped");
+            }
+            EmitOutcome::Delivered
+        }
+        _ = &mut *shutdown_rx => EmitOutcome::ShutdownRequested,
+    }
+}
+
+/// Terminal sequence for a shutdown request: close the transport gracefully,
+/// then deliver `Disconnected` best-effort.
+///
+/// Closing **before** the final event delivery is the point: pre-0.7.0 a
+/// wedged consumer starved the shutdown signal entirely, so the abort tore
+/// the task down with the connection dangling. The final `Disconnected` uses
+/// `try_send` rather than backpressure: the caller *initiated* this shutdown,
+/// so the event is confirmatory, and a receiver that outlives the loop
+/// observes termination anyway when the event channel closes (`recv()`
+/// returns `None`). Blocking here would force every wedged-consumer shutdown
+/// through the timeout/abort path for no information gain.
+#[cfg(feature = "tokio-runtime")]
+async fn finish_shutdown(
+    transport: &mut impl Transport,
+    event_tx: &mpsc::Sender<SignalFishEvent>,
+    state: &ClientState,
+    last_server_error: Option<ServerErrorInfo>,
+) {
+    let _ = transport.close().await;
+    state.connected.store(false, Ordering::Release);
+    state.clear_session_state().await;
+    let _ = event_tx.try_send(SignalFishEvent::Disconnected {
+        reason: Some("client shut down".into()),
+        last_server_error,
+    });
+}
+
 /// Emit a [`Disconnected`](SignalFishEvent::Disconnected) event and update state.
 ///
 /// Like every event, `Disconnected` is delivered with backpressure (see
@@ -1295,10 +1439,18 @@ async fn emit_disconnected(
     event_tx: &mpsc::Sender<SignalFishEvent>,
     state: &ClientState,
     reason: Option<String>,
+    last_server_error: Option<ServerErrorInfo>,
 ) {
     state.connected.store(false, Ordering::Release);
     state.clear_session_state().await;
-    emit_event(event_tx, SignalFishEvent::Disconnected { reason }).await;
+    emit_event(
+        event_tx,
+        SignalFishEvent::Disconnected {
+            reason,
+            last_server_error,
+        },
+    )
+    .await;
 }
 
 // ── Tests ───────────────────────────────────────────────────────────
@@ -1874,6 +2026,7 @@ mod tests {
             ClientStats {
                 game_data_sent: 3,
                 game_data_received: 2,
+                messages_undecodable: 0,
             }
         );
 
@@ -2274,7 +2427,7 @@ mod tests {
         let _ = events.recv().await; // Connected
         let event = events.recv().await.unwrap();
         assert!(matches!(event, SignalFishEvent::Disconnected { .. }));
-        if let SignalFishEvent::Disconnected { reason } = event {
+        if let SignalFishEvent::Disconnected { reason, .. } = event {
             assert!(reason.unwrap().contains("boom"));
         }
 
@@ -2447,7 +2600,7 @@ mod tests {
         // After shutdown, a Disconnected event should have been emitted.
         let event = events.recv().await.unwrap();
         assert!(matches!(event, SignalFishEvent::Disconnected { .. }));
-        if let SignalFishEvent::Disconnected { reason } = event {
+        if let SignalFishEvent::Disconnected { reason, .. } = event {
             assert_eq!(reason.as_deref(), Some("client shut down"));
         }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -1225,8 +1225,15 @@ async fn transport_loop(
                             }
                             Err(e) => {
                                 // Never a silent drop: surface the frame as a
-                                // typed DecodeFailed event and count it.
-                                warn!("failed to deserialize server message: {e} — raw: {text}");
+                                // typed DecodeFailed event and count it. Log the
+                                // error and frame size only — not the raw
+                                // content, which is untrusted, unbounded, and may
+                                // carry application payloads (the DecodeFailed
+                                // event carries a bounded prefix for diagnostics).
+                                warn!(
+                                    "failed to deserialize server message ({} bytes): {e}",
+                                    text.len()
+                                );
                                 state.messages_undecodable.fetch_add(1, Ordering::Relaxed);
                                 let event = SignalFishEvent::decode_failed(&text, &e);
                                 if matches!(

--- a/src/client.rs
+++ b/src/client.rs
@@ -1145,6 +1145,7 @@ async fn transport_loop(
                                 if let Err(e) = transport.send(json).await {
                                     error!("transport send error: {e}");
                                     emit_disconnected_or_shutdown(
+                                        &mut transport,
                                         &event_tx,
                                         &mut shutdown_rx,
                                         &state,
@@ -1166,8 +1167,8 @@ async fn transport_loop(
                     // Command channel closed — client handle dropped.
                     None => {
                         debug!("command channel closed, shutting down transport loop");
-                        let _ = transport.close().await;
                         emit_disconnected_or_shutdown(
+                            &mut transport,
                             &event_tx,
                             &mut shutdown_rx,
                             &state,
@@ -1241,6 +1242,7 @@ async fn transport_loop(
                     Some(Err(e)) => {
                         error!("transport receive error: {e}");
                         emit_disconnected_or_shutdown(
+                            &mut transport,
                             &event_tx,
                             &mut shutdown_rx,
                             &state,
@@ -1256,6 +1258,7 @@ async fn transport_loop(
                             .close_reason()
                             .map(|r| format!("closed by server: {r}"));
                         emit_disconnected_or_shutdown(
+                            &mut transport,
                             &event_tx,
                             &mut shutdown_rx,
                             &state,
@@ -1421,7 +1424,16 @@ async fn finish_shutdown(
 }
 
 /// Deliver the terminal [`Disconnected`](SignalFishEvent::Disconnected) on a
-/// loop break-path, letting a pending `shutdown()` preempt a blocked delivery.
+/// loop break-path, closing the transport and letting a pending `shutdown()`
+/// preempt a blocked delivery.
+///
+/// The transport is closed **first** (best-effort), exactly like
+/// [`finish_shutdown`]: graceful shutdown always releases the connection, so
+/// closing must not depend on the event delivery completing — otherwise a
+/// wedged consumer that lets the shutdown branch win would leave the socket
+/// open until the task is dropped. Closing an already-errored or
+/// server-closed transport is a harmless no-op / completes the close
+/// handshake.
 ///
 /// The break-paths (transport send/receive error, clean server close, dropped
 /// handle) want `Disconnected` delivered losslessly with backpressure — the
@@ -1437,12 +1449,14 @@ async fn finish_shutdown(
 /// never polled again (a completed `oneshot::Receiver` panics if re-polled).
 #[cfg(feature = "tokio-runtime")]
 async fn emit_disconnected_or_shutdown(
+    transport: &mut impl Transport,
     event_tx: &mpsc::Sender<SignalFishEvent>,
     shutdown_rx: &mut tokio::sync::oneshot::Receiver<()>,
     state: &ClientState,
     reason: Option<String>,
     last_server_error: Option<ServerErrorInfo>,
 ) {
+    let _ = transport.close().await;
     state.connected.store(false, Ordering::Release);
     state.clear_session_state().await;
     let event = SignalFishEvent::Disconnected {

--- a/src/error_codes.rs
+++ b/src/error_codes.rs
@@ -84,6 +84,20 @@ pub enum ErrorCode {
 
     // Connection lifecycle (protocol v3)
     ConnectionIdleTimeout,
+
+    // Delivery & liveness
+    /// The server evicted this connection because its outbound queue stayed
+    /// full past the slow-consumer grace window (5 seconds by default): the
+    /// client was not draining messages fast enough.
+    ///
+    /// The farewell `Error` frame carrying this code is written best-effort
+    /// into an already-congested socket, so it may never arrive; a bare
+    /// disconnect can be the only observable signal. Wire: `"SLOW_CONSUMER"`.
+    SlowConsumer,
+    /// The server closed the connection after prolonged protocol inactivity
+    /// (no messages received within the activity window). Wire:
+    /// `"ACTIVITY_TIMEOUT"`.
+    ActivityTimeout,
 }
 
 impl ErrorCode {
@@ -257,6 +271,14 @@ impl ErrorCode {
             // Connection lifecycle (protocol v3)
             Self::ConnectionIdleTimeout => {
                 "The connection was closed by the server after being idle for too long."
+            }
+
+            // Delivery & liveness
+            Self::SlowConsumer => {
+                "The server closed this connection because the client was not reading messages fast enough. Drain events promptly, or reduce inbound volume."
+            }
+            Self::ActivityTimeout => {
+                "The connection was closed by the server due to prolonged inactivity. Send periodic pings to keep the connection alive."
             }
         }
     }

--- a/src/event.rs
+++ b/src/event.rs
@@ -467,6 +467,7 @@ impl SignalFishEvent {
     /// Shared by the async and polling clients so both surface identical
     /// diagnostics: the wire `type` tag when the frame was valid JSON, the
     /// serde error text, and a bounded raw prefix.
+    #[cfg(any(feature = "tokio-runtime", feature = "polling-client"))]
     pub(crate) fn decode_failed(raw: &str, error: &serde_json::Error) -> Self {
         let message_type = serde_json::from_str::<serde_json::Value>(raw)
             .ok()
@@ -481,6 +482,7 @@ impl SignalFishEvent {
 
 /// Returns the longest prefix of `s` that is at most `max_bytes` long and
 /// ends on a UTF-8 character boundary.
+#[cfg(any(feature = "tokio-runtime", feature = "polling-client"))]
 fn truncate_on_char_boundary(s: &str, max_bytes: usize) -> &str {
     if s.len() <= max_bytes {
         return s;

--- a/src/event.rs
+++ b/src/event.rs
@@ -93,7 +93,9 @@ pub enum SignalFishEvent {
     /// or payload corruption.
     ///
     /// Every undecodable frame produces exactly one `DecodeFailed` event
-    /// (no coalescing), delivered losslessly like any other event, and
+    /// (no coalescing), delivered with backpressure like any other event
+    /// (never dropped merely because the consumer is behind; see the delivery
+    /// guarantees on [`SignalFishClient`](crate::SignalFishClient)), and
     /// increments the `messages_undecodable` counter in
     /// [`ClientStats`](crate::ClientStats). Steady growth of that counter
     /// means protocol drift (upgrade this SDK) or a corrupting middlebox.

--- a/src/event.rs
+++ b/src/event.rs
@@ -469,13 +469,28 @@ impl SignalFishEvent {
     /// serde error text, and a bounded raw prefix.
     #[cfg(any(feature = "tokio-runtime", feature = "polling-client"))]
     pub(crate) fn decode_failed(raw: &str, error: &serde_json::Error) -> Self {
-        let message_type = serde_json::from_str::<serde_json::Value>(raw)
-            .ok()
-            .and_then(|v| v.get("type")?.as_str().map(str::to_string));
+        // Compute the bounded prefix once and reuse it for both the type-tag
+        // recovery and the stored `raw_prefix`, so work stays bounded on large
+        // or hostile input.
+        let prefix = truncate_on_char_boundary(raw, DECODE_FAILED_RAW_PREFIX_MAX);
+        // Only recover the wire `type` tag when the frame was well-formed JSON
+        // that simply didn't match our types (a `Data` error — e.g. an unknown
+        // message type or error-code token). Malformed JSON (`Syntax`/`Eof`)
+        // has no recoverable tag, so skip the re-parse entirely rather than
+        // re-scanning untrusted garbage. Parsing only the bounded prefix caps
+        // the secondary parse; a frame larger than the cap yields `None`
+        // (its `type` is still visible in `raw_prefix`).
+        let message_type = if error.classify() == serde_json::error::Category::Data {
+            serde_json::from_str::<serde_json::Value>(prefix)
+                .ok()
+                .and_then(|v| v.get("type")?.as_str().map(str::to_string))
+        } else {
+            None
+        };
         Self::DecodeFailed {
             message_type,
             error: error.to_string(),
-            raw_prefix: truncate_on_char_boundary(raw, DECODE_FAILED_RAW_PREFIX_MAX).to_string(),
+            raw_prefix: prefix.to_string(),
         }
     }
 }
@@ -894,6 +909,70 @@ mod tests {
             assert_eq!(error_code, ErrorCode::InvalidAppId);
         } else {
             panic!("expected AuthenticationError variant");
+        }
+    }
+
+    /// `decode_failed` bounds its work: the wire `type` tag is recovered only
+    /// from well-formed JSON within the prefix cap, never by re-parsing a full
+    /// oversized or malformed frame.
+    #[cfg(any(feature = "tokio-runtime", feature = "polling-client"))]
+    #[test]
+    fn decode_failed_recovers_type_only_for_bounded_well_formed_frames() {
+        // 1. Small, well-formed frame, unknown type (a serde `Data` error) →
+        //    type recovered; the whole frame fits in the prefix.
+        let small = r#"{"type":"SomeFutureMessage","data":{}}"#;
+        let err = serde_json::from_str::<ServerMessage>(small).unwrap_err();
+        assert_eq!(err.classify(), serde_json::error::Category::Data);
+        match SignalFishEvent::decode_failed(small, &err) {
+            SignalFishEvent::DecodeFailed {
+                message_type,
+                raw_prefix,
+                ..
+            } => {
+                assert_eq!(message_type.as_deref(), Some("SomeFutureMessage"));
+                assert_eq!(raw_prefix, small);
+            }
+            other => panic!("expected DecodeFailed, got {other:?}"),
+        }
+
+        // 2. Malformed JSON (a `Syntax` error) → the re-parse is skipped
+        //    entirely, so no `type` is recovered.
+        let garbage = "not valid json {{{";
+        let err = serde_json::from_str::<ServerMessage>(garbage).unwrap_err();
+        assert_ne!(err.classify(), serde_json::error::Category::Data);
+        match SignalFishEvent::decode_failed(garbage, &err) {
+            SignalFishEvent::DecodeFailed { message_type, .. } => {
+                assert_eq!(message_type, None);
+            }
+            other => panic!("expected DecodeFailed, got {other:?}"),
+        }
+
+        // 3. Well-formed unknown-type frame larger than the prefix cap → work
+        //    stays bounded: `message_type` is None (the full frame is never
+        //    re-parsed), while the type is still visible in the capped prefix.
+        let big = format!(
+            r#"{{"type":"SomeFutureMessage","data":{{"pad":"{}"}}}}"#,
+            "x".repeat(DECODE_FAILED_RAW_PREFIX_MAX)
+        );
+        let err = serde_json::from_str::<ServerMessage>(&big).unwrap_err();
+        assert_eq!(err.classify(), serde_json::error::Category::Data);
+        match SignalFishEvent::decode_failed(&big, &err) {
+            SignalFishEvent::DecodeFailed {
+                message_type,
+                raw_prefix,
+                ..
+            } => {
+                assert_eq!(
+                    message_type, None,
+                    "an oversized frame must not be re-parsed to recover its type"
+                );
+                assert!(raw_prefix.len() <= DECODE_FAILED_RAW_PREFIX_MAX);
+                assert!(
+                    raw_prefix.contains("SomeFutureMessage"),
+                    "the type remains visible in the bounded prefix"
+                );
+            }
+            other => panic!("expected DecodeFailed, got {other:?}"),
         }
     }
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,8 +1,8 @@
 //! High-level events emitted by the Signal Fish client.
 //!
 //! [`SignalFishEvent`] provides a 1:1 mapping from every [`ServerMessage`] variant
-//! plus two synthetic events (`Connected` and `Disconnected`) that originate from
-//! the transport layer rather than the server.
+//! plus three synthetic events (`Connected`, `Disconnected`, and `DecodeFailed`)
+//! that originate from the transport layer rather than the server.
 //!
 //! Boxed payload types ([`RoomJoinedPayload`], [`ReconnectedPayload`],
 //! [`SpectatorJoinedPayload`]) are flattened into inline fields so callers can
@@ -31,6 +31,7 @@ use crate::protocol::{
 /// |---|---|
 /// | [`Connected`](Self::Connected) | Transport layer opened successfully |
 /// | [`Disconnected`](Self::Disconnected) | Transport layer closed or errored |
+/// | [`DecodeFailed`](Self::DecodeFailed) | An inbound frame could not be decoded |
 ///
 /// # Example
 ///
@@ -39,7 +40,7 @@ use crate::protocol::{
 /// match event {
 ///     SignalFishEvent::RoomJoined { room_code, current_players, .. } => { /* … */ }
 ///     SignalFishEvent::PlayerJoined { player } => { /* … */ }
-///     SignalFishEvent::Disconnected { reason } => { /* … */ }
+///     SignalFishEvent::Disconnected { reason, .. } => { /* … */ }
 ///     _ => {}
 /// }
 /// ```
@@ -65,7 +66,50 @@ pub enum SignalFishEvent {
     /// The transport connection was closed.
     Disconnected {
         /// Human-readable reason for the disconnection, if available.
+        ///
+        /// When the transport captured a WebSocket Close frame with a reason
+        /// (see [`Transport::close_reason`](crate::Transport::close_reason)),
+        /// it is included here as `"closed by server: …"`.
         reason: Option<String>,
+        /// The most recent `Error`/`AuthenticationError` received on this
+        /// connection, if any.
+        ///
+        /// This is a correlation aid, not a server-attributed close reason:
+        /// a server that evicts a slow consumer writes a best-effort
+        /// `Error { error_code: SlowConsumer }` farewell before closing, and
+        /// when that frame arrives it is surfaced here so the disconnect can
+        /// be attributed. The farewell may never arrive (the socket is
+        /// congested by definition), in which case this is `None`.
+        last_server_error: Option<ServerErrorInfo>,
+    },
+
+    /// An inbound server frame could not be decoded into a
+    /// [`ServerMessage`].
+    ///
+    /// This is a **synthetic event**. The connection stays open and later
+    /// frames are unaffected. Typical causes: a server newer than this SDK
+    /// (an unknown message `type`, or an unknown `error_code` string inside
+    /// an otherwise-known message), a proxy injecting non-protocol frames,
+    /// or payload corruption.
+    ///
+    /// Every undecodable frame produces exactly one `DecodeFailed` event
+    /// (no coalescing), delivered losslessly like any other event, and
+    /// increments the `messages_undecodable` counter in
+    /// [`ClientStats`](crate::ClientStats). Steady growth of that counter
+    /// means protocol drift (upgrade this SDK) or a corrupting middlebox.
+    DecodeFailed {
+        /// The wire `type` tag, when the frame was valid JSON with one.
+        ///
+        /// `Some("Error")` plus a decode failure strongly implies an
+        /// `error_code` string this SDK does not know; any other
+        /// `Some(...)` implies an unknown or malformed message type;
+        /// `None` implies the frame was not valid JSON at all.
+        message_type: Option<String>,
+        /// The deserialization error text.
+        error: String,
+        /// The raw frame text, truncated to at most
+        /// [`DECODE_FAILED_RAW_PREFIX_MAX`] bytes on a UTF-8 boundary.
+        raw_prefix: String,
     },
 
     // ── Authentication ──────────────────────────────────────────────
@@ -397,6 +441,57 @@ pub enum SignalFishEvent {
     },
 }
 
+/// Maximum number of bytes of raw frame text preserved in
+/// [`SignalFishEvent::DecodeFailed::raw_prefix`].
+///
+/// Truncation always lands on a UTF-8 character boundary, so the prefix may
+/// be a few bytes shorter than this cap.
+pub const DECODE_FAILED_RAW_PREFIX_MAX: usize = 512;
+
+/// A server-sent error remembered for disconnect attribution.
+///
+/// Carried by [`SignalFishEvent::Disconnected::last_server_error`]: the most
+/// recent `Error` or `AuthenticationError` frame received on the connection.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServerErrorInfo {
+    /// Human-readable error message from the server.
+    pub message: String,
+    /// Structured error code, if the server provided one.
+    pub error_code: Option<ErrorCode>,
+}
+
+impl SignalFishEvent {
+    /// Builds the [`DecodeFailed`](Self::DecodeFailed) event for a frame that
+    /// failed to deserialize.
+    ///
+    /// Shared by the async and polling clients so both surface identical
+    /// diagnostics: the wire `type` tag when the frame was valid JSON, the
+    /// serde error text, and a bounded raw prefix.
+    pub(crate) fn decode_failed(raw: &str, error: &serde_json::Error) -> Self {
+        let message_type = serde_json::from_str::<serde_json::Value>(raw)
+            .ok()
+            .and_then(|v| v.get("type")?.as_str().map(str::to_string));
+        Self::DecodeFailed {
+            message_type,
+            error: error.to_string(),
+            raw_prefix: truncate_on_char_boundary(raw, DECODE_FAILED_RAW_PREFIX_MAX).to_string(),
+        }
+    }
+}
+
+/// Returns the longest prefix of `s` that is at most `max_bytes` long and
+/// ends on a UTF-8 character boundary.
+fn truncate_on_char_boundary(s: &str, max_bytes: usize) -> &str {
+    if s.len() <= max_bytes {
+        return s;
+    }
+    let mut end = max_bytes;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    s.get(..end).unwrap_or_default()
+}
+
 // ── Conversion ──────────────────────────────────────────────────────
 
 impl From<ServerMessage> for SignalFishEvent {
@@ -615,8 +710,9 @@ mod tests {
     fn disconnected_event_contains_reason() {
         let event = SignalFishEvent::Disconnected {
             reason: Some("server shutdown".into()),
+            last_server_error: None,
         };
-        if let SignalFishEvent::Disconnected { reason } = event {
+        if let SignalFishEvent::Disconnected { reason, .. } = event {
             assert_eq!(reason.as_deref(), Some("server shutdown"));
         } else {
             panic!("expected Disconnected variant");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,7 +124,7 @@ pub const PROTOCOL_VERSION: u16 = 3;
 pub use client::{ClientStats, JoinRoomParams, SignalFishClient, SignalFishConfig};
 pub use error::SignalFishError;
 pub use error_codes::ErrorCode;
-pub use event::SignalFishEvent;
+pub use event::{ServerErrorInfo, SignalFishEvent, DECODE_FAILED_RAW_PREFIX_MAX};
 pub use protocol::{
     ClientMessage, IceServer, ServerMessage, SessionPeer, SessionPlanPayload, Topology,
     TransportKind,

--- a/src/mesh.rs
+++ b/src/mesh.rs
@@ -450,7 +450,10 @@ mod tests {
     #[test]
     fn reset_on_disconnect_and_room_left() {
         for terminal in [
-            SignalFishEvent::Disconnected { reason: None },
+            SignalFishEvent::Disconnected {
+                reason: None,
+                last_server_error: None,
+            },
             SignalFishEvent::RoomLeft,
         ] {
             let mut s = MeshSession::new();
@@ -660,7 +663,10 @@ mod tests {
             vec![
                 plan(Topology::Mesh, None, vec![peer(1, true)], vec![]),
                 SignalFishEvent::RoomLeft,
-                SignalFishEvent::Disconnected { reason: None },
+                SignalFishEvent::Disconnected {
+                    reason: None,
+                    last_server_error: None,
+                },
             ],
         ));
         assert!(changed);

--- a/src/polling_client.rs
+++ b/src/polling_client.rs
@@ -22,7 +22,7 @@ use tracing::{debug, error, warn};
 
 use crate::client::{JoinRoomParams, SignalFishConfig};
 use crate::error::{Result, SignalFishError};
-use crate::event::SignalFishEvent;
+use crate::event::{ServerErrorInfo, SignalFishEvent};
 use crate::protocol::{
     ClientMessage, ConnectionInfo, PlayerId, RoomId, ServerMessage, TransportKind,
 };
@@ -54,6 +54,15 @@ struct PollingClientState {
     /// [`ClientStats::game_data_received`](crate::client::ClientStats)).
     /// Cumulative — intentionally not reset by `clear_session`.
     game_data_received: u64,
+    /// Inbound frames that failed to decode into a `ServerMessage` (see
+    /// [`ClientStats::messages_undecodable`](crate::client::ClientStats)).
+    /// Cumulative — intentionally not reset by `clear_session`.
+    messages_undecodable: u64,
+    /// The most recent `Error`/`AuthenticationError` received on this
+    /// connection, remembered for disconnect attribution (surfaced via
+    /// `Disconnected::last_server_error`). Intentionally not reset by
+    /// `clear_session` — it must survive into the terminal `Disconnected`.
+    last_server_error: Option<ServerErrorInfo>,
 }
 
 impl PollingClientState {
@@ -70,6 +79,8 @@ impl PollingClientState {
             room_code: None,
             game_data_sent: 0,
             game_data_received: 0,
+            messages_undecodable: 0,
+            last_server_error: None,
         }
     }
 
@@ -264,7 +275,11 @@ impl<T: Transport> SignalFishPollingClient<T> {
                             events.push(SignalFishEvent::from(server_msg));
                         }
                         Err(e) => {
+                            // Never a silent drop: surface the frame as a
+                            // typed DecodeFailed event and count it.
                             warn!("failed to deserialize server message: {e} — raw: {text}");
+                            self.state.messages_undecodable += 1;
+                            events.push(SignalFishEvent::decode_failed(&text, &e));
                         }
                     }
                 }
@@ -278,7 +293,11 @@ impl<T: Transport> SignalFishPollingClient<T> {
                 }
                 std::task::Poll::Ready(None) => {
                     debug!("transport closed by server");
-                    self.handle_disconnect(&mut events, None);
+                    let reason = self
+                        .transport
+                        .close_reason()
+                        .map(|r| format!("closed by server: {r}"));
+                    self.handle_disconnect(&mut events, reason);
                     break;
                 }
                 std::task::Poll::Pending => {
@@ -603,6 +622,7 @@ impl<T: Transport> SignalFishPollingClient<T> {
         crate::client::ClientStats {
             game_data_sent: self.state.game_data_sent,
             game_data_received: self.state.game_data_received,
+            messages_undecodable: self.state.messages_undecodable,
         }
     }
 
@@ -676,13 +696,32 @@ impl<T: Transport> SignalFishPollingClient<T> {
     fn handle_disconnect(&mut self, events: &mut Vec<SignalFishEvent>, reason: Option<String>) {
         self.state.connected = false;
         self.state.clear_session();
-        events.push(SignalFishEvent::Disconnected { reason });
+        events.push(SignalFishEvent::Disconnected {
+            reason,
+            last_server_error: self.state.last_server_error.take(),
+        });
     }
 
     fn update_state(&mut self, msg: &ServerMessage) {
         match msg {
             ServerMessage::Authenticated { .. } => {
                 self.state.authenticated = true;
+            }
+            // Remember server errors for disconnect attribution.
+            ServerMessage::Error {
+                message,
+                error_code,
+            } => {
+                self.state.last_server_error = Some(ServerErrorInfo {
+                    message: message.clone(),
+                    error_code: error_code.clone(),
+                });
+            }
+            ServerMessage::AuthenticationError { error, error_code } => {
+                self.state.last_server_error = Some(ServerErrorInfo {
+                    message: error.clone(),
+                    error_code: Some(error_code.clone()),
+                });
             }
             ServerMessage::ProtocolInfo(payload) => {
                 self.state.negotiated_protocol_version = payload.protocol_version.unwrap_or(0);
@@ -1289,9 +1328,10 @@ mod tests {
     }
 
     #[test]
-    fn poll_skips_unknown_message_type_then_next_arrives() {
-        // A well-formed but unknown `type` is skipped (distinct from malformed
-        // JSON), and the following valid message still surfaces.
+    fn poll_surfaces_unknown_message_type_then_next_arrives() {
+        // A well-formed but unknown `type` surfaces as DecodeFailed carrying
+        // the wire tag (distinct from malformed JSON, whose tag is None), and
+        // the following valid message still arrives.
         let transport = MockTransport::new().with_incoming(vec![
             Some(Ok(authenticated_json_str().to_string())),
             Some(Ok(r#"{"type":"SomeFutureV4Message","data":{}}"#.to_string())),
@@ -1299,7 +1339,26 @@ mod tests {
         ]);
         let mut client = SignalFishPollingClient::new(transport, default_config());
         let events = client.poll();
-        assert!(events.iter().any(|e| matches!(e, SignalFishEvent::Pong)));
+        let decode_failed_at = events.iter().position(|e| {
+            matches!(
+                e,
+                SignalFishEvent::DecodeFailed { message_type, .. }
+                    if message_type.as_deref() == Some("SomeFutureV4Message")
+            )
+        });
+        let pong_at = events
+            .iter()
+            .position(|e| matches!(e, SignalFishEvent::Pong));
+        assert!(
+            decode_failed_at.is_some(),
+            "expected DecodeFailed with the wire tag, got: {events:?}"
+        );
+        assert!(pong_at.is_some(), "expected Pong, got: {events:?}");
+        assert!(
+            decode_failed_at < pong_at,
+            "DecodeFailed must precede the following Pong"
+        );
+        assert_eq!(client.stats().messages_undecodable, 1);
         assert!(client.is_connected());
     }
 
@@ -1338,6 +1397,7 @@ mod tests {
             crate::client::ClientStats {
                 game_data_sent: 3,
                 game_data_received: 2,
+                messages_undecodable: 0,
             }
         );
     }
@@ -1697,10 +1757,24 @@ mod tests {
 
         let events = client.poll();
 
-        // Should contain Connected and Authenticated (malformed message skipped).
-        assert_eq!(events.len(), 2, "expected 2 events, got: {events:?}");
+        // Connected, then the malformed frame surfaced as DecodeFailed (never
+        // a silent skip), then Authenticated.
+        assert_eq!(events.len(), 3, "expected 3 events, got: {events:?}");
         assert!(matches!(events[0], SignalFishEvent::Connected));
-        assert!(matches!(events[1], SignalFishEvent::Authenticated { .. }));
+        match &events[1] {
+            SignalFishEvent::DecodeFailed {
+                message_type,
+                raw_prefix,
+                ..
+            } => {
+                // Not valid JSON at all → no wire `type` tag recoverable.
+                assert_eq!(message_type.as_deref(), None);
+                assert_eq!(raw_prefix, malformed_json);
+            }
+            other => panic!("expected DecodeFailed, got: {other:?}"),
+        }
+        assert!(matches!(events[2], SignalFishEvent::Authenticated { .. }));
+        assert_eq!(client.stats().messages_undecodable, 1);
 
         // Should NOT contain a Disconnected event.
         assert!(
@@ -2593,8 +2667,9 @@ mod tests {
             disconnected.is_some(),
             "expected Disconnected event, got: {events:?}"
         );
-        if let SignalFishEvent::Disconnected { reason: Some(r) } =
-            disconnected.expect("Disconnected event must exist (verified by preceding assert)")
+        if let SignalFishEvent::Disconnected {
+            reason: Some(r), ..
+        } = disconnected.expect("Disconnected event must exist (verified by preceding assert)")
         {
             assert!(
                 r.contains("transport send error"),

--- a/src/polling_client.rs
+++ b/src/polling_client.rs
@@ -276,8 +276,15 @@ impl<T: Transport> SignalFishPollingClient<T> {
                         }
                         Err(e) => {
                             // Never a silent drop: surface the frame as a
-                            // typed DecodeFailed event and count it.
-                            warn!("failed to deserialize server message: {e} — raw: {text}");
+                            // typed DecodeFailed event and count it. Log the
+                            // error and frame size only — not the raw content,
+                            // which is untrusted, unbounded, and may carry
+                            // application payloads (the DecodeFailed event
+                            // carries a bounded prefix for diagnostics).
+                            warn!(
+                                "failed to deserialize server message ({} bytes): {e}",
+                                text.len()
+                            );
                             self.state.messages_undecodable += 1;
                             events.push(SignalFishEvent::decode_failed(&text, &e));
                         }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -51,8 +51,12 @@ pub enum GameDataEncoding {
     /// MessagePack payloads delivered over binary frames.
     #[serde(rename = "message_pack")]
     MessagePack,
-    /// Rkyv zero-copy binary format for maximum performance.
-    /// Recommended for: High-frequency updates, large player counts, latency-sensitive games.
+    /// Rkyv zero-copy binary format.
+    ///
+    /// **Caveat:** the current server never advertises or negotiates rkyv —
+    /// requesting it does not fail, it silently downgrades to JSON (the
+    /// server's `game_data_formats` will not include `"rkyv"`). Treat this
+    /// variant as reserved until the server ships rkyv negotiation.
     #[serde(rename = "rkyv")]
     Rkyv,
 }

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -130,4 +130,23 @@ pub trait Transport: Send + 'static {
     fn is_ready(&self) -> bool {
         true
     }
+
+    /// A human-readable close explanation captured by the transport, if the
+    /// peer supplied one (e.g. a WebSocket Close frame's reason and code).
+    ///
+    /// Consulted by the clients after [`recv`](Transport::recv) returns
+    /// `None` to enrich the
+    /// [`Disconnected`](crate::SignalFishEvent::Disconnected) event's
+    /// `reason`. The default implementation returns `None`, which is correct
+    /// for transports that have no close metadata; custom transports should
+    /// override this if their protocol carries a close reason.
+    ///
+    /// The Signal Fish server today closes with a *bare* WebSocket Close
+    /// frame (no code/reason), so even
+    /// [`WebSocketTransport`](crate::WebSocketTransport) usually returns
+    /// `None`; the override exists so richer close signals surface as soon
+    /// as a peer sends them.
+    fn close_reason(&self) -> Option<String> {
+        None
+    }
 }

--- a/src/transports/websocket.rs
+++ b/src/transports/websocket.rs
@@ -72,6 +72,9 @@ pub type WsStream =
 pub struct WebSocketTransport {
     stream: WsStream,
     closed: bool,
+    /// Close-frame text captured from the peer (`"{reason} ({code})"`),
+    /// surfaced via [`Transport::close_reason`]. `None` for a bare close.
+    close_reason: Option<String>,
 }
 
 impl WebSocketTransport {
@@ -102,6 +105,7 @@ impl WebSocketTransport {
         Ok(Self {
             stream,
             closed: false,
+            close_reason: None,
         })
     }
 
@@ -113,6 +117,7 @@ impl WebSocketTransport {
         Self {
             stream,
             closed: false,
+            close_reason: None,
         }
     }
 
@@ -164,6 +169,9 @@ impl Transport for WebSocketTransport {
                 Message::Text(text) => return Some(Ok(text.to_string())),
                 Message::Close(frame) => {
                     tracing::debug!(?frame, "received WebSocket close frame");
+                    // Remember the close explanation (if any) so the client
+                    // can attribute the disconnect via `close_reason()`.
+                    self.close_reason = frame.map(|f| f.to_string());
                     return None;
                 }
                 Message::Ping(_) => {
@@ -198,6 +206,10 @@ impl Transport for WebSocketTransport {
             .close(None)
             .await
             .map_err(|e| SignalFishError::TransportSend(e.to_string()))
+    }
+
+    fn close_reason(&self) -> Option<String> {
+        self.close_reason.clone()
     }
 }
 
@@ -320,6 +332,38 @@ mod tests {
             .expect("WebSocket connect must succeed");
         let result = transport.recv().await;
         assert!(result.is_none());
+        // A bare close (today's server behavior) carries no explanation.
+        assert_eq!(transport.close_reason(), None);
+    }
+
+    #[tokio::test]
+    async fn close_frame_reason_is_captured() {
+        use tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode;
+        use tokio_tungstenite::tungstenite::protocol::frame::CloseFrame;
+
+        let url = start_mock_server(|mut ws| async move {
+            ws.close(Some(CloseFrame {
+                code: CloseCode::Policy,
+                reason: "slow consumer".into(),
+            }))
+            .await
+            .expect("server must close with a frame");
+        })
+        .await;
+
+        let mut transport = WebSocketTransport::connect(&url)
+            .await
+            .expect("WebSocket connect must succeed");
+        let result = transport.recv().await;
+        assert!(result.is_none());
+
+        let reason = transport
+            .close_reason()
+            .expect("close frame explanation must be captured");
+        assert!(
+            reason.contains("slow consumer"),
+            "captured reason should include the frame text: {reason}"
+        );
     }
 
     #[tokio::test]

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -7793,6 +7793,8 @@ mod protocol_wire_conformance_policy {
             "SIGNAL_RATE_LIMITED",
             "SIGNAL_TOO_LARGE",
             "CONNECTION_IDLE_TIMEOUT",
+            "SLOW_CONSUMER",
+            "ACTIVITY_TIMEOUT",
         ] {
             assert!(
                 changelog.contains(code),
@@ -7819,5 +7821,109 @@ mod protocol_wire_conformance_policy {
                 "skill not referenced in the auto-generated index: {skill}"
             );
         }
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // Vendored server AsyncAPI spec (tests/server-spec/) — same provenance
+    // discipline as the wire samples above. The spec backs the error-code
+    // conformance suite (tests/error_code_conformance_tests.rs).
+    // ────────────────────────────────────────────────────────────────────
+
+    const SERVER_SPEC_FILE: &str = "signal-fish-protocol.asyncapi.yaml";
+
+    fn server_spec_path(name: &str) -> String {
+        format!("tests/server-spec/{name}")
+    }
+
+    #[test]
+    fn server_spec_files_exist_and_are_non_empty() {
+        let rel = server_spec_path(SERVER_SPEC_FILE);
+        assert!(project_file_exists(&rel), "missing vendored spec: {rel}");
+        let content = read_project_file(&rel);
+        assert!(
+            content.lines().any(|l| !l.trim().is_empty()),
+            "vendored spec is empty: {rel}"
+        );
+        assert!(
+            project_file_exists("tests/server-spec/PROVENANCE.toml"),
+            "tests/server-spec/PROVENANCE.toml is required"
+        );
+        assert!(
+            project_file_exists("tests/server-spec/README.md"),
+            "tests/server-spec/README.md is required"
+        );
+    }
+
+    #[test]
+    fn server_spec_provenance_marker_is_valid() {
+        let toml_str = read_project_file("tests/server-spec/PROVENANCE.toml");
+        let parsed: toml::Value =
+            toml::from_str(&toml_str).expect("PROVENANCE.toml must be valid TOML");
+
+        let upstream = parsed.get("upstream").expect("[upstream] table required");
+        let commit = upstream
+            .get("commit")
+            .and_then(toml::Value::as_str)
+            .expect("[upstream].commit required");
+        assert_eq!(
+            commit.len(),
+            40,
+            "commit must be a 40-char git SHA: {commit}"
+        );
+        assert!(
+            commit.chars().all(|c| c.is_ascii_hexdigit()),
+            "commit must be hexadecimal: {commit}"
+        );
+        assert!(
+            upstream
+                .get("synced")
+                .and_then(toml::Value::as_str)
+                .is_some(),
+            "[upstream].synced date required"
+        );
+
+        let files = parsed
+            .get("files")
+            .and_then(toml::Value::as_table)
+            .expect("[files] table required");
+        let sum = files
+            .get(SERVER_SPEC_FILE)
+            .and_then(toml::Value::as_str)
+            .unwrap_or_else(|| panic!("[files] missing checksum for {SERVER_SPEC_FILE}"));
+        assert_eq!(
+            sum.len(),
+            64,
+            "{SERVER_SPEC_FILE}: checksum must be 64 hex chars"
+        );
+        assert!(
+            sum.chars().all(|c| c.is_ascii_hexdigit()),
+            "{SERVER_SPEC_FILE}: checksum must be hexadecimal"
+        );
+    }
+
+    #[test]
+    fn server_spec_provenance_checksum_matches_vendored_file() {
+        // Guards against editing the spec without updating the marker (or vice
+        // versa) — the provenance stays honest.
+        let toml_str = read_project_file("tests/server-spec/PROVENANCE.toml");
+        let parsed: toml::Value = toml::from_str(&toml_str).expect("valid TOML");
+        let files = parsed
+            .get("files")
+            .and_then(toml::Value::as_table)
+            .expect("[files] table");
+
+        let expected = files
+            .get(SERVER_SPEC_FILE)
+            .and_then(toml::Value::as_str)
+            .expect("checksum entry");
+        let bytes = std::fs::read(project_root().join(server_spec_path(SERVER_SPEC_FILE)))
+            .unwrap_or_else(|e| panic!("read {SERVER_SPEC_FILE}: {e}"));
+        let actual = hex_encode(&Sha256::digest(&bytes));
+        assert_eq!(
+            actual, expected,
+            "{SERVER_SPEC_FILE}: SHA-256 differs from PROVENANCE.toml — the spec was \
+             edited but the marker was not updated (or vice versa). See \
+             .llm/skills/protocol-wire-conformance.md."
+        );
     }
 }

--- a/tests/client_tests.rs
+++ b/tests/client_tests.rs
@@ -1663,7 +1663,7 @@ async fn shutdown_races_wedged_terminal_disconnect() {
     // terminal delivery blocks. Pre-fix those paths used a blocking emit that
     // ignored shutdown, pinning shutdown() to its full timeout/abort. A
     // generous timeout makes the racing path (ms) unmistakable vs blocking (s).
-    let (transport, _sent, _closed) = MockTransport::new(vec![Some(Err(
+    let (transport, _sent, closed) = MockTransport::new(vec![Some(Err(
         SignalFishError::TransportReceive("boom".into()),
     ))]);
     let config = SignalFishConfig::new("mb_test_integration")
@@ -1682,6 +1682,13 @@ async fn shutdown_races_wedged_terminal_disconnect() {
         elapsed < std::time::Duration::from_secs(3),
         "terminal Disconnected must race shutdown, not block until the abort \
          timeout; took {elapsed:?}"
+    );
+    // Graceful shutdown always releases the connection: the transport must be
+    // closed even when shutdown wins the race against the wedged delivery.
+    assert!(
+        closed.load(std::sync::atomic::Ordering::Relaxed),
+        "the transport must be closed on the terminal break-path, not left \
+         open until the task is dropped"
     );
 }
 

--- a/tests/client_tests.rs
+++ b/tests/client_tests.rs
@@ -1653,6 +1653,38 @@ async fn wedged_consumer_events_before_shutdown_are_not_lost_when_drained() {
     assert!(closed.load(std::sync::atomic::Ordering::Relaxed));
 }
 
+#[tokio::test]
+async fn shutdown_races_wedged_terminal_disconnect() {
+    // The *terminal* Disconnected — emitted on a transport error, a clean
+    // server close, or a dropped handle — must race the shutdown signal too,
+    // not just the normal per-message event path. The four break-paths share
+    // one helper; this exercises it via a transport receive error that fires
+    // while the event channel is full (cap 1, undrained Connected), so the
+    // terminal delivery blocks. Pre-fix those paths used a blocking emit that
+    // ignored shutdown, pinning shutdown() to its full timeout/abort. A
+    // generous timeout makes the racing path (ms) unmistakable vs blocking (s).
+    let (transport, _sent, _closed) = MockTransport::new(vec![Some(Err(
+        SignalFishError::TransportReceive("boom".into()),
+    ))]);
+    let config = SignalFishConfig::new("mb_test_integration")
+        .with_event_channel_capacity(1)
+        .with_shutdown_timeout(std::time::Duration::from_secs(10));
+    // `_events` is bound (not `_`) so the channel stays open and full — that
+    // is what wedges the terminal delivery.
+    let (mut client, _events) = SignalFishClient::start(transport, config);
+
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    let started = std::time::Instant::now();
+    client.shutdown().await;
+    let elapsed = started.elapsed();
+    assert!(
+        elapsed < std::time::Duration::from_secs(3),
+        "terminal Disconnected must race shutdown, not block until the abort \
+         timeout; took {elapsed:?}"
+    );
+}
+
 // ════════════════════════════════════════════════════════════════════
 // PlayerJoined with ConnectionInfo::Direct
 // ════════════════════════════════════════════════════════════════════

--- a/tests/client_tests.rs
+++ b/tests/client_tests.rs
@@ -640,7 +640,7 @@ async fn disconnect_on_transport_error() {
     assert!(matches!(ev, SignalFishEvent::Connected));
 
     let ev = events.recv().await.expect("event");
-    if let SignalFishEvent::Disconnected { reason } = ev {
+    if let SignalFishEvent::Disconnected { reason, .. } = ev {
         let r = reason.expect("reason should be present");
         assert!(r.contains("network failure"), "reason was: {r}");
     } else {
@@ -1410,9 +1410,10 @@ async fn leave_room_sends_leave_room_message() {
 // ════════════════════════════════════════════════════════════════════
 
 #[tokio::test]
-async fn malformed_json_does_not_crash_and_next_message_arrives() {
-    // Send garbled text followed by a valid message.
-    // The transport loop should warn on the invalid JSON and continue.
+async fn malformed_json_emits_decode_failed_then_next_message_arrives() {
+    // Send garbled text followed by a valid message. The transport loop
+    // surfaces the invalid frame as a DecodeFailed event (never a silent
+    // drop) and continues.
     let (mut client, mut events, _sent, _closed) = start_client(vec![
         Some(Ok(authenticated_json())),
         Some(Ok("{{not valid json at all!!!".into())),
@@ -1421,17 +1422,235 @@ async fn malformed_json_does_not_crash_and_next_message_arrives() {
 
     drain_until_authenticated(&mut events).await;
 
-    // The invalid JSON is silently dropped. The next valid message should arrive.
     let ev = events
         .recv()
         .await
-        .expect("expected Pong after malformed JSON");
+        .expect("expected DecodeFailed after malformed JSON");
+    match ev {
+        SignalFishEvent::DecodeFailed {
+            message_type,
+            raw_prefix,
+            ..
+        } => {
+            // Not valid JSON at all → no wire `type` tag recoverable.
+            assert_eq!(message_type.as_deref(), None);
+            assert_eq!(raw_prefix, "{{not valid json at all!!!");
+        }
+        other => panic!("expected DecodeFailed, got {other:?}"),
+    }
+
+    let ev = events
+        .recv()
+        .await
+        .expect("expected Pong after DecodeFailed");
     assert!(
         matches!(ev, SignalFishEvent::Pong),
         "expected Pong event after malformed JSON, got {ev:?}"
     );
+    assert_eq!(client.stats().messages_undecodable, 1);
 
     client.shutdown().await;
+}
+
+#[tokio::test]
+async fn unknown_error_code_string_surfaces_decode_failed_not_silent_drop() {
+    // The core #131-follow-up regression: a server newer than this SDK sends
+    // an Error frame with an error_code string the exhaustive ErrorCode enum
+    // does not know. The whole ServerMessage fails to parse — before 0.7.0 it
+    // was silently dropped (warn! only); now it must surface as DecodeFailed
+    // carrying the wire tag, and the connection must stay open.
+    let unknown_code_frame =
+        r#"{"type":"Error","data":{"message":"evicted","error_code":"FUTURE_CODE_XYZ"}}"#;
+    let (mut client, mut events, _sent, _closed) = start_client(vec![
+        Some(Ok(authenticated_json())),
+        Some(Ok(unknown_code_frame.to_string())),
+        Some(Ok(pong_json())),
+    ]);
+
+    drain_until_authenticated(&mut events).await;
+
+    let ev = events.recv().await.expect("event after unknown error code");
+    match ev {
+        SignalFishEvent::DecodeFailed {
+            message_type,
+            error,
+            raw_prefix,
+        } => {
+            assert_eq!(
+                message_type.as_deref(),
+                Some("Error"),
+                "the wire tag must identify which message type failed"
+            );
+            assert!(
+                error.contains("FUTURE_CODE_XYZ") || error.contains("variant"),
+                "serde error should mention the unknown token: {error}"
+            );
+            assert_eq!(raw_prefix, unknown_code_frame);
+        }
+        other => panic!("expected DecodeFailed, got {other:?}"),
+    }
+
+    // Connection unaffected: the next frame still arrives.
+    let ev = events.recv().await.expect("Pong after DecodeFailed");
+    assert!(matches!(ev, SignalFishEvent::Pong));
+    assert!(client.is_connected());
+    assert_eq!(client.stats().messages_undecodable, 1);
+
+    client.shutdown().await;
+}
+
+#[tokio::test]
+async fn decode_failed_raw_prefix_is_capped_on_utf8_boundary() {
+    use signal_fish_client::DECODE_FAILED_RAW_PREFIX_MAX;
+
+    // Garbage longer than the cap, with multi-byte characters positioned so a
+    // naive byte cut would split one.
+    let garbage = format!("ここは{}", "é".repeat(600));
+    assert!(garbage.len() > DECODE_FAILED_RAW_PREFIX_MAX);
+
+    let (mut client, mut events, _sent, _closed) = start_client(vec![
+        Some(Ok(authenticated_json())),
+        Some(Ok(garbage.clone())),
+    ]);
+    drain_until_authenticated(&mut events).await;
+
+    let ev = events.recv().await.expect("DecodeFailed for garbage");
+    match ev {
+        SignalFishEvent::DecodeFailed { raw_prefix, .. } => {
+            assert!(raw_prefix.len() <= DECODE_FAILED_RAW_PREFIX_MAX);
+            assert!(
+                garbage.starts_with(&raw_prefix),
+                "prefix must be a true prefix of the input"
+            );
+            // String integrity (valid UTF-8) is implied by the type; the cut
+            // landing on a boundary is what this asserts.
+            assert!(!raw_prefix.is_empty());
+        }
+        other => panic!("expected DecodeFailed, got {other:?}"),
+    }
+    client.shutdown().await;
+}
+
+// ════════════════════════════════════════════════════════════════════
+// Disconnected enrichment: last_server_error
+// ════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn disconnected_carries_last_server_error_after_server_close() {
+    // The server's slow-consumer eviction shape: a best-effort Error farewell
+    // followed by a close. The terminal Disconnected must carry the farewell
+    // so the disconnect can be attributed.
+    let (_client, mut events, _sent, _closed) = start_client(vec![
+        Some(Ok(authenticated_json())),
+        Some(Ok(error_json(
+            "Disconnected as a slow consumer",
+            Some(ErrorCode::SlowConsumer),
+        ))),
+        None, // server closes
+    ]);
+
+    drain_until_authenticated(&mut events).await;
+
+    let ev = events.recv().await.expect("Error event");
+    assert!(matches!(ev, SignalFishEvent::Error { .. }));
+
+    let ev = events.recv().await.expect("Disconnected event");
+    match ev {
+        SignalFishEvent::Disconnected {
+            last_server_error, ..
+        } => {
+            let info = last_server_error.expect("farewell must be attributed");
+            assert_eq!(info.error_code, Some(ErrorCode::SlowConsumer));
+            assert!(info.message.contains("slow consumer"));
+        }
+        other => panic!("expected Disconnected, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn disconnected_last_server_error_is_none_without_prior_error() {
+    let (_client, mut events, _sent, _closed) =
+        start_client(vec![Some(Ok(authenticated_json())), None]);
+
+    drain_until_authenticated(&mut events).await;
+
+    let ev = events.recv().await.expect("Disconnected event");
+    match ev {
+        SignalFishEvent::Disconnected {
+            reason,
+            last_server_error,
+        } => {
+            assert_eq!(reason, None, "bare close has no reason");
+            assert_eq!(last_server_error, None);
+        }
+        other => panic!("expected Disconnected, got {other:?}"),
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════
+// Wedged-consumer shutdown: graceful close instead of abort-only
+// ════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn shutdown_completes_gracefully_with_wedged_consumer() {
+    // A consumer that stops draining wedges the transport loop in the event
+    // send. Pre-0.7.0 the shutdown oneshot was starved too, so shutdown()
+    // could only abort the task, leaving the transport unclosed. Now the
+    // event send races the shutdown signal: the loop unblocks, closes the
+    // transport, and shutdown() completes without reaching the abort.
+    let (transport, _sent, closed) = MockTransport::new(vec![
+        Some(Ok(authenticated_json())),
+        Some(Ok(pong_json())),
+        Some(Ok(pong_json())),
+    ]);
+    let config = SignalFishConfig::new("mb_test_integration")
+        .with_event_channel_capacity(1)
+        .with_shutdown_timeout(std::time::Duration::from_secs(5));
+    let (mut client, events) = SignalFishClient::start(transport, config);
+
+    // Never drain `events`; give the loop time to wedge on a full channel.
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    let started = std::time::Instant::now();
+    client.shutdown().await;
+    let elapsed = started.elapsed();
+
+    assert!(
+        closed.load(std::sync::atomic::Ordering::Relaxed),
+        "transport must be closed gracefully even with a wedged consumer"
+    );
+    assert!(
+        elapsed < std::time::Duration::from_secs(4),
+        "shutdown must not need the timeout/abort path; took {elapsed:?}"
+    );
+    drop(events);
+}
+
+#[tokio::test]
+async fn wedged_consumer_events_before_shutdown_are_not_lost_when_drained() {
+    // Guards against over-eager abandonment: a consumer that resumes draining
+    // BEFORE shutdown still receives every event, and shutdown then delivers
+    // the terminal Disconnected.
+    let (transport, _sent, closed) =
+        MockTransport::new(vec![Some(Ok(authenticated_json())), Some(Ok(pong_json()))]);
+    let config = SignalFishConfig::new("mb_test_integration").with_event_channel_capacity(1);
+    let (mut client, mut events) = SignalFishClient::start(transport, config);
+
+    // Let the loop wedge against the capacity-1 channel.
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    // Resume draining: everything must arrive in order.
+    let ev = events.recv().await.expect("Connected");
+    assert!(matches!(ev, SignalFishEvent::Connected));
+    let ev = events.recv().await.expect("Authenticated");
+    assert!(matches!(ev, SignalFishEvent::Authenticated { .. }));
+    let ev = events.recv().await.expect("Pong");
+    assert!(matches!(ev, SignalFishEvent::Pong));
+
+    client.shutdown().await;
+    let ev = events.recv().await.expect("Disconnected");
+    assert!(matches!(ev, SignalFishEvent::Disconnected { .. }));
+    assert!(closed.load(std::sync::atomic::Ordering::Relaxed));
 }
 
 // ════════════════════════════════════════════════════════════════════
@@ -1740,9 +1959,10 @@ async fn new_peer_and_peer_transport_status_events_are_emitted() {
 }
 
 #[tokio::test]
-async fn unknown_server_message_type_is_skipped_then_next_arrives() {
-    // Forward-compat: a well-formed but unknown `type` is logged+skipped, and the
-    // following valid message still surfaces.
+async fn unknown_server_message_type_surfaces_decode_failed_then_next_arrives() {
+    // Forward-compat: a well-formed but unknown `type` surfaces as a
+    // DecodeFailed event carrying the wire tag, and the following valid
+    // message still arrives.
     let (mut client, mut events, _sent, _closed) = start_client(vec![
         Some(Ok(authenticated_json())),
         Some(Ok(r#"{"type":"SomeFutureV4Message","data":{}}"#.to_string())),
@@ -1750,6 +1970,13 @@ async fn unknown_server_message_type_is_skipped_then_next_arrives() {
     ]);
     drain_until_authenticated(&mut events).await;
     let ev = events.recv().await.expect("event after unknown type");
+    match ev {
+        SignalFishEvent::DecodeFailed { message_type, .. } => {
+            assert_eq!(message_type.as_deref(), Some("SomeFutureV4Message"));
+        }
+        other => panic!("expected DecodeFailed, got {other:?}"),
+    }
+    let ev = events.recv().await.expect("event after DecodeFailed");
     assert!(matches!(ev, SignalFishEvent::Pong));
     assert!(client.is_connected());
     client.shutdown().await;

--- a/tests/error_code_conformance_tests.rs
+++ b/tests/error_code_conformance_tests.rs
@@ -1,0 +1,272 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::todo,
+    clippy::unimplemented,
+    clippy::indexing_slicing
+)]
+//! Cross-repo error-code conformance tests.
+//!
+//! The server's AsyncAPI spec (vendored verbatim at
+//! `tests/server-spec/signal-fish-protocol.asyncapi.yaml`, provenance pinned
+//! in `PROVENANCE.toml`) declares the full set of wire error-code tokens the
+//! server may send. The client's [`ErrorCode`] enum is deliberately
+//! exhaustive, so an unknown token fails deserialization of the *entire*
+//! enclosing `ServerMessage`. These tests keep the two value spaces in
+//! lockstep in both directions, closing the drift blind spot where a
+//! server-side code addition passes the wire-sample golden tests (which pin
+//! message *shapes*, not the error-code value space).
+//!
+//! A weekly CI job (`.github/workflows/protocol-sync.yml`) diffs the vendored
+//! spec against the server's `main`, so upstream additions surface here as a
+//! red `every_server_error_code_token_deserializes_into_a_client_variant`.
+
+use signal_fish_client::error_codes::ErrorCode;
+
+const SPEC: &str = include_str!("server-spec/signal-fish-protocol.asyncapi.yaml");
+
+/// Client-only codes intentionally absent from the server spec.
+///
+/// Kept empty on purpose: every client variant is expected to exist because
+/// the server can send it. Add a token here only with a comment explaining
+/// why the client models a code the server does not declare.
+const CLIENT_ONLY_ALLOWLIST: &[&str] = &[];
+
+/// Extracts the wire tokens of the spec's `ErrorCode` enum with a plain line
+/// scan (no YAML dependency).
+///
+/// Anchors on the `ErrorCode:` schema key, then its `enum:` list, and
+/// collects `- SCREAMING_SNAKE` items until the first line that is not one
+/// (dedent or blank line ends the block). Restructuring the spec breaks the
+/// scan loudly via `spec_error_code_extraction_finds_a_plausible_count`.
+fn extract_spec_error_tokens() -> Vec<String> {
+    let mut lines = SPEC.lines();
+
+    // Locate the `ErrorCode:` schema key (indented mapping key, exact name).
+    for line in lines.by_ref() {
+        if line.trim() == "ErrorCode:" {
+            break;
+        }
+    }
+
+    // Locate the `enum:` key within the schema body.
+    for line in lines.by_ref() {
+        if line.trim() == "enum:" {
+            break;
+        }
+    }
+
+    // Collect `- TOKEN` items until the block ends.
+    let mut tokens = Vec::new();
+    for line in lines {
+        let trimmed = line.trim();
+        let Some(item) = trimmed.strip_prefix("- ") else {
+            break;
+        };
+        let is_screaming_snake = !item.is_empty()
+            && item.chars().next().is_some_and(|c| c.is_ascii_uppercase())
+            && item
+                .chars()
+                .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '_');
+        if !is_screaming_snake {
+            break;
+        }
+        tokens.push(item.to_string());
+    }
+    tokens
+}
+
+/// Every client `ErrorCode` variant, exactly once.
+///
+/// Kept honest by [`exhaustiveness_guard`]: adding an enum variant fails to
+/// compile there, forcing an edit to this file — extend BOTH the guard match
+/// and this list.
+fn all_client_error_codes() -> Vec<ErrorCode> {
+    vec![
+        ErrorCode::Unauthorized,
+        ErrorCode::InvalidToken,
+        ErrorCode::AuthenticationRequired,
+        ErrorCode::InvalidAppId,
+        ErrorCode::AppIdExpired,
+        ErrorCode::AppIdRevoked,
+        ErrorCode::AppIdSuspended,
+        ErrorCode::MissingAppId,
+        ErrorCode::AuthenticationTimeout,
+        ErrorCode::SdkVersionUnsupported,
+        ErrorCode::UnsupportedGameDataFormat,
+        ErrorCode::InvalidInput,
+        ErrorCode::InvalidGameName,
+        ErrorCode::InvalidRoomCode,
+        ErrorCode::InvalidPlayerName,
+        ErrorCode::InvalidMaxPlayers,
+        ErrorCode::MessageTooLarge,
+        ErrorCode::RoomNotFound,
+        ErrorCode::RoomFull,
+        ErrorCode::AlreadyInRoom,
+        ErrorCode::NotInRoom,
+        ErrorCode::RoomCreationFailed,
+        ErrorCode::MaxRoomsPerGameExceeded,
+        ErrorCode::InvalidRoomState,
+        ErrorCode::AuthorityNotSupported,
+        ErrorCode::AuthorityConflict,
+        ErrorCode::AuthorityDenied,
+        ErrorCode::RateLimitExceeded,
+        ErrorCode::TooManyConnections,
+        ErrorCode::ReconnectionFailed,
+        ErrorCode::ReconnectionTokenInvalid,
+        ErrorCode::ReconnectionExpired,
+        ErrorCode::PlayerAlreadyConnected,
+        ErrorCode::SpectatorNotAllowed,
+        ErrorCode::TooManySpectators,
+        ErrorCode::NotASpectator,
+        ErrorCode::SpectatorJoinFailed,
+        ErrorCode::InternalError,
+        ErrorCode::StorageError,
+        ErrorCode::ServiceUnavailable,
+        ErrorCode::GameStartNotReady,
+        ErrorCode::GameStartForbidden,
+        ErrorCode::CrossRoomSignal,
+        ErrorCode::UnsupportedTransport,
+        ErrorCode::SignalTargetNotFound,
+        ErrorCode::SignalRateLimited,
+        ErrorCode::SignalTooLarge,
+        ErrorCode::ConnectionIdleTimeout,
+        ErrorCode::SlowConsumer,
+        ErrorCode::ActivityTimeout,
+    ]
+}
+
+/// Compile-time exhaustiveness guard: one arm per variant, no wildcard.
+///
+/// A new `ErrorCode` variant fails compilation here until both this match and
+/// [`all_client_error_codes`] are extended.
+fn exhaustiveness_guard(code: &ErrorCode) {
+    match code {
+        ErrorCode::Unauthorized
+        | ErrorCode::InvalidToken
+        | ErrorCode::AuthenticationRequired
+        | ErrorCode::InvalidAppId
+        | ErrorCode::AppIdExpired
+        | ErrorCode::AppIdRevoked
+        | ErrorCode::AppIdSuspended
+        | ErrorCode::MissingAppId
+        | ErrorCode::AuthenticationTimeout
+        | ErrorCode::SdkVersionUnsupported
+        | ErrorCode::UnsupportedGameDataFormat
+        | ErrorCode::InvalidInput
+        | ErrorCode::InvalidGameName
+        | ErrorCode::InvalidRoomCode
+        | ErrorCode::InvalidPlayerName
+        | ErrorCode::InvalidMaxPlayers
+        | ErrorCode::MessageTooLarge
+        | ErrorCode::RoomNotFound
+        | ErrorCode::RoomFull
+        | ErrorCode::AlreadyInRoom
+        | ErrorCode::NotInRoom
+        | ErrorCode::RoomCreationFailed
+        | ErrorCode::MaxRoomsPerGameExceeded
+        | ErrorCode::InvalidRoomState
+        | ErrorCode::AuthorityNotSupported
+        | ErrorCode::AuthorityConflict
+        | ErrorCode::AuthorityDenied
+        | ErrorCode::RateLimitExceeded
+        | ErrorCode::TooManyConnections
+        | ErrorCode::ReconnectionFailed
+        | ErrorCode::ReconnectionTokenInvalid
+        | ErrorCode::ReconnectionExpired
+        | ErrorCode::PlayerAlreadyConnected
+        | ErrorCode::SpectatorNotAllowed
+        | ErrorCode::TooManySpectators
+        | ErrorCode::NotASpectator
+        | ErrorCode::SpectatorJoinFailed
+        | ErrorCode::InternalError
+        | ErrorCode::StorageError
+        | ErrorCode::ServiceUnavailable
+        | ErrorCode::GameStartNotReady
+        | ErrorCode::GameStartForbidden
+        | ErrorCode::CrossRoomSignal
+        | ErrorCode::UnsupportedTransport
+        | ErrorCode::SignalTargetNotFound
+        | ErrorCode::SignalRateLimited
+        | ErrorCode::SignalTooLarge
+        | ErrorCode::ConnectionIdleTimeout
+        | ErrorCode::SlowConsumer
+        | ErrorCode::ActivityTimeout => {}
+    }
+}
+
+fn wire_token(code: &ErrorCode) -> String {
+    let json = serde_json::to_string(code).expect("ErrorCode must serialize");
+    json.trim_matches('"').to_string()
+}
+
+#[test]
+fn every_server_error_code_token_deserializes_into_a_client_variant() {
+    let tokens = extract_spec_error_tokens();
+    let unknown: Vec<&String> = tokens
+        .iter()
+        .filter(|token| serde_json::from_str::<ErrorCode>(&format!("\"{token}\"")).is_err())
+        .collect();
+    assert!(
+        unknown.is_empty(),
+        "server spec declares error-code tokens the client ErrorCode enum cannot \
+         deserialize (an Error frame carrying one is dropped undecoded): {unknown:?}. \
+         Add the missing variants to src/error_codes.rs."
+    );
+}
+
+#[test]
+fn every_client_error_code_appears_in_server_spec() {
+    let tokens = extract_spec_error_tokens();
+    let stray: Vec<String> = all_client_error_codes()
+        .iter()
+        .map(wire_token)
+        .filter(|token| {
+            !tokens.iter().any(|t| t == token) && !CLIENT_ONLY_ALLOWLIST.contains(&token.as_str())
+        })
+        .collect();
+    assert!(
+        stray.is_empty(),
+        "client ErrorCode variants missing from the server spec (either remove them, \
+         update the vendored spec, or add to CLIENT_ONLY_ALLOWLIST with justification): \
+         {stray:?}"
+    );
+}
+
+#[test]
+fn client_and_spec_error_code_counts_match() {
+    let tokens = extract_spec_error_tokens();
+    let codes = all_client_error_codes();
+    for code in &codes {
+        exhaustiveness_guard(code);
+    }
+    assert_eq!(
+        codes.len(),
+        tokens.len() + CLIENT_ONLY_ALLOWLIST.len(),
+        "client ErrorCode variant count must equal the spec token count plus the \
+         allowlist (spec: {}, client: {}, allowlist: {})",
+        tokens.len(),
+        codes.len(),
+        CLIENT_ONLY_ALLOWLIST.len()
+    );
+}
+
+#[test]
+fn spec_error_code_extraction_finds_a_plausible_count() {
+    let tokens = extract_spec_error_tokens();
+    assert!(
+        tokens.len() >= 50,
+        "expected at least 50 error-code tokens in the vendored spec, found {} — \
+         the line-scan extractor likely no longer matches the spec's structure",
+        tokens.len()
+    );
+    let mut deduped = tokens.clone();
+    deduped.sort();
+    deduped.dedup();
+    assert_eq!(
+        deduped.len(),
+        tokens.len(),
+        "spec error-code enum contains duplicate tokens"
+    );
+}

--- a/tests/negotiation_robustness_tests.rs
+++ b/tests/negotiation_robustness_tests.rs
@@ -295,7 +295,7 @@ async fn send_error_midflight_disconnects_and_clears_state() {
     let mut saw_disconnect = false;
     loop {
         match events.recv().await {
-            Some(SignalFishEvent::Disconnected { reason }) => {
+            Some(SignalFishEvent::Disconnected { reason, .. }) => {
                 assert!(
                     reason.as_deref().unwrap_or("").contains("send"),
                     "reason should mention the send error: {reason:?}"

--- a/tests/polling_parity_tests.rs
+++ b/tests/polling_parity_tests.rs
@@ -362,3 +362,111 @@ async fn parity_disconnect_resets_negotiated_version() {
     assert!(saw_disconnect, "async should have disconnected");
     assert_eq!(client.negotiated_protocol_version(), None);
 }
+
+// ── PARITY 9: DecodeFailed surfacing is identical ─────────────────────
+
+#[tokio::test]
+async fn parity_decode_failed_async_vs_polling() {
+    const BAD_FRAME: &str =
+        r#"{"type":"Error","data":{"message":"x","error_code":"FUTURE_CODE_XYZ"}}"#;
+
+    // Async client.
+    let async_mock = SharedMock::new(vec![AUTH, BAD_FRAME]);
+    let (async_client, mut events) =
+        SignalFishClient::start(async_mock, SignalFishConfig::new("app"));
+    let mut async_decode_failed = None;
+    for _ in 0..6 {
+        match tokio::time::timeout(std::time::Duration::from_millis(150), events.recv()).await {
+            Ok(Some(ev @ SignalFishEvent::DecodeFailed { .. })) => {
+                async_decode_failed = Some(ev);
+                break;
+            }
+            Ok(Some(_)) => {}
+            _ => break,
+        }
+    }
+
+    // Polling client.
+    let poll_mock = SharedMock::new(vec![AUTH, BAD_FRAME]);
+    let mut poll_client = SignalFishPollingClient::new(poll_mock, SignalFishConfig::new("app"));
+    let poll_events = poll_client.poll();
+    let poll_decode_failed = poll_events
+        .into_iter()
+        .find(|e| matches!(e, SignalFishEvent::DecodeFailed { .. }));
+
+    // Both must surface the event, with identical fields.
+    let (
+        Some(SignalFishEvent::DecodeFailed {
+            message_type: a_type,
+            error: a_err,
+            raw_prefix: a_raw,
+        }),
+        Some(SignalFishEvent::DecodeFailed {
+            message_type: p_type,
+            error: p_err,
+            raw_prefix: p_raw,
+        }),
+    ) = (async_decode_failed, poll_decode_failed)
+    else {
+        panic!("both clients must surface DecodeFailed for the same frame");
+    };
+    assert_eq!(a_type, p_type);
+    assert_eq!(a_err, p_err);
+    assert_eq!(a_raw, p_raw);
+    assert_eq!(a_type.as_deref(), Some("Error"));
+
+    // And identical stats accounting.
+    assert_eq!(async_client.stats().messages_undecodable, 1);
+    assert_eq!(poll_client.stats().messages_undecodable, 1);
+}
+
+// ── PARITY 10: Disconnected carries last_server_error identically ─────
+
+#[tokio::test]
+async fn parity_disconnected_carries_last_server_error() {
+    const FAREWELL: &str = r#"{"type":"Error","data":{"message":"Disconnected as a slow consumer","error_code":"SLOW_CONSUMER"}}"#;
+
+    // Async: farewell then clean close.
+    let async_mock = SharedMock::from_msgs(vec![
+        Some(Ok(AUTH.to_string())),
+        Some(Ok(FAREWELL.to_string())),
+        None,
+    ]);
+    let (_client, mut events) = SignalFishClient::start(async_mock, SignalFishConfig::new("app"));
+    let mut async_info = None;
+    for _ in 0..8 {
+        match tokio::time::timeout(std::time::Duration::from_millis(150), events.recv()).await {
+            Ok(Some(SignalFishEvent::Disconnected {
+                last_server_error, ..
+            })) => {
+                async_info = last_server_error;
+                break;
+            }
+            Ok(Some(_)) => {}
+            _ => break,
+        }
+    }
+
+    // Polling: same script.
+    let poll_mock = SharedMock::from_msgs(vec![
+        Some(Ok(AUTH.to_string())),
+        Some(Ok(FAREWELL.to_string())),
+        None,
+    ]);
+    let mut poll_client = SignalFishPollingClient::new(poll_mock, SignalFishConfig::new("app"));
+    let poll_events = poll_client.poll();
+    let poll_info = poll_events.into_iter().find_map(|e| match e {
+        SignalFishEvent::Disconnected {
+            last_server_error, ..
+        } => last_server_error,
+        _ => None,
+    });
+
+    let async_info = async_info.expect("async Disconnected must carry the farewell");
+    let poll_info = poll_info.expect("polling Disconnected must carry the farewell");
+    assert_eq!(async_info, poll_info);
+    assert_eq!(
+        async_info.error_code,
+        Some(signal_fish_client::ErrorCode::SlowConsumer)
+    );
+}

--- a/tests/protocol_tests.rs
+++ b/tests/protocol_tests.rs
@@ -1371,7 +1371,8 @@ fn server_message_tolerates_unknown_fields_forward_compat() {
 
 #[test]
 fn server_message_unknown_type_fails_to_deserialize() {
-    // The transport loop logs+skips an un-deserializable message; we document the
+    // The transport loop surfaces an un-deserializable message as a
+    // `DecodeFailed` event; here we document the
     // hard-fail contract here (no silent catch-all variant).
     let json = r#"{"type":"SomeFutureV4Message","data":{}}"#;
     assert!(serde_json::from_str::<ServerMessage>(json).is_err());

--- a/tests/protocol_tests.rs
+++ b/tests/protocol_tests.rs
@@ -811,6 +811,8 @@ fn error_code_round_trip_all_variants() {
         ErrorCode::SignalRateLimited,
         ErrorCode::SignalTooLarge,
         ErrorCode::ConnectionIdleTimeout,
+        ErrorCode::SlowConsumer,
+        ErrorCode::ActivityTimeout,
     ];
     for variant in &variants {
         let json = serde_json::to_string(variant).expect("serialize");
@@ -852,6 +854,43 @@ fn new_v3_error_codes_serialize_exact_strings() {
             !code.description().is_empty(),
             "{code:?} needs a description"
         );
+    }
+}
+
+#[test]
+fn delivery_liveness_error_codes_serialize_exact_strings() {
+    let cases = [
+        (ErrorCode::SlowConsumer, "SLOW_CONSUMER"),
+        (ErrorCode::ActivityTimeout, "ACTIVITY_TIMEOUT"),
+    ];
+    for (code, expected) in cases {
+        let json = serde_json::to_string(&code).expect("serialize");
+        assert_eq!(json, format!("\"{expected}\""), "wire string for {code:?}");
+        let deser: ErrorCode = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(deser, code);
+        assert!(
+            !code.description().is_empty(),
+            "{code:?} needs a description"
+        );
+    }
+}
+
+#[test]
+fn fixture_error_with_slow_consumer_code_from_server() {
+    // The exact farewell frame the server (851c446) writes best-effort before
+    // evicting a slow consumer. Prior to 0.7.0 this failed to deserialize
+    // (unknown error_code) and was silently dropped by the transport loop.
+    let json = r#"{"type":"Error","data":{"message":"Disconnected as a slow consumer: this connection's outbound queue stayed full for more than 5000 ms","error_code":"SLOW_CONSUMER"}}"#;
+    let msg: ServerMessage = serde_json::from_str(json).expect("deserialize server farewell");
+    match msg {
+        ServerMessage::Error {
+            message,
+            error_code,
+        } => {
+            assert!(message.contains("slow consumer"));
+            assert_eq!(error_code, Some(ErrorCode::SlowConsumer));
+        }
+        other => panic!("expected ServerMessage::Error, got {other:?}"),
     }
 }
 

--- a/tests/protocol_tests.rs
+++ b/tests/protocol_tests.rs
@@ -1214,7 +1214,7 @@ fn authenticate_relay_floor_omits_v3_fields() {
     // to v2 — none of the negotiation keys appear.
     let msg = ClientMessage::Authenticate {
         app_id: "mb_app".into(),
-        sdk_version: Some("0.6.0".into()),
+        sdk_version: Some("0.7.0".into()),
         platform: None,
         game_data_format: None,
         protocol_version: None,

--- a/tests/real_server_e2e.rs
+++ b/tests/real_server_e2e.rs
@@ -1,0 +1,410 @@
+#![cfg(feature = "transport-websocket")]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::todo,
+    clippy::unimplemented,
+    clippy::indexing_slicing
+)]
+//! End-to-end tests against a **real** Signal Fish server.
+//!
+//! Ignored by default so `cargo test --all-features` stays green offline.
+//! Two ways to provide a server:
+//!
+//! 1. **Spawn mode (preferred — tests control server config):**
+//!    `SIGNAL_FISH_SERVER_BIN=/path/to/signal-fish-server \
+//!     cargo test --test real_server_e2e -- --ignored --test-threads=1`
+//!    Each test spawns its own server on an ephemeral port with the
+//!    `SIGNAL_FISH__*` env overrides it needs.
+//! 2. **External mode:** `SIGNAL_FISH_E2E_URL=ws://host:port/v2/ws` — only
+//!    the tests that work with default server config run; tests that need
+//!    custom queue/timeout config skip with a message.
+//!
+//! `SIGNAL_FISH_E2E_APP_ID` overrides the app id (default `e2e-test-app`;
+//! the server accepts any app id unless `require_websocket_auth` is on).
+
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+use signal_fish_client::{
+    ErrorCode, JoinRoomParams, SignalFishClient, SignalFishConfig, SignalFishEvent,
+    WebSocketTransport,
+};
+
+// ── Harness ─────────────────────────────────────────────────────────
+
+struct ServerGuard {
+    child: Child,
+}
+
+impl Drop for ServerGuard {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn app_id() -> String {
+    std::env::var("SIGNAL_FISH_E2E_APP_ID").unwrap_or_else(|_| "e2e-test-app".to_string())
+}
+
+/// Reserve an ephemeral port by binding to :0 and dropping the listener.
+fn free_port() -> u16 {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+    let port = listener.local_addr().expect("local addr").port();
+    drop(listener);
+    port
+}
+
+/// Spawn a server binary (from `SIGNAL_FISH_SERVER_BIN`) with the given
+/// `SIGNAL_FISH__*` overrides. Returns `None` when the env var is unset.
+async fn spawn_server(overrides: &[(&str, &str)]) -> Option<(ServerGuard, String)> {
+    let bin = std::env::var("SIGNAL_FISH_SERVER_BIN").ok()?;
+    let port = free_port();
+
+    let mut cmd = Command::new(&bin);
+    cmd.env("SIGNAL_FISH__PORT", port.to_string())
+        .env("SIGNAL_FISH__LOGGING__LEVEL", "warn")
+        // The server refuses to start without metrics-auth configuration;
+        // this throwaway localhost instance does not expose metrics.
+        .env("SIGNAL_FISH__SECURITY__REQUIRE_METRICS_AUTH", "false")
+        // Secure-by-default builds require registered app ids; the tests use
+        // an arbitrary one, so run the throwaway server in open mode.
+        .env("SIGNAL_FISH__SECURITY__REQUIRE_WEBSOCKET_AUTH", "false")
+        // The default SDK-compatibility registry recognizes only
+        // unity/godot/godot-rust/test — and none with a minimum this crate's
+        // version satisfies — so an honest Rust client cannot authenticate
+        // against a default-config server at all (tracked upstream).
+        .env("SIGNAL_FISH__PROTOCOL__SDK_COMPATIBILITY__ENFORCE", "false")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    for (key, value) in overrides {
+        cmd.env(key, value);
+    }
+    let child = cmd.spawn().expect("spawn signal-fish-server");
+    let guard = ServerGuard { child };
+
+    // Wait for readiness: TCP connect retry with a deadline.
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        match tokio::net::TcpStream::connect(("127.0.0.1", port)).await {
+            Ok(_) => break,
+            Err(_) if Instant::now() < deadline => {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+            Err(e) => panic!("server did not become ready on port {port}: {e}"),
+        }
+    }
+
+    Some((guard, format!("ws://127.0.0.1:{port}/v2/ws")))
+}
+
+/// External server URL, if configured.
+fn external_url() -> Option<String> {
+    std::env::var("SIGNAL_FISH_E2E_URL").ok()
+}
+
+/// Connect a client and drain events until `Authenticated`.
+async fn connect_authenticated(
+    url: &str,
+    config: SignalFishConfig,
+) -> (
+    SignalFishClient,
+    tokio::sync::mpsc::Receiver<SignalFishEvent>,
+) {
+    let transport = WebSocketTransport::connect(url)
+        .await
+        .expect("connect to real server");
+    let (client, mut events) = SignalFishClient::start(transport, config);
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        match tokio::time::timeout(remaining, events.recv()).await {
+            Ok(Some(SignalFishEvent::Authenticated { .. })) => break,
+            Ok(Some(SignalFishEvent::AuthenticationError { error, error_code })) => {
+                panic!("authentication failed: {error} ({error_code:?})")
+            }
+            Ok(Some(_)) => {}
+            Ok(None) => panic!("event stream ended before Authenticated"),
+            Err(_) => panic!("timed out waiting for Authenticated"),
+        }
+    }
+    (client, events)
+}
+
+/// Drain events until the predicate matches, with a deadline. Returns the
+/// matching event; panics on timeout or stream end.
+async fn wait_for_event(
+    events: &mut tokio::sync::mpsc::Receiver<SignalFishEvent>,
+    what: &str,
+    deadline: Duration,
+    mut predicate: impl FnMut(&SignalFishEvent) -> bool,
+) -> SignalFishEvent {
+    let end = Instant::now() + deadline;
+    loop {
+        let remaining = end.saturating_duration_since(Instant::now());
+        match tokio::time::timeout(remaining, events.recv()).await {
+            Ok(Some(ev)) if predicate(&ev) => return ev,
+            Ok(Some(_)) => {}
+            Ok(None) => panic!("event stream ended while waiting for {what}"),
+            Err(_) => panic!("timed out waiting for {what}"),
+        }
+    }
+}
+
+// ── Tests ───────────────────────────────────────────────────────────
+
+/// A fully stalled consumer is evicted loudly: the room observes
+/// `PlayerLeft`, and the victim — once it resumes draining — observes what
+/// the eviction actually looked like from the client side (recorded as
+/// experiment data: whether the best-effort `SLOW_CONSUMER` farewell
+/// arrived, and what `Disconnected` carried).
+#[tokio::test]
+#[ignore = "requires a live signal-fish server; set SIGNAL_FISH_SERVER_BIN (spawn mode)"]
+async fn e2e_slow_consumer_eviction_is_observable() {
+    // Needs custom config → spawn mode only.
+    let Some((_guard, url)) = spawn_server(&[
+        ("SIGNAL_FISH__WEBSOCKET__SEND_QUEUE_CAPACITY", "8"),
+        ("SIGNAL_FISH__WEBSOCKET__SLOW_CONSUMER_TIMEOUT_MS", "500"),
+    ])
+    .await
+    else {
+        eprintln!("skipping: SIGNAL_FISH_SERVER_BIN not set");
+        return;
+    };
+
+    // Sender A: normal config, joins and creates the room.
+    let (a, mut a_events) = connect_authenticated(&url, SignalFishConfig::new(app_id())).await;
+    a.join_room(JoinRoomParams::new("e2e-evict", "sender"))
+        .expect("A join_room");
+    let joined = wait_for_event(&mut a_events, "A RoomJoined", Duration::from_secs(5), |e| {
+        matches!(e, SignalFishEvent::RoomJoined { .. })
+    })
+    .await;
+    let SignalFishEvent::RoomJoined { room_code, .. } = joined else {
+        unreachable!()
+    };
+
+    // Victim B: tiny event channel so it wedges as soon as it stops draining.
+    let (_b, mut b_events) = connect_authenticated(
+        &url,
+        SignalFishConfig::new(app_id()).with_event_channel_capacity(1),
+    )
+    .await;
+    // B joins the room, draining just enough to complete the join.
+    _b.join_room(JoinRoomParams::new("e2e-evict", "victim").with_room_code(&room_code))
+        .expect("B join_room");
+    wait_for_event(&mut b_events, "B RoomJoined", Duration::from_secs(5), |e| {
+        matches!(e, SignalFishEvent::RoomJoined { .. })
+    })
+    .await;
+    // A sees B join.
+    wait_for_event(
+        &mut a_events,
+        "A PlayerJoined",
+        Duration::from_secs(5),
+        |e| matches!(e, SignalFishEvent::PlayerJoined { .. }),
+    )
+    .await;
+
+    // B now stops draining entirely (wedged consumer). A floods with large
+    // payloads: B's kernel receive buffer must fill before the server's
+    // 8-slot outbound queue can exert backpressure, so small payloads would
+    // take far longer to trip the eviction.
+    let payload = serde_json::json!({ "pad": "x".repeat(8 * 1024) });
+    let flood_until = Instant::now() + Duration::from_secs(15);
+    let mut a_saw_player_left = false;
+    while Instant::now() < flood_until {
+        // Keep the flood going; ignore transient SendBufferFull.
+        for _ in 0..64 {
+            let _ = a.send_game_data(payload.clone());
+        }
+        // Drain A's own events opportunistically, watching for PlayerLeft.
+        while let Ok(ev) = a_events.try_recv() {
+            if matches!(ev, SignalFishEvent::PlayerLeft { .. }) {
+                a_saw_player_left = true;
+            }
+        }
+        if a_saw_player_left {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+    assert!(
+        a_saw_player_left,
+        "the room must observe the slow consumer's eviction as PlayerLeft \
+         within the flood window (queue=8, timeout=500ms, 8KiB payloads)"
+    );
+
+    // B resumes draining: record what the eviction looked like client-side.
+    let mut saw_farewell_error = None;
+    let disconnected = wait_for_event(
+        &mut b_events,
+        "B Disconnected",
+        Duration::from_secs(10),
+        |e| {
+            if let SignalFishEvent::Error {
+                message,
+                error_code,
+            } = e
+            {
+                saw_farewell_error = Some((message.clone(), error_code.clone()));
+            }
+            matches!(e, SignalFishEvent::Disconnected { .. })
+        },
+    )
+    .await;
+    let SignalFishEvent::Disconnected {
+        reason,
+        last_server_error,
+    } = disconnected
+    else {
+        unreachable!()
+    };
+
+    // Experiment record (E3): what actually arrived.
+    println!("E3 DATA: farewell Error event pre-disconnect: {saw_farewell_error:?}");
+    println!("E3 DATA: Disconnected.reason = {reason:?}");
+    println!("E3 DATA: Disconnected.last_server_error = {last_server_error:?}");
+
+    // The contract we can assert: B learned it was disconnected, and when
+    // the farewell got through it is attributed on the Disconnected event.
+    if let Some((_, Some(code))) = &saw_farewell_error {
+        assert_eq!(code, &ErrorCode::SlowConsumer);
+        let info = last_server_error.expect("farewell must be attributed when received");
+        assert_eq!(info.error_code, Some(ErrorCode::SlowConsumer));
+    }
+}
+
+/// Documents the reconnect contract end-to-end: the server never surfaces a
+/// reconnect token on the wire, so `reconnect()` cannot legitimately
+/// succeed; a fresh `join_room` is the working recovery path.
+#[tokio::test]
+#[ignore = "requires a live signal-fish server; set SIGNAL_FISH_SERVER_BIN or SIGNAL_FISH_E2E_URL"]
+async fn e2e_reconnect_after_disconnect_requires_unobtainable_token() {
+    let (_guard, url): (Option<ServerGuard>, String) = match external_url() {
+        Some(url) => (None, url),
+        None => match spawn_server(&[]).await {
+            Some((guard, url)) => (Some(guard), url),
+            None => {
+                eprintln!("skipping: neither SIGNAL_FISH_E2E_URL nor SIGNAL_FISH_SERVER_BIN set");
+                return;
+            }
+        },
+    };
+
+    // Join a room, then drop the connection abruptly (no LeaveRoom).
+    let (mut a, mut a_events) = connect_authenticated(&url, SignalFishConfig::new(app_id())).await;
+    a.join_room(JoinRoomParams::new("e2e-reconnect", "alpha"))
+        .expect("join_room");
+    let joined = wait_for_event(&mut a_events, "RoomJoined", Duration::from_secs(5), |e| {
+        matches!(e, SignalFishEvent::RoomJoined { .. })
+    })
+    .await;
+    let SignalFishEvent::RoomJoined {
+        room_id, player_id, ..
+    } = joined
+    else {
+        unreachable!()
+    };
+    a.shutdown().await;
+    drop(a_events);
+
+    // Fresh connection: attempt Reconnect with the only token a client can
+    // produce — none. (No server payload ever carries a reconnect token.)
+    let (mut b, mut b_events) = connect_authenticated(&url, SignalFishConfig::new(app_id())).await;
+    b.reconnect(player_id, room_id, String::new())
+        .expect("queue Reconnect");
+
+    let response = wait_for_event(
+        &mut b_events,
+        "reconnect outcome",
+        Duration::from_secs(5),
+        |e| {
+            matches!(
+                e,
+                SignalFishEvent::Reconnected { .. }
+                    | SignalFishEvent::ReconnectionFailed { .. }
+                    | SignalFishEvent::Error { .. }
+            )
+        },
+    )
+    .await;
+
+    // Experiment record (E5).
+    println!("E5 DATA: reconnect-with-empty-token outcome: {response:?}");
+    assert!(
+        !matches!(response, SignalFishEvent::Reconnected { .. }),
+        "reconnect must NOT succeed without a token — if this fails, the \
+         server started accepting empty tokens (security hole) or began \
+         surfacing tokens (update the docs + this test)"
+    );
+
+    // The working recovery path: a fresh join.
+    b.join_room(JoinRoomParams::new("e2e-reconnect", "alpha-again"))
+        .expect("fallback join_room");
+    wait_for_event(
+        &mut b_events,
+        "fallback RoomJoined",
+        Duration::from_secs(5),
+        |e| matches!(e, SignalFishEvent::RoomJoined { .. }),
+    )
+    .await;
+    b.shutdown().await;
+}
+
+/// Smoke check that a flooding sender's own control plane stays healthy:
+/// Pings sent during a sustained GameData flood still get Pongs promptly
+/// (the sender's outbound queue is not the congested one).
+#[tokio::test]
+#[ignore = "requires a live signal-fish server; set SIGNAL_FISH_SERVER_BIN or SIGNAL_FISH_E2E_URL"]
+async fn e2e_sender_ping_survives_own_game_data_flood() {
+    let (_guard, url): (Option<ServerGuard>, String) = match external_url() {
+        Some(url) => (None, url),
+        None => match spawn_server(&[]).await {
+            Some((guard, url)) => (Some(guard), url),
+            None => {
+                eprintln!("skipping: neither SIGNAL_FISH_E2E_URL nor SIGNAL_FISH_SERVER_BIN set");
+                return;
+            }
+        },
+    };
+
+    let (mut a, mut a_events) = connect_authenticated(&url, SignalFishConfig::new(app_id())).await;
+    a.join_room(JoinRoomParams::new("e2e-ping", "solo"))
+        .expect("join_room");
+    wait_for_event(&mut a_events, "RoomJoined", Duration::from_secs(5), |e| {
+        matches!(e, SignalFishEvent::RoomJoined { .. })
+    })
+    .await;
+
+    // Flood (room of one: relay fan-out is empty, but the inbound path and
+    // parse work are real) while pinging once per 250ms.
+    let payload = serde_json::json!({ "pad": "y".repeat(512) });
+    let mut pongs = 0u32;
+    let mut worst_rtt = Duration::ZERO;
+    for _ in 0..8 {
+        let _ = a.send_game_data(payload.clone());
+        a.ping().expect("queue ping");
+        let sent_at = Instant::now();
+        wait_for_event(&mut a_events, "Pong", Duration::from_secs(3), |e| {
+            matches!(e, SignalFishEvent::Pong)
+        })
+        .await;
+        let rtt = sent_at.elapsed();
+        worst_rtt = worst_rtt.max(rtt);
+        pongs += 1;
+        for _ in 0..50 {
+            let _ = a.send_game_data(payload.clone());
+        }
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+    println!("E4 SMOKE DATA: {pongs} pongs, worst sender-side RTT {worst_rtt:?}");
+    assert_eq!(pongs, 8);
+    assert!(
+        worst_rtt < Duration::from_secs(2),
+        "sender-side Pong RTT should stay low during its own flood; got {worst_rtt:?}"
+    );
+    a.shutdown().await;
+}

--- a/tests/server-spec/PROVENANCE.toml
+++ b/tests/server-spec/PROVENANCE.toml
@@ -1,0 +1,17 @@
+# Provenance for the vendored Signal Fish server AsyncAPI protocol spec.
+#
+# Refresh procedure: see .llm/skills/protocol-wire-conformance.md
+# Update this file IN THE SAME COMMIT as any change to the vendored spec.
+
+[upstream]
+repo = "https://github.com/Ambiguous-Interactive/signal-fish-server"
+path = "spec"
+# Exact server commit the spec bytes were copied from.
+commit = "851c446ecf31a5c374badd2a508b8dd1a697c841"
+# ISO 8601 date of the last refresh.
+synced = "2026-07-02"
+
+# SHA-256 of each vendored file. A policy test recomputes these, so the spec
+# cannot be edited without also updating this marker (keeps provenance honest).
+[files]
+"signal-fish-protocol.asyncapi.yaml" = "d1457152f831a284e569b911909024c41329fd64b9258067afab5e5d2831e0b6"

--- a/tests/server-spec/README.md
+++ b/tests/server-spec/README.md
@@ -1,0 +1,30 @@
+# Vendored server AsyncAPI protocol spec
+
+This YAML file is copied verbatim from the Signal Fish **server** repository
+(`spec/signal-fish-protocol.asyncapi.yaml`) and is the source of truth for the
+[`tests/error_code_conformance_tests.rs`](../error_code_conformance_tests.rs)
+suite, which proves the client's `ErrorCode` enum stays in lockstep with the
+error codes the server may actually send.
+
+- The spec's `ErrorCode` schema lists every wire error-code token
+  (SCREAMING_SNAKE_CASE). The conformance suite extracts that enum block with
+  a plain line scan (no YAML dependency) and asserts, in both directions, that
+  every server token deserializes into a client `ErrorCode` variant and every
+  client variant serializes to a token the spec declares.
+
+Provenance — the exact upstream commit and the file's SHA-256 checksum — is
+recorded in [`PROVENANCE.toml`](PROVENANCE.toml) and verified by a policy test
+in `tests/ci_config_tests.rs`.
+
+## Refreshing when the server protocol changes
+
+See [`.llm/skills/protocol-wire-conformance.md`](../../.llm/skills/protocol-wire-conformance.md)
+for the full procedure. In short:
+
+1. Copy `spec/signal-fish-protocol.asyncapi.yaml` from the server repo into
+   this directory.
+2. Update `PROVENANCE.toml`: the upstream `commit`, the `synced` date, and
+   recompute the `[files]` SHA-256 sum (`sha256sum *.yaml`).
+3. Run `cargo test --test error_code_conformance_tests`. If it is red, add the
+   missing variants to `src/error_codes.rs` until it is green — **never** edit
+   the spec to pass.

--- a/tests/server-spec/signal-fish-protocol.asyncapi.yaml
+++ b/tests/server-spec/signal-fish-protocol.asyncapi.yaml
@@ -1,0 +1,1134 @@
+# Signal Fish Protocol — machine-readable AsyncAPI 3.0 spec
+# ===========================================================
+#
+# This is the SOURCE-OF-TRUTH, codegen-friendly description of the Signal Fish
+# WebSocket signaling protocol. The wire format is JSON over WebSocket; every
+# message is a `{ "type": <Variant>, "data": <payload> }` envelope (serde
+# `#[serde(tag = "type", content = "data")]`). Variants WITHOUT a payload
+# (e.g. LeaveRoom, Ping, RoomLeft, Pong) are sent as `{ "type": <Variant> }`
+# with no `data` field.
+#
+# It models EVERY `ClientMessage` (send / client -> server) and `ServerMessage`
+# (receive / server -> client) variant from `src/protocol/messages.rs`, plus the
+# full `ErrorCode` enum from `src/protocol/error_codes.rs`. A Rust consistency
+# test — `tests/protocol_spec_consistency.rs` — fails the build if this file
+# drifts from those Rust types, so codegen consumers can trust it.
+#
+# ---------------------------------------------------------------------------
+# HOW TO USE FOR CODEGEN
+# ---------------------------------------------------------------------------
+# * AsyncAPI generator (TypeScript / Java / Python / etc. models + clients):
+#       npx @asyncapi/generator spec/signal-fish-protocol.asyncapi.yaml \
+#         @asyncapi/typescript-template -o ./generated
+#   See https://www.asyncapi.com/tools/generator for the template list.
+#
+# * Pure JSON-Schema model generators: every message `payload` below is a plain
+#   JSON Schema (the `components.schemas.*` subtree is self-contained). Point a
+#   JSON-Schema-based generator (quicktype, json-schema-to-typescript, schemafy
+#   for Rust, etc.) at the `components/schemas` block, e.g.:
+#       npx quicktype --src-lang schema --lang rust \
+#         <(yq '.components.schemas' spec/signal-fish-protocol.asyncapi.yaml)
+#
+# * Discriminator: the `type` field is the discriminator on both the
+#   `ClientMessage` and `ServerMessage` unions (see `components.messages.*` and
+#   the `oneOf` wrappers `ClientMessageEnvelope` / `ServerMessageEnvelope`).
+#
+# ---------------------------------------------------------------------------
+# PROTOCOL VERSION FLOOR (v2) vs CAPABILITY UPGRADE (v3)
+# ---------------------------------------------------------------------------
+# * v2 is the RELAY FLOOR every client MUST implement. The mandatory flow is
+#   Authenticate -> JoinRoom -> PlayerReady -> StartGame -> GameStarting ->
+#   GameData -> LeaveRoom. The server relays GameData through the WebSocket.
+# * v3 is an OPTIONAL upgrade that adds capability negotiation
+#   (`supported_transports` / `supported_topologies` / `protocol_version` on
+#   Authenticate) plus the peer-to-peer messages: Signal, SessionPlan, NewPeer,
+#   TransportStatus, PeerTransportStatus. v3 messages are tagged `x-protocol: v3`
+#   below. A relay-only room never emits SessionPlan, so a v2 client never sees
+#   v3 messages.
+# See docs/concepts/protocol-versions.md and docs/guides/building-a-client.md.
+
+asyncapi: 3.0.0
+
+info:
+  title: Signal Fish Signaling Protocol
+  version: 0.2.0
+  description: |
+    JSON-over-WebSocket signaling protocol for peer-to-peer game networking.
+    v2 relay floor + optional v3 capability negotiation / WebRTC signaling.
+  license:
+    name: MIT
+
+defaultContentType: application/json
+
+servers:
+  v2:
+    host: 'localhost:8080'
+    pathname: /v2/ws
+    protocol: ws
+    description: v2 relay-floor endpoint. Default negotiated protocol version is 2.
+  v3:
+    host: 'localhost:8080'
+    pathname: /v3/ws
+    protocol: ws
+    description: |
+      v3 endpoint. Defaults the omitted Authenticate.protocol_version to 3, but a
+      client is relay-only unless it also advertises supported_transports /
+      supported_topologies. Server clamps to its configured protocol range.
+
+channels:
+  signaling:
+    address: /
+    description: The single bidirectional WebSocket channel carrying all messages.
+    messages:
+      # ----- send: client -> server -----
+      Authenticate: { $ref: '#/components/messages/Authenticate' }
+      JoinRoom: { $ref: '#/components/messages/JoinRoom' }
+      LeaveRoom: { $ref: '#/components/messages/LeaveRoom' }
+      ClientGameData: { $ref: '#/components/messages/ClientGameData' }
+      ClientSignal: { $ref: '#/components/messages/ClientSignal' }
+      AuthorityRequest: { $ref: '#/components/messages/AuthorityRequest' }
+      PlayerReady: { $ref: '#/components/messages/PlayerReady' }
+      StartGame: { $ref: '#/components/messages/StartGame' }
+      ProvideConnectionInfo: { $ref: '#/components/messages/ProvideConnectionInfo' }
+      Ping: { $ref: '#/components/messages/Ping' }
+      Reconnect: { $ref: '#/components/messages/Reconnect' }
+      JoinAsSpectator: { $ref: '#/components/messages/JoinAsSpectator' }
+      LeaveSpectator: { $ref: '#/components/messages/LeaveSpectator' }
+      TransportStatus: { $ref: '#/components/messages/TransportStatus' }
+      # ----- receive: server -> client -----
+      Authenticated: { $ref: '#/components/messages/Authenticated' }
+      ProtocolInfo: { $ref: '#/components/messages/ProtocolInfo' }
+      AuthenticationError: { $ref: '#/components/messages/AuthenticationError' }
+      RoomJoined: { $ref: '#/components/messages/RoomJoined' }
+      RoomJoinFailed: { $ref: '#/components/messages/RoomJoinFailed' }
+      RoomLeft: { $ref: '#/components/messages/RoomLeft' }
+      PlayerJoined: { $ref: '#/components/messages/PlayerJoined' }
+      PlayerLeft: { $ref: '#/components/messages/PlayerLeft' }
+      ServerGameData: { $ref: '#/components/messages/ServerGameData' }
+      GameDataBinary: { $ref: '#/components/messages/GameDataBinary' }
+      AuthorityChanged: { $ref: '#/components/messages/AuthorityChanged' }
+      AuthorityResponse: { $ref: '#/components/messages/AuthorityResponse' }
+      LobbyStateChanged: { $ref: '#/components/messages/LobbyStateChanged' }
+      GameStarting: { $ref: '#/components/messages/GameStarting' }
+      ServerSignal: { $ref: '#/components/messages/ServerSignal' }
+      NewPeer: { $ref: '#/components/messages/NewPeer' }
+      SessionPlan: { $ref: '#/components/messages/SessionPlan' }
+      Pong: { $ref: '#/components/messages/Pong' }
+      Reconnected: { $ref: '#/components/messages/Reconnected' }
+      ReconnectionFailed: { $ref: '#/components/messages/ReconnectionFailed' }
+      PlayerReconnected: { $ref: '#/components/messages/PlayerReconnected' }
+      SpectatorJoined: { $ref: '#/components/messages/SpectatorJoined' }
+      SpectatorJoinFailed: { $ref: '#/components/messages/SpectatorJoinFailed' }
+      SpectatorLeft: { $ref: '#/components/messages/SpectatorLeft' }
+      NewSpectatorJoined: { $ref: '#/components/messages/NewSpectatorJoined' }
+      SpectatorDisconnected: { $ref: '#/components/messages/SpectatorDisconnected' }
+      Error: { $ref: '#/components/messages/Error' }
+      PeerTransportStatus: { $ref: '#/components/messages/PeerTransportStatus' }
+
+operations:
+  sendToServer:
+    action: send
+    channel: { $ref: '#/channels/signaling' }
+    title: Client -> Server messages (ClientMessage)
+    messages:
+      - { $ref: '#/channels/signaling/messages/Authenticate' }
+      - { $ref: '#/channels/signaling/messages/JoinRoom' }
+      - { $ref: '#/channels/signaling/messages/LeaveRoom' }
+      - { $ref: '#/channels/signaling/messages/ClientGameData' }
+      - { $ref: '#/channels/signaling/messages/ClientSignal' }
+      - { $ref: '#/channels/signaling/messages/AuthorityRequest' }
+      - { $ref: '#/channels/signaling/messages/PlayerReady' }
+      - { $ref: '#/channels/signaling/messages/StartGame' }
+      - { $ref: '#/channels/signaling/messages/ProvideConnectionInfo' }
+      - { $ref: '#/channels/signaling/messages/Ping' }
+      - { $ref: '#/channels/signaling/messages/Reconnect' }
+      - { $ref: '#/channels/signaling/messages/JoinAsSpectator' }
+      - { $ref: '#/channels/signaling/messages/LeaveSpectator' }
+      - { $ref: '#/channels/signaling/messages/TransportStatus' }
+  receiveFromServer:
+    action: receive
+    channel: { $ref: '#/channels/signaling' }
+    title: Server -> Client messages (ServerMessage)
+    messages:
+      - { $ref: '#/channels/signaling/messages/Authenticated' }
+      - { $ref: '#/channels/signaling/messages/ProtocolInfo' }
+      - { $ref: '#/channels/signaling/messages/AuthenticationError' }
+      - { $ref: '#/channels/signaling/messages/RoomJoined' }
+      - { $ref: '#/channels/signaling/messages/RoomJoinFailed' }
+      - { $ref: '#/channels/signaling/messages/RoomLeft' }
+      - { $ref: '#/channels/signaling/messages/PlayerJoined' }
+      - { $ref: '#/channels/signaling/messages/PlayerLeft' }
+      - { $ref: '#/channels/signaling/messages/ServerGameData' }
+      - { $ref: '#/channels/signaling/messages/GameDataBinary' }
+      - { $ref: '#/channels/signaling/messages/AuthorityChanged' }
+      - { $ref: '#/channels/signaling/messages/AuthorityResponse' }
+      - { $ref: '#/channels/signaling/messages/LobbyStateChanged' }
+      - { $ref: '#/channels/signaling/messages/GameStarting' }
+      - { $ref: '#/channels/signaling/messages/ServerSignal' }
+      - { $ref: '#/channels/signaling/messages/NewPeer' }
+      - { $ref: '#/channels/signaling/messages/SessionPlan' }
+      - { $ref: '#/channels/signaling/messages/Pong' }
+      - { $ref: '#/channels/signaling/messages/Reconnected' }
+      - { $ref: '#/channels/signaling/messages/ReconnectionFailed' }
+      - { $ref: '#/channels/signaling/messages/PlayerReconnected' }
+      - { $ref: '#/channels/signaling/messages/SpectatorJoined' }
+      - { $ref: '#/channels/signaling/messages/SpectatorJoinFailed' }
+      - { $ref: '#/channels/signaling/messages/SpectatorLeft' }
+      - { $ref: '#/channels/signaling/messages/NewSpectatorJoined' }
+      - { $ref: '#/channels/signaling/messages/SpectatorDisconnected' }
+      - { $ref: '#/channels/signaling/messages/Error' }
+      - { $ref: '#/channels/signaling/messages/PeerTransportStatus' }
+
+components:
+  messages:
+    # =====================================================================
+    # CLIENT -> SERVER (ClientMessage)
+    # =====================================================================
+    Authenticate:
+      title: Authenticate
+      summary: MUST be the first message. App ID is a public identifier, not a secret.
+      payload: { $ref: '#/components/schemas/Authenticate' }
+    JoinRoom:
+      title: JoinRoom
+      summary: Join an existing room (room_code) or create one (room_code omitted).
+      payload: { $ref: '#/components/schemas/JoinRoom' }
+    LeaveRoom:
+      title: LeaveRoom
+      summary: Leave the current room. No data payload.
+      payload: { $ref: '#/components/schemas/LeaveRoom' }
+    ClientGameData:
+      title: GameData
+      summary: Send opaque game data to other players in the room (relay floor).
+      payload: { $ref: '#/components/schemas/ClientGameData' }
+    ClientSignal:
+      title: Signal
+      summary: 'v3: relay an opaque WebRTC signal to a specific peer. Forwarded verbatim.'
+      payload: { $ref: '#/components/schemas/ClientSignal' }
+    AuthorityRequest:
+      title: AuthorityRequest
+      summary: Request to become / connect to the authoritative peer.
+      payload: { $ref: '#/components/schemas/AuthorityRequest' }
+    PlayerReady:
+      title: PlayerReady
+      summary: Toggle this player's lobby readiness. No data payload.
+      payload: { $ref: '#/components/schemas/PlayerReady' }
+    StartGame:
+      title: StartGame
+      summary: >-
+        Explicitly finalize the lobby and start. Accepted only when all_ready; if
+        the room has an authority only that authority may start, else any player
+        may. No data payload.
+      payload: { $ref: '#/components/schemas/StartGame' }
+    ProvideConnectionInfo:
+      title: ProvideConnectionInfo
+      summary: Legacy self-declared v2 connection metadata for GameStarting.
+      payload: { $ref: '#/components/schemas/ProvideConnectionInfo' }
+    Ping:
+      title: Ping
+      summary: Heartbeat. No data payload.
+      payload: { $ref: '#/components/schemas/Ping' }
+    Reconnect:
+      title: Reconnect
+      summary: Reconnect to a room after disconnection using the join auth_token.
+      payload: { $ref: '#/components/schemas/Reconnect' }
+    JoinAsSpectator:
+      title: JoinAsSpectator
+      summary: Join a room as a read-only observer.
+      payload: { $ref: '#/components/schemas/JoinAsSpectator' }
+    LeaveSpectator:
+      title: LeaveSpectator
+      summary: Leave spectator mode. No data payload.
+      payload: { $ref: '#/components/schemas/LeaveSpectator' }
+    TransportStatus:
+      title: TransportStatus
+      summary: 'v3: report this client''s data-path transport state (informational).'
+      payload: { $ref: '#/components/schemas/TransportStatus' }
+
+    # =====================================================================
+    # SERVER -> CLIENT (ServerMessage)
+    # =====================================================================
+    Authenticated:
+      title: Authenticated
+      payload: { $ref: '#/components/schemas/Authenticated' }
+    ProtocolInfo:
+      title: ProtocolInfo
+      summary: SDK/protocol compatibility + negotiated version range.
+      payload: { $ref: '#/components/schemas/ProtocolInfo' }
+    AuthenticationError:
+      title: AuthenticationError
+      payload: { $ref: '#/components/schemas/AuthenticationError' }
+    RoomJoined:
+      title: RoomJoined
+      payload: { $ref: '#/components/schemas/RoomJoined' }
+    RoomJoinFailed:
+      title: RoomJoinFailed
+      payload: { $ref: '#/components/schemas/RoomJoinFailed' }
+    RoomLeft:
+      title: RoomLeft
+      summary: Successfully left the room. No data payload.
+      payload: { $ref: '#/components/schemas/RoomLeft' }
+    PlayerJoined:
+      title: PlayerJoined
+      payload: { $ref: '#/components/schemas/PlayerJoined' }
+    PlayerLeft:
+      title: PlayerLeft
+      payload: { $ref: '#/components/schemas/PlayerLeft' }
+    ServerGameData:
+      title: GameData
+      summary: Game data forwarded from another player.
+      payload: { $ref: '#/components/schemas/ServerGameData' }
+    GameDataBinary:
+      title: GameDataBinary
+      summary: >-
+        In-memory broadcast carrier. Negotiated MessagePack clients receive a bare
+        binary WebSocket frame, not this enveloped variant.
+      payload: { $ref: '#/components/schemas/GameDataBinary' }
+    AuthorityChanged:
+      title: AuthorityChanged
+      payload: { $ref: '#/components/schemas/AuthorityChanged' }
+    AuthorityResponse:
+      title: AuthorityResponse
+      payload: { $ref: '#/components/schemas/AuthorityResponse' }
+    LobbyStateChanged:
+      title: LobbyStateChanged
+      payload: { $ref: '#/components/schemas/LobbyStateChanged' }
+    GameStarting:
+      title: GameStarting
+      summary: >-
+        Game is starting with legacy peer metadata. v3 topology/transport/ICE
+        directives are carried by SessionPlan, not here.
+      payload: { $ref: '#/components/schemas/GameStarting' }
+    ServerSignal:
+      title: Signal
+      summary: 'v3: relayed opaque WebRTC signal from another peer. Verbatim.'
+      payload: { $ref: '#/components/schemas/ServerSignal' }
+    NewPeer:
+      title: NewPeer
+      summary: >-
+        v3: a new peer is available for a WebRTC connection. you_initiate
+        designates the single offerer (server-driven glare resolution).
+      payload: { $ref: '#/components/schemas/NewPeer' }
+    SessionPlan:
+      title: SessionPlan
+      summary: >-
+        v3: per-recipient session directive at lobby finalization. Latest
+        SessionPlan wins. A relay-only room emits none.
+      payload: { $ref: '#/components/schemas/SessionPlan' }
+    Pong:
+      title: Pong
+      summary: Pong response to Ping. No data payload.
+      payload: { $ref: '#/components/schemas/Pong' }
+    Reconnected:
+      title: Reconnected
+      payload: { $ref: '#/components/schemas/Reconnected' }
+    ReconnectionFailed:
+      title: ReconnectionFailed
+      payload: { $ref: '#/components/schemas/ReconnectionFailed' }
+    PlayerReconnected:
+      title: PlayerReconnected
+      payload: { $ref: '#/components/schemas/PlayerReconnected' }
+    SpectatorJoined:
+      title: SpectatorJoined
+      payload: { $ref: '#/components/schemas/SpectatorJoined' }
+    SpectatorJoinFailed:
+      title: SpectatorJoinFailed
+      payload: { $ref: '#/components/schemas/SpectatorJoinFailed' }
+    SpectatorLeft:
+      title: SpectatorLeft
+      payload: { $ref: '#/components/schemas/SpectatorLeft' }
+    NewSpectatorJoined:
+      title: NewSpectatorJoined
+      payload: { $ref: '#/components/schemas/NewSpectatorJoined' }
+    SpectatorDisconnected:
+      title: SpectatorDisconnected
+      payload: { $ref: '#/components/schemas/SpectatorDisconnected' }
+    Error:
+      title: Error
+      payload: { $ref: '#/components/schemas/Error' }
+    PeerTransportStatus:
+      title: PeerTransportStatus
+      summary: 'v3: a same-room peer''s reported data-path transport state changed.'
+      payload: { $ref: '#/components/schemas/PeerTransportStatus' }
+
+  schemas:
+    # ---------------------------------------------------------------------
+    # Shared token enums (Appendix A wire tokens)
+    # ---------------------------------------------------------------------
+    Transport:
+      type: string
+      description: Data-path transport. relay is the universal floor.
+      enum: [relay, direct, webrtc]
+    Topology:
+      type: string
+      description: Session topology negotiated for a room.
+      enum: [relay, host, mesh]
+    RelayTransport:
+      type: string
+      description: Preferred relay transport protocol for GameData fan-out.
+      enum: [tcp, udp, websocket, auto]
+    GameDataEncoding:
+      type: string
+      description: Game data encoding. rkyv is reserved/internal and not advertised.
+      enum: [json, message_pack, rkyv]
+    LobbyState:
+      type: string
+      enum: [waiting, lobby, finalized]
+    SpectatorStateChangeReason:
+      type: string
+      enum: [joined, voluntary_leave, disconnected, removed, room_closed]
+    PlayerId:
+      type: string
+      format: uuid
+      description: Player UUID.
+    RoomId:
+      type: string
+      format: uuid
+      description: Room UUID.
+    ErrorCode:
+      type: string
+      description: >-
+        Structured error code (SCREAMING_SNAKE_CASE). Mirrors the ErrorCode enum
+        in src/protocol/error_codes.rs; guarded by tests/protocol_spec_consistency.rs.
+      enum:
+        - UNAUTHORIZED
+        - INVALID_TOKEN
+        - AUTHENTICATION_REQUIRED
+        - INVALID_APP_ID
+        - APP_ID_EXPIRED
+        - APP_ID_REVOKED
+        - APP_ID_SUSPENDED
+        - MISSING_APP_ID
+        - AUTHENTICATION_TIMEOUT
+        - SDK_VERSION_UNSUPPORTED
+        - UNSUPPORTED_GAME_DATA_FORMAT
+        - INVALID_INPUT
+        - INVALID_GAME_NAME
+        - INVALID_ROOM_CODE
+        - INVALID_PLAYER_NAME
+        - INVALID_MAX_PLAYERS
+        - MESSAGE_TOO_LARGE
+        - ROOM_NOT_FOUND
+        - ROOM_FULL
+        - ALREADY_IN_ROOM
+        - NOT_IN_ROOM
+        - ROOM_CREATION_FAILED
+        - MAX_ROOMS_PER_GAME_EXCEEDED
+        - INVALID_ROOM_STATE
+        - AUTHORITY_NOT_SUPPORTED
+        - AUTHORITY_CONFLICT
+        - AUTHORITY_DENIED
+        - RATE_LIMIT_EXCEEDED
+        - TOO_MANY_CONNECTIONS
+        - RECONNECTION_FAILED
+        - RECONNECTION_TOKEN_INVALID
+        - RECONNECTION_EXPIRED
+        - PLAYER_ALREADY_CONNECTED
+        - SPECTATOR_NOT_ALLOWED
+        - TOO_MANY_SPECTATORS
+        - NOT_A_SPECTATOR
+        - SPECTATOR_JOIN_FAILED
+        - INTERNAL_ERROR
+        - STORAGE_ERROR
+        - SERVICE_UNAVAILABLE
+        - CROSS_ROOM_SIGNAL
+        - UNSUPPORTED_TRANSPORT
+        - SIGNAL_TARGET_NOT_FOUND
+        - SIGNAL_RATE_LIMITED
+        - SIGNAL_TOO_LARGE
+        - CONNECTION_IDLE_TIMEOUT
+        - GAME_START_NOT_READY
+        - GAME_START_FORBIDDEN
+        - SLOW_CONSUMER
+        - ACTIVITY_TIMEOUT
+
+    # ---------------------------------------------------------------------
+    # Shared object schemas
+    # ---------------------------------------------------------------------
+    RateLimitInfo:
+      type: object
+      required: [per_minute, per_hour, per_day]
+      properties:
+        per_minute: { type: integer }
+        per_hour: { type: integer }
+        per_day: { type: integer }
+    IceServer:
+      type: object
+      description: Mirrors RTCIceServer. STUN needs no credentials.
+      required: [urls]
+      properties:
+        urls:
+          type: array
+          items: { type: string }
+        username: { type: string }
+        credential: { type: string }
+    PlayerInfo:
+      type: object
+      required: [id, name, is_authority, is_ready, connected_at]
+      properties:
+        id: { $ref: '#/components/schemas/PlayerId' }
+        name: { type: string }
+        is_authority: { type: boolean }
+        is_ready: { type: boolean }
+        connected_at: { type: string, format: date-time }
+        connection_info: { $ref: '#/components/schemas/ConnectionInfo' }
+    SpectatorInfo:
+      type: object
+      required: [id, name, connected_at]
+      properties:
+        id: { $ref: '#/components/schemas/PlayerId' }
+        name: { type: string }
+        connected_at: { type: string, format: date-time }
+    SessionPeer:
+      type: object
+      required: [player_id, player_name, is_authority, initiate]
+      properties:
+        player_id: { $ref: '#/components/schemas/PlayerId' }
+        player_name: { type: string }
+        is_authority: { type: boolean }
+        initiate:
+          type: boolean
+          description: >-
+            True if the recipient sends the WebRTC offer to this peer. Server
+            decides this (glare resolution); clients MUST NOT recompute it.
+    PeerConnectionInfo:
+      type: object
+      required: [player_id, player_name, is_authority, relay_type]
+      properties:
+        player_id: { $ref: '#/components/schemas/PlayerId' }
+        player_name: { type: string }
+        is_authority: { type: boolean }
+        relay_type: { type: string }
+        connection_info: { $ref: '#/components/schemas/ConnectionInfo' }
+    ConnectionInfo:
+      type: object
+      description: >-
+        Legacy self-declared peer metadata (tagged by an inner `type` field:
+        direct | unity_relay | relay | webrtc | custom). Not v3 negotiation.
+      required: [type]
+      properties:
+        type:
+          type: string
+          enum: [direct, unity_relay, relay, webrtc, custom]
+      additionalProperties: true
+    PlayerNameRulesPayload:
+      type: object
+      required:
+        - max_length
+        - min_length
+        - allow_unicode_alphanumeric
+        - allow_spaces
+        - allow_leading_trailing_whitespace
+      properties:
+        max_length: { type: integer }
+        min_length: { type: integer }
+        allow_unicode_alphanumeric: { type: boolean }
+        allow_spaces: { type: boolean }
+        allow_leading_trailing_whitespace: { type: boolean }
+        allowed_symbols:
+          type: array
+          items: { type: string }
+        additional_allowed_characters: { type: string }
+
+    # ---------------------------------------------------------------------
+    # ClientMessage payloads
+    # ---------------------------------------------------------------------
+    Authenticate:
+      type: object
+      properties:
+        type: { const: Authenticate }
+        data:
+          type: object
+          required: [app_id]
+          properties:
+            app_id:
+              type: string
+              description: Public App ID (safe to embed in builds).
+            sdk_version: { type: string }
+            platform: { type: string }
+            game_data_format: { $ref: '#/components/schemas/GameDataEncoding' }
+            protocol_version:
+              type: integer
+              description: 'v3: highest protocol version the client speaks.'
+            supported_transports:
+              type: array
+              description: 'v3: data-path transports the client supports (absent => relay-only).'
+              items: { $ref: '#/components/schemas/Transport' }
+            supported_topologies:
+              type: array
+              description: 'v3: session topologies the client supports (absent => relay-only).'
+              items: { $ref: '#/components/schemas/Topology' }
+      required: [type, data]
+    JoinRoom:
+      type: object
+      properties:
+        type: { const: JoinRoom }
+        data:
+          type: object
+          required: [game_name, player_name]
+          properties:
+            game_name: { type: string }
+            room_code:
+              type: string
+              description: Omit to create a new room; provide to join/create by code.
+            player_name: { type: string }
+            max_players: { type: integer, description: Ceiling, not a required count. }
+            supports_authority: { type: boolean }
+            relay_transport: { $ref: '#/components/schemas/RelayTransport' }
+      required: [type, data]
+    LeaveRoom:
+      type: object
+      description: No data payload.
+      properties:
+        type: { const: LeaveRoom }
+      required: [type]
+    ClientGameData:
+      type: object
+      properties:
+        type: { const: GameData }
+        data:
+          type: object
+          required: [data]
+          properties:
+            data:
+              description: Opaque application game data (any JSON value).
+      required: [type, data]
+    ClientSignal:
+      type: object
+      description: 'v3 only.'
+      properties:
+        type: { const: Signal }
+        data:
+          type: object
+          required: [to, signal]
+          properties:
+            to: { $ref: '#/components/schemas/PlayerId' }
+            signal:
+              description: >-
+                Opaque, forwarded verbatim. By convention matchbox-compatible:
+                {"Offer":..} | {"Answer":..} | {"IceCandidate":..}.
+      required: [type, data]
+    AuthorityRequest:
+      type: object
+      properties:
+        type: { const: AuthorityRequest }
+        data:
+          type: object
+          required: [become_authority]
+          properties:
+            become_authority: { type: boolean }
+      required: [type, data]
+    PlayerReady:
+      type: object
+      description: No data payload. Toggles readiness.
+      properties:
+        type: { const: PlayerReady }
+      required: [type]
+    StartGame:
+      type: object
+      description: >-
+        No data payload. Accepted only when all_ready. Authorization: if the room
+        has a designated authority only that authority may start; otherwise any
+        player may. Rejected with GAME_START_NOT_READY / GAME_START_FORBIDDEN.
+      properties:
+        type: { const: StartGame }
+      required: [type]
+    ProvideConnectionInfo:
+      type: object
+      properties:
+        type: { const: ProvideConnectionInfo }
+        data:
+          type: object
+          required: [connection_info]
+          properties:
+            connection_info: { $ref: '#/components/schemas/ConnectionInfo' }
+      required: [type, data]
+    Ping:
+      type: object
+      description: No data payload.
+      properties:
+        type: { const: Ping }
+      required: [type]
+    Reconnect:
+      type: object
+      properties:
+        type: { const: Reconnect }
+        data:
+          type: object
+          required: [player_id, room_id, auth_token]
+          properties:
+            player_id: { $ref: '#/components/schemas/PlayerId' }
+            room_id: { $ref: '#/components/schemas/RoomId' }
+            auth_token: { type: string, description: Token issued at initial join. }
+      required: [type, data]
+    JoinAsSpectator:
+      type: object
+      properties:
+        type: { const: JoinAsSpectator }
+        data:
+          type: object
+          required: [game_name, room_code, spectator_name]
+          properties:
+            game_name: { type: string }
+            room_code: { type: string }
+            spectator_name: { type: string }
+      required: [type, data]
+    LeaveSpectator:
+      type: object
+      description: No data payload.
+      properties:
+        type: { const: LeaveSpectator }
+      required: [type]
+    TransportStatus:
+      type: object
+      description: 'v3 only. Purely informational; the relay floor never closes.'
+      properties:
+        type: { const: TransportStatus }
+        data:
+          type: object
+          required: [transport, connected]
+          properties:
+            transport: { $ref: '#/components/schemas/Transport' }
+            connected: { type: boolean }
+      required: [type, data]
+
+    # ---------------------------------------------------------------------
+    # ServerMessage payloads
+    # ---------------------------------------------------------------------
+    Authenticated:
+      type: object
+      properties:
+        type: { const: Authenticated }
+        data:
+          type: object
+          required: [app_name, rate_limits]
+          properties:
+            app_name: { type: string }
+            organization: { type: string }
+            rate_limits: { $ref: '#/components/schemas/RateLimitInfo' }
+      required: [type, data]
+    ProtocolInfo:
+      type: object
+      description: >-
+        Payload is a flattened ProtocolInfoPayload (newtype variant). v3 fields
+        protocol_version / min_protocol_version / max_protocol_version are absent
+        on negotiated v2 connections.
+      properties:
+        type: { const: ProtocolInfo }
+        data:
+          type: object
+          properties:
+            platform: { type: string }
+            sdk_version: { type: string }
+            minimum_version: { type: string }
+            recommended_version: { type: string }
+            capabilities:
+              type: array
+              items: { type: string }
+            notes: { type: string }
+            game_data_formats:
+              type: array
+              items: { $ref: '#/components/schemas/GameDataEncoding' }
+            player_name_rules: { $ref: '#/components/schemas/PlayerNameRulesPayload' }
+            protocol_version: { type: integer }
+            min_protocol_version: { type: integer }
+            max_protocol_version: { type: integer }
+      required: [type, data]
+    AuthenticationError:
+      type: object
+      properties:
+        type: { const: AuthenticationError }
+        data:
+          type: object
+          required: [error, error_code]
+          properties:
+            error: { type: string }
+            error_code: { $ref: '#/components/schemas/ErrorCode' }
+      required: [type, data]
+    RoomJoined:
+      type: object
+      description: Payload is a flattened RoomJoinedPayload (boxed newtype variant).
+      properties:
+        type: { const: RoomJoined }
+        data:
+          type: object
+          required:
+            - room_id
+            - room_code
+            - player_id
+            - game_name
+            - max_players
+            - supports_authority
+            - current_players
+            - is_authority
+            - lobby_state
+            - ready_players
+            - relay_type
+          properties:
+            room_id: { $ref: '#/components/schemas/RoomId' }
+            room_code: { type: string }
+            player_id: { $ref: '#/components/schemas/PlayerId' }
+            game_name: { type: string }
+            max_players: { type: integer }
+            supports_authority: { type: boolean }
+            current_players:
+              type: array
+              items: { $ref: '#/components/schemas/PlayerInfo' }
+            is_authority: { type: boolean }
+            lobby_state: { $ref: '#/components/schemas/LobbyState' }
+            ready_players:
+              type: array
+              items: { $ref: '#/components/schemas/PlayerId' }
+            relay_type: { type: string }
+            current_spectators:
+              type: array
+              items: { $ref: '#/components/schemas/SpectatorInfo' }
+            ice_servers:
+              type: array
+              description: 'v3 pre-gather only; superseded by SessionPlan.ice_servers.'
+              items: { $ref: '#/components/schemas/IceServer' }
+      required: [type, data]
+    RoomJoinFailed:
+      type: object
+      properties:
+        type: { const: RoomJoinFailed }
+        data:
+          type: object
+          required: [reason]
+          properties:
+            reason: { type: string }
+            error_code: { $ref: '#/components/schemas/ErrorCode' }
+      required: [type, data]
+    RoomLeft:
+      type: object
+      description: No data payload.
+      properties:
+        type: { const: RoomLeft }
+      required: [type]
+    PlayerJoined:
+      type: object
+      properties:
+        type: { const: PlayerJoined }
+        data:
+          type: object
+          required: [player]
+          properties:
+            player: { $ref: '#/components/schemas/PlayerInfo' }
+      required: [type, data]
+    PlayerLeft:
+      type: object
+      properties:
+        type: { const: PlayerLeft }
+        data:
+          type: object
+          required: [player_id]
+          properties:
+            player_id: { $ref: '#/components/schemas/PlayerId' }
+      required: [type, data]
+    ServerGameData:
+      type: object
+      properties:
+        type: { const: GameData }
+        data:
+          type: object
+          required: [from_player, data]
+          properties:
+            from_player: { $ref: '#/components/schemas/PlayerId' }
+            data:
+              description: Opaque application game data (any JSON value).
+      required: [type, data]
+    GameDataBinary:
+      type: object
+      properties:
+        type: { const: GameDataBinary }
+        data:
+          type: object
+          required: [from_player, encoding, payload]
+          properties:
+            from_player: { $ref: '#/components/schemas/PlayerId' }
+            encoding: { $ref: '#/components/schemas/GameDataEncoding' }
+            payload: { type: string, description: Byte payload (serde_bytes). }
+      required: [type, data]
+    AuthorityChanged:
+      type: object
+      properties:
+        type: { const: AuthorityChanged }
+        data:
+          type: object
+          required: [you_are_authority]
+          properties:
+            authority_player: { $ref: '#/components/schemas/PlayerId' }
+            you_are_authority: { type: boolean }
+      required: [type, data]
+    AuthorityResponse:
+      type: object
+      properties:
+        type: { const: AuthorityResponse }
+        data:
+          type: object
+          required: [granted]
+          properties:
+            granted: { type: boolean }
+            reason: { type: string }
+            error_code: { $ref: '#/components/schemas/ErrorCode' }
+      required: [type, data]
+    LobbyStateChanged:
+      type: object
+      properties:
+        type: { const: LobbyStateChanged }
+        data:
+          type: object
+          required: [lobby_state, ready_players, all_ready]
+          properties:
+            lobby_state: { $ref: '#/components/schemas/LobbyState' }
+            ready_players:
+              type: array
+              items: { $ref: '#/components/schemas/PlayerId' }
+            all_ready: { type: boolean }
+      required: [type, data]
+    GameStarting:
+      type: object
+      properties:
+        type: { const: GameStarting }
+        data:
+          type: object
+          required: [peer_connections]
+          properties:
+            peer_connections:
+              type: array
+              items: { $ref: '#/components/schemas/PeerConnectionInfo' }
+      required: [type, data]
+    ServerSignal:
+      type: object
+      description: 'v3 only.'
+      properties:
+        type: { const: Signal }
+        data:
+          type: object
+          required: [from, signal]
+          properties:
+            from: { $ref: '#/components/schemas/PlayerId' }
+            signal:
+              description: Opaque WebRTC signal forwarded verbatim from a peer.
+      required: [type, data]
+    NewPeer:
+      type: object
+      description: 'v3 only.'
+      properties:
+        type: { const: NewPeer }
+        data:
+          type: object
+          required: [peer_id, you_initiate]
+          properties:
+            peer_id: { $ref: '#/components/schemas/PlayerId' }
+            you_initiate:
+              type: boolean
+              description: >-
+                Server-decided offerer flag (glare resolution). Clients MUST NOT
+                recompute it. On NewPeer, additively connect to the new peer.
+      required: [type, data]
+    SessionPlan:
+      type: object
+      description: >-
+        v3 only. Per-recipient. Payload is a flattened SessionPlanPayload (boxed
+        newtype variant). Latest SessionPlan wins.
+      properties:
+        type: { const: SessionPlan }
+        data:
+          type: object
+          required: [topology, transport, peers, fallback]
+          properties:
+            topology: { $ref: '#/components/schemas/Topology' }
+            transport: { $ref: '#/components/schemas/Transport' }
+            host:
+              allOf: [{ $ref: '#/components/schemas/PlayerId' }]
+              description: Present only for host topology.
+            peers:
+              type: array
+              items: { $ref: '#/components/schemas/SessionPeer' }
+            ice_servers:
+              type: array
+              items: { $ref: '#/components/schemas/IceServer' }
+            fallback:
+              allOf: [{ $ref: '#/components/schemas/Transport' }]
+              description: Universal fallback transport; always relay (the floor).
+      required: [type, data]
+    Pong:
+      type: object
+      description: No data payload.
+      properties:
+        type: { const: Pong }
+      required: [type]
+    Reconnected:
+      type: object
+      description: Payload is a flattened ReconnectedPayload (boxed newtype variant).
+      properties:
+        type: { const: Reconnected }
+        data:
+          type: object
+          required:
+            - room_id
+            - room_code
+            - player_id
+            - game_name
+            - max_players
+            - supports_authority
+            - current_players
+            - is_authority
+            - lobby_state
+            - ready_players
+            - relay_type
+            - missed_events
+          properties:
+            room_id: { $ref: '#/components/schemas/RoomId' }
+            room_code: { type: string }
+            player_id: { $ref: '#/components/schemas/PlayerId' }
+            game_name: { type: string }
+            max_players: { type: integer }
+            supports_authority: { type: boolean }
+            current_players:
+              type: array
+              items: { $ref: '#/components/schemas/PlayerInfo' }
+            is_authority: { type: boolean }
+            lobby_state: { $ref: '#/components/schemas/LobbyState' }
+            ready_players:
+              type: array
+              items: { $ref: '#/components/schemas/PlayerId' }
+            relay_type: { type: string }
+            current_spectators:
+              type: array
+              items: { $ref: '#/components/schemas/SpectatorInfo' }
+            ice_servers:
+              type: array
+              items: { $ref: '#/components/schemas/IceServer' }
+            missed_events:
+              type: array
+              description: Events that occurred while disconnected (ServerMessage values).
+              items: { type: object }
+      required: [type, data]
+    ReconnectionFailed:
+      type: object
+      properties:
+        type: { const: ReconnectionFailed }
+        data:
+          type: object
+          required: [reason, error_code]
+          properties:
+            reason: { type: string }
+            error_code: { $ref: '#/components/schemas/ErrorCode' }
+      required: [type, data]
+    PlayerReconnected:
+      type: object
+      properties:
+        type: { const: PlayerReconnected }
+        data:
+          type: object
+          required: [player_id]
+          properties:
+            player_id: { $ref: '#/components/schemas/PlayerId' }
+      required: [type, data]
+    SpectatorJoined:
+      type: object
+      description: Payload is a flattened SpectatorJoinedPayload (boxed newtype variant).
+      properties:
+        type: { const: SpectatorJoined }
+        data:
+          type: object
+          required:
+            - room_id
+            - room_code
+            - spectator_id
+            - game_name
+            - current_players
+            - current_spectators
+            - lobby_state
+          properties:
+            room_id: { $ref: '#/components/schemas/RoomId' }
+            room_code: { type: string }
+            spectator_id: { $ref: '#/components/schemas/PlayerId' }
+            game_name: { type: string }
+            current_players:
+              type: array
+              items: { $ref: '#/components/schemas/PlayerInfo' }
+            current_spectators:
+              type: array
+              items: { $ref: '#/components/schemas/SpectatorInfo' }
+            lobby_state: { $ref: '#/components/schemas/LobbyState' }
+            reason: { $ref: '#/components/schemas/SpectatorStateChangeReason' }
+      required: [type, data]
+    SpectatorJoinFailed:
+      type: object
+      properties:
+        type: { const: SpectatorJoinFailed }
+        data:
+          type: object
+          required: [reason]
+          properties:
+            reason: { type: string }
+            error_code: { $ref: '#/components/schemas/ErrorCode' }
+      required: [type, data]
+    SpectatorLeft:
+      type: object
+      properties:
+        type: { const: SpectatorLeft }
+        data:
+          type: object
+          properties:
+            room_id: { $ref: '#/components/schemas/RoomId' }
+            room_code: { type: string }
+            reason: { $ref: '#/components/schemas/SpectatorStateChangeReason' }
+            current_spectators:
+              type: array
+              items: { $ref: '#/components/schemas/SpectatorInfo' }
+      required: [type, data]
+    NewSpectatorJoined:
+      type: object
+      properties:
+        type: { const: NewSpectatorJoined }
+        data:
+          type: object
+          required: [spectator]
+          properties:
+            spectator: { $ref: '#/components/schemas/SpectatorInfo' }
+            current_spectators:
+              type: array
+              items: { $ref: '#/components/schemas/SpectatorInfo' }
+            reason: { $ref: '#/components/schemas/SpectatorStateChangeReason' }
+      required: [type, data]
+    SpectatorDisconnected:
+      type: object
+      properties:
+        type: { const: SpectatorDisconnected }
+        data:
+          type: object
+          required: [spectator_id]
+          properties:
+            spectator_id: { $ref: '#/components/schemas/PlayerId' }
+            reason: { $ref: '#/components/schemas/SpectatorStateChangeReason' }
+            current_spectators:
+              type: array
+              items: { $ref: '#/components/schemas/SpectatorInfo' }
+      required: [type, data]
+    Error:
+      type: object
+      properties:
+        type: { const: Error }
+        data:
+          type: object
+          required: [message]
+          properties:
+            message: { type: string }
+            error_code: { $ref: '#/components/schemas/ErrorCode' }
+      required: [type, data]
+    PeerTransportStatus:
+      type: object
+      description: 'v3 only. Informational fan-out of an accepted TransportStatus.'
+      properties:
+        type: { const: PeerTransportStatus }
+        data:
+          type: object
+          required: [peer_id, transport, connected]
+          properties:
+            peer_id: { $ref: '#/components/schemas/PlayerId' }
+            transport: { $ref: '#/components/schemas/Transport' }
+            connected: { type: boolean }
+      required: [type, data]


### PR DESCRIPTION
## Summary

Follow-up to the v0.6.0 no-silent-loss overhaul and the server's delivery rework (signal-fish-server 851c446): a deep, measured, end-to-end audit of the delivery contract found that the **receive-side decode path was still a silent-loss hole**, and that **server evictions were invisible to this client**. This PR closes both, fixes the wedged-consumer shutdown hazard, adds a real-server E2E harness + measurement lab, and documents the end-to-end delivery contract with measured numbers. Breaking (exhaustive enums grew) → **0.7.0**.

Companion server-side proposal (delivery classes, control-priority lane, close codes, reconnect tokens — with all the measurements): Ambiguous-Interactive/signal-fish-server#136.

## The headline bug (red → green)

The server's slow-consumer eviction (server #133) sends a farewell `Error { error_code: "SLOW_CONSUMER" }`. The client's exhaustive `ErrorCode` enum (48 variants) didn't know that token, so **the entire frame failed to deserialize and was silently dropped** with only a `warn!` (`src/client.rs` transport-loop Err arm) — the "loud" eviction arrived silent. The cross-repo drift detector stayed green because the wire-sample golden tests pin message *shapes*, not the error-code value space.

Red evidence, pre-fix: `every_server_error_code_token_deserializes_into_a_client_variant` failed with `["SLOW_CONSUMER", "ACTIVITY_TIMEOUT"]`; count check 48 (client) vs 50 (spec).

## Changes

### Never-silent receive path
- `SignalFishEvent::DecodeFailed { message_type, error, raw_prefix }` — every undecodable inbound frame (unknown message type, unknown error code, malformed JSON) surfaces as a typed event on **both** clients; raw text capped at 512 bytes on a UTF-8 boundary; counted in the new `ClientStats::messages_undecodable`.
- `ErrorCode::SlowConsumer` + `ErrorCode::ActivityTimeout` (enum tail, matching server rkyv ordering).

### Drift can't sneak past CI again
- The server's `spec/signal-fish-protocol.asyncapi.yaml` is vendored under `tests/server-spec/` with SHA-pinned `PROVENANCE.toml` (same idiom as `tests/wire-samples/`); `tests/error_code_conformance_tests.rs` asserts the error-code space matches in **both directions** (compile-time exhaustiveness guard + count pin); the weekly `protocol-sync` workflow now also diffs the vendored spec against server `main`.

### Disconnect attribution
- `Disconnected` gains `last_server_error: Option<ServerErrorInfo>` — the most recent `Error`/`AuthenticationError` on the connection, so a farewell-then-bare-close eviction is attributable.
- `Transport::close_reason()` (defaulted → non-breaking for implementors); `WebSocketTransport` captures the peer's Close-frame text; `Disconnected::reason` carries it as `"closed by server: …"`. (Measured: the server closes bare today — reason stays `None` until server#136's close codes land; the plumbing is ready.)

### Wedged-consumer shutdown fix
- A consumer that stops draining used to starve the shutdown signal too: `shutdown()` could only timeout-abort, leaving the socket dangling. Event delivery now races the shutdown oneshot (biased toward delivery); a shutdown abandons at most the one in-flight event, **closes the transport gracefully**, and delivers the terminal `Disconnected` best-effort (channel close is the authoritative end-of-stream signal).

### Real-server E2E + measurement lab
- `tests/real_server_e2e.rs` (env-gated, `#[ignore]` by default): eviction observability, reconnect contract, ping-under-flood — all green against a local 851c446 build (`SIGNAL_FISH_SERVER_BIN=… cargo test --test real_server_e2e -- --ignored`).
- `examples/load_lab.rs`: CSV-emitting harness (ping / throughput / slow-consumer / control-starvation).

### Docs
- New **Delivery Contract & Backpressure** page (`docs/delivery.md`) with the measured numbers; README wire-parity claim corrected; rkyv marked reserved (server never negotiates it); events/errors/concepts/client/transport pages updated; counts 48→50 codes, 30→31 events.

## Measured (localhost, server 851c446, via load_lab / e2e)

| Experiment | Result |
|---|---|
| Throughput sweep, 3 recipients | **Zero loss at every rate** up to 16 KiB × 1600 msg/s (~78 MB/s fan-out); knee only at the extreme cell (p99 167 ms). The v0.3.0 silent-drop class is gone. |
| Slow-but-alive peer (10/s in a 120/s room, default queue) | Peer ages to **22.9 s stale**, never evicted, nobody signaled. |
| Same with queue=64, 4 KiB | **Healthy** peers p95 5.4 s / p99 6.6 s — one slow member paces the room. |
| Control under flood | Backlogged recipient got **1 of 15 Pongs** in 15 s (baseline p50 3.6 ms). |
| Eviction UX (q=8, 500 ms) | Farewell arrived post-resume and is now attributed via `last_server_error`; close is bare (`reason: None`) pending server close codes. |
| Reconnect | Empty token → `RECONNECTION_TOKEN_INVALID`; no wire path surfaces a token — fresh `join_room` is the recovery path (documented). |

Server-side remediations for the middle four rows are proposed in server#136.

## Breaking changes (0.7.0)

- `ErrorCode` +2 variants; `SignalFishEvent` +`DecodeFailed`, `Disconnected` +`last_server_error`; `ClientStats` +`messages_undecodable` — exhaustive matches / struct literals need updating (`Disconnected { reason, .. }`).
- Shutdown semantics: graceful shutdown now closes the transport even with a wedged consumer and delivers the final `Disconnected` best-effort (previously blocking-then-abort with the socket left dangling).

## Verification

- `cargo fmt` ✓ · `clippy --all-targets --all-features -D warnings` ✓ · `clippy --no-default-features` ✓ · `cargo test --all-features` (10 binaries) ✓ · doc-tests ✓ · `cargo package` ✓ · no-panics / workflows / test-quality / llm-size / admonitions hooks ✓
- Real-server E2E: 3/3 green against a local 851c446 build.
- Red-green discipline: each fix landed with its failing test captured first (see commit messages for the red evidence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking public API (`ErrorCode`, `SignalFishEvent`, `ClientStats`) and changed transport-loop/shutdown behavior affect all connected clients; mitigated by broad tests and parity checks.
> 
> **Overview**
> **0.7.0** closes the receive-side silent-loss hole (unknown server error codes and bad frames used to fail deserialization and disappear) and makes slow-consumer evictions attributable.
> 
> Undecodable inbound frames now emit **`DecodeFailed`** on both async and polling clients, with **`messages_undecodable`** in **`ClientStats`**. **`ErrorCode`** adds **`SlowConsumer`** and **`ActivityTimeout`**. **`Disconnected`** gains **`last_server_error`** (last server **`Error`** / **`AuthenticationError`**) and optional **`Transport::close_reason()`** enrichment (WebSocket close text).
> 
> The transport loop races event delivery against **`shutdown()`** so a wedged full event channel no longer blocks graceful close; terminal **`Disconnected`** is best-effort after close.
> 
> Conformance: vendored server AsyncAPI under **`tests/server-spec/`**, **`error_code_conformance_tests`**, weekly **`protocol-sync`** AsyncAPI drift check, **`load_lab`** example, env-gated **`real_server_e2e`**, and **`docs/delivery.md`** with measured relay/backpressure numbers. Docs/README version bumps and corrected wire-parity / rkyv claims.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8599e82a0b996f0412557f57d1f1cba89854c0f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->