### PR TITLE
feat!: unify client core and synchronous API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ logs_*
 
 pre-commit.txt
 pre-push.txt
+GOAL.md

--- a/.llm/context.md
+++ b/.llm/context.md
@@ -54,7 +54,10 @@ Only add `CHANGELOG.md` entries for user-visible changes.
 | `src/error_codes.rs` | `ErrorCode` enum — 50 variants from server |
 | `src/error.rs` | `SignalFishError` error type |
 | `src/event.rs` | `SignalFishEvent` high-level event stream |
-| `src/client.rs` | `SignalFishClient` async client + `SignalFishConfig` + `JoinRoomParams` |
+| `src/client_core.rs` | Shared command construction, decoding, accountability, state, events, and statistics |
+| `src/client_api.rs` | Object-safe `SignalFishClientApi` common synchronous surface |
+| `src/client.rs` | Thin async driver + `SignalFishConfig` + `JoinRoomParams` |
+| `src/polling_client.rs` | Thin caller-driven polling transport driver (feature: `polling-client`) |
 | `src/mesh.rs` | `MeshSession` v3 state tracker (feature: `mesh`) |
 | `src/webrtc.rs` | `WebRtcDriver` seam + `MeshController` (feature: `mesh`) |
 | `src/transports/websocket.rs` | WebSocket transport (feature: `transport-websocket`) |
@@ -130,6 +133,10 @@ client.join_room(params)?;
 
 All methods except `shutdown` and the `*_reliable` sends are synchronous (they queue a message on the bounded command channel, no round-trip):
 
+Common synchronous commands take `&mut self` through the object-safe
+`SignalFishClientApi`. Driver-specific lifecycle stays concrete; both drivers
+delegate protocol behavior and state to one `ClientCore`.
+
 ```rust,ignore
 client.join_room(params: JoinRoomParams) -> Result<()>
 client.leave_room() -> Result<()>
@@ -173,8 +180,6 @@ capacity accessors, `stats()`, and coherent `snapshot()`.
 
 ## Dependencies
 
-### Runtime
-
 | Crate | Purpose |
 |-------|---------|
 | `tokio` | Async runtime (sync, macros, rt, time features) |
@@ -185,8 +190,6 @@ capacity accessors, `stats()`, and coherent `snapshot()`.
 | `tracing` | Structured logging and diagnostics |
 | `tokio-tungstenite` | WebSocket transport (optional) |
 | `futures-util` | Stream/sink utilities for WebSocket (optional) |
-
-### Dev
 
 `tokio` (full features, for tests) and `tracing-subscriber` (test log output).
 

--- a/.llm/skills/index.md
+++ b/.llm/skills/index.md
@@ -72,6 +72,10 @@ Reference for enum matching policy, semver, re-exports, feature flags, and MSRV 
 
 Reference for serde_json, enum tagging, field attributes, and wire format as used in this codebase.
 
+### [Shared Client Core and Drivers](shared-core-drivers.md)
+
+Reference for preserving semantic parity between `SignalFishClient` and `SignalFishPollingClient`.
+
 ### [Shell Script Portability](shell-portability.md)
 
 Reference for writing portable shell scripts that work on both GNU (Linux) and BSD (macOS) systems.

--- a/.llm/skills/protocol-versioning-and-negotiation.md
+++ b/.llm/skills/protocol-versioning-and-negotiation.md
@@ -31,8 +31,8 @@ MUST be `Option` + `skip_serializing_if` (or `Vec` + `default` + `skip_if-empty`
    keeps the room on the relay floor and emits no v3 messages.
 
 The client tracks the negotiated version from `ProtocolInfo`:
-`SignalFishClient::negotiated_protocol_version()` and `supports_mesh()` (true when
-the negotiated version is ≥ 3).
+`SignalFishClient::negotiated_protocol_version()` and `supports_mesh()` (true
+when WebRTC mesh was advertised and the negotiated version is ≥ 3).
 
 ## Never Advertise What You Cannot Fulfill
 

--- a/.llm/skills/public-api-design.md
+++ b/.llm/skills/public-api-design.md
@@ -210,7 +210,7 @@ Every public item should have a doc comment:
 /// # Errors
 ///
 /// Returns [`SignalFishError::NotConnected`] if the transport has closed.
-pub fn join_room(&self, params: JoinRoomParams) -> Result<()> {
+pub fn join_room(&mut self, params: JoinRoomParams) -> Result<()> {
     // ...
 }
 ```

--- a/.llm/skills/shared-core-drivers.md
+++ b/.llm/skills/shared-core-drivers.md
@@ -1,0 +1,75 @@
+# Shared Client Core and Drivers
+
+Reference for preserving semantic parity between `SignalFishClient` and
+`SignalFishPollingClient`.
+
+## Ownership Boundary
+
+`ClientCore` is the single transport-independent protocol state machine. It
+owns:
+
+- authentication command construction and every common command shape;
+- protocol-v2/v3 guards and binary-format validation;
+- text and binary frame decoding;
+- delivery accountability and violation policy;
+- state transitions, snapshots, counters, and last-server-error attribution;
+- conversion from `ServerMessage` to ordered `SignalFishEvent` values.
+
+The drivers own scheduling only. The async driver owns Tokio channels,
+backpressured event delivery, its transport task, and shutdown timeout. The
+polling driver owns its bounded queue, noop-waker polling, readiness timing,
+pending transport sends, and close progress.
+
+Never add protocol interpretation or state mutation directly to a driver. Add
+it to `ClientCore`, then exercise it through both drivers in the parity matrix.
+
+## Locking Rule
+
+The async handle shares `ClientCore` with its transport task through a standard
+mutex. Hold that lock only for short synchronous core calls. Release it before:
+
+- transport polling or an `.await`;
+- waiting for command-channel capacity;
+- sending an event into the backpressured event channel.
+
+The polling driver owns the core directly and must remain compatible with
+non-`Send` transports.
+
+## Common Public API
+
+`SignalFishClientApi` is object-safe. Common synchronous commands take
+`&mut self`; diagnostics and snapshots take `&self`. Trait methods use concrete
+owned argument types. Do not add:
+
+- generic methods or `impl Trait` arguments;
+- async methods;
+- associated transport types;
+- `Send` or `Sync` supertraits;
+- driver-private command/effect types in public signatures.
+
+Waiting sends and `shutdown` remain async-driver-specific. `poll`, `close`, and
+`is_closing` remain polling-driver-specific.
+
+## Adding a Common Command
+
+1. Add one `ClientOperation` variant.
+2. Construct and validate its exact wire command in `ClientCore::prepare`.
+3. Add matching mutable methods to `SignalFishClientApi` and both inherent
+   clients; the driver methods only enqueue the prepared `CoreCommand`.
+4. Add the operation to the data-driven parity matrix and verify exact frames,
+   returned errors, queue capacity, snapshots, and statistics.
+5. Update public docs and `CHANGELOG.md` when consumer-visible.
+
+## Parity Testing
+
+Use deterministic barriers around the async driver. Compare complete ordered
+frames and events rather than selected fields. Cover:
+
+- pre-negotiation, relay-floor, and v3 modes;
+- JSON and binary representations;
+- full queues, pending sends, disconnects, and close metadata;
+- all violation policies and authoritative quarantine rebaselines;
+- coherent snapshots and cumulative statistics.
+
+`Connected` timing and driver lifecycle calls are intentionally different and
+belong in driver-specific tests.

--- a/.llm/skills/testing-async.md
+++ b/.llm/skills/testing-async.md
@@ -288,8 +288,9 @@ Not every `.unwrap()` needs to become `.expect()`. These cases are acceptable:
 - **Golden-wire conformance**: `tests/wire_golden_tests.rs` round-trips the real
   server samples — see [protocol-wire-conformance](protocol-wire-conformance.md).
 - **Negotiation**: script `protocol_info_json(Some(3))` after `authenticated_json()`
-  through `MockTransport`, then assert `negotiated_protocol_version()`/`supports_mesh()`
-  and that v3 sends succeed; assert `ProtocolUnsupported` before negotiation.
+  through `MockTransport`; assert the negotiated version, v3 sends, and the
+  pre-negotiation error. Assert `supports_mesh()` only with `enable_mesh()`;
+  relay-only `enable_v3()` must remain false.
 - **Frames/accountability**: keep text and binary frames in one scripted order;
   assert malformed binary becomes `DecodeFailed`, while valid accountability
   failures become `ProtocolViolation` and follow the configured policy.

--- a/.llm/skills/tracing-instrumentation.md
+++ b/.llm/skills/tracing-instrumentation.md
@@ -61,7 +61,7 @@ Automatically creates a span around a function:
 use tracing::instrument;
 
 #[instrument(skip(self), fields(game_name = %game_name))]
-pub fn join_room(&self, params: JoinRoomParams) -> Result<(), SignalFishError> {
+pub fn join_room(&mut self, params: JoinRoomParams) -> Result<(), SignalFishError> {
     debug!("sending join_room request");
     // ...
     info!("join_room queued");

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,4 +30,4 @@ For any user-visible change, update `CHANGELOG.md` in the same PR under
 
 Focused reference guides live in `.llm/skills/`. See `.llm/skills/index.md` for a full listing.
 
-Key skills: `async-rust-patterns`, `transport-abstraction`, `websocket-client`, `error-handling`, `serde-patterns`, `testing-async`, `public-api-design`, `tracing-instrumentation`, `crate-publishing`, `changelog-discipline`, `keep-a-changelog-format`.
+Key skills: `async-rust-patterns`, `shared-core-drivers`, `transport-abstraction`, `websocket-client`, `error-handling`, `serde-patterns`, `testing-async`, `public-api-design`, `tracing-instrumentation`, `crate-publishing`, `changelog-discipline`, `keep-a-changelog-format`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ErrorCode::ServerDraining` and `ErrorCode::InvalidDeliveryClass`.
 - `SignalFishError::BinaryFormatNotNegotiated` for binary sends attempted on
   JSON-format connections.
+- Object-safe `SignalFishClientApi` for writing synchronous room, signaling,
+  capacity, statistics, and snapshot logic that works with either client
+  driver.
 
 ### Changed
 
@@ -36,6 +39,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   close metadata, and explicitly flushes automatic Pong responses.
 - Event and snapshot debug formatting no longer prints
   reconnect credentials or arbitrary application payloads.
+- **Breaking:** common synchronous commands on `SignalFishClient` now take
+  `&mut self`, matching `SignalFishPollingClient` and the shared
+  `SignalFishClientApi`. The matching `MeshController` room delegations now
+  take `&mut self` and `client_mut()` exposes other mutable commands. Async
+  waiting sends remain callable through `&self`.
 
 ### Fixed
 
@@ -47,6 +55,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   closes remain driven across `poll()` calls, peer WebSocket Close responses
   are flushed, Emscripten callback payload handling matches its C ABI, and
   debug builds diagnose wake-driven misuse of its polling-only receive path.
+- `supports_mesh()` now requires both local WebRTC advertisement through
+  `enable_mesh()` and negotiated protocol v3; relay-only `enable_v3()` clients
+  no longer report that mesh is available.
 
 ## [0.7.0] - 2026-07-02
 

--- a/docs/client.md
+++ b/docs/client.md
@@ -166,7 +166,7 @@ use signal_fish_client::{
 
 let transport = WebSocketTransport::connect("ws://localhost:3536/ws").await?;
 let config = SignalFishConfig::new("mb_app_abc123");
-let (client, mut event_rx) = SignalFishClient::start(transport, config);
+let (mut client, mut event_rx) = SignalFishClient::start(transport, config);
 ```
 
 !!! note
@@ -182,7 +182,7 @@ let (client, mut event_rx) = SignalFishClient::start(transport, config);
 Join or create a room with the given parameters.
 
 ```rust,ignore
-fn join_room(&self, params: JoinRoomParams) -> Result<()>
+fn join_room(&mut self, params: JoinRoomParams) -> Result<()>
 ```
 
 ```rust,ignore
@@ -201,7 +201,7 @@ Wait for `SignalFishEvent::RoomJoined` to confirm success.
 Leave the current room.
 
 ```rust,ignore
-fn leave_room(&self) -> Result<()>
+fn leave_room(&mut self) -> Result<()>
 ```
 
 ```rust,ignore
@@ -217,7 +217,7 @@ The server will broadcast a player-left event to remaining room members.
 Signal readiness to start the game in the lobby.
 
 ```rust,ignore
-fn set_ready(&self) -> Result<()>
+fn set_ready(&mut self) -> Result<()>
 ```
 
 ```rust,ignore
@@ -234,7 +234,7 @@ Join a room as a read-only spectator.
 
 ```rust,ignore
 fn join_as_spectator(
-    &self,
+    &mut self,
     game_name: String,
     room_code: String,
     spectator_name: String,
@@ -258,7 +258,7 @@ Spectators receive game events but cannot send game data or affect room state.
 Leave spectator mode.
 
 ```rust,ignore
-fn leave_spectator(&self) -> Result<()>
+fn leave_spectator(&mut self) -> Result<()>
 ```
 
 ```rust,ignore
@@ -274,7 +274,7 @@ client.leave_spectator()?;
 Send arbitrary JSON game data to other players in the room.
 
 ```rust,ignore
-fn send_game_data(&self, data: serde_json::Value) -> Result<()>
+fn send_game_data(&mut self, data: serde_json::Value) -> Result<()>
 ```
 
 ```rust,ignore
@@ -417,7 +417,7 @@ println!(
 Request to become (or relinquish) the room authority.
 
 ```rust,ignore
-fn request_authority(&self, become_authority: bool) -> Result<()>
+fn request_authority(&mut self, become_authority: bool) -> Result<()>
 ```
 
 ```rust,ignore
@@ -441,7 +441,7 @@ Provide P2P connection information to the server for relay/direct connection est
 
 ```rust,ignore
 fn provide_connection_info(
-    &self,
+    &mut self,
     connection_info: ConnectionInfo,
 ) -> Result<()>
 ```
@@ -466,7 +466,7 @@ Reconnect to a previous session after a disconnection.
 
 ```rust,ignore
 fn reconnect(
-    &self,
+    &mut self,
     player_id: PlayerId,
     room_id: RoomId,
     auth_token: String,
@@ -490,7 +490,7 @@ do not log them.
 Send a heartbeat ping to the server.
 
 ```rust,ignore
-fn ping(&self) -> Result<()>
+fn ping(&mut self) -> Result<()>
 ```
 
 ```rust,ignore

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -109,7 +109,7 @@ new optional fields, messages, and events that a v2 connection never sees.
 2. The server clamps to its own range and echoes the negotiated
    `protocol_version` (plus min/max) back in `ProtocolInfo`.
 3. The client records it; read it via `negotiated_protocol_version()` and
-   `supports_mesh()` (true once the negotiated version is ≥ 3).
+   `supports_mesh()` (true after `enable_mesh()` and v3 negotiation).
 
 v3-only sends (`send_signal`, `report_transport_status`, …) **fail fast** with
 [`SignalFishError::ProtocolUnsupported`](errors.md) until v3 is negotiated —

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -44,7 +44,7 @@ use signal_fish_client::{
     SignalFishClient, SignalFishConfig, SignalFishError, JoinRoomParams,
 };
 
-fn try_join(client: &SignalFishClient) {
+fn try_join(client: &mut SignalFishClient) {
     let params = JoinRoomParams::new("my-game", "Alice");
     match client.join_room(params) {
         Ok(()) => println!("Join request sent"),
@@ -353,7 +353,7 @@ use signal_fish_client::{
     SignalFishClient, SignalFishError, SignalFishEvent, ErrorCode,
 };
 
-fn send_data(client: &SignalFishClient) {
+fn send_data(client: &mut SignalFishClient) {
     let payload = serde_json::json!({"action": "move", "x": 10, "y": 20});
     match client.send_game_data(payload) {
         Ok(()) => { /* sent successfully */ }

--- a/docs/migration-0.8.md
+++ b/docs/migration-0.8.md
@@ -1,0 +1,66 @@
+# Migrating from 0.7 to 0.8
+
+Version 0.8 unifies the async and polling clients behind one protocol state
+machine and a common object-safe API. Wire behavior remains unchanged: the
+default client still speaks the protocol-v2 relay floor, while v3 remains an
+explicit opt-in.
+
+## Mutable synchronous commands
+
+Common synchronous commands now take `&mut self` on both drivers. Declare the
+client binding mutable and pass a mutable reference to helpers:
+
+```rust,ignore
+// 0.7
+fn join(client: &SignalFishClient) -> Result<(), SignalFishError> {
+    client.join_room(JoinRoomParams::new("game", "Alice"))
+}
+
+// 0.8
+fn join(client: &mut SignalFishClient) -> Result<(), SignalFishError> {
+    client.join_room(JoinRoomParams::new("game", "Alice"))
+}
+```
+
+The async waiting sends (`*_reliable`) still take `&self`; `shutdown` already
+takes `&mut self`. Code that previously shared an async handle through `Arc`
+must provide exclusive access for synchronous commands, for example with a
+mutex, or route commands through an application-owned task.
+
+`MeshController::join_room`, `set_ready`, `start_game`, and `leave_room` also
+take `&mut self`. Use the new `MeshController::client_mut()` accessor for other
+synchronous commands; `client()` remains available for read-only access.
+
+## Driver-independent application logic
+
+Use `SignalFishClientApi` when the same room and signaling logic should work
+with either driver:
+
+```rust,ignore
+use signal_fish_client::{
+    JoinRoomParams, SignalFishClientApi, SignalFishError,
+};
+
+fn enter_lobby(client: &mut dyn SignalFishClientApi) -> Result<(), SignalFishError> {
+    client.join_room(JoinRoomParams::new("game", "Alice"))?;
+    client.set_ready()
+}
+```
+
+The trait contains synchronous commands, queue capacity, statistics, and
+`snapshot()`. Driver-specific lifecycle stays on the concrete types:
+
+- `SignalFishClient`: waiting sends and `shutdown().await`.
+- `SignalFishPollingClient`: `poll()`, `close()`, and `is_closing()`.
+
+The trait uses owned concrete arguments (`PeerSignal`, `String`, and
+`serde_json::Value`) so it remains object-safe. The concrete clients retain
+their ergonomic `impl Into` signal helpers.
+
+## Transport and protocol changes
+
+The frame-capable `Transport` boundary, binary game data, v3 delivery classes,
+reconnection tokens, and accountability policy were introduced in the same
+0.8 development cycle. See the [Transport](transport.md),
+[Protocol Versioning](protocol-versioning.md), and
+[Delivery Contract](delivery.md) guides for those migrations.

--- a/docs/protocol-versioning.md
+++ b/docs/protocol-versioning.md
@@ -117,14 +117,14 @@ match client.negotiated_protocol_version() {
 }
 
 if client.supports_mesh() {
-    // negotiated >= 3: send_signal / report_transport_status are available.
+    // enable_mesh() advertised WebRTC and protocol v3 was negotiated.
 }
 ```
 
 | Accessor | Returns |
 |----------|---------|
 | `negotiated_protocol_version()` | `Option<u16>` — `None` before `ProtocolInfo`, or for a v2 negotiation. |
-| `supports_mesh()` | `bool` — `true` once the negotiated version is ≥ 3. |
+| `supports_mesh()` | `bool` — `true` when WebRTC mesh was advertised and the negotiated version is ≥ 3. |
 
 ---
 

--- a/docs/wasm.md
+++ b/docs/wasm.md
@@ -339,8 +339,9 @@ environment).
 
 !!! tip "Comparison with `SignalFishClient`"
     `SignalFishPollingClient` mirrors the same API surface as `SignalFishClient`
-    but all methods take `&mut self` instead of `&self`, and state accessors are
-    synchronous (no `async`). There is no `shutdown()` — use `close()` instead.
+    for common synchronous commands: both use `&mut self`, and state accessors
+    use `&self`. The polling client has no asynchronous waiting sends or
+    `shutdown()` — drive it with `poll()` and use `close()` instead.
 
 ---
 

--- a/examples/basic_lobby.rs
+++ b/examples/basic_lobby.rs
@@ -143,7 +143,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                             &lobby_state,
                             &missed_events,
                         );
-                        lobby_start.maybe_start_game(&client)?;
+                        lobby_start.maybe_start_game(&mut client)?;
                     }
 
                     SignalFishEvent::PlayerJoined { player } => {
@@ -161,7 +161,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     } => {
                         tracing::info!("Lobby state → {lobby_state:?} (all_ready={ready})");
                         lobby_start.apply_lobby_state(&lobby_state, ready);
-                        lobby_start.maybe_start_game(&client)?;
+                        lobby_start.maybe_start_game(&mut client)?;
                     }
 
                     // ── Authority changes ────────────────────────────
@@ -174,7 +174,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     } => {
                         lobby_start.apply_authority_changed(you_are_authority);
                         tracing::info!("Authority changed (you_are_authority={you_are_authority})");
-                        lobby_start.maybe_start_game(&client)?;
+                        lobby_start.maybe_start_game(&mut client)?;
                     }
 
                     SignalFishEvent::GameStarting {
@@ -308,7 +308,7 @@ impl LobbyStartState {
     /// confirms the game is already starting or finalized.
     fn maybe_start_game(
         &mut self,
-        client: &SignalFishClient,
+        client: &mut SignalFishClient,
     ) -> Result<(), Box<dyn std::error::Error>> {
         if self.should_start_game() {
             client.start_game()?;

--- a/examples/load_lab.rs
+++ b/examples/load_lab.rs
@@ -169,7 +169,7 @@ async fn connect(
 }
 
 async fn join(
-    client: &SignalFishClient,
+    client: &mut SignalFishClient,
     events: &mut tokio::sync::mpsc::Receiver<SignalFishEvent>,
     game: &str,
     name: &str,
@@ -236,7 +236,7 @@ async fn drain_role(
 // ── Modes ───────────────────────────────────────────────────────────
 
 async fn mode_ping(opts: &Options) -> Result<(), Box<dyn Error>> {
-    let (client, mut events) = connect(opts, "pinger", 256).await?;
+    let (mut client, mut events) = connect(opts, "pinger", 256).await?;
     let mut rtts = Vec::new();
     for _ in 0..20 {
         let sent = Instant::now();
@@ -267,14 +267,14 @@ async fn mode_throughput(opts: &Options) -> Result<(), Box<dyn Error>> {
         let suffix = format!("{}-{rate}", std::process::id());
         let game = format!("lab-throughput-{suffix}");
 
-        let (sender, mut sender_events) = connect(opts, "sender", 1024).await?;
-        let room_code = join(&sender, &mut sender_events, &game, "sender", None).await?;
+        let (mut sender, mut sender_events) = connect(opts, "sender", 1024).await?;
+        let room_code = join(&mut sender, &mut sender_events, &game, "sender", None).await?;
 
         let mut receiver_handles = Vec::new();
         for i in 0..opts.recipients {
-            let (rx_client, mut rx_events) = connect(opts, "receiver", 4096).await?;
+            let (mut rx_client, mut rx_events) = connect(opts, "receiver", 4096).await?;
             join(
-                &rx_client,
+                &mut rx_client,
                 &mut rx_events,
                 &game,
                 &format!("rx{i}"),
@@ -331,21 +331,28 @@ async fn mode_slow_consumer(opts: &Options) -> Result<(), Box<dyn Error>> {
     let suffix = std::process::id();
     let game = format!("lab-slow-{suffix}");
 
-    let (sender, mut sender_events) = connect(opts, "sender", 1024).await?;
-    let room_code = join(&sender, &mut sender_events, &game, "sender", None).await?;
+    let (mut sender, mut sender_events) = connect(opts, "sender", 1024).await?;
+    let room_code = join(&mut sender, &mut sender_events, &game, "sender", None).await?;
 
     // Two healthy receivers + one slow one (event capacity 1 so its
     // backpressure reaches the socket quickly).
     let mut healthy = Vec::new();
     for i in 0..2 {
-        let (c, mut e) = connect(opts, "healthy", 4096).await?;
-        join(&c, &mut e, &game, &format!("healthy{i}"), Some(&room_code)).await?;
+        let (mut c, mut e) = connect(opts, "healthy", 4096).await?;
+        join(
+            &mut c,
+            &mut e,
+            &game,
+            &format!("healthy{i}"),
+            Some(&room_code),
+        )
+        .await?;
         let secs = opts.secs;
         healthy.push((c, tokio::spawn(async move { drain_role(e, secs, 0).await })));
     }
-    let (slow_client, mut slow_events) = connect(opts, "slow", 1).await?;
+    let (mut slow_client, mut slow_events) = connect(opts, "slow", 1).await?;
     join(
-        &slow_client,
+        &mut slow_client,
         &mut slow_events,
         &game,
         "slow",
@@ -400,11 +407,11 @@ async fn mode_control_starvation(opts: &Options) -> Result<(), Box<dyn Error>> {
     let game = format!("lab-ctrl-{suffix}");
 
     // Victim joins first (owns the room), then the flooder.
-    let (victim, mut victim_events) = connect(opts, "victim", 256).await?;
-    let room_code = join(&victim, &mut victim_events, &game, "victim", None).await?;
-    let (flooder, mut flooder_events) = connect(opts, "flooder", 1024).await?;
+    let (mut victim, mut victim_events) = connect(opts, "victim", 256).await?;
+    let room_code = join(&mut victim, &mut victim_events, &game, "victim", None).await?;
+    let (mut flooder, mut flooder_events) = connect(opts, "flooder", 1024).await?;
     join(
-        &flooder,
+        &mut flooder,
         &mut flooder_events,
         &game,
         "flooder",

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -134,6 +134,7 @@ nav:
       - Installation & Quick Start: getting-started.md
       - Core Concepts: concepts.md
       - Protocol Versioning: protocol-versioning.md
+      - Migrating 0.7 to 0.8: migration-0.8.md
   - API Reference:
       - Client: client.md
       - Transport: transport.md

--- a/src/client.rs
+++ b/src/client.rs
@@ -50,7 +50,7 @@
 //! ```rust,ignore
 //! let transport = connect_somehow().await;
 //! let config = SignalFishConfig::new("mb_app_abc123");
-//! let (client, mut events) = SignalFishClient::start(transport, config);
+//! let (mut client, mut events) = SignalFishClient::start(transport, config);
 //!
 //! client.join_room(
 //!     JoinRoomParams::new("my-game", "Alice")
@@ -66,31 +66,33 @@
 //! }
 //! ```
 
-use std::sync::atomic::{AtomicBool, AtomicU16, AtomicU64, AtomicU8, Ordering};
-use std::sync::Arc;
+#[cfg(all(test, feature = "tokio-runtime"))]
+use std::sync::atomic::{AtomicBool, Ordering};
+#[cfg(feature = "tokio-runtime")]
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-// tokio/sync is always available (not gated on `tokio-runtime`) because
-// `SignalFishClient` uses `mpsc` and `ClientState` uses `Mutex` unconditionally.
-// These types have no reachable usage path without `tokio-runtime` (the only
-// constructor, `SignalFishClient::start`, is feature-gated), so they are
-// effectively dead code in that configuration — suppressed by
-// `#[cfg_attr(..., allow(dead_code))]` on the struct. If a future refactoring
-// needs a different sync primitive for the no-runtime path, this import and
-// the struct fields would need feature-gating.
-use tokio::sync::{mpsc, Mutex};
+#[cfg(feature = "tokio-runtime")]
+use tokio::sync::mpsc;
 #[cfg(feature = "tokio-runtime")]
 use tracing::{debug, error, warn};
 
+#[cfg(feature = "tokio-runtime")]
+use crate::client_core::{ClientCore, ClientOperation, CoreCommand as ClientCommand};
+#[cfg(feature = "tokio-runtime")]
 use crate::error::{Result, SignalFishError};
 #[cfg(feature = "tokio-runtime")]
-use crate::event::{ServerErrorInfo, SignalFishEvent};
+use crate::event::SignalFishEvent;
+#[cfg(feature = "tokio-runtime")]
+use crate::protocol::ClientMessage;
+#[cfg(feature = "tokio-runtime")]
+use crate::protocol::ConnectionInfo;
 #[cfg(any(feature = "tokio-runtime", feature = "polling-client"))]
 use crate::protocol::ServerMessage;
 use crate::protocol::{
-    ClientMessage, ConnectionInfo, DeliveryClass, GameDataEncoding, PlayerId, RelayTransport,
-    RoomId, Topology, TransportKind,
+    GameDataEncoding, PlayerId, RelayTransport, RoomId, Topology, TransportKind,
 };
+#[cfg(feature = "tokio-runtime")]
 use crate::signal::PeerSignal;
 #[cfg(feature = "tokio-runtime")]
 use crate::transport::{close_transport, recv_frame, send_frame, Transport, TransportFrame};
@@ -541,91 +543,6 @@ impl std::fmt::Debug for ClientSnapshot {
     }
 }
 
-// ── Shared state ────────────────────────────────────────────────────
-
-/// Internal shared state between the client handle and the transport loop.
-struct ClientState {
-    connected: AtomicBool,
-    authenticated: AtomicBool,
-    /// Protocol version negotiated by the server (from `ProtocolInfo`).
-    /// `0` means "not yet negotiated, or negotiated v2" — i.e. not v3-capable.
-    negotiated_protocol_version: AtomicU16,
-    /// Whether a `ProtocolInfo` has been observed on this connection. This
-    /// distinguishes "negotiation hasn't happened yet" from "negotiation
-    /// completed at the v2 relay floor" — both leave
-    /// `negotiated_protocol_version` at `0`, but only the latter is terminal.
-    /// Drives the `ProtocolUnsupported { mode }` diagnostic.
-    protocol_info_seen: AtomicBool,
-    /// Requested format, updated to JSON if the server reports a fallback.
-    game_data_encoding: AtomicU8,
-    player_id: Mutex<Option<PlayerId>>,
-    room_id: Mutex<Option<RoomId>>,
-    room_code: Mutex<Option<String>>,
-    snapshot: std::sync::RwLock<ClientSnapshot>,
-    /// `GameData` messages successfully written to the transport.
-    /// Cumulative — intentionally not reset by `clear_session_state`.
-    game_data_sent: AtomicU64,
-    /// `GameData`/`GameDataBinary` messages received from the server,
-    /// counted at receipt (see [`ClientStats::game_data_received`]).
-    /// Cumulative — intentionally not reset by `clear_session_state`.
-    game_data_received: AtomicU64,
-    /// Inbound frames that failed to decode into a `ServerMessage`
-    /// (see [`ClientStats::messages_undecodable`]).
-    /// Cumulative — intentionally not reset by `clear_session_state`.
-    messages_undecodable: AtomicU64,
-}
-
-#[derive(Debug)]
-#[cfg_attr(not(feature = "tokio-runtime"), allow(dead_code))]
-enum ClientCommand {
-    Message(ClientMessage),
-    Binary(Vec<u8>),
-}
-
-#[cfg_attr(not(feature = "tokio-runtime"), allow(dead_code))]
-impl ClientState {
-    fn new(game_data_encoding: GameDataEncoding) -> Self {
-        Self {
-            connected: AtomicBool::new(true),
-            authenticated: AtomicBool::new(false),
-            negotiated_protocol_version: AtomicU16::new(0),
-            protocol_info_seen: AtomicBool::new(false),
-            game_data_encoding: AtomicU8::new(game_data_encoding as u8),
-            player_id: Mutex::new(None),
-            room_id: Mutex::new(None),
-            room_code: Mutex::new(None),
-            snapshot: std::sync::RwLock::new(ClientSnapshot {
-                connected: true,
-                ..ClientSnapshot::default()
-            }),
-            game_data_sent: AtomicU64::new(0),
-            game_data_received: AtomicU64::new(0),
-            messages_undecodable: AtomicU64::new(0),
-        }
-    }
-
-    async fn clear_session_state(&self) {
-        self.authenticated.store(false, Ordering::Release);
-        self.negotiated_protocol_version.store(0, Ordering::Release);
-        self.protocol_info_seen.store(false, Ordering::Release);
-        *self.player_id.lock().await = None;
-        *self.room_id.lock().await = None;
-        *self.room_code.lock().await = None;
-        let mut snapshot = match self.snapshot.write() {
-            Ok(snapshot) => snapshot,
-            Err(poisoned) => poisoned.into_inner(),
-        };
-        snapshot.connected = self.connected.load(Ordering::Acquire);
-        snapshot.authenticated = false;
-        snapshot.negotiated_protocol_version = None;
-        snapshot.player_id = None;
-        snapshot.room_id = None;
-        snapshot.room_code = None;
-        snapshot.reconnection_token = None;
-        snapshot.quarantined = false;
-    }
-}
-
 // ── Client handle ───────────────────────────────────────────────────
 
 /// Async client handle for the Signal Fish signaling protocol.
@@ -640,12 +557,12 @@ impl ClientState {
 /// variants ([`send_game_data_reliable`](Self::send_game_data_reliable),
 /// [`send_signal_reliable`](Self::send_signal_reliable)) instead await
 /// capacity, pacing the caller to actual transport throughput.
-#[cfg_attr(not(feature = "tokio-runtime"), allow(dead_code))]
+#[cfg(feature = "tokio-runtime")]
 pub struct SignalFishClient {
     /// Sender half of the bounded command channel to the transport loop.
     cmd_tx: mpsc::Sender<ClientCommand>,
     /// Shared state updated by the transport loop.
-    state: Arc<ClientState>,
+    state: Arc<Mutex<ClientCore>>,
     /// Handle to the background transport loop task.
     #[cfg(feature = "tokio-runtime")]
     task: Option<tokio::task::JoinHandle<()>>,
@@ -655,6 +572,12 @@ pub struct SignalFishClient {
     /// Timeout for the graceful shutdown.
     #[cfg(feature = "tokio-runtime")]
     shutdown_timeout: Duration,
+}
+
+/// Async client handle unavailable without the `tokio-runtime` feature.
+#[cfg(not(feature = "tokio-runtime"))]
+pub struct SignalFishClient {
+    _private: (),
 }
 
 #[cfg(feature = "tokio-runtime")]
@@ -693,24 +616,23 @@ impl SignalFishClient {
         let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
 
         let requested_game_data_encoding = config.game_data_format.unwrap_or_default();
-        let state = Arc::new(ClientState::new(requested_game_data_encoding));
+        let mesh_enabled = config
+            .supported_transports
+            .as_ref()
+            .is_some_and(|transports| transports.contains(&TransportKind::WebRtc));
+        let state = Arc::new(Mutex::new(ClientCore::new(
+            requested_game_data_encoding,
+            config.protocol_violation_policy,
+            mesh_enabled,
+        )));
         let loop_state = Arc::clone(&state);
-        let violation_policy = config.protocol_violation_policy;
 
         // Send the Authenticate message through the command channel so the
         // transport loop picks it up as the very first outgoing message.
-        let auth_msg = ClientMessage::Authenticate {
-            app_id: config.app_id,
-            sdk_version: config.sdk_version,
-            platform: config.platform,
-            game_data_format: config.game_data_format,
-            protocol_version: config.protocol_version,
-            supported_transports: config.supported_transports,
-            supported_topologies: config.supported_topologies,
-        };
+        let auth_msg = ClientCore::authenticate(&config);
         // This cannot fail: the channel was just created empty and its
         // capacity is clamped to at least 1.
-        let _ = cmd_tx.try_send(ClientCommand::Message(auth_msg));
+        let _ = cmd_tx.try_send(auth_msg);
 
         let task = tokio::spawn(transport_loop(
             transport,
@@ -718,7 +640,6 @@ impl SignalFishClient {
             event_tx,
             loop_state,
             shutdown_rx,
-            violation_policy,
         ));
 
         let client = Self {
@@ -770,12 +691,14 @@ impl SignalFishClient {
             }
         }
 
-        self.state.connected.store(false, Ordering::Release);
-        self.state.clear_session_state().await;
+        let mut core = lock_core(&self.state);
+        if core.is_connected() {
+            let _ = core.disconnect(Some("client shut down".into()));
+        }
     }
 }
 
-#[cfg_attr(not(feature = "tokio-runtime"), allow(dead_code))]
+#[cfg(feature = "tokio-runtime")]
 impl SignalFishClient {
     // ── Public API methods ──────────────────────────────────────────
 
@@ -786,15 +709,8 @@ impl SignalFishClient {
     /// Returns [`SignalFishError::NotConnected`] if the transport has closed,
     /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
     /// is full (the message is **not** queued; nothing is silently dropped).
-    pub fn join_room(&self, params: JoinRoomParams) -> Result<()> {
-        self.send(ClientMessage::JoinRoom {
-            game_name: params.game_name,
-            room_code: params.room_code,
-            player_name: params.player_name,
-            max_players: params.max_players,
-            supports_authority: params.supports_authority,
-            relay_transport: params.relay_transport,
-        })
+    pub fn join_room(&mut self, params: JoinRoomParams) -> Result<()> {
+        self.send_operation(ClientOperation::JoinRoom(params))
     }
 
     /// Leave the current room.
@@ -804,8 +720,8 @@ impl SignalFishClient {
     /// Returns [`SignalFishError::NotConnected`] if the transport has closed,
     /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
     /// is full (the message is **not** queued; nothing is silently dropped).
-    pub fn leave_room(&self) -> Result<()> {
-        self.send(ClientMessage::LeaveRoom)
+    pub fn leave_room(&mut self) -> Result<()> {
+        self.send_operation(ClientOperation::LeaveRoom)
     }
 
     /// Send arbitrary JSON game data to other players in the room.
@@ -820,39 +736,17 @@ impl SignalFishClient {
     /// Returns [`SignalFishError::NotConnected`] if the transport has closed,
     /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
     /// is full (the message is **not** queued; nothing is silently dropped).
-    pub fn send_game_data(&self, data: serde_json::Value) -> Result<()> {
-        self.send(ClientMessage::GameData {
-            data,
-            class: None,
-            key: None,
-        })
+    pub fn send_game_data(&mut self, data: serde_json::Value) -> Result<()> {
+        self.send_operation(ClientOperation::GameData(data, GameDataDelivery::Reliable))
     }
 
     /// Send JSON game data with an explicit protocol-v3 delivery policy.
     pub fn send_game_data_with_delivery(
-        &self,
+        &mut self,
         data: serde_json::Value,
         delivery: GameDataDelivery,
     ) -> Result<()> {
-        match delivery {
-            GameDataDelivery::Reliable => self.send_game_data(data),
-            GameDataDelivery::Latest { key } => {
-                self.ensure_v3()?;
-                self.send(ClientMessage::GameData {
-                    data,
-                    class: Some(DeliveryClass::Latest),
-                    key: Some(key),
-                })
-            }
-            GameDataDelivery::Volatile => {
-                self.ensure_v3()?;
-                self.send(ClientMessage::GameData {
-                    data,
-                    class: Some(DeliveryClass::Volatile),
-                    key: None,
-                })
-            }
-        }
+        self.send_operation(ClientOperation::GameData(data, delivery))
     }
 
     /// Send arbitrary JSON game data, waiting for space in the outgoing
@@ -881,12 +775,8 @@ impl SignalFishClient {
     ///
     /// Returns [`SignalFishError::NotConnected`] if the transport has closed.
     pub async fn send_game_data_reliable(&self, data: serde_json::Value) -> Result<()> {
-        self.send_reliable(ClientMessage::GameData {
-            data,
-            class: None,
-            key: None,
-        })
-        .await
+        self.send_operation_reliable(ClientOperation::GameData(data, GameDataDelivery::Reliable))
+            .await
     }
 
     /// Waiting counterpart to [`send_game_data_with_delivery`](Self::send_game_data_with_delivery).
@@ -895,33 +785,18 @@ impl SignalFishClient {
         data: serde_json::Value,
         delivery: GameDataDelivery,
     ) -> Result<()> {
-        let (class, key) = match delivery {
-            GameDataDelivery::Reliable => (None, None),
-            GameDataDelivery::Latest { key } => {
-                self.ensure_v3()?;
-                (Some(DeliveryClass::Latest), Some(key))
-            }
-            GameDataDelivery::Volatile => {
-                self.ensure_v3()?;
-                (Some(DeliveryClass::Volatile), None)
-            }
-        };
-        self.send_reliable(ClientMessage::GameData { data, class, key })
+        self.send_operation_reliable(ClientOperation::GameData(data, delivery))
             .await
     }
 
     /// Send opaque binary game data over the negotiated protocol-v3 relay.
-    pub fn send_binary_game_data(&self, payload: Vec<u8>) -> Result<()> {
-        self.ensure_v3()?;
-        self.ensure_binary_format()?;
-        self.send_command(ClientCommand::Binary(payload))
+    pub fn send_binary_game_data(&mut self, payload: Vec<u8>) -> Result<()> {
+        self.send_operation(ClientOperation::Binary(payload))
     }
 
     /// Waiting binary send that paces on command-queue capacity.
     pub async fn send_binary_game_data_reliable(&self, payload: Vec<u8>) -> Result<()> {
-        self.ensure_v3()?;
-        self.ensure_binary_format()?;
-        self.send_command_reliable(ClientCommand::Binary(payload))
+        self.send_operation_reliable(ClientOperation::Binary(payload))
             .await
     }
 
@@ -932,8 +807,8 @@ impl SignalFishClient {
     /// Returns [`SignalFishError::NotConnected`] if the transport has closed,
     /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
     /// is full (the message is **not** queued; nothing is silently dropped).
-    pub fn set_ready(&self) -> Result<()> {
-        self.send(ClientMessage::PlayerReady)
+    pub fn set_ready(&mut self) -> Result<()> {
+        self.send_operation(ClientOperation::SetReady)
     }
 
     /// Request to become (or relinquish) authority.
@@ -943,8 +818,8 @@ impl SignalFishClient {
     /// Returns [`SignalFishError::NotConnected`] if the transport has closed,
     /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
     /// is full (the message is **not** queued; nothing is silently dropped).
-    pub fn request_authority(&self, become_authority: bool) -> Result<()> {
-        self.send(ClientMessage::AuthorityRequest { become_authority })
+    pub fn request_authority(&mut self, become_authority: bool) -> Result<()> {
+        self.send_operation(ClientOperation::RequestAuthority(become_authority))
     }
 
     /// Provide connection information for P2P establishment.
@@ -954,8 +829,8 @@ impl SignalFishClient {
     /// Returns [`SignalFishError::NotConnected`] if the transport has closed,
     /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
     /// is full (the message is **not** queued; nothing is silently dropped).
-    pub fn provide_connection_info(&self, connection_info: ConnectionInfo) -> Result<()> {
-        self.send(ClientMessage::ProvideConnectionInfo { connection_info })
+    pub fn provide_connection_info(&mut self, connection_info: ConnectionInfo) -> Result<()> {
+        self.send_operation(ClientOperation::ProvideConnectionInfo(connection_info))
     }
 
     /// Reconnect to a room after a disconnection.
@@ -966,16 +841,12 @@ impl SignalFishClient {
     /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
     /// is full (the message is **not** queued; nothing is silently dropped).
     pub fn reconnect(
-        &self,
+        &mut self,
         player_id: PlayerId,
         room_id: RoomId,
         auth_token: String,
     ) -> Result<()> {
-        self.send(ClientMessage::Reconnect {
-            player_id,
-            room_id,
-            auth_token,
-        })
+        self.send_operation(ClientOperation::Reconnect(player_id, room_id, auth_token))
     }
 
     /// Join a room as a read-only spectator.
@@ -986,16 +857,16 @@ impl SignalFishClient {
     /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
     /// is full (the message is **not** queued; nothing is silently dropped).
     pub fn join_as_spectator(
-        &self,
+        &mut self,
         game_name: String,
         room_code: String,
         spectator_name: String,
     ) -> Result<()> {
-        self.send(ClientMessage::JoinAsSpectator {
+        self.send_operation(ClientOperation::JoinAsSpectator(
             game_name,
             room_code,
             spectator_name,
-        })
+        ))
     }
 
     /// Leave spectator mode.
@@ -1005,8 +876,8 @@ impl SignalFishClient {
     /// Returns [`SignalFishError::NotConnected`] if the transport has closed,
     /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
     /// is full (the message is **not** queued; nothing is silently dropped).
-    pub fn leave_spectator(&self) -> Result<()> {
-        self.send(ClientMessage::LeaveSpectator)
+    pub fn leave_spectator(&mut self) -> Result<()> {
+        self.send_operation(ClientOperation::LeaveSpectator)
     }
 
     /// Send a heartbeat ping to the server.
@@ -1016,8 +887,8 @@ impl SignalFishClient {
     /// Returns [`SignalFishError::NotConnected`] if the transport has closed,
     /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
     /// is full (the message is **not** queued; nothing is silently dropped).
-    pub fn ping(&self) -> Result<()> {
-        self.send(ClientMessage::Ping)
+    pub fn ping(&mut self) -> Result<()> {
+        self.send_operation(ClientOperation::Ping)
     }
 
     // ── Game start (protocol v2) ────────────────────────────────────
@@ -1039,8 +910,8 @@ impl SignalFishClient {
     /// Returns [`SignalFishError::NotConnected`] if the transport has closed,
     /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
     /// is full (the message is **not** queued; nothing is silently dropped).
-    pub fn start_game(&self) -> Result<()> {
-        self.send(ClientMessage::StartGame)
+    pub fn start_game(&mut self) -> Result<()> {
+        self.send_operation(ClientOperation::StartGame)
     }
 
     // ── Mesh signaling (protocol v3) ────────────────────────────────
@@ -1064,12 +935,8 @@ impl SignalFishClient {
     /// [`SignalFishError::SendBufferFull`] if the outgoing command queue is
     /// full (see [`send_signal_reliable`](Self::send_signal_reliable) for a
     /// waiting variant).
-    pub fn send_signal(&self, to: PlayerId, signal: impl Into<PeerSignal>) -> Result<()> {
-        self.ensure_v3()?;
-        self.send(ClientMessage::Signal {
-            to,
-            signal: signal.into().into(),
-        })
+    pub fn send_signal(&mut self, to: PlayerId, signal: impl Into<PeerSignal>) -> Result<()> {
+        self.send_operation(ClientOperation::Signal(to, signal.into()))
     }
 
     /// Send a typed WebRTC signal, waiting for space in the outgoing command
@@ -1093,12 +960,8 @@ impl SignalFishClient {
         to: PlayerId,
         signal: impl Into<PeerSignal>,
     ) -> Result<()> {
-        self.ensure_v3()?;
-        self.send_reliable(ClientMessage::Signal {
-            to,
-            signal: signal.into().into(),
-        })
-        .await
+        self.send_operation_reliable(ClientOperation::Signal(to, signal.into()))
+            .await
     }
 
     /// Send an SDP offer to a peer. **Protocol v3 only.**
@@ -1107,7 +970,7 @@ impl SignalFishClient {
     /// # Errors
     ///
     /// See [`send_signal`](Self::send_signal).
-    pub fn send_offer(&self, to: PlayerId, sdp: impl Into<String>) -> Result<()> {
+    pub fn send_offer(&mut self, to: PlayerId, sdp: impl Into<String>) -> Result<()> {
         self.send_signal(to, PeerSignal::Offer(sdp.into()))
     }
 
@@ -1117,7 +980,7 @@ impl SignalFishClient {
     /// # Errors
     ///
     /// See [`send_signal`](Self::send_signal).
-    pub fn send_answer(&self, to: PlayerId, sdp: impl Into<String>) -> Result<()> {
+    pub fn send_answer(&mut self, to: PlayerId, sdp: impl Into<String>) -> Result<()> {
         self.send_signal(to, PeerSignal::Answer(sdp.into()))
     }
 
@@ -1127,7 +990,7 @@ impl SignalFishClient {
     /// # Errors
     ///
     /// See [`send_signal`](Self::send_signal).
-    pub fn send_ice_candidate(&self, to: PlayerId, candidate: impl Into<String>) -> Result<()> {
+    pub fn send_ice_candidate(&mut self, to: PlayerId, candidate: impl Into<String>) -> Result<()> {
         self.send_signal(to, PeerSignal::IceCandidate(candidate.into()))
     }
 
@@ -1141,9 +1004,8 @@ impl SignalFishClient {
     /// # Errors
     ///
     /// See [`send_signal`](Self::send_signal).
-    pub fn send_raw_signal(&self, to: PlayerId, signal: serde_json::Value) -> Result<()> {
-        self.ensure_v3()?;
-        self.send(ClientMessage::Signal { to, signal })
+    pub fn send_raw_signal(&mut self, to: PlayerId, signal: serde_json::Value) -> Result<()> {
+        self.send_operation(ClientOperation::RawSignal(to, signal))
     }
 
     /// Report to the server whether a data-path transport is established.
@@ -1159,12 +1021,12 @@ impl SignalFishClient {
     /// negotiated protocol v3, [`SignalFishError::NotConnected`] if the
     /// transport has closed, or [`SignalFishError::SendBufferFull`] if the
     /// outgoing command queue is full.
-    pub fn report_transport_status(&self, transport: TransportKind, connected: bool) -> Result<()> {
-        self.ensure_v3()?;
-        self.send(ClientMessage::TransportStatus {
-            transport,
-            connected,
-        })
+    pub fn report_transport_status(
+        &mut self,
+        transport: TransportKind,
+        connected: bool,
+    ) -> Result<()> {
+        self.send_operation(ClientOperation::TransportStatus(transport, connected))
     }
 
     // ── State accessors ─────────────────────────────────────────────
@@ -1173,50 +1035,45 @@ impl SignalFishClient {
     /// negotiated or negotiated as v2 (the relay floor).
     ///
     /// Set from the server's [`ProtocolInfo`](SignalFishEvent::ProtocolInfo)
-    /// message. A value of `Some(3)` or higher means mesh signaling is available.
+    /// message. A value of `Some(3)` or higher means v3 was negotiated; mesh
+    /// availability additionally requires local [`SignalFishConfig::enable_mesh`]
+    /// advertisement and can be queried with [`Self::supports_mesh`].
     pub fn negotiated_protocol_version(&self) -> Option<u16> {
-        match self
-            .state
-            .negotiated_protocol_version
-            .load(Ordering::Acquire)
-        {
-            0 => None,
-            v => Some(v),
-        }
+        lock_core(&self.state).negotiated_protocol_version()
     }
 
-    /// Returns `true` once the connection has negotiated protocol v3 — i.e. mesh
-    /// signaling (`send_signal`/`report_transport_status`) is available.
+    /// Returns `true` once the connection has negotiated protocol v3 and this
+    /// client advertised WebRTC support through [`SignalFishConfig::enable_mesh`].
     ///
     /// This is the "am I in mesh mode?" check; it returns `false` both before
     /// negotiation completes and on a v2 relay-floor connection.
     pub fn supports_mesh(&self) -> bool {
-        self.negotiated_protocol_version().is_some_and(|v| v >= 3)
+        lock_core(&self.state).supports_mesh()
     }
 
     /// Returns `true` if the transport is believed to be connected.
     pub fn is_connected(&self) -> bool {
-        self.state.connected.load(Ordering::Acquire)
+        lock_core(&self.state).is_connected()
     }
 
     /// Returns `true` if the server has confirmed authentication.
     pub fn is_authenticated(&self) -> bool {
-        self.state.authenticated.load(Ordering::Acquire)
+        lock_core(&self.state).is_authenticated()
     }
 
     /// Returns the current room ID, if the client is in a room.
     pub async fn current_room_id(&self) -> Option<RoomId> {
-        *self.state.room_id.lock().await
+        lock_core(&self.state).snapshot().room_id
     }
 
     /// Returns the current player ID, if assigned by the server.
     pub async fn current_player_id(&self) -> Option<PlayerId> {
-        *self.state.player_id.lock().await
+        lock_core(&self.state).snapshot().player_id
     }
 
     /// Returns the current room code, if the client is in a room.
     pub async fn current_room_code(&self) -> Option<String> {
-        self.state.room_code.lock().await.clone()
+        lock_core(&self.state).snapshot().room_code
     }
 
     /// Number of messages that can currently be queued before the synchronous
@@ -1237,64 +1094,23 @@ impl SignalFishClient {
 
     /// Cumulative game-data traffic counters (see [`ClientStats`]).
     pub fn stats(&self) -> ClientStats {
-        ClientStats {
-            game_data_sent: self.state.game_data_sent.load(Ordering::Relaxed),
-            game_data_received: self.state.game_data_received.load(Ordering::Relaxed),
-            messages_undecodable: self.state.messages_undecodable.load(Ordering::Relaxed),
-        }
+        lock_core(&self.state).stats()
     }
 
     /// Return a coherent synchronous snapshot of connection and room state.
     pub fn snapshot(&self) -> ClientSnapshot {
-        match self.state.snapshot.read() {
-            Ok(snapshot) => snapshot.clone(),
-            Err(poisoned) => poisoned.into_inner().clone(),
-        }
+        lock_core(&self.state).snapshot()
     }
 
     // ── Internal helpers ────────────────────────────────────────────
 
-    /// Guard for protocol-v3-only operations: returns an error unless the
-    /// connection negotiated v3, so signaling never goes out on a relay-floor
-    /// connection the server would reject.
-    fn ensure_v3(&self) -> Result<()> {
-        // Mesh signaling was introduced in protocol v3; any negotiated version
-        // >= 3 supports it (independent of the highest version this SDK speaks).
-        if self
-            .state
-            .negotiated_protocol_version
-            .load(Ordering::Acquire)
-            >= 3
-        {
-            return Ok(());
-        }
-        // A `ProtocolInfo` that resolved below v3 is a terminal relay floor;
-        // its absence means negotiation is still in flight. Keying off the
-        // observed `ProtocolInfo` (not authentication) keeps this diagnostic
-        // correct regardless of handshake message ordering.
-        let mode = if self.state.protocol_info_seen.load(Ordering::Acquire) {
-            "relay-only"
-        } else {
-            "pre-negotiation"
-        };
-        Err(SignalFishError::ProtocolUnsupported { mode })
-    }
-
-    fn ensure_binary_format(&self) -> Result<()> {
-        if self.state.game_data_encoding.load(Ordering::Acquire) == GameDataEncoding::Json as u8 {
-            return Err(SignalFishError::BinaryFormatNotNegotiated);
-        }
-        Ok(())
-    }
-
-    /// Queue a `ClientMessage` to the transport loop, failing fast when the
-    /// bounded command queue is full.
-    fn send(&self, msg: ClientMessage) -> Result<()> {
-        self.send_command(ClientCommand::Message(msg))
+    fn send_operation(&self, operation: ClientOperation) -> Result<()> {
+        let command = lock_core(&self.state).prepare(operation)?;
+        self.send_command(command)
     }
 
     fn send_command(&self, command: ClientCommand) -> Result<()> {
-        if !self.state.connected.load(Ordering::Acquire) {
+        if !lock_core(&self.state).is_connected() {
             return Err(SignalFishError::NotConnected);
         }
         match self.cmd_tx.try_send(command) {
@@ -1306,15 +1122,13 @@ impl SignalFishClient {
         }
     }
 
-    /// Queue a `ClientMessage` to the transport loop, waiting for capacity
-    /// when the bounded command queue is full.
-    async fn send_reliable(&self, msg: ClientMessage) -> Result<()> {
-        self.send_command_reliable(ClientCommand::Message(msg))
-            .await
+    async fn send_operation_reliable(&self, operation: ClientOperation) -> Result<()> {
+        let command = lock_core(&self.state).prepare(operation)?;
+        self.send_command_reliable(command).await
     }
 
     async fn send_command_reliable(&self, command: ClientCommand) -> Result<()> {
-        if !self.state.connected.load(Ordering::Acquire) {
+        if !lock_core(&self.state).is_connected() {
             return Err(SignalFishError::NotConnected);
         }
         self.cmd_tx
@@ -1324,7 +1138,7 @@ impl SignalFishClient {
     }
 }
 
-#[cfg_attr(not(feature = "tokio-runtime"), allow(dead_code))]
+#[cfg(feature = "tokio-runtime")]
 impl std::fmt::Debug for SignalFishClient {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut dbg = f.debug_struct("SignalFishClient");
@@ -1333,6 +1147,107 @@ impl std::fmt::Debug for SignalFishClient {
         #[cfg(feature = "tokio-runtime")]
         dbg.field("has_task", &self.task.is_some());
         dbg.finish()
+    }
+}
+
+#[cfg(feature = "tokio-runtime")]
+impl crate::client_api::SignalFishClientApi for SignalFishClient {
+    fn join_room(&mut self, params: JoinRoomParams) -> Result<()> {
+        SignalFishClient::join_room(self, params)
+    }
+
+    fn leave_room(&mut self) -> Result<()> {
+        SignalFishClient::leave_room(self)
+    }
+
+    fn send_game_data(&mut self, data: serde_json::Value) -> Result<()> {
+        SignalFishClient::send_game_data(self, data)
+    }
+
+    fn send_game_data_with_delivery(
+        &mut self,
+        data: serde_json::Value,
+        delivery: GameDataDelivery,
+    ) -> Result<()> {
+        SignalFishClient::send_game_data_with_delivery(self, data, delivery)
+    }
+
+    fn send_binary_game_data(&mut self, payload: Vec<u8>) -> Result<()> {
+        SignalFishClient::send_binary_game_data(self, payload)
+    }
+
+    fn set_ready(&mut self) -> Result<()> {
+        SignalFishClient::set_ready(self)
+    }
+
+    fn start_game(&mut self) -> Result<()> {
+        SignalFishClient::start_game(self)
+    }
+
+    fn request_authority(&mut self, become_authority: bool) -> Result<()> {
+        SignalFishClient::request_authority(self, become_authority)
+    }
+
+    fn provide_connection_info(&mut self, connection_info: ConnectionInfo) -> Result<()> {
+        SignalFishClient::provide_connection_info(self, connection_info)
+    }
+
+    fn reconnect(
+        &mut self,
+        player_id: PlayerId,
+        room_id: RoomId,
+        auth_token: String,
+    ) -> Result<()> {
+        SignalFishClient::reconnect(self, player_id, room_id, auth_token)
+    }
+
+    fn join_as_spectator(
+        &mut self,
+        game_name: String,
+        room_code: String,
+        spectator_name: String,
+    ) -> Result<()> {
+        SignalFishClient::join_as_spectator(self, game_name, room_code, spectator_name)
+    }
+
+    fn leave_spectator(&mut self) -> Result<()> {
+        SignalFishClient::leave_spectator(self)
+    }
+
+    fn ping(&mut self) -> Result<()> {
+        SignalFishClient::ping(self)
+    }
+
+    fn send_signal(&mut self, to: PlayerId, signal: PeerSignal) -> Result<()> {
+        SignalFishClient::send_signal(self, to, signal)
+    }
+
+    fn send_raw_signal(&mut self, to: PlayerId, signal: serde_json::Value) -> Result<()> {
+        SignalFishClient::send_raw_signal(self, to, signal)
+    }
+
+    fn report_transport_status(&mut self, transport: TransportKind, connected: bool) -> Result<()> {
+        SignalFishClient::report_transport_status(self, transport, connected)
+    }
+
+    fn send_capacity(&self) -> usize {
+        SignalFishClient::send_capacity(self)
+    }
+
+    fn max_send_capacity(&self) -> usize {
+        SignalFishClient::max_send_capacity(self)
+    }
+
+    fn stats(&self) -> ClientStats {
+        SignalFishClient::stats(self)
+    }
+
+    fn snapshot(&self) -> ClientSnapshot {
+        SignalFishClient::snapshot(self)
+    }
+
+    fn supports_mesh(&self) -> bool {
+        SignalFishClient::supports_mesh(self)
     }
 }
 
@@ -1353,6 +1268,48 @@ impl Drop for SignalFishClient {
 
 // ── Transport loop ──────────────────────────────────────────────────
 
+#[cfg(feature = "tokio-runtime")]
+fn lock_core(state: &Arc<Mutex<ClientCore>>) -> std::sync::MutexGuard<'_, ClientCore> {
+    match state.lock() {
+        Ok(core) => core,
+        Err(poisoned) => poisoned.into_inner(),
+    }
+}
+
+#[cfg(feature = "tokio-runtime")]
+async fn finish_core_shutdown(
+    transport: &mut impl Transport,
+    event_tx: &mpsc::Sender<SignalFishEvent>,
+    state: &Arc<Mutex<ClientCore>>,
+) {
+    let _ = close_transport(transport).await;
+    let event = lock_core(state).disconnect(Some("client shut down".into()));
+    let _ = event_tx.try_send(event);
+}
+
+#[cfg(feature = "tokio-runtime")]
+async fn emit_core_disconnected_or_shutdown(
+    transport: &mut impl Transport,
+    event_tx: &mpsc::Sender<SignalFishEvent>,
+    shutdown_rx: &mut tokio::sync::oneshot::Receiver<()>,
+    state: &Arc<Mutex<ClientCore>>,
+    reason: Option<String>,
+) {
+    let _ = close_transport(transport).await;
+    let event = lock_core(state).disconnect(reason);
+    tokio::select! {
+        biased;
+        result = event_tx.send(event.clone()) => {
+            if result.is_err() {
+                debug!("event channel closed, receiver dropped");
+            }
+        }
+        _ = &mut *shutdown_rx => {
+            let _ = event_tx.try_send(event);
+        }
+    }
+}
+
 /// Background transport loop that multiplexes send/receive via `tokio::select!`.
 ///
 /// Exits when:
@@ -1364,527 +1321,121 @@ async fn transport_loop(
     mut transport: impl Transport + Send + 'static,
     mut cmd_rx: mpsc::Receiver<ClientCommand>,
     event_tx: mpsc::Sender<SignalFishEvent>,
-    state: Arc<ClientState>,
+    state: Arc<Mutex<ClientCore>>,
     mut shutdown_rx: tokio::sync::oneshot::Receiver<()>,
-    violation_policy: ProtocolViolationPolicy,
 ) {
     debug!("transport loop started");
 
-    // The most recent Error/AuthenticationError received on this connection,
-    // remembered so a subsequent disconnect can be attributed (e.g. a
-    // best-effort SLOW_CONSUMER farewell followed by a bare close).
-    let mut last_server_error: Option<ServerErrorInfo> = None;
-    let mut accountability = crate::accountability::DeliveryAccountability::new(false);
-    let mut quarantined = false;
-
-    // Emit the synthetic Connected event before entering the select loop.
     if matches!(
         emit_event_or_shutdown(&event_tx, &mut shutdown_rx, SignalFishEvent::Connected).await,
         EmitOutcome::ShutdownRequested
     ) {
-        finish_shutdown(&mut transport, &event_tx, &state, last_server_error).await;
+        finish_core_shutdown(&mut transport, &event_tx, &state).await;
         debug!("transport loop exited");
         return;
     }
 
     loop {
         tokio::select! {
-            // Branch 1: outgoing command from the client handle
-            cmd = cmd_rx.recv() => {
-                match cmd {
-                    Some(command) => {
-                        debug!("sending client command: {:?}", std::mem::discriminant(&command));
-                        let (frame, is_game_data) = match command {
-                            ClientCommand::Message(msg) => match serde_json::to_string(&msg) {
-                                Ok(json) => (
-                                    Some(TransportFrame::Text(json)),
-                                    matches!(msg, ClientMessage::GameData { .. }),
-                                ),
-                                Err(e) => {
-                                    error!("failed to serialize ClientMessage: {e}");
-                                    (None, false)
-                                }
-                            },
-                            ClientCommand::Binary(payload) => {
-                                (Some(TransportFrame::Binary(payload)), true)
-                            }
-                        };
-                        if let Some(frame) = frame {
-                                if let Err(e) = send_frame(&mut transport, frame).await {
-                                    error!("transport send error: {e}");
-                                    emit_disconnected_or_shutdown(
-                                        &mut transport,
-                                        &event_tx,
-                                        &mut shutdown_rx,
-                                        &state,
-                                        Some(format!("transport send error: {e}")),
-                                        last_server_error.take(),
-                                    ).await;
-                                    break;
-                                }
-                                if is_game_data {
-                                    state.game_data_sent.fetch_add(1, Ordering::Relaxed);
-                                }
+            command = cmd_rx.recv() => {
+                let Some(command) = command else {
+                    emit_core_disconnected_or_shutdown(
+                        &mut transport,
+                        &event_tx,
+                        &mut shutdown_rx,
+                        &state,
+                        Some("client shut down".into()),
+                    ).await;
+                    break;
+                };
+                let (frame, is_game_data) = match command {
+                    ClientCommand::Message(message) => match serde_json::to_string(&message) {
+                        Ok(json) => (
+                            Some(TransportFrame::Text(json)),
+                            matches!(message, ClientMessage::GameData { .. }),
+                        ),
+                        Err(error) => {
+                            error!("failed to serialize ClientMessage: {error}");
+                            (None, false)
                         }
+                    },
+                    ClientCommand::Binary(payload) => {
+                        (Some(TransportFrame::Binary(payload)), true)
                     }
-                    // Command channel closed — client handle dropped.
-                    None => {
-                        debug!("command channel closed, shutting down transport loop");
-                        emit_disconnected_or_shutdown(
+                };
+                if let Some(frame) = frame {
+                    if let Err(error) = send_frame(&mut transport, frame).await {
+                        emit_core_disconnected_or_shutdown(
                             &mut transport,
                             &event_tx,
                             &mut shutdown_rx,
                             &state,
-                            Some("client shut down".into()),
-                            last_server_error.take(),
+                            Some(format!("transport send error: {error}")),
                         ).await;
                         break;
                     }
+                    if is_game_data {
+                        lock_core(&state).record_game_data_sent();
+                    }
                 }
             }
-
-            // Branch 2: shutdown signal
             _ = &mut shutdown_rx => {
-                debug!("shutdown signal received");
-                finish_shutdown(&mut transport, &event_tx, &state, last_server_error.take()).await;
+                finish_core_shutdown(&mut transport, &event_tx, &state).await;
                 break;
             }
-
-            // Branch 3: incoming message from the server
             incoming = recv_frame(&mut transport) => {
                 match incoming {
-                    Some(Ok(TransportFrame::Text(text))) => {
-                        match serde_json::from_str::<ServerMessage>(&text) {
-                            Ok(server_msg) => {
-                                let duplicate_protocol_info = matches!(server_msg, ServerMessage::ProtocolInfo(_))
-                                    && state.protocol_info_seen.load(Ordering::Acquire);
-                                if let ServerMessage::ProtocolInfo(payload) = &server_msg {
-                                    if !duplicate_protocol_info {
-                                        accountability = crate::accountability::DeliveryAccountability::new(
-                                            payload.protocol_version.is_some_and(|version| version >= 3),
-                                        );
-                                    }
-                                }
-                                let authoritative_baseline = matches!(
-                                    server_msg,
-                                    ServerMessage::RoomJoined(_)
-                                        | ServerMessage::SpectatorJoined(_)
-                                        | ServerMessage::Reconnected(_)
-                                );
-                                let negotiated_encoding = match state.game_data_encoding.load(Ordering::Acquire) {
-                                    value if value == GameDataEncoding::MessagePack as u8 => GameDataEncoding::MessagePack,
-                                    value if value == GameDataEncoding::Rkyv as u8 => GameDataEncoding::Rkyv,
-                                    _ => GameDataEncoding::Json,
-                                };
-                                let validation = if duplicate_protocol_info {
-                                    accountability.observe_server_message(false).map(|()| {
-                                        crate::accountability::GameDataDisposition::Apply
-                                    })
-                                } else {
-                                    crate::accountability::validate_server_frame(
-                                        &mut accountability,
-                                        &server_msg,
-                                        negotiated_encoding,
-                                        false,
-                                    )
-                                };
-                                let (disposition, validation_failed) = match validation {
-                                    Ok(disposition) => {
-                                        if authoritative_baseline {
-                                            quarantined = false;
-                                        }
-                                        (disposition, false)
-                                    }
-                                    Err(diagnostic) => {
-                                        let event = SignalFishEvent::ProtocolViolation {
-                                            kind: crate::event::ProtocolViolationKind::from_diagnostic(&diagnostic),
-                                            diagnostic,
-                                        };
-                                        if matches!(
-                                            emit_event_or_shutdown(&event_tx, &mut shutdown_rx, event).await,
-                                            EmitOutcome::ShutdownRequested
-                                        ) {
-                                            finish_shutdown(&mut transport, &event_tx, &state, last_server_error).await;
-                                            break;
-                                        }
-                                        match violation_policy {
-                                            ProtocolViolationPolicy::Quarantine => {
-                                                quarantined = true;
-                                                match state.snapshot.write() {
-                                                    Ok(mut snapshot) => snapshot.quarantined = true,
-                                                    Err(poisoned) => poisoned.into_inner().quarantined = true,
-                                                }
-                                            }
-                                            ProtocolViolationPolicy::Disconnect => {
-                                                accountability.observe_terminal();
-                                                emit_disconnected_or_shutdown(
-                                                    &mut transport,
-                                                    &event_tx,
-                                                    &mut shutdown_rx,
-                                                    &state,
-                                                    Some("protocol accountability violation".into()),
-                                                    last_server_error.take(),
-                                                ).await;
-                                                break;
-                                            }
-                                            ProtocolViolationPolicy::Observe => {}
-                                        }
-                                        let disposition = if violation_policy == ProtocolViolationPolicy::Observe {
-                                            crate::accountability::GameDataDisposition::Apply
-                                        } else {
-                                            crate::accountability::GameDataDisposition::Stale
-                                        };
-                                        (disposition, true)
-                                    }
-                                };
-                                if validation_failed
-                                    && violation_policy == ProtocolViolationPolicy::Quarantine
-                                {
-                                    continue;
-                                }
-                                if duplicate_protocol_info {
-                                    continue;
-                                }
-                                let is_game_data = matches!(server_msg, ServerMessage::GameData { .. } | ServerMessage::GameDataBinary { .. });
-                                if is_game_data
-                                    && (disposition == crate::accountability::GameDataDisposition::Stale
-                                        || (quarantined && violation_policy == ProtocolViolationPolicy::Quarantine))
-                                {
-                                    continue;
-                                }
-                                // Remember server errors for disconnect attribution.
-                                match &server_msg {
-                                    ServerMessage::Error { message, error_code } => {
-                                        last_server_error = Some(ServerErrorInfo {
-                                            message: message.clone(),
-                                            error_code: error_code.clone(),
-                                        });
-                                    }
-                                    ServerMessage::AuthenticationError { error, error_code } => {
-                                        last_server_error = Some(ServerErrorInfo {
-                                            message: error.clone(),
-                                            error_code: Some(error_code.clone()),
-                                        });
-                                    }
-                                    _ => {}
-                                }
-
-                                // Update shared state based on the message.
-                                update_state(&state, &server_msg).await;
-
-                                // Convert to event and forward to the event channel.
-                                let event = SignalFishEvent::from(server_msg);
-                                if matches!(
-                                    emit_event_or_shutdown(&event_tx, &mut shutdown_rx, event).await,
-                                    EmitOutcome::ShutdownRequested
-                                ) {
-                                    finish_shutdown(&mut transport, &event_tx, &state, last_server_error).await;
-                                    break;
-                                }
-                            }
-                            Err(e) => {
-                                // Never a silent drop: surface the frame as a
-                                // typed DecodeFailed event and count it. Log the
-                                // error and frame size only — not the raw
-                                // content, which is untrusted, unbounded, and may
-                                // carry application payloads (the DecodeFailed
-                                // event carries a bounded prefix for diagnostics).
-                                warn!(
-                                    "failed to deserialize server message ({} bytes): {e}",
-                                    text.len()
-                                );
-                                let mut disconnect_for_violation = false;
-                                if let Err(diagnostic) =
-                                    accountability.observe_server_message(false)
-                                {
-                                    let event = SignalFishEvent::ProtocolViolation {
-                                        kind: crate::event::ProtocolViolationKind::from_diagnostic(
-                                            &diagnostic,
-                                        ),
-                                        diagnostic,
-                                    };
-                                    if matches!(
-                                        emit_event_or_shutdown(
-                                            &event_tx,
-                                            &mut shutdown_rx,
-                                            event
-                                        )
-                                        .await,
-                                        EmitOutcome::ShutdownRequested
-                                    ) {
-                                        finish_shutdown(
-                                            &mut transport,
-                                            &event_tx,
-                                            &state,
-                                            last_server_error,
-                                        )
-                                        .await;
-                                        break;
-                                    }
-                                    match violation_policy {
-                                        ProtocolViolationPolicy::Quarantine => {
-                                            quarantined = true;
-                                            match state.snapshot.write() {
-                                                Ok(mut snapshot) => snapshot.quarantined = true,
-                                                Err(poisoned) => {
-                                                    poisoned.into_inner().quarantined = true
-                                                }
-                                            }
-                                        }
-                                        ProtocolViolationPolicy::Disconnect => {
-                                            disconnect_for_violation = true;
-                                        }
-                                        ProtocolViolationPolicy::Observe => {}
-                                    }
-                                }
-                                state.messages_undecodable.fetch_add(1, Ordering::Relaxed);
-                                let event = SignalFishEvent::decode_failed(&text, &e);
-                                if matches!(
-                                    emit_event_or_shutdown(&event_tx, &mut shutdown_rx, event).await,
-                                    EmitOutcome::ShutdownRequested
-                                ) {
-                                    finish_shutdown(&mut transport, &event_tx, &state, last_server_error).await;
-                                    break;
-                                }
-                                if disconnect_for_violation {
-                                    accountability.observe_terminal();
-                                    emit_disconnected_or_shutdown(
-                                        &mut transport,
-                                        &event_tx,
-                                        &mut shutdown_rx,
-                                        &state,
-                                        Some("protocol accountability violation".into()),
-                                        last_server_error.take(),
-                                    )
-                                    .await;
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                    Some(Ok(TransportFrame::Binary(bytes))) => {
-                        let negotiated_encoding = match state.game_data_encoding.load(Ordering::Acquire) {
-                            value if value == GameDataEncoding::MessagePack as u8 => GameDataEncoding::MessagePack,
-                            value if value == GameDataEncoding::Rkyv as u8 => GameDataEncoding::Rkyv,
-                            _ => GameDataEncoding::Json,
-                        };
-                        let mut observe_representation_violation = false;
-                        if let Err(diagnostic) = crate::accountability::validate_physical_binary_allowed(
-                            &mut accountability,
-                            negotiated_encoding,
-                        ) {
-                            let event = SignalFishEvent::ProtocolViolation {
-                                kind: crate::event::ProtocolViolationKind::from_diagnostic(&diagnostic),
-                                diagnostic,
-                            };
+                    Some(Ok(frame)) => {
+                        let outcome = lock_core(&state).process_frame(frame);
+                        let disconnect = outcome.disconnect;
+                        let mut shutdown_requested = false;
+                        for event in outcome.events {
                             if matches!(
                                 emit_event_or_shutdown(&event_tx, &mut shutdown_rx, event).await,
                                 EmitOutcome::ShutdownRequested
                             ) {
-                                finish_shutdown(&mut transport, &event_tx, &state, last_server_error).await;
+                                shutdown_requested = true;
                                 break;
                             }
-                            match violation_policy {
-                                ProtocolViolationPolicy::Quarantine => {
-                                    quarantined = true;
-                                    match state.snapshot.write() {
-                                        Ok(mut snapshot) => snapshot.quarantined = true,
-                                        Err(poisoned) => poisoned.into_inner().quarantined = true,
-                                    }
-                                    continue;
-                                }
-                                ProtocolViolationPolicy::Disconnect => {
-                                    accountability.observe_terminal();
-                                    emit_disconnected_or_shutdown(
-                                        &mut transport,
-                                        &event_tx,
-                                        &mut shutdown_rx,
-                                        &state,
-                                        Some("protocol accountability violation".into()),
-                                        last_server_error.take(),
-                                    ).await;
-                                    break;
-                                }
-                                ProtocolViolationPolicy::Observe => {
-                                    observe_representation_violation = true;
-                                }
-                            }
                         }
-                        let protocol_v3 = state.negotiated_protocol_version.load(Ordering::Acquire) >= 3;
-                        match decode_binary_server_message(&bytes, protocol_v3) {
-                            Ok(server_msg) => {
-                                let validation = if observe_representation_violation {
-                                    crate::accountability::validate_server_message(
-                                        &mut accountability,
-                                        &server_msg,
-                                    )
-                                } else {
-                                    crate::accountability::validate_server_frame(
-                                        &mut accountability,
-                                        &server_msg,
-                                        negotiated_encoding,
-                                        true,
-                                    )
-                                };
-                                let disposition = match validation {
-                                    Ok(disposition) => disposition,
-                                    Err(diagnostic) => {
-                                        let event = SignalFishEvent::ProtocolViolation {
-                                            kind: crate::event::ProtocolViolationKind::from_diagnostic(&diagnostic),
-                                            diagnostic,
-                                        };
-                                        if matches!(
-                                            emit_event_or_shutdown(&event_tx, &mut shutdown_rx, event).await,
-                                            EmitOutcome::ShutdownRequested
-                                        ) {
-                                            finish_shutdown(&mut transport, &event_tx, &state, last_server_error).await;
-                                            break;
-                                        }
-                                        match violation_policy {
-                                            ProtocolViolationPolicy::Quarantine => {
-                                                quarantined = true;
-                                                match state.snapshot.write() {
-                                                    Ok(mut snapshot) => snapshot.quarantined = true,
-                                                    Err(poisoned) => poisoned.into_inner().quarantined = true,
-                                                }
-                                            }
-                                            ProtocolViolationPolicy::Disconnect => {
-                                                accountability.observe_terminal();
-                                                emit_disconnected_or_shutdown(
-                                                    &mut transport,
-                                                    &event_tx,
-                                                    &mut shutdown_rx,
-                                                    &state,
-                                                    Some("protocol accountability violation".into()),
-                                                    last_server_error.take(),
-                                                ).await;
-                                                break;
-                                            }
-                                            ProtocolViolationPolicy::Observe => {}
-                                        }
-                                        if violation_policy == ProtocolViolationPolicy::Observe {
-                                            crate::accountability::GameDataDisposition::Apply
-                                        } else {
-                                            crate::accountability::GameDataDisposition::Stale
-                                        }
-                                    }
-                                };
-                                if disposition == crate::accountability::GameDataDisposition::Stale
-                                    || (quarantined
-                                        && violation_policy == ProtocolViolationPolicy::Quarantine)
-                                {
-                                    continue;
-                                }
-                                update_state(&state, &server_msg).await;
-                                let event = SignalFishEvent::from(server_msg);
-                                if matches!(
-                                    emit_event_or_shutdown(&event_tx, &mut shutdown_rx, event).await,
-                                    EmitOutcome::ShutdownRequested
-                                ) {
-                                    finish_shutdown(&mut transport, &event_tx, &state, last_server_error).await;
-                                    break;
-                                }
-                            }
-                            Err(error) => {
-                                let mut disconnect_for_violation = false;
-                                if let Err(diagnostic) =
-                                    accountability.observe_server_message(false)
-                                {
-                                    let event = SignalFishEvent::ProtocolViolation {
-                                        kind: crate::event::ProtocolViolationKind::from_diagnostic(
-                                            &diagnostic,
-                                        ),
-                                        diagnostic,
-                                    };
-                                    if matches!(
-                                        emit_event_or_shutdown(
-                                            &event_tx,
-                                            &mut shutdown_rx,
-                                            event
-                                        )
-                                        .await,
-                                        EmitOutcome::ShutdownRequested
-                                    ) {
-                                        finish_shutdown(
-                                            &mut transport,
-                                            &event_tx,
-                                            &state,
-                                            last_server_error,
-                                        )
-                                        .await;
-                                        break;
-                                    }
-                                    match violation_policy {
-                                        ProtocolViolationPolicy::Quarantine => {
-                                            quarantined = true;
-                                            match state.snapshot.write() {
-                                                Ok(mut snapshot) => snapshot.quarantined = true,
-                                                Err(poisoned) => {
-                                                    poisoned.into_inner().quarantined = true
-                                                }
-                                            }
-                                        }
-                                        ProtocolViolationPolicy::Disconnect => {
-                                            disconnect_for_violation = true;
-                                        }
-                                        ProtocolViolationPolicy::Observe => {}
-                                    }
-                                }
-                                state.messages_undecodable.fetch_add(1, Ordering::Relaxed);
-                                let event = SignalFishEvent::DecodeFailed {
-                                    message_type: Some("BinaryGameData".into()),
-                                    error,
-                                    raw_prefix: bounded_binary_preview(&bytes),
-                                };
-                                if matches!(
-                                    emit_event_or_shutdown(&event_tx, &mut shutdown_rx, event).await,
-                                    EmitOutcome::ShutdownRequested
-                                ) {
-                                    finish_shutdown(&mut transport, &event_tx, &state, last_server_error).await;
-                                    break;
-                                }
-                                if disconnect_for_violation {
-                                    accountability.observe_terminal();
-                                    emit_disconnected_or_shutdown(
-                                        &mut transport,
-                                        &event_tx,
-                                        &mut shutdown_rx,
-                                        &state,
-                                        Some("protocol accountability violation".into()),
-                                        last_server_error.take(),
-                                    )
-                                    .await;
-                                    break;
-                                }
-                            }
+                        if shutdown_requested {
+                            finish_core_shutdown(&mut transport, &event_tx, &state).await;
+                            break;
+                        }
+                        if disconnect {
+                            emit_core_disconnected_or_shutdown(
+                                &mut transport,
+                                &event_tx,
+                                &mut shutdown_rx,
+                                &state,
+                                Some("protocol accountability violation".into()),
+                            ).await;
+                            break;
                         }
                     }
-                    Some(Err(e)) => {
-                        error!("transport receive error: {e}");
-                        emit_disconnected_or_shutdown(
+                    Some(Err(error)) => {
+                        emit_core_disconnected_or_shutdown(
                             &mut transport,
                             &event_tx,
                             &mut shutdown_rx,
                             &state,
-                            Some(format!("transport receive error: {e}")),
-                            last_server_error.take(),
+                            Some(format!("transport receive error: {error}")),
                         ).await;
                         break;
                     }
-                    // Transport closed cleanly.
                     None => {
-                        debug!("transport closed by server");
-                        accountability.observe_terminal();
                         let reason = transport.close_info().map(|info| {
-                            format!("closed by server: code={:?}, reason={:?}", info.code, info.reason)
+                            format!(
+                                "closed by server: code={:?}, reason={:?}",
+                                info.code, info.reason
+                            )
                         });
-                        emit_disconnected_or_shutdown(
+                        emit_core_disconnected_or_shutdown(
                             &mut transport,
                             &event_tx,
                             &mut shutdown_rx,
                             &state,
                             reason,
-                            last_server_error.take(),
                         ).await;
                         break;
                     }
@@ -1892,156 +1443,7 @@ async fn transport_loop(
             }
         }
     }
-
     debug!("transport loop exited");
-}
-
-/// Update shared [`ClientState`] based on a received [`ServerMessage`].
-#[cfg(feature = "tokio-runtime")]
-async fn update_state(state: &ClientState, msg: &ServerMessage) {
-    match msg {
-        ServerMessage::Authenticated { .. } => {
-            state.authenticated.store(true, Ordering::Release);
-            match state.snapshot.write() {
-                Ok(mut snapshot) => snapshot.authenticated = true,
-                Err(poisoned) => poisoned.into_inner().authenticated = true,
-            }
-            debug!("state: authenticated");
-        }
-        ServerMessage::ProtocolInfo(payload) => {
-            // Record the negotiated protocol version so v3-only sends can fail
-            // fast on a relay-floor connection. v2 negotiation omits the field
-            // (parses as None → 0 → not v3-capable).
-            let version = payload.protocol_version.unwrap_or(0);
-            state
-                .negotiated_protocol_version
-                .store(version, Ordering::Release);
-            // Mark negotiation as observed even for a v2 floor (version 0): this
-            // is what separates "relay-only" from "pre-negotiation" in the guard.
-            state.protocol_info_seen.store(true, Ordering::Release);
-            match state.snapshot.write() {
-                Ok(mut snapshot) => {
-                    snapshot.negotiated_protocol_version = (version >= 3).then_some(version)
-                }
-                Err(poisoned) => {
-                    poisoned.into_inner().negotiated_protocol_version =
-                        (version >= 3).then_some(version)
-                }
-            }
-            debug!("state: negotiated protocol version {version}");
-        }
-        ServerMessage::Error {
-            error_code: Some(crate::ErrorCode::UnsupportedGameDataFormat),
-            ..
-        } => {
-            state
-                .game_data_encoding
-                .store(GameDataEncoding::Json as u8, Ordering::Release);
-        }
-        ServerMessage::RoomJoined(payload) => {
-            *state.player_id.lock().await = Some(payload.player_id);
-            *state.room_id.lock().await = Some(payload.room_id);
-            *state.room_code.lock().await = Some(payload.room_code.clone());
-            let mut snapshot = match state.snapshot.write() {
-                Ok(snapshot) => snapshot,
-                Err(poisoned) => poisoned.into_inner(),
-            };
-            snapshot.player_id = Some(payload.player_id);
-            snapshot.room_id = Some(payload.room_id);
-            snapshot.room_code = Some(payload.room_code.clone());
-            snapshot.reconnection_token = payload.reconnection_token.clone();
-            snapshot.quarantined = false;
-            debug!(
-                "state: joined room {} ({})",
-                payload.room_code, payload.room_id
-            );
-        }
-        ServerMessage::RoomLeft => {
-            *state.room_id.lock().await = None;
-            *state.room_code.lock().await = None;
-            let mut snapshot = match state.snapshot.write() {
-                Ok(snapshot) => snapshot,
-                Err(poisoned) => poisoned.into_inner(),
-            };
-            snapshot.room_id = None;
-            snapshot.room_code = None;
-            snapshot.reconnection_token = None;
-            snapshot.quarantined = false;
-            debug!("state: left room");
-        }
-        ServerMessage::Reconnected(payload) => {
-            *state.player_id.lock().await = Some(payload.player_id);
-            *state.room_id.lock().await = Some(payload.room_id);
-            *state.room_code.lock().await = Some(payload.room_code.clone());
-            let mut snapshot = match state.snapshot.write() {
-                Ok(snapshot) => snapshot,
-                Err(poisoned) => poisoned.into_inner(),
-            };
-            snapshot.player_id = Some(payload.player_id);
-            snapshot.room_id = Some(payload.room_id);
-            snapshot.room_code = Some(payload.room_code.clone());
-            snapshot.reconnection_token = payload.reconnection_token.clone();
-            snapshot.quarantined = false;
-            // If the negotiated version was replayed via missed_events, restore
-            // it so v3 sends aren't wrongly blocked after a reconnect. (A
-            // top-level ProtocolInfo is already handled by its own arm.) Only a
-            // versioned (v3+) ProtocolInfo restores — a replayed v2 one must not
-            // silently downgrade an active v3 session.
-            if let Some(version) =
-                crate::protocol::replayed_negotiated_version(&payload.missed_events)
-            {
-                state
-                    .negotiated_protocol_version
-                    .store(version, Ordering::Release);
-                // A replayed `ProtocolInfo` *was* observed, so keep the flag
-                // consistent with its name. (Behaviorally moot while the guard
-                // short-circuits on version >= 3, but it preserves the
-                // "seen implies a ProtocolInfo arrived" invariant for any future
-                // reader.)
-                state.protocol_info_seen.store(true, Ordering::Release);
-                snapshot.negotiated_protocol_version = Some(version);
-            }
-            debug!(
-                "state: reconnected to room {} ({})",
-                payload.room_code, payload.room_id
-            );
-        }
-        ServerMessage::SpectatorJoined(payload) => {
-            *state.player_id.lock().await = Some(payload.spectator_id);
-            *state.room_id.lock().await = Some(payload.room_id);
-            *state.room_code.lock().await = Some(payload.room_code.clone());
-            let mut snapshot = match state.snapshot.write() {
-                Ok(snapshot) => snapshot,
-                Err(poisoned) => poisoned.into_inner(),
-            };
-            snapshot.player_id = Some(payload.spectator_id);
-            snapshot.room_id = Some(payload.room_id);
-            snapshot.room_code = Some(payload.room_code.clone());
-            snapshot.reconnection_token = None;
-            snapshot.quarantined = false;
-            debug!(
-                "state: spectator joined room {} ({})",
-                payload.room_code, payload.room_id
-            );
-        }
-        ServerMessage::SpectatorLeft { .. } => {
-            *state.room_id.lock().await = None;
-            *state.room_code.lock().await = None;
-            let mut snapshot = match state.snapshot.write() {
-                Ok(snapshot) => snapshot,
-                Err(poisoned) => poisoned.into_inner(),
-            };
-            snapshot.room_id = None;
-            snapshot.room_code = None;
-            snapshot.reconnection_token = None;
-            snapshot.quarantined = false;
-            debug!("state: left spectator mode");
-        }
-        ServerMessage::GameData { .. } | ServerMessage::GameDataBinary { .. } => {
-            state.game_data_received.fetch_add(1, Ordering::Relaxed);
-        }
-        _ => {}
-    }
 }
 
 /// Result of racing an event delivery against the shutdown signal.
@@ -2062,7 +1464,7 @@ enum EmitOutcome {
 /// still delivered; only a genuinely blocked delivery (consumer not draining)
 /// lets shutdown win. On [`EmitOutcome::ShutdownRequested`] exactly the one
 /// in-flight event is abandoned — the caller must then run
-/// [`finish_shutdown`] and exit the loop **without polling `shutdown_rx`
+/// [`finish_core_shutdown`] and exit the loop **without polling `shutdown_rx`
 /// again** (a completed `oneshot::Receiver` panics if re-polled).
 #[cfg(feature = "tokio-runtime")]
 async fn emit_event_or_shutdown(
@@ -2079,89 +1481,6 @@ async fn emit_event_or_shutdown(
             EmitOutcome::Delivered
         }
         _ = &mut *shutdown_rx => EmitOutcome::ShutdownRequested,
-    }
-}
-
-/// Terminal sequence for a shutdown request: close the transport gracefully,
-/// then deliver `Disconnected` best-effort.
-///
-/// Closing **before** the final event delivery is the point: pre-0.7.0 a
-/// wedged consumer starved the shutdown signal entirely, so the abort tore
-/// the task down with the connection dangling. The final `Disconnected` uses
-/// `try_send` rather than backpressure: the caller *initiated* this shutdown,
-/// so the event is confirmatory, and a receiver that outlives the loop
-/// observes termination anyway when the event channel closes (`recv()`
-/// returns `None`). Blocking here would force every wedged-consumer shutdown
-/// through the timeout/abort path for no information gain.
-#[cfg(feature = "tokio-runtime")]
-async fn finish_shutdown(
-    transport: &mut impl Transport,
-    event_tx: &mpsc::Sender<SignalFishEvent>,
-    state: &ClientState,
-    last_server_error: Option<ServerErrorInfo>,
-) {
-    let _ = close_transport(transport).await;
-    state.connected.store(false, Ordering::Release);
-    state.clear_session_state().await;
-    let _ = event_tx.try_send(SignalFishEvent::Disconnected {
-        reason: Some("client shut down".into()),
-        last_server_error,
-    });
-}
-
-/// Deliver the terminal [`Disconnected`](SignalFishEvent::Disconnected) on a
-/// loop break-path, closing the transport and letting a pending `shutdown()`
-/// preempt a blocked delivery.
-///
-/// The transport is closed **first** (best-effort), exactly like
-/// [`finish_shutdown`]: graceful shutdown always releases the connection, so
-/// closing must not depend on the event delivery completing — otherwise a
-/// wedged consumer that lets the shutdown branch win would leave the socket
-/// open until the task is dropped. Closing an already-errored or
-/// server-closed transport is a harmless no-op / completes the close
-/// handshake.
-///
-/// The break-paths (transport send/receive error, clean server close, dropped
-/// handle) want `Disconnected` delivered with backpressure — the normal,
-/// never-drop case. But if the consumer has wedged (event channel
-/// full) *and* a shutdown is pending, a plain blocking send would starve the
-/// shutdown signal and force `shutdown()` down its timeout/abort path (the
-/// same starvation [`emit_event_or_shutdown`] fixes for per-message events).
-/// So this races the backpressured send against the shutdown signal, `biased`
-/// toward delivery; on preemption it re-sends best-effort via `try_send` so
-/// the event is still likely delivered and the loop exits promptly.
-///
-/// Terminal: every caller `break`s immediately afterwards, so `shutdown_rx` is
-/// never polled again (a completed `oneshot::Receiver` panics if re-polled).
-#[cfg(feature = "tokio-runtime")]
-async fn emit_disconnected_or_shutdown(
-    transport: &mut impl Transport,
-    event_tx: &mpsc::Sender<SignalFishEvent>,
-    shutdown_rx: &mut tokio::sync::oneshot::Receiver<()>,
-    state: &ClientState,
-    reason: Option<String>,
-    last_server_error: Option<ServerErrorInfo>,
-) {
-    let _ = close_transport(transport).await;
-    state.connected.store(false, Ordering::Release);
-    state.clear_session_state().await;
-    let event = SignalFishEvent::Disconnected {
-        reason,
-        last_server_error,
-    };
-    tokio::select! {
-        biased;
-        res = event_tx.send(event.clone()) => {
-            if res.is_err() {
-                debug!("event channel closed, receiver dropped");
-            }
-        }
-        _ = &mut *shutdown_rx => {
-            // Consumer wedged and a shutdown is pending: preempt the blocked
-            // delivery and re-send best-effort so shutdown() completes promptly
-            // instead of waiting out the abort timeout.
-            let _ = event_tx.try_send(event);
-        }
     }
 }
 
@@ -2956,7 +2275,7 @@ mod tests {
         let (transport, entered_send, permits, sent) = GatedSendTransport::new(0);
 
         let config = SignalFishConfig::new("mb_test").with_command_channel_capacity(1);
-        let (client, mut events) = SignalFishClient::start(transport, config);
+        let (mut client, mut events) = SignalFishClient::start(transport, config);
 
         let _ = events.recv().await; // Connected
         wait_until(|| entered_send.load(Ordering::Acquire)).await;

--- a/src/client_api.rs
+++ b/src/client_api.rs
@@ -1,0 +1,99 @@
+//! Common synchronous API implemented by both Signal Fish client drivers.
+
+use crate::client::{ClientSnapshot, ClientStats, GameDataDelivery, JoinRoomParams};
+use crate::error::Result;
+use crate::protocol::{ConnectionInfo, PlayerId, RoomId, TransportKind};
+use crate::signal::PeerSignal;
+
+/// Object-safe synchronous command and state surface shared by both clients.
+///
+/// Use this trait when application logic should be independent of whether the
+/// connection is driven by `SignalFishClient` or `SignalFishPollingClient`.
+/// Driver-specific
+/// operations such as async waiting sends, `shutdown`, `poll`, and `close` are
+/// intentionally excluded.
+pub trait SignalFishClientApi {
+    /// Join or create a room.
+    fn join_room(&mut self, params: JoinRoomParams) -> Result<()>;
+    /// Leave the current room.
+    fn leave_room(&mut self) -> Result<()>;
+    /// Send wire-reliable JSON game data.
+    fn send_game_data(&mut self, data: serde_json::Value) -> Result<()>;
+    /// Send JSON game data with a selected delivery class.
+    fn send_game_data_with_delivery(
+        &mut self,
+        data: serde_json::Value,
+        delivery: GameDataDelivery,
+    ) -> Result<()>;
+    /// Send opaque binary game data.
+    fn send_binary_game_data(&mut self, payload: Vec<u8>) -> Result<()>;
+    /// Mark the local player ready.
+    fn set_ready(&mut self) -> Result<()>;
+    /// Request the protocol-v2 game start.
+    fn start_game(&mut self) -> Result<()>;
+    /// Request or relinquish authority.
+    fn request_authority(&mut self, become_authority: bool) -> Result<()>;
+    /// Provide peer connection information.
+    fn provide_connection_info(&mut self, connection_info: ConnectionInfo) -> Result<()>;
+    /// Reconnect using a server-issued token.
+    fn reconnect(&mut self, player_id: PlayerId, room_id: RoomId, auth_token: String)
+        -> Result<()>;
+    /// Join a room as a spectator.
+    fn join_as_spectator(
+        &mut self,
+        game_name: String,
+        room_code: String,
+        spectator_name: String,
+    ) -> Result<()>;
+    /// Leave spectator mode.
+    fn leave_spectator(&mut self) -> Result<()>;
+    /// Send an application heartbeat.
+    fn ping(&mut self) -> Result<()>;
+    /// Relay a typed WebRTC signal.
+    fn send_signal(&mut self, to: PlayerId, signal: PeerSignal) -> Result<()>;
+    /// Relay an unmodeled WebRTC signal.
+    fn send_raw_signal(&mut self, to: PlayerId, signal: serde_json::Value) -> Result<()>;
+    /// Report data-path transport status.
+    fn report_transport_status(&mut self, transport: TransportKind, connected: bool) -> Result<()>;
+    /// Remaining command-queue capacity.
+    fn send_capacity(&self) -> usize;
+    /// Configured command-queue capacity.
+    fn max_send_capacity(&self) -> usize;
+    /// Cumulative traffic statistics.
+    fn stats(&self) -> ClientStats;
+    /// Coherent connection and room snapshot.
+    fn snapshot(&self) -> ClientSnapshot;
+
+    /// Whether the physical connection is active.
+    fn is_connected(&self) -> bool {
+        self.snapshot().connected
+    }
+
+    /// Whether authentication has completed.
+    fn is_authenticated(&self) -> bool {
+        self.snapshot().authenticated
+    }
+
+    /// Negotiated v3-or-newer protocol version.
+    fn negotiated_protocol_version(&self) -> Option<u16> {
+        self.snapshot().negotiated_protocol_version
+    }
+
+    /// Whether WebRTC mesh was advertised and protocol v3 was negotiated.
+    fn supports_mesh(&self) -> bool;
+
+    /// Send an SDP offer.
+    fn send_offer(&mut self, to: PlayerId, sdp: String) -> Result<()> {
+        self.send_signal(to, PeerSignal::Offer(sdp))
+    }
+
+    /// Send an SDP answer.
+    fn send_answer(&mut self, to: PlayerId, sdp: String) -> Result<()> {
+        self.send_signal(to, PeerSignal::Answer(sdp))
+    }
+
+    /// Send a trickle ICE candidate.
+    fn send_ice_candidate(&mut self, to: PlayerId, candidate: String) -> Result<()> {
+        self.send_signal(to, PeerSignal::IceCandidate(candidate))
+    }
+}

--- a/src/client_core.rs
+++ b/src/client_core.rs
@@ -1,0 +1,542 @@
+//! Shared, transport-independent Signal Fish client state machine.
+//!
+//! The async and polling clients deliberately keep their driving mechanics
+//! separate. Everything that interprets protocol frames or mutates observable
+//! client state lives here so both drivers cannot drift semantically.
+
+use crate::accountability::{self, DeliveryAccountability, GameDataDisposition};
+use crate::client::{
+    bounded_binary_preview, decode_binary_server_message, ClientSnapshot, ClientStats,
+    GameDataDelivery, JoinRoomParams, ProtocolViolationPolicy, SignalFishConfig,
+};
+use crate::event::{ProtocolViolationKind, ServerErrorInfo, SignalFishEvent};
+use crate::protocol::{
+    ClientMessage, ConnectionInfo, DeliveryClass, GameDataEncoding, PlayerId, RoomId,
+    ServerMessage, TransportKind,
+};
+use crate::signal::PeerSignal;
+use crate::transport::TransportFrame;
+
+/// Result of processing one physical server frame.
+pub(crate) struct FrameOutcome {
+    pub(crate) events: Vec<SignalFishEvent>,
+    pub(crate) disconnect: bool,
+}
+
+#[derive(Debug)]
+pub(crate) enum CoreCommand {
+    Message(ClientMessage),
+    Binary(Vec<u8>),
+}
+
+pub(crate) enum ClientOperation {
+    JoinRoom(JoinRoomParams),
+    LeaveRoom,
+    GameData(serde_json::Value, GameDataDelivery),
+    Binary(Vec<u8>),
+    SetReady,
+    StartGame,
+    RequestAuthority(bool),
+    ProvideConnectionInfo(ConnectionInfo),
+    Reconnect(PlayerId, RoomId, String),
+    JoinAsSpectator(String, String, String),
+    LeaveSpectator,
+    Ping,
+    Signal(PlayerId, PeerSignal),
+    RawSignal(PlayerId, serde_json::Value),
+    TransportStatus(TransportKind, bool),
+}
+
+impl FrameOutcome {
+    fn new() -> Self {
+        Self {
+            events: Vec::new(),
+            disconnect: false,
+        }
+    }
+}
+
+/// Shared protocol state and behavior used by both public client drivers.
+pub(crate) struct ClientCore {
+    snapshot: ClientSnapshot,
+    protocol_info_seen: bool,
+    mesh_enabled: bool,
+    game_data_encoding: GameDataEncoding,
+    stats: ClientStats,
+    last_server_error: Option<ServerErrorInfo>,
+    violation_policy: ProtocolViolationPolicy,
+    accountability: DeliveryAccountability,
+}
+
+impl ClientCore {
+    pub(crate) fn authenticate(config: &SignalFishConfig) -> CoreCommand {
+        CoreCommand::Message(ClientMessage::Authenticate {
+            app_id: config.app_id.clone(),
+            sdk_version: config.sdk_version.clone(),
+            platform: config.platform.clone(),
+            game_data_format: config.game_data_format,
+            protocol_version: config.protocol_version,
+            supported_transports: config.supported_transports.clone(),
+            supported_topologies: config.supported_topologies.clone(),
+        })
+    }
+
+    pub(crate) fn new(
+        game_data_encoding: GameDataEncoding,
+        violation_policy: ProtocolViolationPolicy,
+        mesh_enabled: bool,
+    ) -> Self {
+        Self {
+            snapshot: ClientSnapshot {
+                connected: true,
+                ..ClientSnapshot::default()
+            },
+            protocol_info_seen: false,
+            mesh_enabled,
+            game_data_encoding,
+            stats: ClientStats::default(),
+            last_server_error: None,
+            violation_policy,
+            accountability: DeliveryAccountability::new(false),
+        }
+    }
+
+    pub(crate) fn snapshot(&self) -> ClientSnapshot {
+        self.snapshot.clone()
+    }
+
+    pub(crate) fn stats(&self) -> ClientStats {
+        self.stats
+    }
+
+    pub(crate) fn is_connected(&self) -> bool {
+        self.snapshot.connected
+    }
+
+    pub(crate) fn is_authenticated(&self) -> bool {
+        self.snapshot.authenticated
+    }
+
+    pub(crate) fn negotiated_protocol_version(&self) -> Option<u16> {
+        self.snapshot.negotiated_protocol_version
+    }
+
+    pub(crate) fn supports_mesh(&self) -> bool {
+        self.mesh_enabled
+            && self
+                .negotiated_protocol_version()
+                .is_some_and(|version| version >= 3)
+    }
+
+    #[cfg(feature = "polling-client")]
+    pub(crate) fn current_player_id(&self) -> Option<PlayerId> {
+        self.snapshot.player_id
+    }
+
+    #[cfg(feature = "polling-client")]
+    pub(crate) fn current_room_id(&self) -> Option<RoomId> {
+        self.snapshot.room_id
+    }
+
+    #[cfg(feature = "polling-client")]
+    pub(crate) fn current_room_code(&self) -> Option<&str> {
+        self.snapshot.room_code.as_deref()
+    }
+
+    pub(crate) fn prepare(&self, operation: ClientOperation) -> crate::error::Result<CoreCommand> {
+        if !self.is_connected() {
+            return Err(crate::SignalFishError::NotConnected);
+        }
+        match &operation {
+            ClientOperation::GameData(_, GameDataDelivery::Latest { .. })
+            | ClientOperation::GameData(_, GameDataDelivery::Volatile)
+            | ClientOperation::Binary(_)
+            | ClientOperation::Signal(..)
+            | ClientOperation::RawSignal(..)
+            | ClientOperation::TransportStatus(..) => self.ensure_v3()?,
+            _ => {}
+        }
+        if matches!(&operation, ClientOperation::Binary(_))
+            && self.game_data_encoding == GameDataEncoding::Json
+        {
+            return Err(crate::SignalFishError::BinaryFormatNotNegotiated);
+        }
+        let message = match operation {
+            ClientOperation::JoinRoom(params) => ClientMessage::JoinRoom {
+                game_name: params.game_name,
+                room_code: params.room_code,
+                player_name: params.player_name,
+                max_players: params.max_players,
+                supports_authority: params.supports_authority,
+                relay_transport: params.relay_transport,
+            },
+            ClientOperation::LeaveRoom => ClientMessage::LeaveRoom,
+            ClientOperation::GameData(data, delivery) => {
+                let (class, key) = match delivery {
+                    GameDataDelivery::Reliable => (None, None),
+                    GameDataDelivery::Latest { key } => (Some(DeliveryClass::Latest), Some(key)),
+                    GameDataDelivery::Volatile => (Some(DeliveryClass::Volatile), None),
+                };
+                ClientMessage::GameData { data, class, key }
+            }
+            ClientOperation::Binary(payload) => {
+                return Ok(CoreCommand::Binary(payload));
+            }
+            ClientOperation::SetReady => ClientMessage::PlayerReady,
+            ClientOperation::StartGame => ClientMessage::StartGame,
+            ClientOperation::RequestAuthority(become_authority) => {
+                ClientMessage::AuthorityRequest { become_authority }
+            }
+            ClientOperation::ProvideConnectionInfo(connection_info) => {
+                ClientMessage::ProvideConnectionInfo { connection_info }
+            }
+            ClientOperation::Reconnect(player_id, room_id, auth_token) => {
+                ClientMessage::Reconnect {
+                    player_id,
+                    room_id,
+                    auth_token,
+                }
+            }
+            ClientOperation::JoinAsSpectator(game_name, room_code, spectator_name) => {
+                ClientMessage::JoinAsSpectator {
+                    game_name,
+                    room_code,
+                    spectator_name,
+                }
+            }
+            ClientOperation::LeaveSpectator => ClientMessage::LeaveSpectator,
+            ClientOperation::Ping => ClientMessage::Ping,
+            ClientOperation::Signal(to, signal) => ClientMessage::Signal {
+                to,
+                signal: signal.into(),
+            },
+            ClientOperation::RawSignal(to, signal) => ClientMessage::Signal { to, signal },
+            ClientOperation::TransportStatus(transport, connected) => {
+                ClientMessage::TransportStatus {
+                    transport,
+                    connected,
+                }
+            }
+        };
+        Ok(CoreCommand::Message(message))
+    }
+
+    fn ensure_v3(&self) -> crate::error::Result<()> {
+        if self
+            .negotiated_protocol_version()
+            .is_some_and(|version| version >= 3)
+        {
+            return Ok(());
+        }
+        let mode = if self.protocol_info_seen {
+            "relay-only"
+        } else {
+            "pre-negotiation"
+        };
+        Err(crate::SignalFishError::ProtocolUnsupported { mode })
+    }
+
+    pub(crate) fn record_game_data_sent(&mut self) {
+        self.stats.game_data_sent = self.stats.game_data_sent.saturating_add(1);
+    }
+
+    pub(crate) fn clear_session(&mut self) {
+        self.snapshot.authenticated = false;
+        self.snapshot.negotiated_protocol_version = None;
+        self.snapshot.player_id = None;
+        self.snapshot.room_id = None;
+        self.snapshot.room_code = None;
+        self.snapshot.reconnection_token = None;
+        self.snapshot.quarantined = false;
+        self.protocol_info_seen = false;
+    }
+
+    pub(crate) fn disconnect(&mut self, reason: Option<String>) -> SignalFishEvent {
+        self.accountability.observe_terminal();
+        self.snapshot.connected = false;
+        self.clear_session();
+        SignalFishEvent::Disconnected {
+            reason,
+            last_server_error: self.last_server_error.take(),
+        }
+    }
+
+    pub(crate) fn process_frame(&mut self, frame: TransportFrame) -> FrameOutcome {
+        match frame {
+            TransportFrame::Text(text) => self.process_text(text),
+            TransportFrame::Binary(bytes) => self.process_binary(bytes),
+        }
+    }
+
+    fn process_text(&mut self, text: String) -> FrameOutcome {
+        let mut outcome = FrameOutcome::new();
+        let server_msg = match serde_json::from_str::<ServerMessage>(&text) {
+            Ok(message) => message,
+            Err(error) => {
+                tracing::warn!(
+                    "failed to deserialize server message ({} bytes): {error}",
+                    text.len()
+                );
+                let disconnect = self.observe_undecodable(&mut outcome.events);
+                self.stats.messages_undecodable = self.stats.messages_undecodable.saturating_add(1);
+                outcome
+                    .events
+                    .push(SignalFishEvent::decode_failed(&text, &error));
+                outcome.disconnect = disconnect;
+                return outcome;
+            }
+        };
+
+        let duplicate_protocol_info =
+            matches!(server_msg, ServerMessage::ProtocolInfo(_)) && self.protocol_info_seen;
+        if let ServerMessage::ProtocolInfo(payload) = &server_msg {
+            if !duplicate_protocol_info {
+                self.accountability = DeliveryAccountability::new(
+                    payload.protocol_version.is_some_and(|version| version >= 3),
+                );
+            }
+        }
+
+        let authoritative_baseline = matches!(
+            server_msg,
+            ServerMessage::RoomJoined(_)
+                | ServerMessage::SpectatorJoined(_)
+                | ServerMessage::Reconnected(_)
+        );
+        let validation = if duplicate_protocol_info {
+            self.accountability
+                .observe_server_message(false)
+                .map(|()| GameDataDisposition::Apply)
+        } else {
+            accountability::validate_server_frame(
+                &mut self.accountability,
+                &server_msg,
+                self.game_data_encoding,
+                false,
+            )
+        };
+
+        let (disposition, validation_failed) = match validation {
+            Ok(disposition) => {
+                if authoritative_baseline {
+                    self.snapshot.quarantined = false;
+                }
+                (disposition, false)
+            }
+            Err(diagnostic) => {
+                self.push_violation(&mut outcome.events, diagnostic);
+                if self.violation_policy == ProtocolViolationPolicy::Disconnect {
+                    outcome.disconnect = true;
+                    return outcome;
+                }
+                let disposition = if self.violation_policy == ProtocolViolationPolicy::Observe {
+                    GameDataDisposition::Apply
+                } else {
+                    GameDataDisposition::Stale
+                };
+                (disposition, true)
+            }
+        };
+
+        if validation_failed && self.violation_policy == ProtocolViolationPolicy::Quarantine {
+            return outcome;
+        }
+        if duplicate_protocol_info {
+            return outcome;
+        }
+        let is_game_data = matches!(
+            server_msg,
+            ServerMessage::GameData { .. } | ServerMessage::GameDataBinary { .. }
+        );
+        if is_game_data
+            && (disposition == GameDataDisposition::Stale
+                || (self.snapshot.quarantined
+                    && self.violation_policy == ProtocolViolationPolicy::Quarantine))
+        {
+            return outcome;
+        }
+
+        self.update_state(&server_msg);
+        outcome.events.push(SignalFishEvent::from(server_msg));
+        outcome
+    }
+
+    fn process_binary(&mut self, bytes: Vec<u8>) -> FrameOutcome {
+        let mut outcome = FrameOutcome::new();
+        let mut observe_representation_violation = false;
+        if let Err(diagnostic) = accountability::validate_physical_binary_allowed(
+            &mut self.accountability,
+            self.game_data_encoding,
+        ) {
+            self.push_violation(&mut outcome.events, diagnostic);
+            match self.violation_policy {
+                ProtocolViolationPolicy::Quarantine => return outcome,
+                ProtocolViolationPolicy::Disconnect => {
+                    outcome.disconnect = true;
+                    return outcome;
+                }
+                ProtocolViolationPolicy::Observe => observe_representation_violation = true,
+            }
+        }
+
+        let protocol_v3 = self
+            .snapshot
+            .negotiated_protocol_version
+            .is_some_and(|version| version >= 3);
+        let server_msg = match decode_binary_server_message(&bytes, protocol_v3) {
+            Ok(message) => message,
+            Err(error) => {
+                let disconnect = self.observe_undecodable(&mut outcome.events);
+                self.stats.messages_undecodable = self.stats.messages_undecodable.saturating_add(1);
+                outcome.events.push(SignalFishEvent::DecodeFailed {
+                    message_type: Some("BinaryGameData".into()),
+                    error,
+                    raw_prefix: bounded_binary_preview(&bytes),
+                });
+                outcome.disconnect = disconnect;
+                return outcome;
+            }
+        };
+
+        let validation = if observe_representation_violation {
+            accountability::validate_server_message(&mut self.accountability, &server_msg)
+        } else {
+            accountability::validate_server_frame(
+                &mut self.accountability,
+                &server_msg,
+                self.game_data_encoding,
+                true,
+            )
+        };
+        let disposition = match validation {
+            Ok(disposition) => disposition,
+            Err(diagnostic) => {
+                self.push_violation(&mut outcome.events, diagnostic);
+                if self.violation_policy == ProtocolViolationPolicy::Disconnect {
+                    outcome.disconnect = true;
+                    return outcome;
+                }
+                if self.violation_policy == ProtocolViolationPolicy::Observe {
+                    GameDataDisposition::Apply
+                } else {
+                    GameDataDisposition::Stale
+                }
+            }
+        };
+
+        if disposition == GameDataDisposition::Stale
+            || (self.snapshot.quarantined
+                && self.violation_policy == ProtocolViolationPolicy::Quarantine)
+        {
+            return outcome;
+        }
+
+        self.update_state(&server_msg);
+        outcome.events.push(SignalFishEvent::from(server_msg));
+        outcome
+    }
+
+    fn observe_undecodable(&mut self, events: &mut Vec<SignalFishEvent>) -> bool {
+        if let Err(diagnostic) = self.accountability.observe_server_message(false) {
+            self.push_violation(events, diagnostic);
+            return self.violation_policy == ProtocolViolationPolicy::Disconnect;
+        }
+        false
+    }
+
+    fn push_violation(&mut self, events: &mut Vec<SignalFishEvent>, diagnostic: String) {
+        events.push(SignalFishEvent::ProtocolViolation {
+            kind: ProtocolViolationKind::from_diagnostic(&diagnostic),
+            diagnostic,
+        });
+        if self.violation_policy == ProtocolViolationPolicy::Quarantine {
+            self.snapshot.quarantined = true;
+        }
+    }
+
+    fn update_state(&mut self, message: &ServerMessage) {
+        match message {
+            ServerMessage::Authenticated { .. } => self.snapshot.authenticated = true,
+            ServerMessage::Error {
+                message,
+                error_code,
+            } => {
+                if error_code.as_ref() == Some(&crate::ErrorCode::UnsupportedGameDataFormat) {
+                    self.game_data_encoding = GameDataEncoding::Json;
+                }
+                self.last_server_error = Some(ServerErrorInfo {
+                    message: message.clone(),
+                    error_code: error_code.clone(),
+                });
+            }
+            ServerMessage::AuthenticationError { error, error_code } => {
+                self.last_server_error = Some(ServerErrorInfo {
+                    message: error.clone(),
+                    error_code: Some(error_code.clone()),
+                });
+            }
+            ServerMessage::ProtocolInfo(payload) => {
+                self.snapshot.negotiated_protocol_version =
+                    payload.protocol_version.filter(|version| *version >= 3);
+                self.protocol_info_seen = true;
+            }
+            ServerMessage::RoomJoined(payload) => {
+                self.set_room(
+                    payload.player_id,
+                    payload.room_id,
+                    payload.room_code.clone(),
+                    payload.reconnection_token.clone(),
+                );
+            }
+            ServerMessage::RoomLeft => self.clear_room(),
+            ServerMessage::Reconnected(payload) => {
+                self.set_room(
+                    payload.player_id,
+                    payload.room_id,
+                    payload.room_code.clone(),
+                    payload.reconnection_token.clone(),
+                );
+                if let Some(version) =
+                    crate::protocol::replayed_negotiated_version(&payload.missed_events)
+                {
+                    self.snapshot.negotiated_protocol_version = Some(version);
+                    self.protocol_info_seen = true;
+                }
+            }
+            ServerMessage::SpectatorJoined(payload) => {
+                self.set_room(
+                    payload.spectator_id,
+                    payload.room_id,
+                    payload.room_code.clone(),
+                    None,
+                );
+            }
+            ServerMessage::SpectatorLeft { .. } => self.clear_room(),
+            ServerMessage::GameData { .. } | ServerMessage::GameDataBinary { .. } => {
+                self.stats.game_data_received = self.stats.game_data_received.saturating_add(1);
+            }
+            _ => {}
+        }
+    }
+
+    fn set_room(
+        &mut self,
+        player_id: PlayerId,
+        room_id: RoomId,
+        room_code: String,
+        reconnection_token: Option<String>,
+    ) {
+        self.snapshot.player_id = Some(player_id);
+        self.snapshot.room_id = Some(room_id);
+        self.snapshot.room_code = Some(room_code);
+        self.snapshot.reconnection_token = reconnection_token;
+        self.snapshot.quarantined = false;
+    }
+
+    fn clear_room(&mut self) {
+        self.snapshot.room_id = None;
+        self.snapshot.room_code = None;
+        self.snapshot.reconnection_token = None;
+        self.snapshot.quarantined = false;
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -70,7 +70,7 @@ pub enum SignalFishError {
     /// [`SignalFishConfig::enable_mesh`](crate::SignalFishConfig::enable_mesh).
     #[error(
         "operation requires a negotiated protocol v3 session (current mode: {mode}); \
-         opt into v3 with SignalFishConfig::enable_v3() or enable_mesh()"
+         opt into v3 with SignalFishConfig::enable_v3() or SignalFishConfig::enable_mesh()"
     )]
     ProtocolUnsupported {
         /// Why v3 is unavailable:

--- a/src/error.rs
+++ b/src/error.rs
@@ -59,21 +59,24 @@ pub enum SignalFishError {
         error_code: Option<ErrorCode>,
     },
 
-    /// A protocol-v3-only operation (sending a WebRTC signal or transport
-    /// status) was attempted on a connection that has not negotiated v3.
+    /// A protocol-v3-only operation was attempted on a connection that has not
+    /// negotiated v3.
     ///
     /// The server would reject the message, so the client fails fast at the call
     /// site instead — better UX than an asynchronous, unattributed error event.
-    /// Opt into v3 with [`SignalFishConfig::enable_mesh`](crate::SignalFishConfig::enable_mesh).
+    /// Opt into relay/accountability v3 with
+    /// [`SignalFishConfig::enable_v3`](crate::SignalFishConfig::enable_v3), or
+    /// opt into mesh signaling with
+    /// [`SignalFishConfig::enable_mesh`](crate::SignalFishConfig::enable_mesh).
     #[error(
         "operation requires a negotiated protocol v3 session (current mode: {mode}); \
-         opt into the mesh with SignalFishConfig::enable_mesh()"
+         opt into v3 with SignalFishConfig::enable_v3() or enable_mesh()"
     )]
     ProtocolUnsupported {
         /// Why v3 is unavailable:
         /// - `"relay-only"` — a `ProtocolInfo` was received but negotiated below
-        ///   v3 (the v2 relay floor); waiting will not help. Opt into the mesh
-        ///   and reconnect.
+        ///   v3 (the v2 relay floor); waiting will not help. Enable the required
+        ///   v3 capabilities and reconnect.
         /// - `"pre-negotiation"` — no `ProtocolInfo` has been received yet;
         ///   negotiation is still in flight, so retry once it completes.
         mode: &'static str,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,6 +108,9 @@
 #[cfg(any(feature = "tokio-runtime", feature = "polling-client"))]
 mod accountability;
 pub mod client;
+pub mod client_api;
+#[cfg(any(feature = "tokio-runtime", feature = "polling-client"))]
+mod client_core;
 pub mod error;
 pub mod error_codes;
 pub mod event;
@@ -127,6 +130,7 @@ pub use client::{
     ClientSnapshot, ClientStats, GameDataDelivery, JoinRoomParams, ProtocolViolationPolicy,
     SignalFishClient, SignalFishConfig,
 };
+pub use client_api::SignalFishClientApi;
 pub use error::SignalFishError;
 pub use error_codes::ErrorCode;
 pub use event::{

--- a/src/polling_client.rs
+++ b/src/polling_client.rs
@@ -18,94 +18,17 @@
 
 use std::collections::VecDeque;
 
-use tracing::{debug, error, warn};
+use tracing::{debug, error};
 
 use crate::client::{ClientSnapshot, GameDataDelivery, JoinRoomParams, SignalFishConfig};
+use crate::client_core::{ClientCore, ClientOperation, CoreCommand as PollingCommand};
 use crate::error::{Result, SignalFishError};
-use crate::event::{ServerErrorInfo, SignalFishEvent};
-use crate::protocol::{
-    ClientMessage, ConnectionInfo, DeliveryClass, GameDataEncoding, PlayerId, RoomId,
-    ServerMessage, TransportKind,
-};
+use crate::event::SignalFishEvent;
+#[cfg(test)]
+use crate::protocol::GameDataEncoding;
+use crate::protocol::{ClientMessage, ConnectionInfo, PlayerId, RoomId, TransportKind};
 use crate::signal::PeerSignal;
 use crate::transport::{Transport, TransportFrame};
-
-#[derive(Debug)]
-enum PollingCommand {
-    Message(ClientMessage),
-    Binary(Vec<u8>),
-}
-
-// ── Internal state ──────────────────────────────────────────────────
-
-/// Internal state for the polling client. No `Arc`/`Mutex` needed — single-threaded.
-struct PollingClientState {
-    connected: bool,
-    authenticated: bool,
-    /// Protocol version negotiated by the server (from `ProtocolInfo`).
-    /// `0` means not-yet-negotiated or negotiated v2 — i.e. not v3-capable.
-    negotiated_protocol_version: u16,
-    /// Whether a `ProtocolInfo` has been observed on this connection. Separates
-    /// "negotiation hasn't happened yet" from "negotiation completed at the v2
-    /// relay floor" — both leave `negotiated_protocol_version` at `0`. Drives
-    /// the `ProtocolUnsupported { mode }` diagnostic.
-    protocol_info_seen: bool,
-    player_id: Option<PlayerId>,
-    room_id: Option<RoomId>,
-    room_code: Option<String>,
-    reconnection_token: Option<String>,
-    quarantined: bool,
-    /// `GameData` messages successfully written to the transport.
-    /// Cumulative — intentionally not reset by `clear_session`.
-    game_data_sent: u64,
-    /// `GameData`/`GameDataBinary` messages received from the server,
-    /// counted at receipt (see
-    /// [`ClientStats::game_data_received`](crate::client::ClientStats)).
-    /// Cumulative — intentionally not reset by `clear_session`.
-    game_data_received: u64,
-    /// Inbound frames that failed to decode into a `ServerMessage` (see
-    /// [`ClientStats::messages_undecodable`](crate::client::ClientStats)).
-    /// Cumulative — intentionally not reset by `clear_session`.
-    messages_undecodable: u64,
-    /// The most recent `Error`/`AuthenticationError` received on this
-    /// connection, remembered for disconnect attribution (surfaced via
-    /// `Disconnected::last_server_error`). Intentionally not reset by
-    /// `clear_session` — it must survive into the terminal `Disconnected`.
-    last_server_error: Option<ServerErrorInfo>,
-}
-
-impl PollingClientState {
-    fn new() -> Self {
-        Self {
-            // Tracks whether the client is active (not disconnected).
-            // Set true at construction; set false by handle_disconnect().
-            connected: true,
-            authenticated: false,
-            negotiated_protocol_version: 0,
-            protocol_info_seen: false,
-            player_id: None,
-            room_id: None,
-            room_code: None,
-            reconnection_token: None,
-            quarantined: false,
-            game_data_sent: 0,
-            game_data_received: 0,
-            messages_undecodable: 0,
-            last_server_error: None,
-        }
-    }
-
-    fn clear_session(&mut self) {
-        self.authenticated = false;
-        self.negotiated_protocol_version = 0;
-        self.protocol_info_seen = false;
-        self.player_id = None;
-        self.room_id = None;
-        self.room_code = None;
-        self.reconnection_token = None;
-        self.quarantined = false;
-    }
-}
 
 // ── Public client ───────────────────────────────────────────────────
 
@@ -161,14 +84,14 @@ pub struct SignalFishPollingClient<T: Transport> {
     /// [`SignalFishError::SendBufferFull`]. Mirrors the async client's
     /// bounded command channel.
     command_capacity: usize,
-    state: PollingClientState,
+    core: ClientCore,
     started: bool,
     pending_frame: Option<TransportFrame>,
+    /// The transport accepted the current frame and is still completing it.
+    /// While true, poll with `None` and do not dequeue a replacement frame.
+    send_in_flight: bool,
     pending_frame_is_game_data: bool,
-    protocol_violation_policy: crate::client::ProtocolViolationPolicy,
-    accountability: crate::accountability::DeliveryAccountability,
     closing: bool,
-    game_data_encoding: GameDataEncoding,
 }
 
 impl<T: Transport> SignalFishPollingClient<T> {
@@ -181,31 +104,29 @@ impl<T: Transport> SignalFishPollingClient<T> {
     #[must_use]
     pub fn new(transport: T, config: SignalFishConfig) -> Self {
         let requested_game_data_encoding = config.game_data_format.unwrap_or_default();
-        let auth_msg = ClientMessage::Authenticate {
-            app_id: config.app_id,
-            sdk_version: config.sdk_version,
-            platform: config.platform,
-            game_data_format: config.game_data_format,
-            protocol_version: config.protocol_version,
-            supported_transports: config.supported_transports,
-            supported_topologies: config.supported_topologies,
-        };
+        let mesh_enabled = config
+            .supported_transports
+            .as_ref()
+            .is_some_and(|transports| transports.contains(&TransportKind::WebRtc));
+        let auth_msg = ClientCore::authenticate(&config);
 
         let mut cmd_queue = VecDeque::new();
-        cmd_queue.push_back(PollingCommand::Message(auth_msg));
+        cmd_queue.push_back(auth_msg);
 
         Self {
             transport,
             cmd_queue,
             command_capacity: config.command_channel_capacity.max(1),
-            state: PollingClientState::new(),
+            core: ClientCore::new(
+                requested_game_data_encoding,
+                config.protocol_violation_policy,
+                mesh_enabled,
+            ),
             started: false,
             pending_frame: None,
+            send_in_flight: false,
             pending_frame_is_game_data: false,
-            protocol_violation_policy: config.protocol_violation_policy,
-            accountability: crate::accountability::DeliveryAccountability::new(false),
             closing: false,
-            game_data_encoding: requested_game_data_encoding,
         }
     }
 
@@ -253,7 +174,7 @@ impl<T: Transport> SignalFishPollingClient<T> {
             return events;
         }
 
-        if !self.state.connected {
+        if !self.core.is_connected() {
             return events;
         }
 
@@ -263,7 +184,7 @@ impl<T: Transport> SignalFishPollingClient<T> {
 
         // ── Flush outgoing commands ──
         loop {
-            if self.pending_frame.is_none() {
+            if self.pending_frame.is_none() && !self.send_in_flight {
                 let Some(command) = self.cmd_queue.pop_front() else {
                     break;
                 };
@@ -292,8 +213,9 @@ impl<T: Transport> SignalFishPollingClient<T> {
             match send_result {
                 std::task::Poll::Ready(Ok(())) => {
                     if self.pending_frame_is_game_data {
-                        self.state.game_data_sent += 1;
+                        self.core.record_game_data_sent();
                     }
+                    self.send_in_flight = false;
                     self.pending_frame_is_game_data = false;
                 }
                 std::task::Poll::Ready(Err(e)) => {
@@ -306,286 +228,27 @@ impl<T: Transport> SignalFishPollingClient<T> {
                     return events;
                 }
                 std::task::Poll::Pending => {
+                    if self.pending_frame.is_none() {
+                        self.send_in_flight = true;
+                    }
                     break;
                 }
             }
         }
 
-        // ── Drain incoming messages ──
+        // ── Drain incoming messages through the shared protocol core ──
         loop {
-            // Poll transport.recv() and capture the result before using self again.
-            let recv_result = self.transport.poll_recv(&mut cx);
-
-            match recv_result {
-                std::task::Poll::Ready(Some(Ok(TransportFrame::Text(text)))) => {
-                    match serde_json::from_str::<ServerMessage>(&text) {
-                        Ok(server_msg) => {
-                            let duplicate_protocol_info =
-                                matches!(server_msg, ServerMessage::ProtocolInfo(_))
-                                    && self.state.protocol_info_seen;
-                            if let ServerMessage::ProtocolInfo(payload) = &server_msg {
-                                if !duplicate_protocol_info {
-                                    self.accountability =
-                                        crate::accountability::DeliveryAccountability::new(
-                                            payload
-                                                .protocol_version
-                                                .is_some_and(|version| version >= 3),
-                                        );
-                                }
-                            }
-                            let authoritative_baseline = matches!(
-                                server_msg,
-                                ServerMessage::RoomJoined(_)
-                                    | ServerMessage::SpectatorJoined(_)
-                                    | ServerMessage::Reconnected(_)
-                            );
-                            let validation = if duplicate_protocol_info {
-                                self.accountability
-                                    .observe_server_message(false)
-                                    .map(|()| crate::accountability::GameDataDisposition::Apply)
-                            } else {
-                                crate::accountability::validate_server_frame(
-                                    &mut self.accountability,
-                                    &server_msg,
-                                    self.game_data_encoding,
-                                    false,
-                                )
-                            };
-                            let (disposition, validation_failed) = match validation {
-                                Ok(disposition) => {
-                                    if authoritative_baseline {
-                                        self.state.quarantined = false;
-                                    }
-                                    (disposition, false)
-                                }
-                                Err(diagnostic) => {
-                                    events.push(SignalFishEvent::ProtocolViolation {
-                                        kind: crate::event::ProtocolViolationKind::from_diagnostic(
-                                            &diagnostic,
-                                        ),
-                                        diagnostic,
-                                    });
-                                    match self.protocol_violation_policy {
-                                        crate::client::ProtocolViolationPolicy::Quarantine => {
-                                            self.state.quarantined = true;
-                                        }
-                                        crate::client::ProtocolViolationPolicy::Disconnect => {
-                                            self.accountability.observe_terminal();
-                                            self.handle_disconnect(
-                                                &mut events,
-                                                Some("protocol accountability violation".into()),
-                                                &mut cx,
-                                            );
-                                            return events;
-                                        }
-                                        crate::client::ProtocolViolationPolicy::Observe => {}
-                                    }
-                                    let disposition = if self.protocol_violation_policy
-                                        == crate::client::ProtocolViolationPolicy::Observe
-                                    {
-                                        crate::accountability::GameDataDisposition::Apply
-                                    } else {
-                                        crate::accountability::GameDataDisposition::Stale
-                                    };
-                                    (disposition, true)
-                                }
-                            };
-                            if validation_failed
-                                && self.protocol_violation_policy
-                                    == crate::client::ProtocolViolationPolicy::Quarantine
-                            {
-                                continue;
-                            }
-                            if duplicate_protocol_info {
-                                continue;
-                            }
-                            let is_game_data = matches!(
-                                server_msg,
-                                ServerMessage::GameData { .. }
-                                    | ServerMessage::GameDataBinary { .. }
-                            );
-                            if is_game_data
-                                && (disposition
-                                    == crate::accountability::GameDataDisposition::Stale
-                                    || (self.state.quarantined
-                                        && self.protocol_violation_policy
-                                            == crate::client::ProtocolViolationPolicy::Quarantine))
-                            {
-                                continue;
-                            }
-                            self.update_state(&server_msg);
-                            events.push(SignalFishEvent::from(server_msg));
-                        }
-                        Err(e) => {
-                            // Never a silent drop: surface the frame as a
-                            // typed DecodeFailed event and count it. Log the
-                            // error and frame size only — not the raw content,
-                            // which is untrusted, unbounded, and may carry
-                            // application payloads (the DecodeFailed event
-                            // carries a bounded prefix for diagnostics).
-                            warn!(
-                                "failed to deserialize server message ({} bytes): {e}",
-                                text.len()
-                            );
-                            let mut disconnect_for_violation = false;
-                            if let Err(diagnostic) =
-                                self.accountability.observe_server_message(false)
-                            {
-                                events.push(SignalFishEvent::ProtocolViolation {
-                                    kind: crate::event::ProtocolViolationKind::from_diagnostic(
-                                        &diagnostic,
-                                    ),
-                                    diagnostic,
-                                });
-                                match self.protocol_violation_policy {
-                                    crate::client::ProtocolViolationPolicy::Quarantine => {
-                                        self.state.quarantined = true;
-                                    }
-                                    crate::client::ProtocolViolationPolicy::Disconnect => {
-                                        disconnect_for_violation = true;
-                                    }
-                                    crate::client::ProtocolViolationPolicy::Observe => {}
-                                }
-                            }
-                            self.state.messages_undecodable += 1;
-                            events.push(SignalFishEvent::decode_failed(&text, &e));
-                            if disconnect_for_violation {
-                                self.accountability.observe_terminal();
-                                self.handle_disconnect(
-                                    &mut events,
-                                    Some("protocol accountability violation".into()),
-                                    &mut cx,
-                                );
-                                return events;
-                            }
-                        }
-                    }
-                }
-                std::task::Poll::Ready(Some(Ok(TransportFrame::Binary(bytes)))) => {
-                    let mut observe_representation_violation = false;
-                    if let Err(diagnostic) = crate::accountability::validate_physical_binary_allowed(
-                        &mut self.accountability,
-                        self.game_data_encoding,
-                    ) {
-                        events.push(SignalFishEvent::ProtocolViolation {
-                            kind: crate::event::ProtocolViolationKind::from_diagnostic(&diagnostic),
-                            diagnostic,
-                        });
-                        match self.protocol_violation_policy {
-                            crate::client::ProtocolViolationPolicy::Quarantine => {
-                                self.state.quarantined = true;
-                                continue;
-                            }
-                            crate::client::ProtocolViolationPolicy::Disconnect => {
-                                self.accountability.observe_terminal();
-                                self.handle_disconnect(
-                                    &mut events,
-                                    Some("protocol accountability violation".into()),
-                                    &mut cx,
-                                );
-                                return events;
-                            }
-                            crate::client::ProtocolViolationPolicy::Observe => {
-                                observe_representation_violation = true;
-                            }
-                        }
-                    }
-                    let protocol_v3 = self.state.negotiated_protocol_version >= 3;
-                    match crate::client::decode_binary_server_message(&bytes, protocol_v3) {
-                        Ok(server_msg) => {
-                            let validation = if observe_representation_violation {
-                                crate::accountability::validate_server_message(
-                                    &mut self.accountability,
-                                    &server_msg,
-                                )
-                            } else {
-                                crate::accountability::validate_server_frame(
-                                    &mut self.accountability,
-                                    &server_msg,
-                                    self.game_data_encoding,
-                                    true,
-                                )
-                            };
-                            let disposition = match validation {
-                                Ok(disposition) => disposition,
-                                Err(diagnostic) => {
-                                    events.push(SignalFishEvent::ProtocolViolation {
-                                        kind: crate::event::ProtocolViolationKind::from_diagnostic(
-                                            &diagnostic,
-                                        ),
-                                        diagnostic,
-                                    });
-                                    match self.protocol_violation_policy {
-                                        crate::client::ProtocolViolationPolicy::Quarantine => {
-                                            self.state.quarantined = true;
-                                        }
-                                        crate::client::ProtocolViolationPolicy::Disconnect => {
-                                            self.accountability.observe_terminal();
-                                            self.handle_disconnect(
-                                                &mut events,
-                                                Some("protocol accountability violation".into()),
-                                                &mut cx,
-                                            );
-                                            return events;
-                                        }
-                                        crate::client::ProtocolViolationPolicy::Observe => {}
-                                    }
-                                    if self.protocol_violation_policy
-                                        == crate::client::ProtocolViolationPolicy::Observe
-                                    {
-                                        crate::accountability::GameDataDisposition::Apply
-                                    } else {
-                                        crate::accountability::GameDataDisposition::Stale
-                                    }
-                                }
-                            };
-                            if disposition == crate::accountability::GameDataDisposition::Stale
-                                || (self.state.quarantined
-                                    && self.protocol_violation_policy
-                                        == crate::client::ProtocolViolationPolicy::Quarantine)
-                            {
-                                continue;
-                            }
-                            self.update_state(&server_msg);
-                            events.push(SignalFishEvent::from(server_msg));
-                        }
-                        Err(error) => {
-                            let mut disconnect_for_violation = false;
-                            if let Err(diagnostic) =
-                                self.accountability.observe_server_message(false)
-                            {
-                                events.push(SignalFishEvent::ProtocolViolation {
-                                    kind: crate::event::ProtocolViolationKind::from_diagnostic(
-                                        &diagnostic,
-                                    ),
-                                    diagnostic,
-                                });
-                                match self.protocol_violation_policy {
-                                    crate::client::ProtocolViolationPolicy::Quarantine => {
-                                        self.state.quarantined = true;
-                                    }
-                                    crate::client::ProtocolViolationPolicy::Disconnect => {
-                                        disconnect_for_violation = true;
-                                    }
-                                    crate::client::ProtocolViolationPolicy::Observe => {}
-                                }
-                            }
-                            self.state.messages_undecodable += 1;
-                            events.push(SignalFishEvent::DecodeFailed {
-                                message_type: Some("BinaryGameData".into()),
-                                error,
-                                raw_prefix: crate::client::bounded_binary_preview(&bytes),
-                            });
-                            if disconnect_for_violation {
-                                self.accountability.observe_terminal();
-                                self.handle_disconnect(
-                                    &mut events,
-                                    Some("protocol accountability violation".into()),
-                                    &mut cx,
-                                );
-                                return events;
-                            }
-                        }
+            match self.transport.poll_recv(&mut cx) {
+                std::task::Poll::Ready(Some(Ok(frame))) => {
+                    let outcome = self.core.process_frame(frame);
+                    events.extend(outcome.events);
+                    if outcome.disconnect {
+                        self.handle_disconnect(
+                            &mut events,
+                            Some("protocol accountability violation".into()),
+                            &mut cx,
+                        );
+                        return events;
                     }
                 }
                 std::task::Poll::Ready(Some(Err(e))) => {
@@ -599,7 +262,6 @@ impl<T: Transport> SignalFishPollingClient<T> {
                 }
                 std::task::Poll::Ready(None) => {
                     debug!("transport closed by server");
-                    self.accountability.observe_terminal();
                     let reason = self.transport.close_info().map(|info| {
                         format!(
                             "closed by server: code={:?}, reason={:?}",
@@ -640,14 +302,7 @@ impl<T: Transport> SignalFishPollingClient<T> {
     /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
     /// is full (the message is **not** queued; nothing is silently dropped).
     pub fn join_room(&mut self, params: JoinRoomParams) -> Result<()> {
-        self.queue_cmd(ClientMessage::JoinRoom {
-            game_name: params.game_name,
-            room_code: params.room_code,
-            player_name: params.player_name,
-            max_players: params.max_players,
-            supports_authority: params.supports_authority,
-            relay_transport: params.relay_transport,
-        })
+        self.queue_operation(ClientOperation::JoinRoom(params))
     }
 
     /// Leave the current room.
@@ -658,7 +313,7 @@ impl<T: Transport> SignalFishPollingClient<T> {
     /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
     /// is full (the message is **not** queued; nothing is silently dropped).
     pub fn leave_room(&mut self) -> Result<()> {
-        self.queue_cmd(ClientMessage::LeaveRoom)
+        self.queue_operation(ClientOperation::LeaveRoom)
     }
 
     /// Send game data to other players in the room.
@@ -669,11 +324,7 @@ impl<T: Transport> SignalFishPollingClient<T> {
     /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
     /// is full (the message is **not** queued; nothing is silently dropped).
     pub fn send_game_data(&mut self, data: serde_json::Value) -> Result<()> {
-        self.queue_cmd(ClientMessage::GameData {
-            data,
-            class: None,
-            key: None,
-        })
+        self.queue_operation(ClientOperation::GameData(data, GameDataDelivery::Reliable))
     }
 
     /// Send JSON game data with an explicit protocol-v3 delivery policy.
@@ -682,32 +333,12 @@ impl<T: Transport> SignalFishPollingClient<T> {
         data: serde_json::Value,
         delivery: GameDataDelivery,
     ) -> Result<()> {
-        match delivery {
-            GameDataDelivery::Reliable => self.send_game_data(data),
-            GameDataDelivery::Latest { key } => {
-                self.ensure_v3()?;
-                self.queue_cmd(ClientMessage::GameData {
-                    data,
-                    class: Some(DeliveryClass::Latest),
-                    key: Some(key),
-                })
-            }
-            GameDataDelivery::Volatile => {
-                self.ensure_v3()?;
-                self.queue_cmd(ClientMessage::GameData {
-                    data,
-                    class: Some(DeliveryClass::Volatile),
-                    key: None,
-                })
-            }
-        }
+        self.queue_operation(ClientOperation::GameData(data, delivery))
     }
 
     /// Queue opaque binary game data for the negotiated protocol-v3 relay.
     pub fn send_binary_game_data(&mut self, payload: Vec<u8>) -> Result<()> {
-        self.ensure_v3()?;
-        self.ensure_binary_format()?;
-        self.queue_command(PollingCommand::Binary(payload))
+        self.queue_operation(ClientOperation::Binary(payload))
     }
 
     /// Signal readiness to start the game.
@@ -718,7 +349,7 @@ impl<T: Transport> SignalFishPollingClient<T> {
     /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
     /// is full (the message is **not** queued; nothing is silently dropped).
     pub fn set_ready(&mut self) -> Result<()> {
-        self.queue_cmd(ClientMessage::PlayerReady)
+        self.queue_operation(ClientOperation::SetReady)
     }
 
     /// Request or relinquish authority status.
@@ -729,7 +360,7 @@ impl<T: Transport> SignalFishPollingClient<T> {
     /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
     /// is full (the message is **not** queued; nothing is silently dropped).
     pub fn request_authority(&mut self, become_authority: bool) -> Result<()> {
-        self.queue_cmd(ClientMessage::AuthorityRequest { become_authority })
+        self.queue_operation(ClientOperation::RequestAuthority(become_authority))
     }
 
     /// Provide connection info for P2P establishment.
@@ -740,7 +371,7 @@ impl<T: Transport> SignalFishPollingClient<T> {
     /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
     /// is full (the message is **not** queued; nothing is silently dropped).
     pub fn provide_connection_info(&mut self, connection_info: ConnectionInfo) -> Result<()> {
-        self.queue_cmd(ClientMessage::ProvideConnectionInfo { connection_info })
+        self.queue_operation(ClientOperation::ProvideConnectionInfo(connection_info))
     }
 
     /// Reconnect to a room after disconnection.
@@ -756,11 +387,7 @@ impl<T: Transport> SignalFishPollingClient<T> {
         room_id: RoomId,
         auth_token: String,
     ) -> Result<()> {
-        self.queue_cmd(ClientMessage::Reconnect {
-            player_id,
-            room_id,
-            auth_token,
-        })
+        self.queue_operation(ClientOperation::Reconnect(player_id, room_id, auth_token))
     }
 
     /// Join a room as a spectator (read-only observer).
@@ -776,11 +403,11 @@ impl<T: Transport> SignalFishPollingClient<T> {
         room_code: String,
         spectator_name: String,
     ) -> Result<()> {
-        self.queue_cmd(ClientMessage::JoinAsSpectator {
+        self.queue_operation(ClientOperation::JoinAsSpectator(
             game_name,
             room_code,
             spectator_name,
-        })
+        ))
     }
 
     /// Leave spectator mode.
@@ -791,7 +418,7 @@ impl<T: Transport> SignalFishPollingClient<T> {
     /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
     /// is full (the message is **not** queued; nothing is silently dropped).
     pub fn leave_spectator(&mut self) -> Result<()> {
-        self.queue_cmd(ClientMessage::LeaveSpectator)
+        self.queue_operation(ClientOperation::LeaveSpectator)
     }
 
     /// Send a heartbeat ping.
@@ -802,7 +429,7 @@ impl<T: Transport> SignalFishPollingClient<T> {
     /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
     /// is full (the message is **not** queued; nothing is silently dropped).
     pub fn ping(&mut self) -> Result<()> {
-        self.queue_cmd(ClientMessage::Ping)
+        self.queue_operation(ClientOperation::Ping)
     }
 
     // ── Game start (protocol v2) ────────────────────────────────────
@@ -819,7 +446,7 @@ impl<T: Transport> SignalFishPollingClient<T> {
     /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
     /// is full (the message is **not** queued; nothing is silently dropped).
     pub fn start_game(&mut self) -> Result<()> {
-        self.queue_cmd(ClientMessage::StartGame)
+        self.queue_operation(ClientOperation::StartGame)
     }
 
     // ── Mesh signaling (protocol v3) ────────────────────────────────
@@ -837,11 +464,7 @@ impl<T: Transport> SignalFishPollingClient<T> {
     /// transport has closed, or [`SignalFishError::SendBufferFull`] if the
     /// outgoing command queue is full.
     pub fn send_signal(&mut self, to: PlayerId, signal: impl Into<PeerSignal>) -> Result<()> {
-        self.ensure_v3()?;
-        self.queue_cmd(ClientMessage::Signal {
-            to,
-            signal: signal.into().into(),
-        })
+        self.queue_operation(ClientOperation::Signal(to, signal.into()))
     }
 
     /// Send an SDP offer to a peer. **Protocol v3 only.**
@@ -880,8 +503,7 @@ impl<T: Transport> SignalFishPollingClient<T> {
     ///
     /// See [`send_signal`](Self::send_signal).
     pub fn send_raw_signal(&mut self, to: PlayerId, signal: serde_json::Value) -> Result<()> {
-        self.ensure_v3()?;
-        self.queue_cmd(ClientMessage::Signal { to, signal })
+        self.queue_operation(ClientOperation::RawSignal(to, signal))
     }
 
     /// Report whether a data-path transport is established. **Protocol v3 only.**
@@ -899,11 +521,7 @@ impl<T: Transport> SignalFishPollingClient<T> {
         transport: TransportKind,
         connected: bool,
     ) -> Result<()> {
-        self.ensure_v3()?;
-        self.queue_cmd(ClientMessage::TransportStatus {
-            transport,
-            connected,
-        })
+        self.queue_operation(ClientOperation::TransportStatus(transport, connected))
     }
 
     // ── State accessors ─────────────────────────────────────────────
@@ -911,21 +529,19 @@ impl<T: Transport> SignalFishPollingClient<T> {
     /// The protocol version negotiated with the server, or `None` if not yet
     /// negotiated or negotiated as v2 (the relay floor).
     pub fn negotiated_protocol_version(&self) -> Option<u16> {
-        match self.state.negotiated_protocol_version {
-            0 => None,
-            v => Some(v),
-        }
+        self.core.negotiated_protocol_version()
     }
 
-    /// Returns `true` once the connection has negotiated protocol v3 — i.e. mesh
-    /// signaling is available. The "am I in mesh mode?" check.
+    /// Returns `true` once the connection has negotiated protocol v3 and this
+    /// client advertised WebRTC support through [`SignalFishConfig::enable_mesh`].
+    /// This is the "am I in mesh mode?" check.
     pub fn supports_mesh(&self) -> bool {
-        self.negotiated_protocol_version().is_some_and(|v| v >= 3)
+        self.core.supports_mesh()
     }
 
     /// Whether the transport connection is still alive.
     pub fn is_connected(&self) -> bool {
-        self.state.connected
+        self.core.is_connected()
     }
 
     /// Whether a transport close handshake still needs to be driven by
@@ -936,22 +552,22 @@ impl<T: Transport> SignalFishPollingClient<T> {
 
     /// Whether the client has received an `Authenticated` response.
     pub fn is_authenticated(&self) -> bool {
-        self.state.authenticated
+        self.core.is_authenticated()
     }
 
     /// The local player's ID, set after joining a room.
     pub fn current_player_id(&self) -> Option<PlayerId> {
-        self.state.player_id
+        self.core.current_player_id()
     }
 
     /// The current room ID, set after joining a room.
     pub fn current_room_id(&self) -> Option<RoomId> {
-        self.state.room_id
+        self.core.current_room_id()
     }
 
     /// The current room code, set after joining a room.
     pub fn current_room_code(&self) -> Option<&str> {
-        self.state.room_code.as_deref()
+        self.core.current_room_code()
     }
 
     /// Number of messages that can currently be queued before send methods
@@ -960,8 +576,7 @@ impl<T: Transport> SignalFishPollingClient<T> {
     /// The queue drains on every [`poll()`](Self::poll) while the transport
     /// accepts writes, so a shrinking value means the transport is congested.
     pub fn send_capacity(&self) -> usize {
-        self.command_capacity
-            .saturating_sub(self.cmd_queue.len() + usize::from(self.pending_frame.is_some()))
+        self.command_capacity.saturating_sub(self.cmd_queue.len())
     }
 
     /// Configured capacity of the outgoing command queue
@@ -973,25 +588,12 @@ impl<T: Transport> SignalFishPollingClient<T> {
     /// Cumulative game-data traffic counters
     /// (see [`ClientStats`](crate::client::ClientStats)).
     pub fn stats(&self) -> crate::client::ClientStats {
-        crate::client::ClientStats {
-            game_data_sent: self.state.game_data_sent,
-            game_data_received: self.state.game_data_received,
-            messages_undecodable: self.state.messages_undecodable,
-        }
+        self.core.stats()
     }
 
     /// Return a coherent synchronous snapshot of connection and room state.
     pub fn snapshot(&self) -> ClientSnapshot {
-        ClientSnapshot {
-            connected: self.state.connected,
-            authenticated: self.state.authenticated,
-            negotiated_protocol_version: self.negotiated_protocol_version(),
-            player_id: self.state.player_id,
-            room_id: self.state.room_id,
-            room_code: self.state.room_code.clone(),
-            reconnection_token: self.state.reconnection_token.clone(),
-            quarantined: self.state.quarantined,
-        }
+        self.core.snapshot()
     }
 
     // ── Close ───────────────────────────────────────────────────────
@@ -1002,10 +604,9 @@ impl<T: Transport> SignalFishPollingClient<T> {
     /// `Pending`, subsequent [`poll()`](Self::poll) calls continue driving it;
     /// [`is_closing()`](Self::is_closing) becomes `false` when it completes.
     pub fn close(&mut self) {
-        if !self.state.connected && !self.closing {
+        if !self.core.is_connected() && !self.closing {
             return;
         }
-        self.state.connected = false;
         self.closing = true;
 
         // Poll transport.close() in a separate scope to avoid borrow conflicts.
@@ -1018,53 +619,25 @@ impl<T: Transport> SignalFishPollingClient<T> {
             self.closing = false;
         }
 
-        self.state.clear_session();
+        let _ = self.core.disconnect(Some("client closed".into()));
     }
 
     // ── Private helpers ─────────────────────────────────────────────
 
-    /// Guard for protocol-v3-only operations: returns an error unless the
-    /// connection negotiated v3, so signaling never goes out on a relay-floor
-    /// connection the server would reject.
-    fn ensure_v3(&self) -> Result<()> {
-        // Mesh signaling was introduced in protocol v3; any negotiated version
-        // >= 3 supports it.
-        if self.state.negotiated_protocol_version >= 3 {
-            return Ok(());
-        }
-        // A `ProtocolInfo` that resolved below v3 is a terminal relay floor;
-        // its absence means negotiation is still in flight. Keying off the
-        // observed `ProtocolInfo` (not authentication) keeps this diagnostic
-        // correct regardless of handshake message ordering.
-        let mode = if self.state.protocol_info_seen {
-            "relay-only"
-        } else {
-            "pre-negotiation"
-        };
-        Err(SignalFishError::ProtocolUnsupported { mode })
-    }
-
-    fn ensure_binary_format(&self) -> Result<()> {
-        if self.game_data_encoding == GameDataEncoding::Json {
-            return Err(SignalFishError::BinaryFormatNotNegotiated);
-        }
-        Ok(())
-    }
-
-    fn queue_cmd(&mut self, msg: ClientMessage) -> Result<()> {
-        self.queue_command(PollingCommand::Message(msg))
+    fn queue_operation(&mut self, operation: ClientOperation) -> Result<()> {
+        let command = self.core.prepare(operation)?;
+        self.queue_command(command)
     }
 
     fn queue_command(&mut self, command: PollingCommand) -> Result<()> {
-        if !self.state.connected {
+        if !self.core.is_connected() {
             return Err(SignalFishError::NotConnected);
         }
         // The queue only backs up while the transport reports Pending across
         // polls; refusing (rather than growing without bound) surfaces the
         // congestion to the caller, mirroring the async client's bounded
         // command channel.
-        if self.cmd_queue.len() + usize::from(self.pending_frame.is_some()) >= self.command_capacity
-        {
+        if self.cmd_queue.len() >= self.command_capacity {
             return Err(SignalFishError::SendBufferFull {
                 capacity: self.command_capacity,
             });
@@ -1083,96 +656,7 @@ impl<T: Transport> SignalFishPollingClient<T> {
         if matches!(self.transport.poll_close(cx), std::task::Poll::Ready(_)) {
             self.closing = false;
         }
-        self.state.connected = false;
-        self.state.clear_session();
-        events.push(SignalFishEvent::Disconnected {
-            reason,
-            last_server_error: self.state.last_server_error.take(),
-        });
-    }
-
-    fn update_state(&mut self, msg: &ServerMessage) {
-        match msg {
-            ServerMessage::Authenticated { .. } => {
-                self.state.authenticated = true;
-            }
-            // Remember server errors for disconnect attribution.
-            ServerMessage::Error {
-                message,
-                error_code,
-            } => {
-                if error_code.as_ref() == Some(&crate::ErrorCode::UnsupportedGameDataFormat) {
-                    self.game_data_encoding = GameDataEncoding::Json;
-                }
-                self.state.last_server_error = Some(ServerErrorInfo {
-                    message: message.clone(),
-                    error_code: error_code.clone(),
-                });
-            }
-            ServerMessage::AuthenticationError { error, error_code } => {
-                self.state.last_server_error = Some(ServerErrorInfo {
-                    message: error.clone(),
-                    error_code: Some(error_code.clone()),
-                });
-            }
-            ServerMessage::ProtocolInfo(payload) => {
-                self.state.negotiated_protocol_version = payload.protocol_version.unwrap_or(0);
-                // Mark negotiation as observed even for a v2 floor (version 0):
-                // this separates "relay-only" from "pre-negotiation" in the guard.
-                self.state.protocol_info_seen = true;
-            }
-            ServerMessage::RoomJoined(payload) => {
-                self.state.player_id = Some(payload.player_id);
-                self.state.room_id = Some(payload.room_id);
-                self.state.room_code = Some(payload.room_code.clone());
-                self.state.reconnection_token = payload.reconnection_token.clone();
-                self.state.quarantined = false;
-            }
-            ServerMessage::RoomLeft => {
-                self.state.room_id = None;
-                self.state.room_code = None;
-                self.state.reconnection_token = None;
-                self.state.quarantined = false;
-            }
-            ServerMessage::Reconnected(payload) => {
-                self.state.player_id = Some(payload.player_id);
-                self.state.room_id = Some(payload.room_id);
-                self.state.room_code = Some(payload.room_code.clone());
-                self.state.reconnection_token = payload.reconnection_token.clone();
-                self.state.quarantined = false;
-                // Restore the negotiated version if it was replayed via
-                // missed_events, so v3 sends aren't wrongly blocked after a
-                // reconnect. Only a versioned (v3+) ProtocolInfo restores — a
-                // replayed v2 one must not silently downgrade an active session.
-                if let Some(version) =
-                    crate::protocol::replayed_negotiated_version(&payload.missed_events)
-                {
-                    self.state.negotiated_protocol_version = version;
-                    // A replayed `ProtocolInfo` *was* observed; keep the flag
-                    // consistent with its name (moot while the guard
-                    // short-circuits on version >= 3, but preserves the
-                    // "seen implies a ProtocolInfo arrived" invariant).
-                    self.state.protocol_info_seen = true;
-                }
-            }
-            ServerMessage::SpectatorJoined(payload) => {
-                self.state.player_id = Some(payload.spectator_id);
-                self.state.room_id = Some(payload.room_id);
-                self.state.room_code = Some(payload.room_code.clone());
-                self.state.reconnection_token = None;
-                self.state.quarantined = false;
-            }
-            ServerMessage::SpectatorLeft { .. } => {
-                self.state.room_id = None;
-                self.state.room_code = None;
-                self.state.reconnection_token = None;
-                self.state.quarantined = false;
-            }
-            ServerMessage::GameData { .. } | ServerMessage::GameDataBinary { .. } => {
-                self.state.game_data_received += 1;
-            }
-            _ => {}
-        }
+        events.push(self.core.disconnect(reason));
     }
 }
 
@@ -1181,11 +665,111 @@ impl<T: Transport> SignalFishPollingClient<T> {
 impl<T: Transport> std::fmt::Debug for SignalFishPollingClient<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SignalFishPollingClient")
-            .field("connected", &self.state.connected)
-            .field("authenticated", &self.state.authenticated)
+            .field("connected", &self.core.is_connected())
+            .field("authenticated", &self.core.is_authenticated())
             .field("started", &self.started)
             .field("queued_commands", &self.cmd_queue.len())
             .finish()
+    }
+}
+
+impl<T: Transport> crate::client_api::SignalFishClientApi for SignalFishPollingClient<T> {
+    fn join_room(&mut self, params: JoinRoomParams) -> Result<()> {
+        SignalFishPollingClient::join_room(self, params)
+    }
+
+    fn leave_room(&mut self) -> Result<()> {
+        SignalFishPollingClient::leave_room(self)
+    }
+
+    fn send_game_data(&mut self, data: serde_json::Value) -> Result<()> {
+        SignalFishPollingClient::send_game_data(self, data)
+    }
+
+    fn send_game_data_with_delivery(
+        &mut self,
+        data: serde_json::Value,
+        delivery: GameDataDelivery,
+    ) -> Result<()> {
+        SignalFishPollingClient::send_game_data_with_delivery(self, data, delivery)
+    }
+
+    fn send_binary_game_data(&mut self, payload: Vec<u8>) -> Result<()> {
+        SignalFishPollingClient::send_binary_game_data(self, payload)
+    }
+
+    fn set_ready(&mut self) -> Result<()> {
+        SignalFishPollingClient::set_ready(self)
+    }
+
+    fn start_game(&mut self) -> Result<()> {
+        SignalFishPollingClient::start_game(self)
+    }
+
+    fn request_authority(&mut self, become_authority: bool) -> Result<()> {
+        SignalFishPollingClient::request_authority(self, become_authority)
+    }
+
+    fn provide_connection_info(&mut self, connection_info: ConnectionInfo) -> Result<()> {
+        SignalFishPollingClient::provide_connection_info(self, connection_info)
+    }
+
+    fn reconnect(
+        &mut self,
+        player_id: PlayerId,
+        room_id: RoomId,
+        auth_token: String,
+    ) -> Result<()> {
+        SignalFishPollingClient::reconnect(self, player_id, room_id, auth_token)
+    }
+
+    fn join_as_spectator(
+        &mut self,
+        game_name: String,
+        room_code: String,
+        spectator_name: String,
+    ) -> Result<()> {
+        SignalFishPollingClient::join_as_spectator(self, game_name, room_code, spectator_name)
+    }
+
+    fn leave_spectator(&mut self) -> Result<()> {
+        SignalFishPollingClient::leave_spectator(self)
+    }
+
+    fn ping(&mut self) -> Result<()> {
+        SignalFishPollingClient::ping(self)
+    }
+
+    fn send_signal(&mut self, to: PlayerId, signal: PeerSignal) -> Result<()> {
+        SignalFishPollingClient::send_signal(self, to, signal)
+    }
+
+    fn send_raw_signal(&mut self, to: PlayerId, signal: serde_json::Value) -> Result<()> {
+        SignalFishPollingClient::send_raw_signal(self, to, signal)
+    }
+
+    fn report_transport_status(&mut self, transport: TransportKind, connected: bool) -> Result<()> {
+        SignalFishPollingClient::report_transport_status(self, transport, connected)
+    }
+
+    fn send_capacity(&self) -> usize {
+        SignalFishPollingClient::send_capacity(self)
+    }
+
+    fn max_send_capacity(&self) -> usize {
+        SignalFishPollingClient::max_send_capacity(self)
+    }
+
+    fn stats(&self) -> crate::client::ClientStats {
+        SignalFishPollingClient::stats(self)
+    }
+
+    fn snapshot(&self) -> ClientSnapshot {
+        SignalFishPollingClient::snapshot(self)
+    }
+
+    fn supports_mesh(&self) -> bool {
+        SignalFishPollingClient::supports_mesh(self)
     }
 }
 
@@ -1204,6 +788,7 @@ mod tests {
     use std::collections::VecDeque;
 
     use super::*;
+    use crate::protocol::ServerMessage;
     use crate::transport::TransportFrame;
 
     // ── Mock transport ──────────────────────────────────────────────
@@ -1507,7 +1092,11 @@ mod tests {
     fn binary_send_requires_a_negotiated_binary_format() {
         let transport = MockTransport::new();
         let mut client = SignalFishPollingClient::new(transport, default_config().enable_v3());
-        client.state.negotiated_protocol_version = 3;
+        let protocol_info = serde_json::to_string(&ServerMessage::ProtocolInfo(protocol_info_v3()))
+            .expect("serialize protocol negotiation fixture");
+        let _ = client
+            .core
+            .process_frame(TransportFrame::Text(protocol_info));
         assert!(matches!(
             client.send_binary_game_data(vec![1, 2, 3]),
             Err(SignalFishError::BinaryFormatNotNegotiated)
@@ -1517,7 +1106,11 @@ mod tests {
         let mut config = default_config().enable_v3();
         config.game_data_format = Some(GameDataEncoding::MessagePack);
         let mut client = SignalFishPollingClient::new(transport, config);
-        client.state.negotiated_protocol_version = 3;
+        let protocol_info = serde_json::to_string(&ServerMessage::ProtocolInfo(protocol_info_v3()))
+            .expect("serialize protocol negotiation fixture");
+        let _ = client
+            .core
+            .process_frame(TransportFrame::Text(protocol_info));
         client
             .send_binary_game_data(vec![1, 2, 3])
             .expect("MessagePack negotiation permits binary sends");
@@ -1825,7 +1418,7 @@ mod tests {
     fn send_signal_before_v3_returns_protocol_unsupported() {
         let transport = MockTransport::new()
             .with_incoming(vec![Some(Ok(authenticated_json_str().to_string()))]);
-        let mut client = SignalFishPollingClient::new(transport, default_config());
+        let mut client = SignalFishPollingClient::new(transport, default_config().enable_mesh());
         client.poll();
         assert!(client.negotiated_protocol_version().is_none());
         assert!(!client.supports_mesh());
@@ -1866,15 +1459,14 @@ mod tests {
     }
 
     #[test]
-    fn disconnect_resets_protocol_info_seen_to_pre_negotiation() {
-        // Negotiate v3, then disconnect: the guard must fall all the way back to
-        // "pre-negotiation" (proving `protocol_info_seen` is cleared with the
-        // rest of the session state, not just the version).
+    fn disconnect_resets_negotiation_and_commands_return_not_connected() {
+        // A closed connection takes precedence over protocol guards while the
+        // cleared snapshot still proves negotiation state was reset.
         let transport = MockTransport::new().with_incoming(vec![
             Some(Ok(authenticated_json_str().to_string())),
             Some(Ok(PROTOCOL_INFO_V3.to_string())),
         ]);
-        let mut client = SignalFishPollingClient::new(transport, default_config());
+        let mut client = SignalFishPollingClient::new(transport, default_config().enable_mesh());
         client.poll();
         assert!(client.supports_mesh());
         client.close();
@@ -1882,9 +1474,7 @@ mod tests {
         let peer: PlayerId = PEER_UUID.parse().unwrap();
         assert!(matches!(
             client.send_offer(peer, "sdp"),
-            Err(SignalFishError::ProtocolUnsupported {
-                mode: "pre-negotiation"
-            })
+            Err(SignalFishError::NotConnected)
         ));
     }
 
@@ -1908,7 +1498,7 @@ mod tests {
             Some(Ok(authenticated_json_str().to_string())),
             Some(Ok(PROTOCOL_INFO_V3.to_string())),
         ]);
-        let mut client = SignalFishPollingClient::new(transport, default_config());
+        let mut client = SignalFishPollingClient::new(transport, default_config().enable_mesh());
         client.poll();
         assert_eq!(client.negotiated_protocol_version(), Some(3));
         assert!(client.supports_mesh());
@@ -1976,7 +1566,7 @@ mod tests {
             Some(Ok(authenticated_json_str().to_string())),
             Some(Ok(PROTOCOL_INFO_V3.to_string())),
         ]);
-        let mut client = SignalFishPollingClient::new(transport, default_config());
+        let mut client = SignalFishPollingClient::new(transport, default_config().enable_mesh());
         client.poll();
         assert!(client.supports_mesh());
         client.close();
@@ -2012,7 +1602,7 @@ mod tests {
             Some(Ok(authenticated_json_str().to_string())),
             Some(Ok(reconnected)),
         ]);
-        let mut client = SignalFishPollingClient::new(transport, default_config());
+        let mut client = SignalFishPollingClient::new(transport, default_config().enable_mesh());
         client.poll();
         assert_eq!(client.negotiated_protocol_version(), Some(3));
         assert!(client.supports_mesh());
@@ -2035,7 +1625,7 @@ mod tests {
             Some(Ok(authenticated_json_str().to_string())),
             Some(Ok(pi_v4.to_string())),
         ]);
-        let mut client = SignalFishPollingClient::new(transport, default_config());
+        let mut client = SignalFishPollingClient::new(transport, default_config().enable_mesh());
         client.poll();
         assert_eq!(client.negotiated_protocol_version(), Some(4));
         assert!(client.supports_mesh());
@@ -2623,6 +2213,47 @@ mod tests {
     impl PendingOnSendTransport {
         fn new() -> Self {
             Self
+        }
+    }
+
+    /// Accepts a frame before returning `Pending`, then completes it on the
+    /// next poll. A replacement frame during completion violates `Transport`.
+    struct AcceptedPendingSendTransport {
+        retained: Option<TransportFrame>,
+        sent: Vec<TransportFrame>,
+        replacement_seen: bool,
+    }
+
+    impl Transport for AcceptedPendingSendTransport {
+        fn poll_send(
+            &mut self,
+            _cx: &mut std::task::Context<'_>,
+            frame: &mut Option<TransportFrame>,
+        ) -> std::task::Poll<std::result::Result<(), SignalFishError>> {
+            if let Some(retained) = self.retained.take() {
+                self.replacement_seen |= frame.is_some();
+                self.sent.push(retained);
+                return std::task::Poll::Ready(Ok(()));
+            }
+            if let Some(accepted) = frame.take() {
+                self.retained = Some(accepted);
+                return std::task::Poll::Pending;
+            }
+            std::task::Poll::Ready(Ok(()))
+        }
+
+        fn poll_recv(
+            &mut self,
+            _cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<Option<std::result::Result<TransportFrame, SignalFishError>>> {
+            std::task::Poll::Pending
+        }
+
+        fn poll_close(
+            &mut self,
+            _cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<std::result::Result<(), SignalFishError>> {
+            std::task::Poll::Ready(Ok(()))
         }
     }
 
@@ -3605,17 +3236,21 @@ mod tests {
             "expected SendBufferFull, got {err:?}"
         );
 
-        // A stalled transport keeps the queue full across polls — nothing is
-        // lost and nothing grows without bound.
+        // Once Authenticate leaves the queue for the transport, that queue
+        // slot is free, matching the async mpsc driver's capacity semantics.
         let _ = client.poll();
-        assert_eq!(client.send_capacity(), 0);
+        assert_eq!(client.send_capacity(), 1);
         assert!(client.is_connected());
+        client
+            .send_game_data(serde_json::json!({ "seq": 2 }))
+            .expect("one queue slot should be free behind the pending send");
+        assert_eq!(client.send_capacity(), 0);
 
         // Once the transport accepts writes again, one poll drains everything.
         allow.store(true, std::sync::atomic::Ordering::Release);
         let _ = client.poll();
         assert_eq!(client.send_capacity(), 3);
-        assert_eq!(client.transport.sent.len(), 3);
+        assert_eq!(client.transport.sent.len(), 4);
         client
             .send_game_data(serde_json::json!({ "seq": 3 }))
             .unwrap();
@@ -3642,6 +3277,41 @@ mod tests {
             client.pending_frame.is_some(),
             "expected pending frame to remain retained"
         );
+    }
+
+    #[test]
+    fn accepted_pending_send_completes_before_dequeuing_replacement() {
+        let transport = AcceptedPendingSendTransport {
+            retained: None,
+            sent: Vec::new(),
+            replacement_seen: false,
+        };
+        let mut client = SignalFishPollingClient::new(
+            transport,
+            default_config().with_command_channel_capacity(2),
+        );
+
+        let _ = client.poll();
+        assert!(client.send_in_flight, "Authenticate should be in flight");
+        client
+            .send_game_data(serde_json::json!({"frame": 1}))
+            .expect("one queued command should fit behind the in-flight send");
+
+        let _ = client.poll();
+        assert!(client.send_in_flight, "game data should now be in flight");
+        let _ = client.poll();
+
+        assert!(!client.transport.replacement_seen);
+        assert_eq!(client.transport.sent.len(), 2);
+        assert!(matches!(
+            client.transport.sent.first(),
+            Some(TransportFrame::Text(text)) if text.contains("Authenticate")
+        ));
+        assert!(matches!(
+            client.transport.sent.get(1),
+            Some(TransportFrame::Text(text)) if text.contains("GameData")
+        ));
+        assert_eq!(client.stats().game_data_sent, 1);
     }
 
     // ── E. Integration Scenarios ───────────────────────────────────

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -872,8 +872,8 @@ where
 ///
 /// Gated to its consumers (the async client needs `tokio-runtime`; the polling
 /// client needs `polling-client`) so it is not dead code in a build with neither.
-#[cfg(any(feature = "tokio-runtime", feature = "polling-client"))]
 #[must_use]
+#[cfg(any(feature = "tokio-runtime", feature = "polling-client"))]
 pub(crate) fn replayed_negotiated_version(missed_events: &[ServerMessage]) -> Option<u16> {
     missed_events.iter().rev().find_map(|msg| match msg {
         ServerMessage::ProtocolInfo(info) => info.protocol_version,

--- a/src/webrtc.rs
+++ b/src/webrtc.rs
@@ -596,7 +596,10 @@ mod controller {
         /// # Errors
         ///
         /// See [`SignalFishClient::join_room`].
-        pub fn join_room(&self, params: crate::client::JoinRoomParams) -> crate::error::Result<()> {
+        pub fn join_room(
+            &mut self,
+            params: crate::client::JoinRoomParams,
+        ) -> crate::error::Result<()> {
             self.client.join_room(params)
         }
 
@@ -605,7 +608,7 @@ mod controller {
         /// # Errors
         ///
         /// See [`SignalFishClient::set_ready`].
-        pub fn set_ready(&self) -> crate::error::Result<()> {
+        pub fn set_ready(&mut self) -> crate::error::Result<()> {
             self.client.set_ready()
         }
 
@@ -614,7 +617,7 @@ mod controller {
         /// # Errors
         ///
         /// See [`SignalFishClient::start_game`].
-        pub fn start_game(&self) -> crate::error::Result<()> {
+        pub fn start_game(&mut self) -> crate::error::Result<()> {
             self.client.start_game()
         }
 
@@ -623,7 +626,7 @@ mod controller {
         /// # Errors
         ///
         /// See [`SignalFishClient::leave_room`].
-        pub fn leave_room(&self) -> crate::error::Result<()> {
+        pub fn leave_room(&mut self) -> crate::error::Result<()> {
             self.client.leave_room()
         }
 
@@ -631,6 +634,11 @@ mod controller {
         #[must_use]
         pub fn client(&self) -> &SignalFishClient {
             &self.client
+        }
+
+        /// Mutably access the underlying client for synchronous commands.
+        pub fn client_mut(&mut self) -> &mut SignalFishClient {
+            &mut self.client
         }
 
         /// Gracefully shut down the controller and its client.
@@ -1179,7 +1187,7 @@ mod tests {
         // Saturate the capacity-1 command queue: the first filler is pulled
         // by the loop, which then parks inside the permit-less transport
         // send; the second filler occupies the queue's single slot.
-        mesh.client()
+        mesh.client_mut()
             .send_game_data(serde_json::json!({ "filler": 1 }))
             .unwrap();
         tokio::time::timeout(std::time::Duration::from_secs(5), async {
@@ -1189,7 +1197,7 @@ mod tests {
         })
         .await
         .expect("transport loop never parked in the gated send");
-        mesh.client()
+        mesh.client_mut()
             .send_game_data(serde_json::json!({ "filler": 2 }))
             .unwrap();
 
@@ -1271,7 +1279,7 @@ mod tests {
 
         // Saturate the capacity-1 command queue (loop parks in the gated
         // send; the second filler occupies the queue slot).
-        mesh.client()
+        mesh.client_mut()
             .send_game_data(serde_json::json!({ "filler": 1 }))
             .unwrap();
         tokio::time::timeout(std::time::Duration::from_secs(5), async {
@@ -1281,7 +1289,7 @@ mod tests {
         })
         .await
         .expect("transport loop never parked in the gated send");
-        mesh.client()
+        mesh.client_mut()
             .send_game_data(serde_json::json!({ "filler": 2 }))
             .unwrap();
 

--- a/tests/client_tests.rs
+++ b/tests/client_tests.rs
@@ -26,6 +26,13 @@ use signal_fish_client::{
     SignalFishEvent, Transport,
 };
 
+type StartedClient = (
+    SignalFishClient,
+    tokio::sync::mpsc::Receiver<SignalFishEvent>,
+    std::sync::Arc<std::sync::Mutex<Vec<String>>>,
+    std::sync::Arc<std::sync::atomic::AtomicBool>,
+);
+
 use common::{
     authenticated_json, authority_response_json, error_json, game_data_json, new_peer_json,
     peer_transport_status_json, player_left_json, pong_json, protocol_info_json, reconnected_json,
@@ -40,16 +47,15 @@ use common::{
 /// Start a client with the given scripted server responses. The first item
 /// is typically `authenticated_json()` so the auth handshake succeeds.
 #[allow(clippy::type_complexity)]
-fn start_client(
+fn start_client(incoming: Vec<Option<Result<String, SignalFishError>>>) -> StartedClient {
+    start_client_with_config(incoming, SignalFishConfig::new("mb_test_integration"))
+}
+
+fn start_client_with_config(
     incoming: Vec<Option<Result<String, SignalFishError>>>,
-) -> (
-    SignalFishClient,
-    tokio::sync::mpsc::Receiver<SignalFishEvent>,
-    std::sync::Arc<std::sync::Mutex<Vec<String>>>,
-    std::sync::Arc<std::sync::atomic::AtomicBool>,
-) {
+    config: SignalFishConfig,
+) -> StartedClient {
     let (transport, sent, closed) = MockTransport::new(incoming);
-    let config = SignalFishConfig::new("mb_test_integration");
     let (client, events) = SignalFishClient::start(transport, config);
     (client, events, sent, closed)
 }
@@ -2293,10 +2299,13 @@ async fn negotiated_version_resets_on_disconnect() {
 #[tokio::test]
 async fn reconnect_restores_negotiated_version_from_missed_events() {
     let peer = uuid::Uuid::from_u128(2);
-    let (mut client, mut events, sent, _closed) = start_client(vec![
-        Some(Ok(authenticated_json())),
-        Some(Ok(reconnected_with_protocol_info_json(Some(3)))),
-    ]);
+    let (mut client, mut events, sent, _closed) = start_client_with_config(
+        vec![
+            Some(Ok(authenticated_json())),
+            Some(Ok(reconnected_with_protocol_info_json(Some(3)))),
+        ],
+        SignalFishConfig::new("mb_test_integration").enable_mesh(),
+    );
     drain_until_authenticated(&mut events).await;
     // Drain until the Reconnected event (state updated by then).
     loop {
@@ -2323,10 +2332,13 @@ async fn reconnect_restores_negotiated_version_from_missed_events() {
 #[tokio::test]
 async fn v4_negotiation_still_enables_mesh() {
     // `>= 3` (not `== 3`) semantics: a future v4 negotiation must still enable mesh.
-    let (mut client, mut events, _sent, _closed) = start_client(vec![
-        Some(Ok(authenticated_json())),
-        Some(Ok(protocol_info_json(Some(4)))),
-    ]);
+    let (mut client, mut events, _sent, _closed) = start_client_with_config(
+        vec![
+            Some(Ok(authenticated_json())),
+            Some(Ok(protocol_info_json(Some(4)))),
+        ],
+        SignalFishConfig::new("mb_test_integration").enable_mesh(),
+    );
     drain_until_authenticated(&mut events).await;
     drain_until_protocol_info(&mut events).await;
     assert_eq!(client.negotiated_protocol_version(), Some(4));

--- a/tests/negotiation_robustness_tests.rs
+++ b/tests/negotiation_robustness_tests.rs
@@ -40,7 +40,7 @@ fn start_client(
     Arc<AtomicBool>,
 ) {
     let (transport, sent, closed) = common::MockTransport::new(incoming);
-    let config = SignalFishConfig::new("mb_audit");
+    let config = SignalFishConfig::new("mb_audit").enable_mesh();
     let (client, events) = SignalFishClient::start(transport, config);
     (client, events, sent, closed)
 }
@@ -290,7 +290,7 @@ async fn send_error_midflight_disconnects_and_clears_state() {
         vec![Some(Ok(authenticated_json())), Some(Ok(room_joined_json()))],
         2,
     );
-    let config = SignalFishConfig::new("mb_audit");
+    let config = SignalFishConfig::new("mb_audit").enable_mesh();
     let (mut client, mut events) = SignalFishClient::start(transport, config);
 
     drain_until_authenticated(&mut events).await;
@@ -343,7 +343,7 @@ async fn v3_send_after_disconnect_does_not_panic() {
         ],
         2,
     );
-    let config = SignalFishConfig::new("mb_audit");
+    let config = SignalFishConfig::new("mb_audit").enable_mesh();
     let (mut client, mut events) = SignalFishClient::start(transport, config);
 
     drain_until_authenticated(&mut events).await;

--- a/tests/polling_parity_tests.rs
+++ b/tests/polling_parity_tests.rs
@@ -23,10 +23,171 @@ use signal_fish_client::client::{SignalFishClient, SignalFishConfig};
 use signal_fish_client::error::SignalFishError;
 use signal_fish_client::polling_client::SignalFishPollingClient;
 use signal_fish_client::protocol::{
-    LobbyState, PlayerId, ProtocolInfoPayload, ReconnectedPayload, ServerMessage,
+    ConnectionInfo, GameDataEncoding, LobbyState, PlayerId, PlayerInfo, ProtocolInfoPayload,
+    ReconnectedPayload, RoomJoinedPayload, ServerMessage, TransportKind, V2BinaryGameDataFrame,
+    V3BinaryGameDataFrame,
 };
 use signal_fish_client::transport::TransportFrame;
-use signal_fish_client::{SignalFishEvent, Transport};
+use signal_fish_client::ProtocolViolationPolicy;
+use signal_fish_client::{
+    GameDataDelivery, JoinRoomParams, PeerSignal, SignalFishClientApi, SignalFishEvent, Transport,
+};
+
+fn assert_common_api_is_object_safe(_client: &mut dyn signal_fish_client::SignalFishClientApi) {}
+
+#[derive(Clone)]
+struct FrameMock {
+    incoming: Arc<Mutex<VecDeque<TransportFrame>>>,
+    sent: Arc<Mutex<Vec<TransportFrame>>>,
+}
+
+#[derive(Clone)]
+struct NeverSendMock {
+    attempted: Arc<std::sync::atomic::AtomicBool>,
+}
+
+impl NeverSendMock {
+    fn new() -> Self {
+        Self {
+            attempted: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        }
+    }
+}
+
+impl Transport for NeverSendMock {
+    fn poll_send(
+        &mut self,
+        _cx: &mut std::task::Context<'_>,
+        _frame: &mut Option<TransportFrame>,
+    ) -> std::task::Poll<Result<(), SignalFishError>> {
+        self.attempted
+            .store(true, std::sync::atomic::Ordering::Release);
+        std::task::Poll::Pending
+    }
+
+    fn poll_recv(
+        &mut self,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Result<TransportFrame, SignalFishError>>> {
+        std::task::Poll::Pending
+    }
+
+    fn poll_close(
+        &mut self,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), SignalFishError>> {
+        std::task::Poll::Ready(Ok(()))
+    }
+}
+
+impl FrameMock {
+    fn v3() -> Self {
+        Self {
+            incoming: Arc::new(Mutex::new(VecDeque::from([TransportFrame::Text(
+                PI_V3.into(),
+            )]))),
+            sent: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+}
+
+impl Transport for FrameMock {
+    fn poll_send(
+        &mut self,
+        _cx: &mut std::task::Context<'_>,
+        frame: &mut Option<TransportFrame>,
+    ) -> std::task::Poll<Result<(), SignalFishError>> {
+        if let Some(frame) = frame.take() {
+            self.sent.lock().unwrap().push(frame);
+        }
+        std::task::Poll::Ready(Ok(()))
+    }
+
+    fn poll_recv(
+        &mut self,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Result<TransportFrame, SignalFishError>>> {
+        match self.incoming.lock().unwrap().pop_front() {
+            Some(frame) => std::task::Poll::Ready(Some(Ok(frame))),
+            None => std::task::Poll::Pending,
+        }
+    }
+
+    fn poll_close(
+        &mut self,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), SignalFishError>> {
+        std::task::Poll::Ready(Ok(()))
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum CommonCommandCase {
+    JoinRoom,
+    LeaveRoom,
+    ReliableData,
+    LatestData,
+    VolatileData,
+    BinaryData,
+    SetReady,
+    StartGame,
+    RequestAuthority,
+    ProvideConnectionInfo,
+    Reconnect,
+    JoinSpectator,
+    LeaveSpectator,
+    Ping,
+    Signal,
+    Offer,
+    Answer,
+    IceCandidate,
+    RawSignal,
+    TransportStatus,
+}
+
+impl CommonCommandCase {
+    fn invoke(self, client: &mut dyn SignalFishClientApi) -> Result<(), SignalFishError> {
+        let peer = uuid::Uuid::from_u128(7);
+        match self {
+            Self::JoinRoom => client.join_room(
+                JoinRoomParams::new("game", "Alice")
+                    .with_room_code("ROOM")
+                    .with_max_players(4)
+                    .with_supports_authority(true),
+            ),
+            Self::LeaveRoom => client.leave_room(),
+            Self::ReliableData => client.send_game_data(serde_json::json!({"n": 1})),
+            Self::LatestData => client.send_game_data_with_delivery(
+                serde_json::json!({"n": 2}),
+                GameDataDelivery::Latest { key: 9 },
+            ),
+            Self::VolatileData => client.send_game_data_with_delivery(
+                serde_json::json!({"n": 3}),
+                GameDataDelivery::Volatile,
+            ),
+            Self::BinaryData => client.send_binary_game_data(vec![1, 2, 3]),
+            Self::SetReady => client.set_ready(),
+            Self::StartGame => client.start_game(),
+            Self::RequestAuthority => client.request_authority(true),
+            Self::ProvideConnectionInfo => client.provide_connection_info(ConnectionInfo::Direct {
+                host: "127.0.0.1".into(),
+                port: 9000,
+            }),
+            Self::Reconnect => client.reconnect(peer, uuid::Uuid::from_u128(8), "token".into()),
+            Self::JoinSpectator => {
+                client.join_as_spectator("game".into(), "ROOM".into(), "Observer".into())
+            }
+            Self::LeaveSpectator => client.leave_spectator(),
+            Self::Ping => client.ping(),
+            Self::Signal => client.send_signal(peer, PeerSignal::Offer("sdp".into())),
+            Self::Offer => client.send_offer(peer, "offer".into()),
+            Self::Answer => client.send_answer(peer, "answer".into()),
+            Self::IceCandidate => client.send_ice_candidate(peer, "candidate".into()),
+            Self::RawSignal => client.send_raw_signal(peer, serde_json::json!({"Custom": 1})),
+            Self::TransportStatus => client.report_transport_status(TransportKind::WebRtc, true),
+        }
+    }
+}
 
 const PEER_UUID: &str = "00000000-0000-0000-0000-000000000007";
 const AUTH: &str = r#"{"type":"Authenticated","data":{"app_name":"test","rate_limits":{"per_minute":60,"per_hour":1000,"per_day":10000}}}"#;
@@ -160,6 +321,360 @@ async fn wait_for_sent_len(mock: &SharedMock, expected_len: usize) {
     });
 }
 
+#[derive(Clone)]
+struct TraceMock {
+    incoming: Arc<Mutex<VecDeque<Option<Result<TransportFrame, SignalFishError>>>>>,
+}
+
+impl TraceMock {
+    fn new(frames: Vec<TransportFrame>) -> Self {
+        Self {
+            incoming: Arc::new(Mutex::new(
+                frames
+                    .into_iter()
+                    .map(|frame| Some(Ok(frame)))
+                    .chain(std::iter::once(None))
+                    .collect(),
+            )),
+        }
+    }
+}
+
+impl Transport for TraceMock {
+    fn poll_send(
+        &mut self,
+        _cx: &mut std::task::Context<'_>,
+        frame: &mut Option<TransportFrame>,
+    ) -> std::task::Poll<Result<(), SignalFishError>> {
+        let _ = frame.take();
+        std::task::Poll::Ready(Ok(()))
+    }
+
+    fn poll_recv(
+        &mut self,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Result<TransportFrame, SignalFishError>>> {
+        match self.incoming.lock().unwrap().pop_front() {
+            Some(item) => std::task::Poll::Ready(item),
+            None => std::task::Poll::Pending,
+        }
+    }
+
+    fn poll_close(
+        &mut self,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), SignalFishError>> {
+        std::task::Poll::Ready(Ok(()))
+    }
+}
+
+fn canonical_event(event: &SignalFishEvent) -> String {
+    use std::fmt::Write as _;
+
+    macro_rules! event_fields {
+        ($name:literal) => {
+            String::from($name)
+        };
+        ($name:literal, $first:expr $(, $field:expr)*) => {{
+            let mut result = String::from($name);
+            write!(&mut result, "|{:?}", $first).expect("write event projection");
+            $(write!(&mut result, "|{:?}", $field).expect("write event projection");)*
+            result
+        }};
+    }
+
+    match event {
+        SignalFishEvent::Connected => event_fields!("Connected"),
+        SignalFishEvent::Disconnected {
+            reason,
+            last_server_error,
+        } => event_fields!("Disconnected", reason, last_server_error),
+        SignalFishEvent::DecodeFailed {
+            message_type,
+            error,
+            raw_prefix,
+        } => event_fields!("DecodeFailed", message_type, error, raw_prefix),
+        SignalFishEvent::ProtocolViolation { kind, diagnostic } => {
+            event_fields!("ProtocolViolation", kind, diagnostic)
+        }
+        SignalFishEvent::Authenticated {
+            app_name,
+            organization,
+            rate_limits,
+        } => event_fields!("Authenticated", app_name, organization, rate_limits),
+        SignalFishEvent::ProtocolInfo(payload) => event_fields!("ProtocolInfo", payload),
+        SignalFishEvent::AuthenticationError { error, error_code } => {
+            event_fields!("AuthenticationError", error, error_code)
+        }
+        SignalFishEvent::RoomJoined {
+            room_id,
+            room_code,
+            player_id,
+            game_name,
+            max_players,
+            supports_authority,
+            current_players,
+            is_authority,
+            lobby_state,
+            ready_players,
+            relay_type,
+            current_spectators,
+            ice_servers,
+            reconnection_token,
+        } => event_fields!(
+            "RoomJoined",
+            room_id,
+            room_code,
+            player_id,
+            game_name,
+            max_players,
+            supports_authority,
+            current_players,
+            is_authority,
+            lobby_state,
+            ready_players,
+            relay_type,
+            current_spectators,
+            ice_servers,
+            reconnection_token
+        ),
+        SignalFishEvent::RoomJoinFailed { reason, error_code } => {
+            event_fields!("RoomJoinFailed", reason, error_code)
+        }
+        SignalFishEvent::RoomLeft => event_fields!("RoomLeft"),
+        SignalFishEvent::PlayerJoined { player } => event_fields!("PlayerJoined", player),
+        SignalFishEvent::PlayerLeft {
+            player_id,
+            epoch,
+            final_seq,
+        } => event_fields!("PlayerLeft", player_id, epoch, final_seq),
+        SignalFishEvent::GameData {
+            from_player,
+            data,
+            seq,
+            epoch,
+            class,
+            key,
+        } => event_fields!("GameData", from_player, data, seq, epoch, class, key),
+        SignalFishEvent::GameDataBinary {
+            from_player,
+            encoding,
+            payload,
+            seq,
+            epoch,
+        } => event_fields!("GameDataBinary", from_player, encoding, payload, seq, epoch),
+        SignalFishEvent::AuthorityChanged {
+            authority_player,
+            you_are_authority,
+        } => event_fields!("AuthorityChanged", authority_player, you_are_authority),
+        SignalFishEvent::AuthorityResponse {
+            granted,
+            reason,
+            error_code,
+        } => event_fields!("AuthorityResponse", granted, reason, error_code),
+        SignalFishEvent::LobbyStateChanged {
+            lobby_state,
+            ready_players,
+            all_ready,
+        } => event_fields!("LobbyStateChanged", lobby_state, ready_players, all_ready),
+        SignalFishEvent::GameStarting { peer_connections } => {
+            event_fields!("GameStarting", peer_connections)
+        }
+        SignalFishEvent::SessionPlan {
+            topology,
+            transport,
+            host,
+            peers,
+            ice_servers,
+            fallback,
+        } => event_fields!(
+            "SessionPlan",
+            topology,
+            transport,
+            host,
+            peers,
+            ice_servers,
+            fallback
+        ),
+        SignalFishEvent::NewPeer {
+            peer_id,
+            you_initiate,
+        } => event_fields!("NewPeer", peer_id, you_initiate),
+        SignalFishEvent::SignalReceived { from, signal } => {
+            event_fields!("SignalReceived", from, signal)
+        }
+        SignalFishEvent::PeerTransportStatus {
+            peer_id,
+            transport,
+            connected,
+        } => event_fields!("PeerTransportStatus", peer_id, transport, connected),
+        SignalFishEvent::RelayStats {
+            interval_ms,
+            sent_to_you,
+            dropped_for_you,
+            backpressure_events,
+        } => event_fields!(
+            "RelayStats",
+            interval_ms,
+            sent_to_you,
+            dropped_for_you,
+            backpressure_events
+        ),
+        SignalFishEvent::GoingAway {
+            deadline_ms,
+            retry_after_secs,
+        } => event_fields!("GoingAway", deadline_ms, retry_after_secs),
+        SignalFishEvent::DeliveryReport(payload) => event_fields!("DeliveryReport", payload),
+        SignalFishEvent::Pong => event_fields!("Pong"),
+        SignalFishEvent::Reconnected {
+            room_id,
+            room_code,
+            player_id,
+            game_name,
+            max_players,
+            supports_authority,
+            current_players,
+            is_authority,
+            lobby_state,
+            ready_players,
+            relay_type,
+            current_spectators,
+            ice_servers,
+            missed_events,
+            replay,
+            sender_watermarks,
+            reconnection_token,
+        } => {
+            let missed_events = missed_events
+                .iter()
+                .map(canonical_event)
+                .collect::<Vec<_>>();
+            event_fields!(
+                "Reconnected",
+                room_id,
+                room_code,
+                player_id,
+                game_name,
+                max_players,
+                supports_authority,
+                current_players,
+                is_authority,
+                lobby_state,
+                ready_players,
+                relay_type,
+                current_spectators,
+                ice_servers,
+                missed_events,
+                replay,
+                sender_watermarks,
+                reconnection_token
+            )
+        }
+        SignalFishEvent::ReconnectionFailed { reason, error_code } => {
+            event_fields!("ReconnectionFailed", reason, error_code)
+        }
+        SignalFishEvent::PlayerReconnected { player_id, epoch } => {
+            event_fields!("PlayerReconnected", player_id, epoch)
+        }
+        SignalFishEvent::SpectatorJoined {
+            room_id,
+            room_code,
+            spectator_id,
+            game_name,
+            current_players,
+            current_spectators,
+            lobby_state,
+            reason,
+        } => event_fields!(
+            "SpectatorJoined",
+            room_id,
+            room_code,
+            spectator_id,
+            game_name,
+            current_players,
+            current_spectators,
+            lobby_state,
+            reason
+        ),
+        SignalFishEvent::SpectatorJoinFailed { reason, error_code } => {
+            event_fields!("SpectatorJoinFailed", reason, error_code)
+        }
+        SignalFishEvent::SpectatorLeft {
+            room_id,
+            room_code,
+            reason,
+            current_spectators,
+        } => event_fields!(
+            "SpectatorLeft",
+            room_id,
+            room_code,
+            reason,
+            current_spectators
+        ),
+        SignalFishEvent::NewSpectatorJoined {
+            spectator,
+            current_spectators,
+            reason,
+        } => event_fields!("NewSpectatorJoined", spectator, current_spectators, reason),
+        SignalFishEvent::SpectatorDisconnected {
+            spectator_id,
+            reason,
+            current_spectators,
+        } => event_fields!(
+            "SpectatorDisconnected",
+            spectator_id,
+            reason,
+            current_spectators
+        ),
+        SignalFishEvent::Error {
+            message,
+            error_code,
+        } => event_fields!("Error", message, error_code),
+    }
+}
+
+async fn assert_frame_trace_parity(frames: Vec<TransportFrame>, config: SignalFishConfig) {
+    let make_mock = || TraceMock::new(frames.clone());
+
+    let async_mock = make_mock();
+    let (async_client, mut async_rx) = SignalFishClient::start(async_mock, config.clone());
+    let mut async_events = Vec::new();
+    tokio::time::timeout(std::time::Duration::from_secs(1), async {
+        while let Some(event) = async_rx.recv().await {
+            async_events.push(event);
+        }
+    })
+    .await
+    .expect("async server trace should terminate on scripted close");
+
+    let polling_mock = make_mock();
+    let mut polling_client = SignalFishPollingClient::new(polling_mock, config);
+    let polling_events = polling_client.poll();
+
+    let async_events = async_events
+        .iter()
+        .filter(|event| !matches!(event, SignalFishEvent::Connected))
+        .map(canonical_event)
+        .collect::<Vec<_>>();
+    let polling_events = polling_events
+        .iter()
+        .filter(|event| !matches!(event, SignalFishEvent::Connected))
+        .map(canonical_event)
+        .collect::<Vec<_>>();
+    assert_eq!(async_events, polling_events);
+    assert_eq!(async_client.snapshot(), polling_client.snapshot());
+    assert_eq!(async_client.stats(), polling_client.stats());
+}
+
+async fn assert_server_trace_parity(lines: &str, config: SignalFishConfig) {
+    let frames = lines
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| TransportFrame::Text(line.to_owned()))
+        .collect();
+    assert_frame_trace_parity(frames, config).await;
+}
+
 // ── PARITY 1: relay-floor Authenticate byte-identity ─────────────────
 
 #[tokio::test]
@@ -188,6 +703,285 @@ async fn parity_relay_floor_authenticate_is_byte_identical() {
     assert!(v["data"].get("supported_topologies").is_none());
 }
 
+#[tokio::test]
+async fn both_drivers_implement_the_object_safe_common_api() {
+    let async_mock = SharedMock::new(vec![]);
+    let (mut async_client, _events) =
+        SignalFishClient::start(async_mock, SignalFishConfig::new("app"));
+    assert_common_api_is_object_safe(&mut async_client);
+
+    let poll_mock = SharedMock::new(vec![]);
+    let mut polling_client = SignalFishPollingClient::new(poll_mock, SignalFishConfig::new("app"));
+    assert_common_api_is_object_safe(&mut polling_client);
+
+    async_client.shutdown().await;
+}
+
+#[tokio::test]
+async fn vendored_v2_and_v3_server_message_traces_have_complete_parity() {
+    assert_server_trace_parity(
+        include_str!("wire-samples/v2-server-messages.jsonl"),
+        SignalFishConfig::new("app"),
+    )
+    .await;
+    for policy in [
+        ProtocolViolationPolicy::Quarantine,
+        ProtocolViolationPolicy::Disconnect,
+        ProtocolViolationPolicy::Observe,
+    ] {
+        assert_server_trace_parity(
+            include_str!("wire-samples/v3-server-messages.jsonl"),
+            SignalFishConfig::new("app")
+                .enable_v3()
+                .with_protocol_violation_policy(policy),
+        )
+        .await;
+    }
+}
+
+fn binary_accountability_prefix(player_id: PlayerId) -> Vec<TransportFrame> {
+    let room_joined = ServerMessage::RoomJoined(Box::new(RoomJoinedPayload {
+        room_id: uuid::Uuid::from_u128(200),
+        room_code: "BINARY".into(),
+        player_id: uuid::Uuid::from_u128(100),
+        game_name: "binary-parity".into(),
+        max_players: 4,
+        supports_authority: false,
+        current_players: vec![PlayerInfo {
+            id: player_id,
+            name: "sender".into(),
+            is_authority: false,
+            is_ready: false,
+            connected_at: "2026-01-01T00:00:00Z".into(),
+            connection_info: None,
+            epoch: Some(1),
+            seq: Some(0),
+        }],
+        is_authority: false,
+        lobby_state: LobbyState::Lobby,
+        ready_players: vec![],
+        relay_type: "websocket".into(),
+        current_spectators: vec![],
+        ice_servers: vec![],
+        reconnection_token: Some("binary-parity-token".into()),
+    }));
+    vec![
+        TransportFrame::Text(PI_V3.into()),
+        TransportFrame::Text(serde_json::to_string(&room_joined).unwrap()),
+    ]
+}
+
+#[tokio::test]
+async fn inbound_binary_events_decode_failures_and_accountability_have_complete_parity() {
+    let v2 = V2BinaryGameDataFrame {
+        from_player: uuid::Uuid::from_u128(98),
+        encoding: GameDataEncoding::MessagePack,
+        payload: vec![4, 5, 6],
+    };
+    let mut v2_config = SignalFishConfig::new("app");
+    v2_config.game_data_format = Some(GameDataEncoding::MessagePack);
+    assert_frame_trace_parity(
+        vec![
+            TransportFrame::Text(PI_V2.into()),
+            TransportFrame::Binary(rmp_serde::to_vec_named(&v2).unwrap()),
+            TransportFrame::Binary(vec![0xc1]),
+        ],
+        v2_config,
+    )
+    .await;
+
+    let player_id = uuid::Uuid::from_u128(301);
+    for policy in [
+        ProtocolViolationPolicy::Quarantine,
+        ProtocolViolationPolicy::Disconnect,
+        ProtocolViolationPolicy::Observe,
+    ] {
+        let mut frames = binary_accountability_prefix(player_id);
+        for seq in [1, 3] {
+            let frame = V3BinaryGameDataFrame {
+                from_player: player_id,
+                encoding: GameDataEncoding::MessagePack,
+                payload: vec![seq as u8],
+                seq,
+                epoch: 1,
+            };
+            frames.push(TransportFrame::Binary(
+                rmp_serde::to_vec_named(&frame).unwrap(),
+            ));
+        }
+        let mut config = SignalFishConfig::new("app")
+            .enable_v3()
+            .with_protocol_violation_policy(policy);
+        config.game_data_format = Some(GameDataEncoding::MessagePack);
+        assert_frame_trace_parity(frames, config).await;
+    }
+}
+
+#[tokio::test]
+async fn every_common_command_produces_identical_physical_frames() {
+    let cases = [
+        CommonCommandCase::JoinRoom,
+        CommonCommandCase::LeaveRoom,
+        CommonCommandCase::ReliableData,
+        CommonCommandCase::LatestData,
+        CommonCommandCase::VolatileData,
+        CommonCommandCase::BinaryData,
+        CommonCommandCase::SetReady,
+        CommonCommandCase::StartGame,
+        CommonCommandCase::RequestAuthority,
+        CommonCommandCase::ProvideConnectionInfo,
+        CommonCommandCase::Reconnect,
+        CommonCommandCase::JoinSpectator,
+        CommonCommandCase::LeaveSpectator,
+        CommonCommandCase::Ping,
+        CommonCommandCase::Signal,
+        CommonCommandCase::Offer,
+        CommonCommandCase::Answer,
+        CommonCommandCase::IceCandidate,
+        CommonCommandCase::RawSignal,
+        CommonCommandCase::TransportStatus,
+    ];
+
+    for case in cases {
+        let mut config = SignalFishConfig::new("app").enable_v3();
+        config.game_data_format = Some(GameDataEncoding::MessagePack);
+
+        let async_mock = FrameMock::v3();
+        let async_sent = Arc::clone(&async_mock.sent);
+        let (mut async_client, mut async_events) =
+            SignalFishClient::start(async_mock, config.clone());
+        for _ in 0..2 {
+            tokio::time::timeout(std::time::Duration::from_secs(1), async_events.recv())
+                .await
+                .unwrap_or_else(|_| panic!("{case:?}: async negotiation event timed out"));
+        }
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while async_sent.lock().unwrap().is_empty() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap_or_else(|_| panic!("{case:?}: async Authenticate timed out"));
+        async_sent.lock().unwrap().clear();
+        case.invoke(&mut async_client)
+            .unwrap_or_else(|error| panic!("{case:?}: async command failed: {error}"));
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while async_sent.lock().unwrap().is_empty() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap_or_else(|_| panic!("{case:?}: async frame timed out"));
+        let async_frames = async_sent.lock().unwrap().clone();
+
+        let polling_mock = FrameMock::v3();
+        let polling_sent = Arc::clone(&polling_mock.sent);
+        let mut polling_client = SignalFishPollingClient::new(polling_mock, config);
+        let _ = polling_client.poll();
+        polling_sent.lock().unwrap().clear();
+        case.invoke(&mut polling_client)
+            .unwrap_or_else(|error| panic!("{case:?}: polling command failed: {error}"));
+        let _ = polling_client.poll();
+        let polling_frames = polling_sent.lock().unwrap().clone();
+
+        assert_eq!(async_frames, polling_frames, "{case:?} frame drift");
+        assert_eq!(
+            SignalFishClientApi::snapshot(&async_client),
+            SignalFishClientApi::snapshot(&polling_client),
+            "{case:?} snapshot drift"
+        );
+        assert_eq!(
+            SignalFishClientApi::stats(&async_client),
+            SignalFishClientApi::stats(&polling_client),
+            "{case:?} statistics drift"
+        );
+        async_client.shutdown().await;
+    }
+}
+
+#[tokio::test]
+async fn pending_transport_queue_capacity_and_errors_match() {
+    let config = SignalFishConfig::new("app").with_command_channel_capacity(1);
+
+    let async_mock = NeverSendMock::new();
+    let attempted = Arc::clone(&async_mock.attempted);
+    let (mut async_client, _events) = SignalFishClient::start(async_mock, config.clone());
+    tokio::time::timeout(std::time::Duration::from_secs(1), async {
+        while !attempted.load(std::sync::atomic::Ordering::Acquire) {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("async Authenticate should reach the stalled transport");
+
+    let polling_mock = NeverSendMock::new();
+    let mut polling_client = SignalFishPollingClient::new(polling_mock, config);
+    let _ = polling_client.poll();
+
+    assert_eq!(async_client.send_capacity(), 1);
+    assert_eq!(polling_client.send_capacity(), 1);
+    async_client
+        .ping()
+        .expect("one async queue slot should fit");
+    polling_client
+        .ping()
+        .expect("one polling queue slot should fit");
+    assert_eq!(async_client.send_capacity(), 0);
+    assert_eq!(polling_client.send_capacity(), 0);
+
+    let async_error = async_client.ping().expect_err("async queue must be full");
+    let polling_error = polling_client
+        .ping()
+        .expect_err("polling queue must be full");
+    assert_eq!(format!("{async_error:?}"), format!("{polling_error:?}"));
+    async_client.shutdown().await;
+}
+
+#[tokio::test]
+async fn disconnected_common_commands_consistently_return_not_connected() {
+    let async_mock = SharedMock::new(vec![]);
+    let (mut async_client, _events) =
+        SignalFishClient::start(async_mock, SignalFishConfig::new("app"));
+    async_client.shutdown().await;
+
+    let polling_mock = SharedMock::new(vec![]);
+    let mut polling_client =
+        SignalFishPollingClient::new(polling_mock, SignalFishConfig::new("app"));
+    polling_client.close();
+
+    for case in [
+        CommonCommandCase::JoinRoom,
+        CommonCommandCase::LeaveRoom,
+        CommonCommandCase::ReliableData,
+        CommonCommandCase::LatestData,
+        CommonCommandCase::VolatileData,
+        CommonCommandCase::BinaryData,
+        CommonCommandCase::SetReady,
+        CommonCommandCase::StartGame,
+        CommonCommandCase::RequestAuthority,
+        CommonCommandCase::ProvideConnectionInfo,
+        CommonCommandCase::Reconnect,
+        CommonCommandCase::JoinSpectator,
+        CommonCommandCase::LeaveSpectator,
+        CommonCommandCase::Ping,
+        CommonCommandCase::Signal,
+        CommonCommandCase::Offer,
+        CommonCommandCase::Answer,
+        CommonCommandCase::IceCandidate,
+        CommonCommandCase::RawSignal,
+        CommonCommandCase::TransportStatus,
+    ] {
+        assert!(matches!(
+            case.invoke(&mut async_client),
+            Err(SignalFishError::NotConnected)
+        ));
+        assert!(matches!(
+            case.invoke(&mut polling_client),
+            Err(SignalFishError::NotConnected)
+        ));
+    }
+}
+
 // ── PARITY 2: ensure_v3 guard modes ──────────────────────────────────
 
 #[tokio::test]
@@ -195,11 +989,12 @@ async fn parity_ensure_v3_pre_negotiation_mode() {
     let peer: PlayerId = PEER_UUID.parse().unwrap();
 
     let async_mock = SharedMock::new(vec![]);
-    let (client, _events) = SignalFishClient::start(async_mock, SignalFishConfig::new("app"));
+    let (mut client, _events) = SignalFishClient::start(async_mock, SignalFishConfig::new("app"));
     let async_err = client.send_offer(peer, "sdp").unwrap_err();
 
     let poll_mock = SharedMock::new(vec![]);
-    let mut poll_client = SignalFishPollingClient::new(poll_mock, SignalFishConfig::new("app"));
+    let mut poll_client =
+        SignalFishPollingClient::new(poll_mock, SignalFishConfig::new("app").enable_mesh());
     let poll_err = poll_client.send_offer(peer, "sdp").unwrap_err();
 
     assert!(matches!(
@@ -224,7 +1019,8 @@ async fn parity_ensure_v3_relay_only_mode_after_v2_negotiation() {
     let peer: PlayerId = PEER_UUID.parse().unwrap();
 
     let async_mock = SharedMock::new(vec![AUTH, PI_V2]);
-    let (client, mut events) = SignalFishClient::start(async_mock, SignalFishConfig::new("app"));
+    let (mut client, mut events) =
+        SignalFishClient::start(async_mock, SignalFishConfig::new("app"));
     // Drain until the v2 ProtocolInfo has been processed into client state.
     loop {
         match events.recv().await {
@@ -249,7 +1045,7 @@ async fn parity_ensure_v3_relay_only_mode_after_v2_negotiation() {
     ));
 }
 
-// ── PARITY 3: negotiated version + supports_mesh after v3 ─────────────
+// ── PARITY 3: relay-only v3 negotiation does not claim mesh ──────────
 
 #[tokio::test]
 async fn parity_negotiated_version_after_v3() {
@@ -259,13 +1055,13 @@ async fn parity_negotiated_version_after_v3() {
         let _ = tokio::time::timeout(std::time::Duration::from_millis(100), events.recv()).await;
     }
     assert_eq!(client.negotiated_protocol_version(), Some(3));
-    assert!(client.supports_mesh());
+    assert!(!client.supports_mesh());
 
     let poll_mock = SharedMock::new(vec![AUTH, PI_V3]);
     let mut poll_client = SignalFishPollingClient::new(poll_mock, SignalFishConfig::new("app"));
     poll_client.poll();
     assert_eq!(poll_client.negotiated_protocol_version(), Some(3));
-    assert!(poll_client.supports_mesh());
+    assert!(!poll_client.supports_mesh());
 }
 
 // ── PARITY 4: reconnect replay restores v3 (downgrade-risk hunt) ──────
@@ -275,7 +1071,8 @@ async fn parity_reconnect_replay_restores_v3_from_missed_events() {
     let recon = reconnected_with_missed(vec![ServerMessage::ProtocolInfo(pi_v3_payload())]);
 
     let async_mock = SharedMock::new(vec![AUTH, &recon]);
-    let (client, mut events) = SignalFishClient::start(async_mock, SignalFishConfig::new("app"));
+    let (client, mut events) =
+        SignalFishClient::start(async_mock, SignalFishConfig::new("app").enable_mesh());
     for _ in 0..4 {
         let _ = tokio::time::timeout(std::time::Duration::from_millis(100), events.recv()).await;
     }
@@ -353,7 +1150,8 @@ async fn parity_enable_mesh_authenticate_is_byte_identical() {
 #[tokio::test]
 async fn parity_disconnect_resets_negotiated_version() {
     let poll_mock = SharedMock::new(vec![AUTH, PI_V3]);
-    let mut poll_client = SignalFishPollingClient::new(poll_mock, SignalFishConfig::new("app"));
+    let mut poll_client =
+        SignalFishPollingClient::new(poll_mock, SignalFishConfig::new("app").enable_mesh());
     poll_client.poll();
     assert!(poll_client.supports_mesh());
     poll_client.close();
@@ -364,7 +1162,8 @@ async fn parity_disconnect_resets_negotiated_version() {
         Some(Ok(PI_V3.to_string())),
         Some(Err(SignalFishError::TransportReceive("reset".into()))),
     ]);
-    let (client, mut events) = SignalFishClient::start(async_mock, SignalFishConfig::new("app"));
+    let (client, mut events) =
+        SignalFishClient::start(async_mock, SignalFishConfig::new("app").enable_mesh());
     let mut saw_disconnect = false;
     for _ in 0..6 {
         match tokio::time::timeout(std::time::Duration::from_millis(150), events.recv()).await {

--- a/tests/real_server_e2e.rs
+++ b/tests/real_server_e2e.rs
@@ -175,7 +175,7 @@ async fn e2e_slow_consumer_eviction_is_observable() {
     };
 
     // Sender A: normal config, joins and creates the room.
-    let (a, mut a_events) = connect_authenticated(&url, SignalFishConfig::new(app_id())).await;
+    let (mut a, mut a_events) = connect_authenticated(&url, SignalFishConfig::new(app_id())).await;
     a.join_room(JoinRoomParams::new("e2e-evict", "sender"))
         .expect("A join_room");
     let joined = wait_for_event(&mut a_events, "A RoomJoined", Duration::from_secs(5), |e| {
@@ -187,7 +187,7 @@ async fn e2e_slow_consumer_eviction_is_observable() {
     };
 
     // Victim B: tiny event channel so it wedges as soon as it stops draining.
-    let (_b, mut b_events) = connect_authenticated(
+    let (mut _b, mut b_events) = connect_authenticated(
         &url,
         SignalFishConfig::new(app_id()).with_event_channel_capacity(1),
     )
@@ -296,7 +296,7 @@ async fn e2e_reconnect_after_disconnect_uses_server_token() {
 
     // Join a v3 room, retain the server-issued token, then drop the connection
     // abruptly (no LeaveRoom and no graceful shutdown).
-    let (a, mut a_events) =
+    let (mut a, mut a_events) =
         connect_authenticated(&url, SignalFishConfig::new(app_id()).enable_v3()).await;
     a.join_room(JoinRoomParams::new("e2e-reconnect", "alpha"))
         .expect("join_room");

--- a/tests/shared_core_policy_tests.rs
+++ b/tests/shared_core_policy_tests.rs
@@ -1,0 +1,50 @@
+#![allow(clippy::panic)]
+
+use std::fs;
+
+#[test]
+fn shared_core_guide_pins_driver_ownership_and_object_safety() {
+    let path = ".llm/skills/shared-core-drivers.md";
+    let guide = fs::read_to_string(path).unwrap_or_else(|error| {
+        panic!("failed to read {path}: {error}");
+    });
+    for required in [
+        "ClientCore",
+        "SignalFishClientApi",
+        "object-safe",
+        "Common synchronous commands take",
+        "Waiting sends and `shutdown`",
+        "`poll`, `close`, and",
+        "parity matrix",
+        "Release it before",
+    ] {
+        assert!(
+            guide.contains(required),
+            "{path} must document shared-core invariant {required:?}"
+        );
+    }
+}
+
+#[test]
+fn both_drivers_delegate_inbound_frames_to_client_core() {
+    for path in ["src/client.rs", "src/polling_client.rs"] {
+        let source = fs::read_to_string(path).unwrap_or_else(|error| {
+            panic!("failed to read {path}: {error}");
+        });
+        assert!(
+            source.contains(".process_frame(frame)"),
+            "{path} must delegate inbound frames to ClientCore"
+        );
+        for forbidden in [
+            "from_str::<ServerMessage>",
+            "validate_server_frame",
+            "DeliveryAccountability::new",
+            "#[cfg(any())]",
+        ] {
+            assert!(
+                !source.contains(forbidden),
+                "{path} must not reintroduce driver-owned protocol logic {forbidden:?}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- extract shared `ClientCore` ownership for command construction, inbound text/binary processing, state, statistics, and accountability
- add object-safe `SignalFishClientApi` and align common async/polling commands on mutable receivers
- add exhaustive command, event-field, snapshot, statistics, error, quarantine, and inbound binary parity coverage
- document the 0.7→0.8 migration and update changelog/LLM guidance

## Verification

- `cargo fmt && cargo clippy --all-targets --all-features -- -D warnings && cargo test --all-features`
- `bash scripts/check-all.sh --quick`
- `bash scripts/check-all.sh` (all available checks passed; unavailable optional tools skipped)
- `cargo publish --dry-run --allow-dirty`
- final adversarial audit: zero findings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Breaking public API (`&mut self` on widespread sync methods) plus a large refactor of the async client’s core path; incorrect locking or core/driver drift could change wire timing, state, or accountability behavior despite parity tests.
> 
> **Overview**
> **Breaking refactor** that moves protocol behavior into shared **`ClientCore`** and exposes a driver-agnostic **`SignalFishClientApi`**, so async and polling clients stay semantically aligned.
> 
> **`SignalFishClient`** is now a thin Tokio driver: shared state lives in **`Arc<Mutex<ClientCore>>`**, outbound commands go through **`ClientCore::prepare`**, and inbound frames are handled by **`ClientCore::process_frame`** instead of duplicated loop logic. **`supports_mesh()`** now requires both negotiated v3 **and** local WebRTC advertisement via **`enable_mesh()`** (relay-only **`enable_v3()`** no longer reports mesh).
> 
> Common synchronous room/signaling APIs on the async client take **`&mut self`** (matching the polling client and the trait); **`send_*_reliable`** and **`shutdown`** still use **`&self`** / **`&mut self`** as before. **`MeshController`** room helpers follow the same mutable pattern, with **`client_mut()`** for other commands.
> 
> Adds **`docs/migration-0.8.md`**, changelog entries, and **`.llm/skills/shared-core-drivers.md`** for parity expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae4a121f7936c14d641565479285ca1b51329fcc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->