### PR TITLE
ci: add fail-closed release automation

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,116 @@
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: Version component to increment
+        required: true
+        type: choice
+        options:
+          - major
+          - minor
+          - patch
+      dry_run:
+        description: Validate and show the release changes without pushing a branch
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: prepare-release
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Require the default branch
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          if [ "$REF_NAME" != "$DEFAULT_BRANCH" ]; then
+            printf '::error::Prepare Release must run from %s, not %s.\n' "$DEFAULT_BRANCH" "$REF_NAME"
+            exit 1
+          fi
+
+      - name: Create release-app token
+        id: app-token
+        if: ${{ !inputs.dry_run }}
+        uses: actions/create-github-app-token@v3.2.0
+        with:
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
+      - name: Checkout default-branch HEAD
+        uses: actions/checkout@v7.0.0
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          token: ${{ steps.app-token.outputs.token || github.token }}
+          fetch-depth: 0
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache Cargo artifacts
+        uses: Swatinem/rust-cache@v2.9.1
+
+      - name: Test release tooling
+        run: python3 -m unittest scripts/test_release.py
+
+      - name: Prepare release files
+        id: version
+        env:
+          BUMP: ${{ inputs.bump }}
+        run: |
+          version=$(python3 scripts/release.py prepare "$BUMP")
+          printf 'version=%s\n' "$version" >> "$GITHUB_OUTPUT"
+          printf 'branch=release/%s\n' "$version" >> "$GITHUB_OUTPUT"
+
+      - name: Run mandatory verification
+        run: cargo fmt --check && cargo clippy --all-targets --all-features -- -D warnings && cargo test --all-features
+
+      - name: Verify package and documentation
+        run: |
+          cargo package
+          cargo publish --dry-run --allow-dirty
+          rustup toolchain install nightly --profile minimal
+          bash scripts/check-docsrs.sh
+
+      - name: Show dry-run changes
+        if: inputs.dry_run
+        run: git diff --check && git diff --stat && git diff
+
+      - name: Commit release preparation
+        if: ${{ !inputs.dry_run }}
+        env:
+          BRANCH: ${{ steps.version.outputs.branch }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          git switch -c "$BRANCH"
+          git config user.name "signal-fish-release[bot]"
+          git config user.email "signal-fish-release[bot]@users.noreply.github.com"
+          git add Cargo.toml README.md CHANGELOG.md docs .llm tests/compatibility.toml tests/server-spec/PROVENANCE.toml tests/wire-samples/PROVENANCE.toml
+          git commit -m "chore!: prepare release ${VERSION}"
+          git push --set-upstream origin "$BRANCH"
+
+      - name: Open release pull request
+        if: ${{ !inputs.dry_run }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          BRANCH: ${{ steps.version.outputs.branch }}
+          VERSION: ${{ steps.version.outputs.version }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          gh pr create \
+            --base "$DEFAULT_BRANCH" \
+            --head "$BRANCH" \
+            --title "chore!: prepare release ${VERSION}" \
+            --body "Automated release preparation for \`${VERSION}\`. Merge only after every required check and review is green."

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Verify package and documentation
         run: |
-          cargo package
+          cargo package --allow-dirty
           cargo publish --dry-run --allow-dirty
           rustup toolchain install nightly --profile minimal
           bash scripts/check-docsrs.sh
@@ -98,7 +98,7 @@ jobs:
           git config user.name "signal-fish-release[bot]"
           git config user.email "signal-fish-release[bot]@users.noreply.github.com"
           git add Cargo.toml README.md CHANGELOG.md docs .llm tests/compatibility.toml tests/server-spec/PROVENANCE.toml tests/wire-samples/PROVENANCE.toml
-          git commit -m "chore!: prepare release ${VERSION}"
+          git commit -m "chore: prepare release ${VERSION}"
           git push --set-upstream origin "$BRANCH"
 
       - name: Open release pull request
@@ -112,5 +112,5 @@ jobs:
           gh pr create \
             --base "$DEFAULT_BRANCH" \
             --head "$BRANCH" \
-            --title "chore!: prepare release ${VERSION}" \
+            --title "chore: prepare release ${VERSION}" \
             --body "Automated release preparation for \`${VERSION}\`. Merge only after every required check and review is green."

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -16,6 +16,11 @@ on:
         required: true
         default: true
         type: boolean
+      breaking:
+        description: This pre-1.0 minor or major release contains intentional API breaks
+        required: true
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -69,8 +74,13 @@ jobs:
         id: version
         env:
           BUMP: ${{ inputs.bump }}
+          BREAKING: ${{ inputs.breaking }}
         run: |
-          version=$(python3 scripts/release.py prepare "$BUMP")
+          args=()
+          if [ "$BREAKING" = true ]; then
+            args+=(--breaking)
+          fi
+          version=$(python3 scripts/release.py prepare "$BUMP" "${args[@]}")
           printf 'version=%s\n' "$version" >> "$GITHUB_OUTPUT"
           printf 'branch=release/%s\n' "$version" >> "$GITHUB_OUTPUT"
 
@@ -93,12 +103,17 @@ jobs:
         env:
           BRANCH: ${{ steps.version.outputs.branch }}
           VERSION: ${{ steps.version.outputs.version }}
+          BREAKING: ${{ inputs.breaking }}
         run: |
           git switch -c "$BRANCH"
           git config user.name "signal-fish-release[bot]"
           git config user.email "signal-fish-release[bot]@users.noreply.github.com"
           git add Cargo.toml README.md CHANGELOG.md docs .llm tests/compatibility.toml tests/server-spec/PROVENANCE.toml tests/wire-samples/PROVENANCE.toml
-          git commit -m "chore: prepare release ${VERSION}"
+          subject="chore: prepare release ${VERSION}"
+          if [ "$BREAKING" = true ]; then
+            subject="chore!: prepare release ${VERSION}"
+          fi
+          git commit -m "$subject"
           git push --set-upstream origin "$BRANCH"
 
       - name: Open release pull request
@@ -108,9 +123,14 @@ jobs:
           BRANCH: ${{ steps.version.outputs.branch }}
           VERSION: ${{ steps.version.outputs.version }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          BREAKING: ${{ inputs.breaking }}
         run: |
+          title="chore: prepare release ${VERSION}"
+          if [ "$BREAKING" = true ]; then
+            title="chore!: prepare release ${VERSION}"
+          fi
           gh pr create \
             --base "$DEFAULT_BRANCH" \
             --head "$BRANCH" \
-            --title "chore: prepare release ${VERSION}" \
+            --title "$title" \
             --body "Automated release preparation for \`${VERSION}\`. Merge only after every required check and review is green."

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,6 +57,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          RUN_ID: ${{ github.run_id }}
         run: |
           remote_sha=$(gh api "repos/${REPOSITORY}/branches/${DEFAULT_BRANCH}" --jq '.commit.sha')
           local_sha=$(git rev-parse HEAD)
@@ -64,20 +65,23 @@ jobs:
             printf '::error::Checked-out SHA %s is not default-branch HEAD %s.\n' "$local_sha" "$remote_sha"
             exit 1
           fi
+          current_run="/actions/runs/${RUN_ID}/"
           checks=$(
             gh api --paginate \
               "repos/${REPOSITORY}/commits/${local_sha}/check-runs?filter=latest&per_page=100" \
-              --jq '[.check_runs[] | select(.name != "Release publication")] | length' |
+              --jq "[.check_runs[] | select(
+                ((.details_url // \"\") | contains(\"${current_run}\")) | not)] | length" |
               awk '{ total += $1 } END { print total + 0 }'
           )
           failures=$(
             gh api --paginate \
               "repos/${REPOSITORY}/commits/${local_sha}/check-runs?filter=latest&per_page=100" \
-              --jq '[.check_runs[] | select(.name != "Release publication") | select(
-                .status != "completed" or
-                (.conclusion != "success" and
-                 .conclusion != "neutral" and
-                 .conclusion != "skipped"))] | length' |
+              --jq "[.check_runs[] | select(
+                ((.details_url // \"\") | contains(\"${current_run}\")) | not) | select(
+                  .status != \"completed\" or
+                  (.conclusion != \"success\" and
+                   .conclusion != \"neutral\" and
+                   .conclusion != \"skipped\"))] | length" |
               awk '{ total += $1 } END { print total + 0 }'
           )
           if [ "$checks" -eq 0 ] || [ "$failures" -ne 0 ]; then
@@ -103,7 +107,7 @@ jobs:
         env:
           VERSION: ${{ inputs.version }}
         run: |
-          cargo_version=$(python3 -c 'import pathlib, re; print(re.search(r"^version = \"([^\"]+)\"$", pathlib.Path("Cargo.toml").read_text(), re.M).group(1))')
+          cargo_version=$(python3 scripts/release.py package-version)
           if [ "$VERSION" != "$cargo_version" ]; then
             printf '::error::Input %s does not match Cargo.toml %s.\n' "$VERSION" "$cargo_version"
             exit 1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -161,9 +161,16 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ inputs.version }}
           CHECKSUM: ${{ steps.artifact.outputs.checksum }}
+          REPOSITORY: ${{ github.repository }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           tag="v${VERSION}"
           head_sha=$(git rev-parse HEAD)
+          remote_sha=$(gh api "repos/${REPOSITORY}/branches/${DEFAULT_BRANCH}" --jq '.commit.sha')
+          if [ "$head_sha" != "$remote_sha" ]; then
+            printf '::error::Default branch moved to %s during verification; restart from that HEAD.\n' "$remote_sha"
+            exit 1
+          fi
           tag_sha=$(git rev-list -n 1 "$tag" 2>/dev/null || true)
           if [ -n "$tag_sha" ] && [ "$tag_sha" != "$head_sha" ]; then
             printf '::error::Existing tag %s targets %s, not %s.\n' "$tag" "$tag_sha" "$head_sha"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: write
+  checks: read
   id-token: write
   attestations: write
 
@@ -135,8 +136,13 @@ jobs:
           cargo cyclonedx --format json
           mkdir -p release-assets
           crate="target/package/signal-fish-client-${VERSION}.crate"
+          mapfile -t sboms < <(find . -type f -name '*.cdx.json' -not -path './target/*' -print)
+          if [ "${#sboms[@]}" -ne 1 ]; then
+            printf '::error::Expected one CycloneDX JSON file, found %s.\n' "${#sboms[@]}"
+            exit 1
+          fi
           cp "$crate" release-assets/
-          cp signal-fish-client.cdx.json release-assets/
+          cp "${sboms[0]}" "release-assets/signal-fish-client-${VERSION}.cdx.json"
           checksum=$(python3 scripts/release.py checksum "$crate")
           printf '%s  %s\n' "$checksum" "signal-fish-client-${VERSION}.crate" > release-assets/SHA256SUMS
           {

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,52 +1,84 @@
-# Release workflow for signal-fish-client
-#
-# Publishes the crate to crates.io and creates a GitHub Release.
-# Triggers: manual dispatch (workflow_dispatch) or pushing a v* tag.
-
-name: Release - Publish Crate
+name: Release
 
 on:
   workflow_dispatch:
     inputs:
-      release_version:
-        description: "Version to publish (must match Cargo.toml)"
+      version:
+        description: Release version in strict X.Y.Z form
         required: true
-  push:
-    tags:
-      - "v*"
+        type: string
 
 permissions:
   contents: write
+  id-token: write
+  attestations: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  # Never cancel an in-progress publish — partial releases are hard to recover from
+  group: release
   cancel-in-progress: false
 
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
-  # Deny warnings in CI for doc builds
   RUSTDOCFLAGS: "-D warnings"
 
 jobs:
-  publish:
+  release:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 45
     environment: crates-io
-    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.actor != 'github-actions[bot]')
-
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7.0.0
-
-      - name: Validate release_version format
-        if: github.event_name == 'workflow_dispatch'
+      - name: Validate strict version input
         env:
-          INPUT_VERSION: ${{ github.event.inputs.release_version }}
+          VERSION: ${{ inputs.version }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          if ! echo "$INPUT_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?(\+[a-zA-Z0-9.-]+)?$'; then
-            echo "::error::Invalid semver format: '$INPUT_VERSION'. Expected format: MAJOR.MINOR.PATCH[-PRERELEASE][+BUILD]"
+          if ! printf '%s\n' "$VERSION" | grep -qE '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'; then
+            printf '::error::Invalid version %s; expected strict X.Y.Z.\n' "$VERSION"
+            exit 1
+          fi
+          if [ "$REF_NAME" != "$DEFAULT_BRANCH" ]; then
+            printf '::error::Release must run from %s, not %s.\n' "$DEFAULT_BRANCH" "$REF_NAME"
+            exit 1
+          fi
+
+      - name: Checkout default-branch HEAD
+        uses: actions/checkout@v7.0.0
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 0
+
+      - name: Verify default-branch HEAD and successful checks
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          remote_sha=$(gh api "repos/${REPOSITORY}/branches/${DEFAULT_BRANCH}" --jq '.commit.sha')
+          local_sha=$(git rev-parse HEAD)
+          if [ "$local_sha" != "$remote_sha" ]; then
+            printf '::error::Checked-out SHA %s is not default-branch HEAD %s.\n' "$local_sha" "$remote_sha"
+            exit 1
+          fi
+          checks=$(
+            gh api --paginate \
+              "repos/${REPOSITORY}/commits/${local_sha}/check-runs?per_page=100" \
+              --jq '[.check_runs[]] | length' |
+              awk '{ total += $1 } END { print total + 0 }'
+          )
+          failures=$(
+            gh api --paginate \
+              "repos/${REPOSITORY}/commits/${local_sha}/check-runs?per_page=100" \
+              --jq '[.check_runs[] | select(
+                .status != "completed" or
+                (.conclusion != "success" and
+                 .conclusion != "neutral" and
+                 .conclusion != "skipped"))] | length' |
+              awk '{ total += $1 } END { print total + 0 }'
+          )
+          if [ "$checks" -eq 0 ] || [ "$failures" -ne 0 ]; then
+            printf '::error::Default-branch HEAD has %s check runs and %s non-successful runs.\n' "$checks" "$failures"
             exit 1
           fi
 
@@ -55,145 +87,160 @@ jobs:
         with:
           components: rustfmt, clippy
 
-      - name: Configure sccache
-        id: sccache
-        uses: mozilla-actions/sccache-action@v0.0.10
-        continue-on-error: true
-
-      - name: Verify sccache is working
-        id: sccache-check
-        if: steps.sccache.outcome == 'success'
-        run: ./scripts/verify-sccache.sh
-        continue-on-error: true
-
-      - name: Clear sccache env on failure
-        if: steps.sccache.outcome != 'success' || steps.sccache-check.outcome != 'success'
-        run: |
-          echo "RUSTC_WRAPPER=" >> "$GITHUB_ENV"
-          echo "SCCACHE_GHA_ENABLED=" >> "$GITHUB_ENV"
-
       - name: Cache Cargo artifacts
         uses: Swatinem/rust-cache@v2.9.1
 
-      - name: Verify version matches tag (if tag push)
-        if: startsWith(github.ref, 'refs/tags/')
+      - name: Install release tools
+        uses: taiki-e/install-action@v2.82.9
+        with:
+          tool: cargo-cyclonedx@0.5.7,cargo-semver-checks@0.46.0
+
+      - name: Validate release files
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
-          TAG_VERSION=${GITHUB_REF#refs/tags/}
-          CARGO_VERSION=$(grep '^version = ' Cargo.toml | head -n1 | cut -d '"' -f2)
-          if [ "$TAG_VERSION" != "v${CARGO_VERSION}" ]; then
-            echo "Tag version $TAG_VERSION does not match Cargo.toml version $CARGO_VERSION" >&2
+          cargo_version=$(python3 -c 'import pathlib, re; print(re.search(r"^version = \"([^\"]+)\"$", pathlib.Path("Cargo.toml").read_text(), re.M).group(1))')
+          if [ "$VERSION" != "$cargo_version" ]; then
+            printf '::error::Input %s does not match Cargo.toml %s.\n' "$VERSION" "$cargo_version"
             exit 1
           fi
-
-      - name: Verify version matches input (if manual dispatch)
-        if: github.event_name == 'workflow_dispatch'
-        env:
-          INPUT_VERSION: ${{ github.event.inputs.release_version }}
-        run: |
-          CARGO_VERSION=$(grep '^version = ' Cargo.toml | head -n1 | cut -d '"' -f2)
-          if [ "$INPUT_VERSION" != "$CARGO_VERSION" ]; then
-            echo "Input version $INPUT_VERSION does not match Cargo.toml version $CARGO_VERSION" >&2
+          if ! grep -qF "## [${VERSION}] - " CHANGELOG.md; then
+            printf '::error::CHANGELOG.md has no dated %s section.\n' "$VERSION"
             exit 1
           fi
+          python3 -m unittest scripts/test_release.py
 
-      - name: Run fmt check
-        run: cargo fmt --check
-
-      - name: Run clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings
-        env:
-          RUSTC_WRAPPER: ${{ steps.sccache-check.outputs.working == 'true' && 'sccache' || '' }}
-          SCCACHE_GHA_ENABLED: ${{ steps.sccache-check.outputs.working == 'true' && 'true' || 'false' }}
-          SCCACHE_IGNORE_SERVER_IO_ERROR: "1"
-          SCCACHE_STARTUP_NOTIFY_TIMEOUT: "60"
-          SCCACHE_IDLE_TIMEOUT: "0"
-
-      - name: Run tests
-        run: cargo test --all-features
-        env:
-          RUSTC_WRAPPER: ${{ steps.sccache-check.outputs.working == 'true' && 'sccache' || '' }}
-          SCCACHE_GHA_ENABLED: ${{ steps.sccache-check.outputs.working == 'true' && 'true' || 'false' }}
-          SCCACHE_IGNORE_SERVER_IO_ERROR: "1"
-          SCCACHE_STARTUP_NOTIFY_TIMEOUT: "60"
-          SCCACHE_IDLE_TIMEOUT: "0"
-
-      - name: Verify docs.rs compatibility
+      - name: Run complete release verification
         run: |
+          cargo fmt --check
+          cargo clippy --all-targets --all-features -- -D warnings
+          cargo test --all-features
+          cargo semver-checks check-release --release-type major
           rustup toolchain install nightly --profile minimal
           bash scripts/check-docsrs.sh
+          cargo publish --dry-run
 
-      - name: Publish (dry-run)
-        run: cargo publish --dry-run
+      - name: Build release artifacts
+        id: artifact
         env:
-          RUSTC_WRAPPER: ${{ steps.sccache-check.outputs.working == 'true' && 'sccache' || '' }}
-          SCCACHE_GHA_ENABLED: ${{ steps.sccache-check.outputs.working == 'true' && 'true' || 'false' }}
-          SCCACHE_IGNORE_SERVER_IO_ERROR: "1"
-          SCCACHE_STARTUP_NOTIFY_TIMEOUT: "60"
-          SCCACHE_IDLE_TIMEOUT: "0"
-
-      - name: Publish to crates.io
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
-          RUSTC_WRAPPER: ${{ steps.sccache-check.outputs.working == 'true' && 'sccache' || '' }}
-          SCCACHE_GHA_ENABLED: ${{ steps.sccache-check.outputs.working == 'true' && 'true' || 'false' }}
-          SCCACHE_IGNORE_SERVER_IO_ERROR: "1"
-          SCCACHE_STARTUP_NOTIFY_TIMEOUT: "60"
-          SCCACHE_IDLE_TIMEOUT: "0"
-        run: cargo publish
-
-      - name: Create and push git tag
-        if: github.event_name == 'workflow_dispatch'
+          VERSION: ${{ inputs.version }}
         run: |
-          CARGO_VERSION=$(grep '^version = ' Cargo.toml | head -n1 | cut -d '"' -f2)
-          TAG_NAME="v${CARGO_VERSION}"
+          cargo package
+          cargo cyclonedx --format json
+          mkdir -p release-assets
+          crate="target/package/signal-fish-client-${VERSION}.crate"
+          cp "$crate" release-assets/
+          cp signal-fish-client.cdx.json release-assets/
+          checksum=$(python3 scripts/release.py checksum "$crate")
+          printf '%s  %s\n' "$checksum" "signal-fish-client-${VERSION}.crate" > release-assets/SHA256SUMS
+          {
+            printf 'crate=%s\n' "$crate"
+            printf 'checksum=%s\n' "$checksum"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Validate recovery state
+        id: state
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+          CHECKSUM: ${{ steps.artifact.outputs.checksum }}
+        run: |
+          tag="v${VERSION}"
+          head_sha=$(git rev-parse HEAD)
+          tag_sha=$(git rev-list -n 1 "$tag" 2>/dev/null || true)
+          if [ -n "$tag_sha" ] && [ "$tag_sha" != "$head_sha" ]; then
+            printf '::error::Existing tag %s targets %s, not %s.\n' "$tag" "$tag_sha" "$head_sha"
+            exit 1
+          fi
+          registry_checksum=$(python3 scripts/release.py registry-checksum signal-fish-client "$VERSION")
+          if [ "$registry_checksum" != "UNPUBLISHED" ] && [ "$registry_checksum" != "$CHECKSUM" ]; then
+            printf '::error::Published crate checksum does not match the reproduced package.\n'
+            exit 1
+          fi
+          if gh release view "$tag" >/dev/null 2>&1 && [ -z "$tag_sha" ]; then
+            printf '::error::GitHub release %s exists without a matching local tag.\n' "$tag"
+            exit 1
+          fi
+          tag_exists=$([ -n "$tag_sha" ] && printf true || printf false)
+          published=$([ "$registry_checksum" != UNPUBLISHED ] && printf true || printf false)
+          release_exists=$(gh release view "$tag" >/dev/null 2>&1 && printf true || printf false)
+          {
+            printf 'tag_exists=%s\n' "$tag_exists"
+            printf 'published=%s\n' "$published"
+            printf 'release_exists=%s\n' "$release_exists"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create annotated tag
+        if: steps.state.outputs.tag_exists != 'true'
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a "$TAG_NAME" -m "Release $TAG_NAME"
-          git push origin "$TAG_NAME"
+          git tag -a "v${VERSION}" -m "Release ${VERSION}"
+          git push origin "v${VERSION}"
 
-      - name: Get version for release
-        id: get_version
+      - name: Attest package provenance
+        uses: actions/attest@v4.1.1
+        with:
+          subject-path: ${{ steps.artifact.outputs.crate }}
+
+      - name: Publish to crates.io
+        if: steps.state.outputs.published != 'true'
         env:
-          EVENT_NAME: ${{ github.event_name }}
-        run: |
-          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            VERSION=$(grep '^version = ' Cargo.toml | head -n1 | cut -d '"' -f2)
-          else
-            VERSION=${GITHUB_REF#refs/tags/v}
-          fi
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+        run: cargo publish
 
-      - name: Extract changelog for release
-        id: changelog
+      - name: Wait for crates.io and verify checksum
         env:
-          VERSION: ${{ steps.get_version.outputs.version }}
+          VERSION: ${{ inputs.version }}
+          CHECKSUM: ${{ steps.artifact.outputs.checksum }}
         run: |
-          CHANGELOG_CONTENT=""
-          if [ -f CHANGELOG.md ]; then
-            CHANGELOG_CONTENT=$(awk -v ver="$VERSION" '
-              BEGIN { printing=0 }
-              /^## \[/ {
-                if (printing) { exit }
-                if (index($0, "[" ver "]") > 0) { printing=1; next }
-              }
-              printing { print }
-            ' CHANGELOG.md)
-          fi
+          attempt=1
+          while [ "$attempt" -le 30 ]; do
+            registry_checksum=$(python3 scripts/release.py registry-checksum signal-fish-client "$VERSION")
+            if [ "$registry_checksum" = "$CHECKSUM" ]; then
+              exit 0
+            fi
+            if [ "$registry_checksum" != UNPUBLISHED ]; then
+              printf '::error::Registry checksum changed to an unexpected value.\n'
+              exit 1
+            fi
+            sleep 10
+            attempt=$((attempt + 1))
+          done
+          printf '::error::Timed out waiting for crates.io visibility.\n'
+          exit 1
 
-          if [ -z "$CHANGELOG_CONTENT" ]; then
-            CHANGELOG_CONTENT="Release $VERSION"
+      - name: Extract release notes
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          awk -v version="$VERSION" '
+            $0 ~ "^## \\[" version "\\]" { found=1; next }
+            found && /^## \[/ { exit }
+            found { print }
+          ' CHANGELOG.md > release-assets/release-notes.md
+          if [ ! -s release-assets/release-notes.md ]; then
+            printf '::error::Release notes are empty.\n'
+            exit 1
           fi
-
-          printf '%s\n' "$CHANGELOG_CONTENT" > "$RUNNER_TEMP/release_notes.md"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3.0.1
-        with:
-          tag_name: ${{ steps.get_version.outputs.tag }}
-          name: ${{ steps.get_version.outputs.tag }}
-          body_path: ${{ runner.temp }}/release_notes.md
-          draft: false
-          prerelease: false
+        if: steps.state.outputs.release_exists != 'true'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          gh release create "v${VERSION}" \
+            release-assets/*.crate release-assets/SHA256SUMS release-assets/*.cdx.json \
+            --title "v${VERSION}" \
+            --notes-file release-assets/release-notes.md \
+            --verify-tag
+
+      - name: Repair assets on an existing matching release
+        if: steps.state.outputs.release_exists == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+        run: gh release upload "v${VERSION}" release-assets/*.crate release-assets/SHA256SUMS release-assets/*.cdx.json --clobber

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,7 @@ env:
 
 jobs:
   release:
+    name: Release publication
     runs-on: ubuntu-latest
     timeout-minutes: 45
     environment: crates-io
@@ -49,6 +50,7 @@ jobs:
         with:
           ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Verify default-branch HEAD and successful checks
         env:
@@ -65,13 +67,13 @@ jobs:
           checks=$(
             gh api --paginate \
               "repos/${REPOSITORY}/commits/${local_sha}/check-runs?filter=latest&per_page=100" \
-              --jq '[.check_runs[]] | length' |
+              --jq '[.check_runs[] | select(.name != "Release publication")] | length' |
               awk '{ total += $1 } END { print total + 0 }'
           )
           failures=$(
             gh api --paginate \
               "repos/${REPOSITORY}/commits/${local_sha}/check-runs?filter=latest&per_page=100" \
-              --jq '[.check_runs[] | select(
+              --jq '[.check_runs[] | select(.name != "Release publication") | select(
                 .status != "completed" or
                 (.conclusion != "success" and
                  .conclusion != "neutral" and
@@ -110,8 +112,7 @@ jobs:
             printf '::error::CHANGELOG.md has no dated %s section.\n' "$VERSION"
             exit 1
           fi
-          previous=$(python3 scripts/release.py previous-version "$VERSION")
-          release_type=$(python3 scripts/release.py release-type "$previous" "$VERSION")
+          release_type=$(python3 scripts/release.py semver-policy "$VERSION")
           printf 'release_type=%s\n' "$release_type" >> "$GITHUB_OUTPUT"
           python3 -m unittest scripts/test_release.py
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,13 +63,13 @@ jobs:
           fi
           checks=$(
             gh api --paginate \
-              "repos/${REPOSITORY}/commits/${local_sha}/check-runs?per_page=100" \
+              "repos/${REPOSITORY}/commits/${local_sha}/check-runs?filter=latest&per_page=100" \
               --jq '[.check_runs[]] | length' |
               awk '{ total += $1 } END { print total + 0 }'
           )
           failures=$(
             gh api --paginate \
-              "repos/${REPOSITORY}/commits/${local_sha}/check-runs?per_page=100" \
+              "repos/${REPOSITORY}/commits/${local_sha}/check-runs?filter=latest&per_page=100" \
               --jq '[.check_runs[] | select(
                 .status != "completed" or
                 (.conclusion != "success" and
@@ -96,6 +96,7 @@ jobs:
           tool: cargo-cyclonedx@0.5.7,cargo-semver-checks@0.46.0
 
       - name: Validate release files
+        id: release-metadata
         env:
           VERSION: ${{ inputs.version }}
         run: |
@@ -108,14 +109,19 @@ jobs:
             printf '::error::CHANGELOG.md has no dated %s section.\n' "$VERSION"
             exit 1
           fi
+          previous=$(python3 scripts/release.py previous-version "$VERSION")
+          release_type=$(python3 scripts/release.py release-type "$previous" "$VERSION")
+          printf 'release_type=%s\n' "$release_type" >> "$GITHUB_OUTPUT"
           python3 -m unittest scripts/test_release.py
 
       - name: Run complete release verification
+        env:
+          RELEASE_TYPE: ${{ steps.release-metadata.outputs.release_type }}
         run: |
           cargo fmt --check
           cargo clippy --all-targets --all-features -- -D warnings
           cargo test --all-features
-          cargo semver-checks check-release --release-type major
+          cargo semver-checks check-release --release-type "$RELEASE_TYPE"
           rustup toolchain install nightly --profile minimal
           bash scripts/check-docsrs.sh
           cargo publish --dry-run

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -139,17 +139,18 @@ jobs:
         run: |
           cargo package
           cargo cyclonedx --format json
-          mkdir -p release-assets
+          asset_dir="$RUNNER_TEMP/release-assets"
+          mkdir -p "$asset_dir"
           crate="target/package/signal-fish-client-${VERSION}.crate"
           mapfile -t sboms < <(find . -type f -name '*.cdx.json' -not -path './target/*' -print)
           if [ "${#sboms[@]}" -ne 1 ]; then
             printf '::error::Expected one CycloneDX JSON file, found %s.\n' "${#sboms[@]}"
             exit 1
           fi
-          cp "$crate" release-assets/
-          cp "${sboms[0]}" "release-assets/signal-fish-client-${VERSION}.cdx.json"
+          cp "$crate" "$asset_dir/"
+          mv "${sboms[0]}" "$asset_dir/signal-fish-client-${VERSION}.cdx.json"
           checksum=$(python3 scripts/release.py checksum "$crate")
-          printf '%s  %s\n' "$checksum" "signal-fish-client-${VERSION}.crate" > release-assets/SHA256SUMS
+          printf '%s  %s\n' "$checksum" "signal-fish-client-${VERSION}.crate" > "$asset_dir/SHA256SUMS"
           {
             printf 'crate=%s\n' "$crate"
             printf 'checksum=%s\n' "$checksum"
@@ -166,6 +167,11 @@ jobs:
         run: |
           tag="v${VERSION}"
           head_sha=$(git rev-parse HEAD)
+          if [ -n "$(git status --porcelain --untracked-files=all)" ]; then
+            printf '::error::Release tooling dirtied the checkout before publication.\n'
+            git status --short
+            exit 1
+          fi
           remote_sha=$(gh api "repos/${REPOSITORY}/branches/${DEFAULT_BRANCH}" --jq '.commit.sha')
           if [ "$head_sha" != "$remote_sha" ]; then
             printf '::error::Default branch moved to %s during verification; restart from that HEAD.\n' "$remote_sha"
@@ -244,8 +250,8 @@ jobs:
             $0 ~ "^## \\[" version "\\]" { found=1; next }
             found && /^## \[/ { exit }
             found { print }
-          ' CHANGELOG.md > release-assets/release-notes.md
-          if [ ! -s release-assets/release-notes.md ]; then
+          ' CHANGELOG.md > "$RUNNER_TEMP/release-assets/release-notes.md"
+          if [ ! -s "$RUNNER_TEMP/release-assets/release-notes.md" ]; then
             printf '::error::Release notes are empty.\n'
             exit 1
           fi
@@ -257,9 +263,11 @@ jobs:
           VERSION: ${{ inputs.version }}
         run: |
           gh release create "v${VERSION}" \
-            release-assets/*.crate release-assets/SHA256SUMS release-assets/*.cdx.json \
+            "$RUNNER_TEMP"/release-assets/*.crate \
+            "$RUNNER_TEMP"/release-assets/SHA256SUMS \
+            "$RUNNER_TEMP"/release-assets/*.cdx.json \
             --title "v${VERSION}" \
-            --notes-file release-assets/release-notes.md \
+            --notes-file "$RUNNER_TEMP/release-assets/release-notes.md" \
             --verify-tag
 
       - name: Repair assets on an existing matching release
@@ -267,4 +275,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ inputs.version }}
-        run: gh release upload "v${VERSION}" release-assets/*.crate release-assets/SHA256SUMS release-assets/*.cdx.json --clobber
+        run: |
+          gh release upload "v${VERSION}" \
+            "$RUNNER_TEMP"/release-assets/*.crate \
+            "$RUNNER_TEMP"/release-assets/SHA256SUMS \
+            "$RUNNER_TEMP"/release-assets/*.cdx.json \
+            --clobber

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -192,7 +192,7 @@ jobs:
             exit 1
           fi
           tag_exists=$([ -n "$tag_sha" ] && printf true || printf false)
-          published=$([ "$registry_checksum" != UNPUBLISHED ] && printf true || printf false)
+          published=$([ "$registry_checksum" != "UNPUBLISHED" ] && printf true || printf false)
           release_exists=$(gh release view "$tag" >/dev/null 2>&1 && printf true || printf false)
           {
             printf 'tag_exists=%s\n' "$tag_exists"
@@ -232,7 +232,7 @@ jobs:
             if [ "$registry_checksum" = "$CHECKSUM" ]; then
               exit 0
             fi
-            if [ "$registry_checksum" != UNPUBLISHED ]; then
+            if [ "$registry_checksum" != "UNPUBLISHED" ]; then
               printf '::error::Registry checksum changed to an unexpected value.\n'
               exit 1
             fi

--- a/.llm/context.md
+++ b/.llm/context.md
@@ -25,15 +25,15 @@ cargo fmt && cargo clippy --all-targets --all-features -- -D warnings && cargo t
 
 Run this before every commit. All three steps must pass with zero warnings.
 
+## Release Automation
+
+Use the manual **Prepare Release** and **Release** workflows; see
+`skills/release-recovery.md` and `docs/releasing.md` for fail-closed recovery.
+
 ## CI/CD Action Reference Policy
 
-Use version tags in workflow `uses:` references, not commit hashes.
-
-- Prefer: `owner/action@vN.N.N` (immutable tag); `owner/action@vN` acceptable
-  (mutable major pin, flagged by Phase 7 warning)
-- Exceptions: `dtolnay/rust-toolchain@stable|nightly|beta`,
-  `mymindstorm/setup-emsdk@vN` (no patch releases available)
-- Avoid commit-SHA refs unless a workflow has an explicit unavoidable requirement
+Use `owner/action@vN.N.N` (preferred) or `@vN`, not commit hashes. Exceptions:
+`dtolnay/rust-toolchain@stable|nightly|beta` and `mymindstorm/setup-emsdk@vN`.
 
 ## Changelog Policy
 

--- a/.llm/skills/index.md
+++ b/.llm/skills/index.md
@@ -72,6 +72,10 @@ Reference for the vendored golden wire samples, the provenance marker, and the p
 
 Reference for enum matching policy, semver, re-exports, feature flags, and MSRV in this crate.
 
+### [Release Preparation and Recovery](release-recovery.md)
+
+Reference for the two-stage 0.8+ release automation and its fail-closed recovery rules.
+
 ### [Serde Patterns](serde-patterns.md)
 
 Reference for serde_json, enum tagging, field attributes, and wire format as used in this codebase.

--- a/.llm/skills/release-recovery.md
+++ b/.llm/skills/release-recovery.md
@@ -7,7 +7,8 @@ recovery rules.
 
 `.github/workflows/prepare-release.yml` is the reversible stage. It runs only
 by manual dispatch from the default branch, accepts a `major`, `minor`, or
-`patch` bump, and supports a dry run. A repository GitHub App creates the
+`patch` bump, a deliberate breaking-release marker, and supports a dry run. A
+repository GitHub App creates the
 `release/X.Y.Z` branch and pull request so ordinary CI triggers on the generated
 change.
 
@@ -26,6 +27,8 @@ Use `python3 scripts/release.py prepare <major|minor|patch>`. The script:
   compatibility marker, and provenance dates.
 - Moves non-empty `[Unreleased]` content into a dated release section and
   updates compare links.
+- Persists intentional major or pre-1.0 breaking-minor policy so release-time
+  semver checks distinguish it from ordinary minor and patch releases.
 - Fails when an expected reference is absent instead of producing a partial
   release bump.
 

--- a/.llm/skills/release-recovery.md
+++ b/.llm/skills/release-recovery.md
@@ -1,0 +1,73 @@
+# Release Preparation and Recovery
+
+Reference for the two-stage 0.8+ release automation and its fail-closed
+recovery rules.
+
+## Workflow split
+
+`.github/workflows/prepare-release.yml` is the reversible stage. It runs only
+by manual dispatch from the default branch, accepts a `major`, `minor`, or
+`patch` bump, and supports a dry run. A repository GitHub App creates the
+`release/X.Y.Z` branch and pull request so ordinary CI triggers on the generated
+change.
+
+`.github/workflows/publish.yml` is the irreversible stage. It runs only by
+manual dispatch from the default branch, accepts strict `X.Y.Z`, and uses the
+protected `crates-io` environment. Never add a tag-push trigger: a tag is an
+output of a verified release, not permission to publish.
+
+## Preparation invariants
+
+Use `python3 scripts/release.py prepare <major|minor|patch>`. The script:
+
+- Requires a clean worktree.
+- Calculates the next version without prerelease or build metadata.
+- Updates Cargo, dependency snippets, SDK examples, LLM references, the
+  compatibility marker, and provenance dates.
+- Moves non-empty `[Unreleased]` content into a dated release section and
+  updates compare links.
+- Fails when an expected reference is absent instead of producing a partial
+  release bump.
+
+Update `scripts/test_release.py` whenever the version-reference inventory or
+workflow invariants change.
+
+## Publishing order
+
+The release workflow must retain this order:
+
+1. Verify strict input, default-branch HEAD, and successful check runs.
+2. Match Cargo and the dated changelog section.
+3. Run formatting, Clippy, tests, semver checks, docs.rs simulation, packaging,
+   and publish dry-run.
+4. Reproduce the `.crate`, SHA-256 manifest, and CycloneDX SBOM.
+5. Validate all existing tag, GitHub Release, and crates.io state.
+6. Create the annotated tag if absent.
+7. Create package provenance and publish if absent.
+8. Wait for crates.io to report the reproduced checksum.
+9. Create the GitHub Release or repair assets on its matching existing release.
+
+Crates.io versions cannot be overwritten. Never move an existing release tag,
+delete state automatically, or publish before package reproduction and dry-run.
+
+## Allowed recovery states
+
+A rerun may proceed when an existing tag targets the current default-branch
+SHA or an existing registry version has the exact checksum returned by
+`python3 scripts/release.py checksum`. An existing GitHub Release must have the
+matching tag.
+
+Any mismatched SHA or checksum is an integrity failure, not a transient CI
+failure. Stop and investigate. Recovery may skip an already-matching publish
+and upload the reproduced crate, checksum manifest, and SBOM to the matching
+GitHub Release with replacement enabled.
+
+## Repository configuration
+
+The release GitHub App needs only Contents and Pull requests read/write access.
+Store its client ID in `RELEASE_APP_CLIENT_ID` and private key in
+`RELEASE_APP_PRIVATE_KEY`. Store the crate-scoped token as `CRATES_IO_TOKEN` in
+the protected `crates-io` environment, with required reviewers and a default
+branch deployment restriction.
+
+See `docs/releasing.md` for the operator-facing runbook.

--- a/.llm/skills/release-recovery.md
+++ b/.llm/skills/release-recovery.md
@@ -44,7 +44,8 @@ The release workflow must retain this order:
 3. Run formatting, Clippy, tests, semver checks, docs.rs simulation, packaging,
    and publish dry-run.
 4. Reproduce the `.crate`, SHA-256 manifest, and CycloneDX SBOM.
-5. Validate all existing tag, GitHub Release, and crates.io state.
+5. Revalidate default-branch HEAD, then validate all existing tag, GitHub
+   Release, and crates.io state.
 6. Create the annotated tag if absent.
 7. Create package provenance and publish if absent.
 8. Wait for crates.io to report the reproduced checksum.

--- a/README.md
+++ b/README.md
@@ -326,6 +326,10 @@ cargo fmt && cargo clippy --all-targets --all-features -- -D warnings && cargo t
 | `cargo mutants --file src/protocol.rs ...` | deep-safety.yml | `cargo install cargo-mutants` |
 | `cargo llvm-cov --all-features --summary-only` | coverage.yml | `cargo install cargo-llvm-cov` + `rustup component add llvm-tools-preview` |
 
+Release operators should follow the [release runbook](docs/releasing.md) for
+the reviewed preparation workflow, protected crates.io publication, and
+fail-closed recovery procedure.
+
 ## Minimum Supported Rust Version (MSRV)
 
 <!-- markdownlint-disable-next-line MD036 -->

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -21,7 +21,9 @@ Actions and attestations to be enabled in repository settings.
 ## Prepare a release
 
 1. Run **Prepare Release** from the default branch.
-2. Select `major`, `minor`, or `patch` and leave `dry_run` enabled first.
+2. Select `major`, `minor`, or `patch` and leave `dry_run` enabled first. Enable
+   `breaking` only for an intentional major release or pre-1.0 breaking minor
+   release; this persists the stricter semver-checks policy in the changelog.
 3. Inspect the generated diff and validation output.
 4. Run it again with `dry_run` disabled. The workflow creates
    `release/X.Y.Z`, updates every version and provenance marker, cuts the

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,74 @@
+# Release Operations
+
+Signal Fish Client releases use two manually dispatched workflows. The split
+keeps ordinary version-file changes reviewable before the irreversible
+crates.io publish.
+
+## One-time repository setup
+
+Create and install a GitHub App with repository **Contents: read and write** and
+**Pull requests: read and write** permissions. Add its client ID as the
+`RELEASE_APP_CLIENT_ID` repository variable and its private key as the
+`RELEASE_APP_PRIVATE_KEY` repository secret. The App token is required because
+branches and pull requests created with the normal workflow token do not
+reliably trigger the repository's full CI policy.
+
+Configure the protected `crates-io` environment with required reviewers and a
+`CRATES_IO_TOKEN` secret scoped to the `signal-fish-client` crate. Restrict the
+environment to the default branch. Artifact attestations also require GitHub
+Actions and attestations to be enabled in repository settings.
+
+## Prepare a release
+
+1. Run **Prepare Release** from the default branch.
+2. Select `major`, `minor`, or `patch` and leave `dry_run` enabled first.
+3. Inspect the generated diff and validation output.
+4. Run it again with `dry_run` disabled. The workflow creates
+   `release/X.Y.Z`, updates every version and provenance marker, cuts the
+   changelog, and opens a pull request.
+5. Review and merge only after all required CI and reviewer feedback is green.
+
+Preparation fails if the default branch is not selected, the worktree is not
+clean, a version reference is missing, or `[Unreleased]` has no content. The
+underlying deterministic command is:
+
+```sh
+python3 scripts/release.py prepare minor
+```
+
+## Publish a release
+
+Run **Release** from the default branch and enter the strict `X.Y.Z` version
+from the merged preparation pull request. After the protected-environment
+approval, the workflow verifies default-branch HEAD and its checks, package and
+changelog versions, the full Rust suite, docs.rs compatibility, semver policy,
+and `cargo publish --dry-run`.
+
+The workflow then reproduces the `.crate`, checksum manifest, and CycloneDX
+SBOM; creates an annotated `vX.Y.Z` tag; attests the package; publishes to
+crates.io; waits until the registry reports the exact package checksum; and
+creates the GitHub Release with all three assets.
+
+## Recovery rules
+
+Re-run **Release** with the same version after a transient failure. Recovery is
+allowed only when every existing artifact agrees with the current
+default-branch commit:
+
+- An existing tag must target the current SHA.
+- An existing crates.io version must have the exact checksum of the locally
+  reproduced package.
+- An existing GitHub Release must have the matching tag.
+
+The workflow fails closed on any mismatch. It never overwrites a crate version;
+when registry publication already matches, it skips publishing and repairs only
+the GitHub Release assets. If a tag or registry checksum points elsewhere, stop
+and investigate rather than deleting or moving release state.
+
+After success, confirm the version and assets on crates.io and GitHub, confirm
+docs.rs built the same version, and verify the package attestation with:
+
+```sh
+gh attestation verify signal-fish-client-X.Y.Z.crate \
+  --repo Ambiguous-Interactive/signal-fish-client-rust
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -145,5 +145,6 @@ nav:
       - Delivery Contract & Backpressure: delivery.md
       - Mesh (v3): mesh-guide.md
       - WebAssembly: wasm.md
+      - Release Operations: releasing.md
   - Examples:
       - Walkthroughs: examples.md

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -87,6 +87,35 @@ def package_version(root: Path) -> str:
     return match.group(1)
 
 
+def replace_package_version(path: Path, old: str, new: str) -> None:
+    cargo = path.read_text(encoding="utf-8")
+    package = re.search(
+        r"^\[package\][ \t]*$\n(.*?)(?=^\[|\Z)",
+        cargo,
+        re.MULTILINE | re.DOTALL,
+    )
+    if package is None:
+        raise ReleaseError("Cargo.toml has no [package] section")
+    updated, count = re.subn(
+        rf'^version = "{re.escape(old)}"$',
+        f'version = "{new}"',
+        package.group(1),
+        count=1,
+        flags=re.MULTILINE,
+    )
+    if count != 1:
+        raise ReleaseError(f"Cargo.toml [package] does not contain version {old!r}")
+    path.write_text(cargo[: package.start(1)] + updated + cargo[package.end(1) :], encoding="utf-8")
+
+
+def release_heading(version: str) -> re.Pattern[str]:
+    parse_version(version)
+    return re.compile(
+        rf"^## \[{re.escape(version)}\](?: - [0-9]{{4}}-[0-9]{{2}}-[0-9]{{2}})?[ \t]*$",
+        re.MULTILINE,
+    )
+
+
 def previous_version(root: Path, version: str) -> str:
     parse_version(version)
     changelog = (root / "CHANGELOG.md").read_text(encoding="utf-8")
@@ -123,7 +152,7 @@ def cut_changelog(path: Path, old: str, new: str, date: str, breaking: bool = Fa
     unreleased = text[content_start:next_heading].strip()
     if not unreleased:
         raise ReleaseError("CHANGELOG.md [Unreleased] section is empty")
-    if f"## [{new}]" in text:
+    if release_heading(new).search(text) is not None:
         raise ReleaseError(f"CHANGELOG.md already contains release {new}")
 
     policy_marker = "\n<!-- semver-checks: major -->\n" if breaking else ""
@@ -199,10 +228,10 @@ def prepare(
         raise ReleaseError("CHANGELOG.md has no complete [Unreleased] section")
     if not changelog_text[unreleased_start + len("## [Unreleased]") : next_release].strip():
         raise ReleaseError("CHANGELOG.md [Unreleased] section is empty")
-    if f"## [{new}]" in changelog_text:
+    if release_heading(new).search(changelog_text) is not None:
         raise ReleaseError(f"CHANGELOG.md already contains release {new}")
 
-    replace_required(root / "Cargo.toml", f'version = "{old}"', f'version = "{new}"')
+    replace_package_version(root / "Cargo.toml", old, new)
     for relative in VERSION_FILES:
         replace_required(root / relative, old, new)
     compatibility = root / "tests/compatibility.toml"
@@ -236,9 +265,12 @@ def semver_policy(root: Path, version: str) -> str:
     previous = previous_version(root, version)
     policy = release_type(previous, version)
     changelog = (root / "CHANGELOG.md").read_text(encoding="utf-8")
-    start = changelog.find(f"## [{version}]")
-    end = changelog.find("\n## [", start + 1)
-    if start < 0 or end < 0:
+    heading = release_heading(version).search(changelog)
+    if heading is None:
+        raise ReleaseError(f"CHANGELOG.md has no complete release section for {version}")
+    start = heading.start()
+    end = changelog.find("\n## [", heading.end())
+    if end < 0:
         raise ReleaseError(f"CHANGELOG.md has no complete release section for {version}")
     breaking = "<!-- semver-checks: major -->" in changelog[start:end]
     if not breaking:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -73,7 +73,14 @@ def release_type(base: str, target: str) -> str:
 
 def package_version(root: Path) -> str:
     cargo = (root / "Cargo.toml").read_text(encoding="utf-8")
-    match = re.search(r'^version = "([^"]+)"$', cargo, re.MULTILINE)
+    package = re.search(
+        r"^\[package\][ \t]*$\n(.*?)(?=^\[|\Z)",
+        cargo,
+        re.MULTILINE | re.DOTALL,
+    )
+    if package is None:
+        raise ReleaseError("Cargo.toml has no [package] section")
+    match = re.search(r'^version = "([^"]+)"$', package.group(1), re.MULTILINE)
     if match is None:
         raise ReleaseError("Cargo.toml has no package version")
     parse_version(match.group(1))

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -110,7 +110,7 @@ def replace_required(path: Path, old: str, new: str) -> None:
     path.write_text(text.replace(old, new), encoding="utf-8")
 
 
-def cut_changelog(path: Path, old: str, new: str, date: str) -> None:
+def cut_changelog(path: Path, old: str, new: str, date: str, breaking: bool = False) -> None:
     text = path.read_text(encoding="utf-8")
     heading = "## [Unreleased]"
     start = text.find(heading)
@@ -126,9 +126,10 @@ def cut_changelog(path: Path, old: str, new: str, date: str) -> None:
     if f"## [{new}]" in text:
         raise ReleaseError(f"CHANGELOG.md already contains release {new}")
 
+    policy_marker = "\n<!-- semver-checks: major -->\n" if breaking else ""
     body = (
         text[:start]
-        + f"{heading}\n\n## [{new}] - {date}\n\n{unreleased}\n"
+        + f"{heading}\n\n## [{new}] - {date}\n{policy_marker}\n{unreleased}\n"
         + text[next_heading:]
     )
     reference_re = re.compile(r"^\[Unreleased\]:.*$", re.MULTILINE)
@@ -159,7 +160,13 @@ def require_clean(root: Path) -> None:
         raise ReleaseError("worktree must be clean before release preparation")
 
 
-def prepare(root: Path, level: str, date: str, allow_dirty: bool = False) -> str:
+def prepare(
+    root: Path,
+    level: str,
+    date: str,
+    allow_dirty: bool = False,
+    breaking: bool = False,
+) -> str:
     if re.fullmatch(r"[0-9]{4}-[0-9]{2}-[0-9]{2}", date) is None:
         raise ReleaseError(f"invalid date {date!r}; expected YYYY-MM-DD")
     dt.date.fromisoformat(date)
@@ -167,6 +174,11 @@ def prepare(root: Path, level: str, date: str, allow_dirty: bool = False) -> str
         require_clean(root)
     old = package_version(root)
     new = bump_version(old, level)
+    if breaking:
+        policy = release_type(old, new)
+        old_major = parse_version(old)[0]
+        if policy != "major" and not (old_major == 0 and policy == "minor"):
+            raise ReleaseError("breaking releases require a major bump or a pre-1.0 minor bump")
 
     # Validate every required source before writing any file. A stale inventory
     # must not leave a plausible-looking partial release bump behind.
@@ -216,8 +228,25 @@ def prepare(root: Path, level: str, date: str, allow_dirty: bool = False) -> str
         if count != 1:
             raise ReleaseError(f"{relative} has no unique synced date")
         path.write_text(provenance, encoding="utf-8")
-    cut_changelog(root / "CHANGELOG.md", old, new, date)
+    cut_changelog(root / "CHANGELOG.md", old, new, date, breaking)
     return new
+
+
+def semver_policy(root: Path, version: str) -> str:
+    previous = previous_version(root, version)
+    policy = release_type(previous, version)
+    changelog = (root / "CHANGELOG.md").read_text(encoding="utf-8")
+    start = changelog.find(f"## [{version}]")
+    end = changelog.find("\n## [", start + 1)
+    if start < 0 or end < 0:
+        raise ReleaseError(f"CHANGELOG.md has no complete release section for {version}")
+    breaking = "<!-- semver-checks: major -->" in changelog[start:end]
+    if not breaking:
+        return policy
+    previous_major = parse_version(previous)[0]
+    if policy == "major" or (previous_major == 0 and policy == "minor"):
+        return "major"
+    raise ReleaseError("major semver policy is invalid for this version bump")
 
 
 def sha256(path: Path) -> str:
@@ -266,6 +295,7 @@ def main(argv: list[str] | None = None) -> int:
     prep.add_argument("--root", type=Path, default=Path.cwd())
     prep.add_argument("--date", default=dt.date.today().isoformat())
     prep.add_argument("--allow-dirty", action="store_true", help=argparse.SUPPRESS)
+    prep.add_argument("--breaking", action="store_true")
 
     checksum = subparsers.add_parser("checksum")
     checksum.add_argument("crate", type=Path)
@@ -283,10 +313,14 @@ def main(argv: list[str] | None = None) -> int:
     policy.add_argument("base")
     policy.add_argument("target")
 
+    semver = subparsers.add_parser("semver-policy")
+    semver.add_argument("version")
+    semver.add_argument("--root", type=Path, default=Path.cwd())
+
     args = parser.parse_args(argv)
     try:
         if args.command == "prepare":
-            print(prepare(args.root.resolve(), args.bump, args.date, args.allow_dirty))
+            print(prepare(args.root.resolve(), args.bump, args.date, args.allow_dirty, args.breaking))
         elif args.command == "checksum":
             print(verify_artifact(args.crate, args.expected))
         elif args.command == "registry-checksum":
@@ -294,8 +328,10 @@ def main(argv: list[str] | None = None) -> int:
             print(value or "UNPUBLISHED")
         elif args.command == "previous-version":
             print(previous_version(args.root.resolve(), args.version))
-        else:
+        elif args.command == "release-type":
             print(release_type(args.base, args.target))
+        else:
+            print(semver_policy(args.root.resolve(), args.version))
     except (OSError, ValueError, ReleaseError, subprocess.CalledProcessError) as error:
         print(f"release error: {error}", file=sys.stderr)
         return 1

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -57,6 +57,20 @@ def bump_version(current: str, level: str) -> str:
     raise ReleaseError(f"invalid bump {level!r}; expected major, minor, or patch")
 
 
+def release_type(base: str, target: str) -> str:
+    """Return the one-component SemVer bump from base to target."""
+    base_parts = parse_version(base)
+    target_parts = parse_version(target)
+    major, minor, patch = base_parts
+    if target_parts == (major + 1, 0, 0):
+        return "major"
+    if target_parts == (major, minor + 1, 0):
+        return "minor"
+    if target_parts == (major, minor, patch + 1):
+        return "patch"
+    raise ReleaseError(f"{base} to {target} is not a single major, minor, or patch bump")
+
+
 def package_version(root: Path) -> str:
     cargo = (root / "Cargo.toml").read_text(encoding="utf-8")
     match = re.search(r'^version = "([^"]+)"$', cargo, re.MULTILINE)
@@ -64,6 +78,22 @@ def package_version(root: Path) -> str:
         raise ReleaseError("Cargo.toml has no package version")
     parse_version(match.group(1))
     return match.group(1)
+
+
+def previous_version(root: Path, version: str) -> str:
+    parse_version(version)
+    changelog = (root / "CHANGELOG.md").read_text(encoding="utf-8")
+    pattern = re.compile(
+        rf"^\[{re.escape(version)}\]: .*/compare/v"
+        rf"({SEMVER_RE.pattern[1:-1]})\.\.\.v{re.escape(version)}$",
+        re.MULTILINE,
+    )
+    match = pattern.search(changelog)
+    if match is None:
+        raise ReleaseError(f"CHANGELOG.md has no exact compare link for {version}")
+    previous = match.group(1)
+    parse_version(previous)
+    return previous
 
 
 def replace_required(path: Path, old: str, new: str) -> None:
@@ -238,15 +268,27 @@ def main(argv: list[str] | None = None) -> int:
     registry.add_argument("crate_name")
     registry.add_argument("version")
 
+    previous = subparsers.add_parser("previous-version")
+    previous.add_argument("version")
+    previous.add_argument("--root", type=Path, default=Path.cwd())
+
+    policy = subparsers.add_parser("release-type")
+    policy.add_argument("base")
+    policy.add_argument("target")
+
     args = parser.parse_args(argv)
     try:
         if args.command == "prepare":
             print(prepare(args.root.resolve(), args.bump, args.date, args.allow_dirty))
         elif args.command == "checksum":
             print(verify_artifact(args.crate, args.expected))
-        else:
+        elif args.command == "registry-checksum":
             value = registry_checksum(args.crate_name, args.version)
             print(value or "UNPUBLISHED")
+        elif args.command == "previous-version":
+            print(previous_version(args.root.resolve(), args.version))
+        else:
+            print(release_type(args.base, args.target))
     except (OSError, ValueError, ReleaseError, subprocess.CalledProcessError) as error:
         print(f"release error: {error}", file=sys.stderr)
         return 1

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -301,6 +301,9 @@ def main(argv: list[str] | None = None) -> int:
     checksum.add_argument("crate", type=Path)
     checksum.add_argument("--expected")
 
+    package = subparsers.add_parser("package-version")
+    package.add_argument("--root", type=Path, default=Path.cwd())
+
     registry = subparsers.add_parser("registry-checksum")
     registry.add_argument("crate_name")
     registry.add_argument("version")
@@ -323,6 +326,8 @@ def main(argv: list[str] | None = None) -> int:
             print(prepare(args.root.resolve(), args.bump, args.date, args.allow_dirty, args.breaking))
         elif args.command == "checksum":
             print(verify_artifact(args.crate, args.expected))
+        elif args.command == "package-version":
+            print(package_version(args.root.resolve()))
         elif args.command == "registry-checksum":
             value = registry_checksum(args.crate_name, args.version)
             print(value or "UNPUBLISHED")

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""Deterministic release preparation and artifact verification helpers."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+SEMVER_RE = re.compile(r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$")
+VERSION_FILES = (
+    "README.md",
+    "docs/client.md",
+    "docs/examples.md",
+    "docs/getting-started.md",
+    "docs/index.md",
+    "docs/mesh-guide.md",
+    "docs/protocol.md",
+    "docs/wasm.md",
+    ".llm/context.md",
+    ".llm/skills/crate-publishing.md",
+    ".llm/skills/godot-websocket.md",
+)
+PROVENANCE_FILES = (
+    "tests/compatibility.toml",
+    "tests/server-spec/PROVENANCE.toml",
+    "tests/wire-samples/PROVENANCE.toml",
+)
+
+
+class ReleaseError(RuntimeError):
+    """A release invariant was not satisfied."""
+
+
+def parse_version(value: str) -> tuple[int, int, int]:
+    match = SEMVER_RE.fullmatch(value)
+    if match is None:
+        raise ReleaseError(f"invalid version {value!r}; expected strict X.Y.Z")
+    return tuple(int(part) for part in match.groups())  # type: ignore[return-value]
+
+
+def bump_version(current: str, level: str) -> str:
+    major, minor, patch = parse_version(current)
+    if level == "major":
+        return f"{major + 1}.0.0"
+    if level == "minor":
+        return f"{major}.{minor + 1}.0"
+    if level == "patch":
+        return f"{major}.{minor}.{patch + 1}"
+    raise ReleaseError(f"invalid bump {level!r}; expected major, minor, or patch")
+
+
+def package_version(root: Path) -> str:
+    cargo = (root / "Cargo.toml").read_text(encoding="utf-8")
+    match = re.search(r'^version = "([^"]+)"$', cargo, re.MULTILINE)
+    if match is None:
+        raise ReleaseError("Cargo.toml has no package version")
+    parse_version(match.group(1))
+    return match.group(1)
+
+
+def replace_required(path: Path, old: str, new: str) -> None:
+    text = path.read_text(encoding="utf-8")
+    if old not in text:
+        raise ReleaseError(f"{path} does not contain required value {old!r}")
+    path.write_text(text.replace(old, new), encoding="utf-8")
+
+
+def cut_changelog(path: Path, old: str, new: str, date: str) -> None:
+    text = path.read_text(encoding="utf-8")
+    heading = "## [Unreleased]"
+    start = text.find(heading)
+    if start < 0:
+        raise ReleaseError("CHANGELOG.md has no [Unreleased] section")
+    content_start = start + len(heading)
+    next_heading = text.find("\n## [", content_start)
+    if next_heading < 0:
+        raise ReleaseError("CHANGELOG.md has no released section after [Unreleased]")
+    unreleased = text[content_start:next_heading].strip()
+    if not unreleased:
+        raise ReleaseError("CHANGELOG.md [Unreleased] section is empty")
+    if f"## [{new}]" in text:
+        raise ReleaseError(f"CHANGELOG.md already contains release {new}")
+
+    body = (
+        text[:start]
+        + f"{heading}\n\n## [{new}] - {date}\n\n{unreleased}\n"
+        + text[next_heading:]
+    )
+    reference_re = re.compile(r"^\[Unreleased\]:.*$", re.MULTILINE)
+    release_link = (
+        f"[{new}]: https://github.com/Ambiguous-Interactive/"
+        f"signal-fish-client-rust/compare/v{old}...v{new}"
+    )
+    unreleased_link = (
+        "[Unreleased]: https://github.com/Ambiguous-Interactive/"
+        f"signal-fish-client-rust/compare/v{new}...HEAD"
+    )
+    if reference_re.search(body):
+        body = reference_re.sub(f"{unreleased_link}\n{release_link}", body, count=1)
+    else:
+        body = body.rstrip() + f"\n\n{unreleased_link}\n{release_link}\n"
+    path.write_text(body, encoding="utf-8")
+
+
+def require_clean(root: Path) -> None:
+    result = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    if result.stdout:
+        raise ReleaseError("worktree must be clean before release preparation")
+
+
+def prepare(root: Path, level: str, date: str, allow_dirty: bool = False) -> str:
+    if re.fullmatch(r"[0-9]{4}-[0-9]{2}-[0-9]{2}", date) is None:
+        raise ReleaseError(f"invalid date {date!r}; expected YYYY-MM-DD")
+    dt.date.fromisoformat(date)
+    if not allow_dirty:
+        require_clean(root)
+    old = package_version(root)
+    new = bump_version(old, level)
+
+    # Validate every required source before writing any file. A stale inventory
+    # must not leave a plausible-looking partial release bump behind.
+    for relative in VERSION_FILES:
+        if old not in (root / relative).read_text(encoding="utf-8"):
+            raise ReleaseError(f"{relative} does not contain required value {old!r}")
+    compatibility_text = (root / "tests/compatibility.toml").read_text(encoding="utf-8")
+    if len(re.findall(r'^client_version = "[^"]+"$', compatibility_text, re.MULTILINE)) != 1:
+        raise ReleaseError("tests/compatibility.toml has no unique client_version")
+    for relative in PROVENANCE_FILES:
+        provenance = (root / relative).read_text(encoding="utf-8")
+        if len(re.findall(r'^synced = "[0-9]{4}-[0-9]{2}-[0-9]{2}"$', provenance, re.MULTILINE)) != 1:
+            raise ReleaseError(f"{relative} has no unique synced date")
+    changelog_text = (root / "CHANGELOG.md").read_text(encoding="utf-8")
+    unreleased_start = changelog_text.find("## [Unreleased]")
+    next_release = changelog_text.find("\n## [", unreleased_start + len("## [Unreleased]"))
+    if unreleased_start < 0 or next_release < 0:
+        raise ReleaseError("CHANGELOG.md has no complete [Unreleased] section")
+    if not changelog_text[unreleased_start + len("## [Unreleased]") : next_release].strip():
+        raise ReleaseError("CHANGELOG.md [Unreleased] section is empty")
+    if f"## [{new}]" in changelog_text:
+        raise ReleaseError(f"CHANGELOG.md already contains release {new}")
+
+    replace_required(root / "Cargo.toml", f'version = "{old}"', f'version = "{new}"')
+    for relative in VERSION_FILES:
+        replace_required(root / relative, old, new)
+    compatibility = root / "tests/compatibility.toml"
+    text = compatibility_text
+    text = re.sub(
+        r'^client_version = "[^"]+"$',
+        f'client_version = "{new}"',
+        text,
+        count=1,
+        flags=re.MULTILINE,
+    )
+    compatibility.write_text(text, encoding="utf-8")
+    for relative in PROVENANCE_FILES:
+        path = root / relative
+        provenance = path.read_text(encoding="utf-8")
+        provenance, count = re.subn(
+            r'^synced = "[0-9]{4}-[0-9]{2}-[0-9]{2}"$',
+            f'synced = "{date}"',
+            provenance,
+            count=1,
+            flags=re.MULTILINE,
+        )
+        if count != 1:
+            raise ReleaseError(f"{relative} has no unique synced date")
+        path.write_text(provenance, encoding="utf-8")
+    cut_changelog(root / "CHANGELOG.md", old, new, date)
+    return new
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def verify_artifact(crate: Path, expected_checksum: str | None) -> str:
+    if not crate.is_file():
+        raise ReleaseError(f"crate artifact does not exist: {crate}")
+    checksum = sha256(crate)
+    if expected_checksum is not None and checksum != expected_checksum.lower():
+        raise ReleaseError(
+            f"crate checksum mismatch: local {checksum}, registry {expected_checksum.lower()}"
+        )
+    return checksum
+
+
+def registry_checksum(crate_name: str, version: str) -> str | None:
+    parse_version(version)
+    request = urllib.request.Request(
+        f"https://crates.io/api/v1/crates/{crate_name}/{version}",
+        headers={"User-Agent": "signal-fish-client-release-workflow"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            payload = json.load(response)
+    except urllib.error.HTTPError as error:
+        if error.code == 404:
+            return None
+        raise ReleaseError(f"crates.io query failed with HTTP {error.code}") from error
+    checksum = payload.get("version", {}).get("checksum")
+    if not isinstance(checksum, str) or not re.fullmatch(r"[0-9a-f]{64}", checksum):
+        raise ReleaseError("crates.io returned an invalid checksum")
+    return checksum
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    prep = subparsers.add_parser("prepare")
+    prep.add_argument("bump", choices=("major", "minor", "patch"))
+    prep.add_argument("--root", type=Path, default=Path.cwd())
+    prep.add_argument("--date", default=dt.date.today().isoformat())
+    prep.add_argument("--allow-dirty", action="store_true", help=argparse.SUPPRESS)
+
+    checksum = subparsers.add_parser("checksum")
+    checksum.add_argument("crate", type=Path)
+    checksum.add_argument("--expected")
+
+    registry = subparsers.add_parser("registry-checksum")
+    registry.add_argument("crate_name")
+    registry.add_argument("version")
+
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "prepare":
+            print(prepare(args.root.resolve(), args.bump, args.date, args.allow_dirty))
+        elif args.command == "checksum":
+            print(verify_artifact(args.crate, args.expected))
+        else:
+            value = registry_checksum(args.crate_name, args.version)
+            print(value or "UNPUBLISHED")
+    except (OSError, ValueError, ReleaseError, subprocess.CalledProcessError) as error:
+        print(f"release error: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_release.py
+++ b/scripts/test_release.py
@@ -36,6 +36,11 @@ class VersionTests(unittest.TestCase):
                 encoding="utf-8",
             )
             self.assertEqual(release.package_version(root), "1.2.3")
+            release.replace_package_version(root / "Cargo.toml", "1.2.3", "1.2.4")
+            cargo = (root / "Cargo.toml").read_text(encoding="utf-8")
+            self.assertIn('[workspace.package]\nversion = "9.9.9"', cargo)
+            self.assertIn('demo = { version = "8.8.8" }', cargo)
+            self.assertEqual(release.package_version(root), "1.2.4")
 
     def test_release_type_requires_one_exact_component_bump(self) -> None:
         self.assertEqual(release.release_type("1.2.3", "2.0.0"), "major")
@@ -141,6 +146,12 @@ class PreparationTests(unittest.TestCase):
         with self.assertRaisesRegex(release.ReleaseError, "already contains"):
             release.prepare(self.root, "patch", "2026-07-13", allow_dirty=True)
         self.assertEqual(release.package_version(self.root), "1.2.3")
+
+    def test_release_heading_does_not_prefix_match(self) -> None:
+        changelog = self.root / "CHANGELOG.md"
+        text = changelog.read_text(encoding="utf-8").replace("## [1.2.3]", "## [1.2.30]")
+        changelog.write_text(text, encoding="utf-8")
+        self.assertIsNone(release.release_heading("1.2.3").search(text))
 
     @mock.patch.object(release.subprocess, "run")
     def test_dirty_worktree_is_rejected(self, run: mock.Mock) -> None:

--- a/scripts/test_release.py
+++ b/scripts/test_release.py
@@ -81,6 +81,37 @@ class PreparationTests(unittest.TestCase):
         self.assertIn('client_version = "1.3.0"', compatibility)
         self.assertIn('synced = "2026-07-13"', compatibility)
         self.assertEqual(release.previous_version(self.root, "1.3.0"), "1.2.3")
+        self.assertEqual(release.semver_policy(self.root, "1.3.0"), "minor")
+
+    def test_pre_one_minor_can_persist_intentional_breaking_policy(self) -> None:
+        for path in self.root.rglob("*"):
+            if path.is_file():
+                path.write_text(
+                    path.read_text(encoding="utf-8").replace("1.2.3", "0.7.0"),
+                    encoding="utf-8",
+                )
+        version = release.prepare(
+            self.root,
+            "minor",
+            "2026-07-13",
+            allow_dirty=True,
+            breaking=True,
+        )
+        self.assertEqual(version, "0.8.0")
+        self.assertEqual(release.semver_policy(self.root, version), "major")
+        changelog = (self.root / "CHANGELOG.md").read_text(encoding="utf-8")
+        self.assertIn("<!-- semver-checks: major -->", changelog)
+
+    def test_breaking_patch_is_rejected_before_writes(self) -> None:
+        with self.assertRaisesRegex(release.ReleaseError, "breaking releases"):
+            release.prepare(
+                self.root,
+                "patch",
+                "2026-07-13",
+                allow_dirty=True,
+                breaking=True,
+            )
+        self.assertEqual(release.package_version(self.root), "1.2.3")
 
     def test_empty_unreleased_section_fails_closed(self) -> None:
         (self.root / "CHANGELOG.md").write_text(
@@ -177,11 +208,14 @@ class WorkflowPolicyTests(unittest.TestCase):
                 self.assertIn(marker, self.publish)
 
     def test_semver_policy_is_derived_and_check_runs_are_latest_only(self) -> None:
-        self.assertIn('release-type "$previous" "$VERSION"', self.publish)
+        self.assertIn('semver-policy "$VERSION"', self.publish)
         self.assertIn('--release-type "$RELEASE_TYPE"', self.publish)
-        self.assertNotIn("chore!: prepare release", self.prepare)
+        self.assertIn('if [ "$BREAKING" = true ]', self.prepare)
+        self.assertIn("chore!: prepare release", self.prepare)
         self.assertEqual(self.publish.count("check-runs?filter=latest"), 2)
         self.assertIn("Expected one CycloneDX JSON file", self.publish)
+        self.assertIn("Release publication", self.publish)
+        self.assertIn("fetch-tags: true", self.publish)
 
 
 if __name__ == "__main__":

--- a/scripts/test_release.py
+++ b/scripts/test_release.py
@@ -26,6 +26,17 @@ class VersionTests(unittest.TestCase):
             with self.subTest(value=value), self.assertRaises(release.ReleaseError):
                 release.parse_version(value)
 
+    def test_package_version_is_scoped_to_package_section(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "Cargo.toml").write_text(
+                '[workspace.package]\nversion = "9.9.9"\n\n'
+                '[package]\nname = "demo"\nversion = "1.2.3"\n\n'
+                '[dependencies]\ndemo = { version = "8.8.8" }\n',
+                encoding="utf-8",
+            )
+            self.assertEqual(release.package_version(root), "1.2.3")
+
     def test_release_type_requires_one_exact_component_bump(self) -> None:
         self.assertEqual(release.release_type("1.2.3", "2.0.0"), "major")
         self.assertEqual(release.release_type("1.2.3", "1.3.0"), "minor")
@@ -148,6 +159,7 @@ class WorkflowPolicyTests(unittest.TestCase):
         self.assertIn("environment: crates-io", self.publish)
         self.assertIn("cancel-in-progress: false", self.publish)
         self.assertIn("expected strict X.Y.Z", self.publish)
+        self.assertIn("checks: read", self.publish)
 
     def test_publish_has_fail_closed_recovery_and_assets(self) -> None:
         for marker in (
@@ -169,6 +181,7 @@ class WorkflowPolicyTests(unittest.TestCase):
         self.assertIn('--release-type "$RELEASE_TYPE"', self.publish)
         self.assertNotIn("chore!: prepare release", self.prepare)
         self.assertEqual(self.publish.count("check-runs?filter=latest"), 2)
+        self.assertIn("Expected one CycloneDX JSON file", self.publish)
 
 
 if __name__ == "__main__":

--- a/scripts/test_release.py
+++ b/scripts/test_release.py
@@ -216,6 +216,8 @@ class WorkflowPolicyTests(unittest.TestCase):
         self.assertIn("Expected one CycloneDX JSON file", self.publish)
         self.assertIn("Release publication", self.publish)
         self.assertIn("fetch-tags: true", self.publish)
+        self.assertIn("github.run_id", self.publish)
+        self.assertIn("scripts/release.py package-version", self.publish)
 
 
 if __name__ == "__main__":

--- a/scripts/test_release.py
+++ b/scripts/test_release.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Tests for release.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+SPEC = importlib.util.spec_from_file_location("release", Path(__file__).with_name("release.py"))
+assert SPEC is not None and SPEC.loader is not None
+release = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(release)
+
+
+class VersionTests(unittest.TestCase):
+    def test_bumps_reset_lower_components(self) -> None:
+        self.assertEqual(release.bump_version("1.2.3", "major"), "2.0.0")
+        self.assertEqual(release.bump_version("1.2.3", "minor"), "1.3.0")
+        self.assertEqual(release.bump_version("1.2.3", "patch"), "1.2.4")
+
+    def test_rejects_non_strict_versions(self) -> None:
+        for value in ("v1.2.3", "1.2", "1.2.3-rc.1", "01.2.3"):
+            with self.subTest(value=value), self.assertRaises(release.ReleaseError):
+                release.parse_version(value)
+
+
+class PreparationTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        (self.root / "Cargo.toml").write_text('[package]\nversion = "1.2.3"\n', encoding="utf-8")
+        for relative in release.VERSION_FILES:
+            path = self.root / relative
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("release 1.2.3\n", encoding="utf-8")
+        for relative in release.PROVENANCE_FILES:
+            path = self.root / relative
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text('client_version = "1.2.3"\nsynced = "2020-01-01"\n', encoding="utf-8")
+        (self.root / "CHANGELOG.md").write_text(
+            "# Changelog\n\n## [Unreleased]\n\n### Added\n\n- Good thing.\n\n"
+            "## [1.2.3] - 2020-01-01\n\n- Old.\n\n"
+            "[Unreleased]: https://example.test/compare/v1.2.3...HEAD\n",
+            encoding="utf-8",
+        )
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def test_prepare_updates_all_release_references(self) -> None:
+        version = release.prepare(self.root, "minor", "2026-07-13", allow_dirty=True)
+        self.assertEqual(version, "1.3.0")
+        self.assertEqual(release.package_version(self.root), "1.3.0")
+        changelog = (self.root / "CHANGELOG.md").read_text(encoding="utf-8")
+        self.assertIn("## [Unreleased]\n\n## [1.3.0] - 2026-07-13", changelog)
+        self.assertIn("compare/v1.2.3...v1.3.0", changelog)
+        self.assertIn("compare/v1.3.0...HEAD", changelog)
+        compatibility = (self.root / "tests/compatibility.toml").read_text(encoding="utf-8")
+        self.assertIn('client_version = "1.3.0"', compatibility)
+        self.assertIn('synced = "2026-07-13"', compatibility)
+
+    def test_empty_unreleased_section_fails_closed(self) -> None:
+        (self.root / "CHANGELOG.md").write_text(
+            "# Changelog\n\n## [Unreleased]\n\n## [1.2.3] - 2020-01-01\n",
+            encoding="utf-8",
+        )
+        with self.assertRaisesRegex(release.ReleaseError, "empty"):
+            release.prepare(self.root, "patch", "2026-07-13", allow_dirty=True)
+
+    def test_missing_reference_does_not_partially_update(self) -> None:
+        missing = self.root / release.VERSION_FILES[-1]
+        missing.write_text("stale\n", encoding="utf-8")
+        with self.assertRaisesRegex(release.ReleaseError, "required value"):
+            release.prepare(self.root, "patch", "2026-07-13", allow_dirty=True)
+        self.assertEqual(release.package_version(self.root), "1.2.3")
+
+    def test_date_must_use_canonical_iso_form(self) -> None:
+        with self.assertRaisesRegex(release.ReleaseError, "YYYY-MM-DD"):
+            release.prepare(self.root, "patch", "20260713", allow_dirty=True)
+
+    def test_duplicate_release_fails_before_writes(self) -> None:
+        changelog = self.root / "CHANGELOG.md"
+        changelog.write_text(
+            changelog.read_text(encoding="utf-8") + "\n## [1.2.4] - 2026-01-01\n",
+            encoding="utf-8",
+        )
+        with self.assertRaisesRegex(release.ReleaseError, "already contains"):
+            release.prepare(self.root, "patch", "2026-07-13", allow_dirty=True)
+        self.assertEqual(release.package_version(self.root), "1.2.3")
+
+    @mock.patch.object(release.subprocess, "run")
+    def test_dirty_worktree_is_rejected(self, run: mock.Mock) -> None:
+        run.return_value = mock.Mock(stdout=" M Cargo.toml\n")
+        with self.assertRaisesRegex(release.ReleaseError, "clean"):
+            release.prepare(self.root, "patch", "2026-07-13")
+        self.assertEqual(release.package_version(self.root), "1.2.3")
+
+
+class ArtifactTests(unittest.TestCase):
+    def test_checksum_recovery_requires_exact_match(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            artifact = Path(directory) / "crate"
+            artifact.write_bytes(b"package")
+            checksum = release.sha256(artifact)
+            self.assertEqual(release.verify_artifact(artifact, checksum), checksum)
+            with self.assertRaisesRegex(release.ReleaseError, "mismatch"):
+                release.verify_artifact(artifact, "0" * 64)
+
+    @mock.patch.object(release.urllib.request, "urlopen")
+    def test_registry_404_means_unpublished(self, urlopen: mock.Mock) -> None:
+        urlopen.side_effect = release.urllib.error.HTTPError("url", 404, "missing", {}, None)
+        self.assertIsNone(release.registry_checksum("demo", "1.2.3"))
+
+
+class WorkflowPolicyTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        root = Path(__file__).resolve().parents[1]
+        cls.prepare = (root / ".github/workflows/prepare-release.yml").read_text(
+            encoding="utf-8"
+        )
+        cls.publish = (root / ".github/workflows/publish.yml").read_text(
+            encoding="utf-8"
+        )
+
+    def test_prepare_uses_app_token_and_supports_dry_run(self) -> None:
+        self.assertIn("actions/create-github-app-token@v3.2.0", self.prepare)
+        self.assertIn("RELEASE_APP_PRIVATE_KEY", self.prepare)
+        self.assertIn("dry_run:", self.prepare)
+        self.assertIn('branch=release/%s', self.prepare)
+        self.assertIn("gh pr create", self.prepare)
+
+    def test_publish_is_manual_only_and_protected(self) -> None:
+        self.assertIn("workflow_dispatch:", self.publish)
+        self.assertNotIn("push:\n", self.publish)
+        self.assertIn("environment: crates-io", self.publish)
+        self.assertIn("cancel-in-progress: false", self.publish)
+        self.assertIn("expected strict X.Y.Z", self.publish)
+
+    def test_publish_has_fail_closed_recovery_and_assets(self) -> None:
+        for marker in (
+            "Existing tag",
+            "Published crate checksum",
+            "registry-checksum",
+            "SHA256SUMS",
+            "cargo cyclonedx",
+            "actions/attest@v4.1.1",
+            "cargo publish --dry-run",
+            "cargo publish",
+            "gh release create",
+        ):
+            with self.subTest(marker=marker):
+                self.assertIn(marker, self.publish)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_release.py
+++ b/scripts/test_release.py
@@ -225,6 +225,8 @@ class WorkflowPolicyTests(unittest.TestCase):
         self.assertIn("chore!: prepare release", self.prepare)
         self.assertEqual(self.publish.count("check-runs?filter=latest"), 2)
         self.assertIn("Expected one CycloneDX JSON file", self.publish)
+        self.assertIn('$RUNNER_TEMP/release-assets', self.publish)
+        self.assertIn("Release tooling dirtied the checkout", self.publish)
         self.assertIn("Release publication", self.publish)
         self.assertIn("fetch-tags: true", self.publish)
         self.assertIn("github.run_id", self.publish)

--- a/scripts/test_release.py
+++ b/scripts/test_release.py
@@ -10,7 +10,8 @@ from pathlib import Path
 from unittest import mock
 
 SPEC = importlib.util.spec_from_file_location("release", Path(__file__).with_name("release.py"))
-assert SPEC is not None and SPEC.loader is not None
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError("could not load scripts/release.py for testing")
 release = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(release)
 

--- a/scripts/test_release.py
+++ b/scripts/test_release.py
@@ -26,6 +26,14 @@ class VersionTests(unittest.TestCase):
             with self.subTest(value=value), self.assertRaises(release.ReleaseError):
                 release.parse_version(value)
 
+    def test_release_type_requires_one_exact_component_bump(self) -> None:
+        self.assertEqual(release.release_type("1.2.3", "2.0.0"), "major")
+        self.assertEqual(release.release_type("1.2.3", "1.3.0"), "minor")
+        self.assertEqual(release.release_type("1.2.3", "1.2.4"), "patch")
+        for target in ("1.4.0", "1.3.1", "1.2.3", "1.2.2"):
+            with self.subTest(target=target), self.assertRaises(release.ReleaseError):
+                release.release_type("1.2.3", target)
+
 
 class PreparationTests(unittest.TestCase):
     def setUp(self) -> None:
@@ -61,6 +69,7 @@ class PreparationTests(unittest.TestCase):
         compatibility = (self.root / "tests/compatibility.toml").read_text(encoding="utf-8")
         self.assertIn('client_version = "1.3.0"', compatibility)
         self.assertIn('synced = "2026-07-13"', compatibility)
+        self.assertEqual(release.previous_version(self.root, "1.3.0"), "1.2.3")
 
     def test_empty_unreleased_section_fails_closed(self) -> None:
         (self.root / "CHANGELOG.md").write_text(
@@ -154,6 +163,12 @@ class WorkflowPolicyTests(unittest.TestCase):
         ):
             with self.subTest(marker=marker):
                 self.assertIn(marker, self.publish)
+
+    def test_semver_policy_is_derived_and_check_runs_are_latest_only(self) -> None:
+        self.assertIn('release-type "$previous" "$VERSION"', self.publish)
+        self.assertIn('--release-type "$RELEASE_TYPE"', self.publish)
+        self.assertNotIn("chore!: prepare release", self.prepare)
+        self.assertEqual(self.publish.count("check-runs?filter=latest"), 2)
 
 
 if __name__ == "__main__":

--- a/tests/compatibility_manifest_tests.rs
+++ b/tests/compatibility_manifest_tests.rs
@@ -24,13 +24,21 @@ fn compatibility_manifest_binds_exact_server_040_artifacts() {
     let client_version = manifest["client_version"]
         .as_str()
         .unwrap_or_else(|| panic!("client_version must be a string"));
-    let version_parts = client_version.split('.').collect::<Vec<_>>();
-    assert_eq!(version_parts.len(), 3, "client_version must be X.Y.Z");
+    let mut version_parts = client_version.split('.');
+    for _ in 0..3 {
+        let part = version_parts
+            .next()
+            .unwrap_or_else(|| panic!("client_version must be strict X.Y.Z"));
+        assert!(
+            !part.is_empty()
+                && part.chars().all(|character| character.is_ascii_digit())
+                && (part == "0" || !part.starts_with('0')),
+            "client_version must be strict X.Y.Z"
+        );
+    }
     assert!(
-        version_parts.iter().all(
-            |part| !part.is_empty() && part.chars().all(|character| character.is_ascii_digit())
-        ),
-        "client_version must be X.Y.Z"
+        version_parts.next().is_none(),
+        "client_version must be strict X.Y.Z"
     );
     assert_eq!(manifest["server_version"].as_str(), Some("0.4.0"));
     assert_eq!(manifest["server_tag"].as_str(), Some("v0.4.0"));

--- a/tests/compatibility_manifest_tests.rs
+++ b/tests/compatibility_manifest_tests.rs
@@ -21,7 +21,17 @@ fn compatibility_manifest_binds_exact_server_040_artifacts() {
     )
     .unwrap_or_else(|error| panic!("parse compatibility manifest: {error}"));
 
-    assert_eq!(manifest["client_version"].as_str(), Some("0.8.0"));
+    let client_version = manifest["client_version"]
+        .as_str()
+        .unwrap_or_else(|| panic!("client_version must be a string"));
+    let version_parts = client_version.split('.').collect::<Vec<_>>();
+    assert_eq!(version_parts.len(), 3, "client_version must be X.Y.Z");
+    assert!(
+        version_parts.iter().all(
+            |part| !part.is_empty() && part.chars().all(|character| character.is_ascii_digit())
+        ),
+        "client_version must be X.Y.Z"
+    );
     assert_eq!(manifest["server_version"].as_str(), Some("0.4.0"));
     assert_eq!(manifest["server_tag"].as_str(), Some("v0.4.0"));
     let commit = manifest["server_commit"]


### PR DESCRIPTION
## Summary

- add a GitHub-App-backed Prepare Release workflow with bump choice, explicit breaking policy, and dry-run mode
- replace dual-trigger publishing with a strict manual Release workflow and protected crates.io environment
- add deterministic, tested version/changelog preparation and exact-checksum recovery
- attach the reproduced crate, SHA-256 manifest, CycloneDX SBOM, and package attestation
- document operator setup and fail-closed recovery

## Verification

- `cargo fmt && cargo clippy --all-targets --all-features -- -D warnings && cargo test --all-features`
- `python3 -m unittest scripts/test_release.py` (18 tests)
- simulated 0.7.0→0.8.0 preparation, post-bump compatibility test, and package verification
- `actionlint v1.7.7 .github/workflows/*.yml`
- `bash scripts/check-workflows.sh`
- `bash scripts/validate-docs.sh`
- `cargo package --allow-dirty`
- `bash scripts/check-docsrs.sh`
- repository pre-commit and pre-push hooks

Release automation is internal tooling, so no consumer-facing changelog entry is required by the repository changelog policy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how crates are published (protected env, no tag triggers) and adds integrity gates; mistakes in recovery logic could block or mishandle releases, but runtime crate behavior is unchanged.
> 
> **Overview**
> Introduces a **two-stage release pipeline** so version bumps are reviewable before anything irreversible hits crates.io.
> 
> **Prepare Release** (`prepare-release.yml`) is manual-only from the default branch: bump choice, optional **breaking** policy, and **dry_run** (default on). It runs `scripts/release.py prepare`, full fmt/clippy/test, packaging, and docs.rs checks; when not dry-run, a GitHub App opens `release/X.Y.Z` and a prep PR.
> 
> **Release** (`publish.yml`) replaces tag-push and loose manual publish with strict `X.Y.Z` dispatch only, protected `crates-io` environment, default-branch HEAD + green check-runs gating, semver-checks from changelog policy, reproduced `.crate` / SHA256SUMS / CycloneDX SBOM, package attestation, and **fail-closed recovery** (tag/registry checksum/SHA must agree or the run stops).
> 
> New **`scripts/release.py`** (with **`scripts/test_release.py`**) centralizes version inventory updates, changelog cut, registry checksum lookup, and semver policy. Operator docs land in **`docs/releasing.md`** (MkDocs nav), **`.llm/skills/release-recovery.md`**, and README pointers. Compatibility tests now validate **`client_version`** as strict X.Y.Z instead of a fixed `0.8.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99d20d4ebca5a378cbf19695176ecc44528f3fa2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->