### PR TITLE
Harden polling queue-age and Godot rollback reliability

### DIFF
--- a/.github/workflows/godot-web.yml
+++ b/.github/workflows/godot-web.yml
@@ -20,12 +20,15 @@ env:
   PLAYWRIGHT_VERSION: "1.61.1"
   RUST_NIGHTLY: "nightly-2026-03-01"
   SERVER_VERSION: "0.4.0"
+  NETEM_SEED: "6101"
+  IPROUTE2_VERSION: "6.6.0"
+  IPROUTE2_SHA256: "8738c804afd09f0bf756937f0c3de23117832a98d8cbbf50386cf5005cd613ce"
 
 jobs:
-  browser-smoke:
-    name: Official template browser E2E
-    runs-on: ubuntu-latest
-    timeout-minutes: 45
+  build-export:
+    name: Build and export official template
+    runs-on: ubuntu-24.04
+    timeout-minutes: 35
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.0
@@ -66,6 +69,16 @@ jobs:
             "${HOME}/.local/share/godot/export_templates/${GODOT_VERSION}.stable"
           chmod +x ".godot/Godot_v${release}_linux.x86_64"
 
+      - name: Test standalone fixture and pure browser oracles
+        env:
+          GODOT4_BIN: ${{ github.workspace }}/.godot/Godot_v4.5-stable_linux.x86_64
+        run: |
+          set -euo pipefail
+          cargo clippy --manifest-path tests/godot-web-smoke/Cargo.toml \
+            --all-targets --locked -- -D warnings
+          cargo test --manifest-path tests/godot-web-smoke/Cargo.toml --locked
+          node --test scripts/test-godot-e2e-validators.mjs
+
       - name: Build Godot GDExtension for web
         env:
           RUSTFLAGS: >-
@@ -83,19 +96,16 @@ jobs:
             --manifest-path tests/godot-web-smoke/Cargo.toml \
             --target-dir target/godot-web-smoke \
             --target wasm32-unknown-emscripten \
-            --release \
-            --locked \
-            --features raw-emscripten-proof
+            --release --locked --features raw-emscripten-proof
           cp target/godot-web-smoke/wasm32-unknown-emscripten/release/signal_fish_godot_smoke.wasm \
             target/godot-web-smoke/raw-emscripten-proof.wasm
           cargo +"${RUST_NIGHTLY}" build -Zbuild-std=std \
             --manifest-path tests/godot-web-smoke/Cargo.toml \
             --target-dir target/godot-web-smoke \
             --target wasm32-unknown-emscripten \
-            --release \
-            --locked
+            --release --locked
 
-      - name: Export with the official no-thread extension template
+      - name: Export official no-thread extension templates
         run: |
           set -euo pipefail
           fixture="tests/godot-web-smoke"
@@ -114,17 +124,45 @@ jobs:
             --headless --path "${fixture}/project" \
             --export-release Web build/index.html
 
-      - name: Install Chromium automation
+      - name: Upload exported browser fixture
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: godot-web-export
+          path: |
+            tests/godot-web-smoke/project/build
+            tests/godot-web-smoke/project/build-negative
+          if-no-files-found: error
+          retention-days: 3
+
+  browser-scenarios:
+    name: Browser E2E (${{ matrix.scenario }})
+    needs: build-export
+    runs-on: ubuntu-24.04
+    timeout-minutes: ${{ matrix.timeout }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - scenario: clean
+            timeout: 30
+          - scenario: impaired
+            timeout: 30
+          - scenario: soak
+            timeout: 75
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7.0.0
+
+      - name: Download exported browser fixture
+        uses: actions/download-artifact@v7.0.0
+        with:
+          name: godot-web-export
+          path: tests/godot-web-smoke/project
+
+      - name: Install pinned Chromium automation
         run: |
           npm install --no-save --no-package-lock "playwright@${PLAYWRIGHT_VERSION}"
           npx playwright install --with-deps chromium
-
-      - name: Prove raw Emscripten transport is rejected by the standard template
-        run: |
-          set -euo pipefail
-          node scripts/run-godot-web-smoke.mjs \
-            tests/godot-web-smoke/project/build-negative \
-            --expect-raw-emscripten-link-failure 2>&1 | tee raw-emscripten.log
 
       - name: Download pinned Signal Fish server
         run: |
@@ -137,60 +175,167 @@ jobs:
           mkdir -p .signal-fish-server
           tar -xzf "${asset}" -C .signal-fish-server
 
-      - name: Run browser interoperability test
+      - name: Run required browser scenario
+        env:
+          SCENARIO: ${{ matrix.scenario }}
         run: |
           set -euo pipefail
           server_bin="$(find .signal-fish-server -type f -name signal-fish-server -print -quit)"
           chmod +x "${server_bin}"
-          SIGNAL_FISH__PORT=3536 \
-          SIGNAL_FISH__LOGGING__LEVEL=debug \
-          SIGNAL_FISH__SERVER__DRAIN_GRACE_SECS=1 \
-          SIGNAL_FISH__SECURITY__REQUIRE_METRICS_AUTH=false \
-          SIGNAL_FISH__SECURITY__REQUIRE_WEBSOCKET_AUTH=false \
-          SIGNAL_FISH__PROTOCOL__SDK_COMPATIBILITY__ENFORCE=false \
-            "${server_bin}" >server.log 2>&1 &
+          server_url="ws://127.0.0.1:3536/v2/ws"
+          tc_netem="tc"
+          if [ "${SCENARIO}" = "clean" ]; then
+            echo "scenario=clean status=disabled" >netem.txt
+          else
+            echo \
+              "scenario=${SCENARIO} status=setup-pending seed=${NETEM_SEED} profile=40ms/10ms/0.2%/25%/10mbit" \
+              >netem.txt
+          fi
+
+          cleanup() {
+            if [ -n "${server_pid:-}" ]; then
+              kill "${server_pid}" 2>/dev/null || true
+              wait "${server_pid}" 2>/dev/null || true
+            fi
+            if [ "${SCENARIO}" != "clean" ]; then
+              {
+                sudo "${tc_netem}" -s qdisc show dev ifb-host
+                sudo "${tc_netem}" -s filter show dev veth-host parent ffff:
+                sudo ip netns exec sf-server "${tc_netem}" -s qdisc show dev ifb-server
+                sudo ip netns exec sf-server "${tc_netem}" \
+                  -s filter show dev veth-server parent ffff:
+              } >>netem.txt 2>&1 || true
+              sudo ip netns delete sf-server 2>/dev/null || true
+              sudo ip link delete veth-host 2>/dev/null || true
+              sudo ip link delete ifb-host 2>/dev/null || true
+            fi
+          }
+          trap cleanup EXIT
+
+          if [ "${SCENARIO}" != "clean" ]; then
+            sudo apt-get update
+            sudo apt-get install --yes bison build-essential flex iproute2 libmnl-dev pkg-config
+            archive="iproute2-${IPROUTE2_VERSION}.tar.xz"
+            curl --fail --location --silent --show-error \
+              "https://www.kernel.org/pub/linux/utils/net/iproute2/${archive}" \
+              --output "${archive}"
+            echo "${IPROUTE2_SHA256}  ${archive}" | sha256sum --check
+            mkdir -p .netem-tools/iproute2
+            tar -xJf "${archive}" -C .netem-tools/iproute2 --strip-components=1
+            make -C .netem-tools/iproute2 --jobs=2 SUBDIRS="lib tc"
+            tc_netem="${PWD}/.netem-tools/iproute2/tc/tc"
+            "${tc_netem}" -Version
+            sudo modprobe ifb numifbs=2
+            sudo ip netns add sf-server
+            sudo ip link add veth-host type veth peer name veth-server
+            sudo ip link set veth-server netns sf-server
+            sudo ip address add 10.77.0.1/24 dev veth-host
+            sudo ip link set veth-host up
+            sudo ip netns exec sf-server ip address add 10.77.0.2/24 dev veth-server
+            sudo ip netns exec sf-server ip link set lo up
+            sudo ip netns exec sf-server ip link set veth-server up
+
+            sudo ip link add ifb-host type ifb
+            sudo ip link set ifb-host up
+            sudo "${tc_netem}" qdisc add dev veth-host handle ffff: ingress
+            sudo "${tc_netem}" filter add dev veth-host parent ffff: protocol all u32 \
+              match u32 0 0 action mirred egress redirect dev ifb-host
+            sudo "${tc_netem}" qdisc add dev ifb-host root netem \
+              delay 40ms 10ms loss random 0.2% 25% rate 10mbit seed "${NETEM_SEED}"
+
+            sudo ip netns exec sf-server ip link add ifb-server type ifb
+            sudo ip netns exec sf-server ip link set ifb-server up
+            sudo ip netns exec sf-server "${tc_netem}" \
+              qdisc add dev veth-server handle ffff: ingress
+            sudo ip netns exec sf-server "${tc_netem}" \
+              filter add dev veth-server parent ffff: protocol all u32 \
+              match u32 0 0 action mirred egress redirect dev ifb-server
+            sudo ip netns exec sf-server "${tc_netem}" qdisc add dev ifb-server root netem \
+              delay 40ms 10ms loss random 0.2% 25% rate 10mbit seed "${NETEM_SEED}"
+            {
+              echo "scenario=${SCENARIO} status=applied seed=${NETEM_SEED}"
+              "${tc_netem}" -Version
+              sudo "${tc_netem}" -s qdisc show dev ifb-host
+              sudo "${tc_netem}" -s filter show dev veth-host parent ffff:
+              sudo ip netns exec sf-server "${tc_netem}" -s qdisc show dev ifb-server
+              sudo ip netns exec sf-server "${tc_netem}" \
+                -s filter show dev veth-server parent ffff:
+            } >netem.txt
+            server_url="ws://10.77.0.2:3536/v2/ws"
+            # The runner owns server.log; sudo is only for network namespace entry.
+            # shellcheck disable=SC2024
+            sudo ip netns exec sf-server env \
+              SIGNAL_FISH__PORT=3536 \
+              SIGNAL_FISH__LOGGING__LEVEL=debug \
+              SIGNAL_FISH__SERVER__DRAIN_GRACE_SECS=1 \
+              SIGNAL_FISH__SECURITY__REQUIRE_METRICS_AUTH=false \
+              SIGNAL_FISH__SECURITY__REQUIRE_WEBSOCKET_AUTH=false \
+              SIGNAL_FISH__PROTOCOL__SDK_COMPATIBILITY__ENFORCE=false \
+              "${PWD}/${server_bin}" >server.log 2>&1 &
+          else
+            SIGNAL_FISH__PORT=3536 \
+            SIGNAL_FISH__LOGGING__LEVEL=debug \
+            SIGNAL_FISH__SERVER__DRAIN_GRACE_SECS=1 \
+            SIGNAL_FISH__SECURITY__REQUIRE_METRICS_AUTH=false \
+            SIGNAL_FISH__SECURITY__REQUIRE_WEBSOCKET_AUTH=false \
+            SIGNAL_FISH__PROTOCOL__SDK_COMPATIBILITY__ENFORCE=false \
+              "${server_bin}" >server.log 2>&1 &
+          fi
           server_pid=$!
-          trap 'kill "${server_pid}" 2>/dev/null || true' EXIT
-          for attempt in $(seq 1 100); do
-            if (echo > /dev/tcp/127.0.0.1/3536) 2>/dev/null; then
+
+          host="$(node -e 'process.stdout.write(new URL(process.argv[1]).hostname)' "${server_url}")"
+          for attempt in $(seq 1 150); do
+            if timeout 1 bash -c "echo >/dev/tcp/${host}/3536" 2>/dev/null; then
               break
             fi
-            if [ "${attempt}" -eq 100 ]; then
+            if [ "${attempt}" -eq 150 ]; then
               echo "Signal Fish server did not become ready" >&2
               exit 1
             fi
             sleep 0.1
           done
-          node scripts/run-godot-fortress-e2e.mjs \
-            tests/godot-web-smoke/project/build 2>&1 | tee fortress-browser.log
-          node scripts/run-godot-web-smoke.mjs \
-            tests/godot-web-smoke/project/build "${server_pid}" 2>&1 | tee browser.log
-          wait "${server_pid}"
-          trap - EXIT
 
-      - name: Upload browser and server logs on failure
-        if: failure()
+          if [ "${SCENARIO}" = "clean" ]; then
+            node scripts/run-godot-fortress-e2e.mjs \
+              tests/godot-web-smoke/project/build \
+              --scenario clean --server-url "${server_url}" 2>&1 | tee fortress-browser.log
+            node scripts/run-godot-web-smoke.mjs \
+              tests/godot-web-smoke/project/build "${server_pid}" 2>&1 | tee browser.log
+            wait "${server_pid}"
+            server_pid=""
+            node scripts/run-godot-web-smoke.mjs \
+              tests/godot-web-smoke/project/build-negative \
+              --expect-raw-emscripten-link-failure 2>&1 | tee raw-emscripten.log
+          else
+            node scripts/run-godot-fortress-e2e.mjs \
+              tests/godot-web-smoke/project/build \
+              --scenario "${SCENARIO}" --server-url "${server_url}" \
+              2>&1 | tee fortress-browser.log
+            kill -TERM "${server_pid}"
+            wait "${server_pid}" || true
+            server_pid=""
+          fi
+          trap - EXIT
+          cleanup
+
+      - name: Upload complete scenario evidence
+        if: always()
         uses: actions/upload-artifact@v7.0.1
         with:
-          name: godot-web-smoke-logs
+          name: godot-web-${{ matrix.scenario }}-evidence
           path: |
             browser.log
             fortress-browser.log
             raw-emscripten.log
             server.log
-          if-no-files-found: warn
-
-      - name: Upload Godot throughput time series
-        if: always()
-        uses: actions/upload-artifact@v7.0.1
-        with:
-          name: godot-web-throughput
-          path: |
+            netem.txt
             godot-throughput.json
             godot-throughput.csv
             metrics-before.prom
             metrics-after.prom
             godot-fortress-summary.json
+            godot-fortress-timeseries.json
+            godot-fortress-timeseries.csv
             godot-fortress-a.log
             godot-fortress-b.log
             fortress-metrics-before.prom

--- a/.github/workflows/godot-web.yml
+++ b/.github/workflows/godot-web.yml
@@ -39,6 +39,11 @@ jobs:
           toolchain: ${{ env.RUST_NIGHTLY }}
           components: rust-src
 
+      - name: Install Rust stable with Clippy
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
       - name: Install Emscripten SDK
         uses: emscripten-core/setup-emsdk@v16
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,29 @@ __pycache__/
 # MkDocs build output
 site/
 
+# Local Godot/browser E2E tools and retained evidence
+node_modules/
+.signal-fish-server/
+.netem-tools/
+logs/
+/browser.log
+/fortress-browser.log
+/raw-emscripten.log
+/server.log
+/netem.txt
+/godot-throughput.json
+/godot-throughput.csv
+/metrics-before.prom
+/metrics-after.prom
+/fortress-metrics-before.prom
+/fortress-metrics-after.prom
+/godot-fortress-summary.json
+/godot-fortress-timeseries.json
+/godot-fortress-timeseries.csv
+/godot-fortress-a.log
+/godot-fortress-b.log
+/iproute2-*.tar.xz
+
 # Fuzz artifacts
 fuzz/artifacts/
 fuzz/corpus/

--- a/.llm/context.md
+++ b/.llm/context.md
@@ -100,8 +100,9 @@ leaves recovery headroom while scenario oracles still enforce eight-frame
 clean, 13-frame impaired, and 12-frame soak lag bounds. The fixture uses a
 peer-independent fixed 18 Hz simulation cadence that preserves elapsed
 deadline debt and catches up by at most one frame per rendered callback, plus
-a one-time causal startup barrier that prevents process-launch order from
-becoming frame advantage. A bounded causal relay hold and the polling-hitch
+a one-time proposal/ack/commit startup barrier that maps a shared same-host
+wall-clock deadline to each browser's monotonic clock, preventing process-launch
+order from becoming frame advantage. A bounded causal relay hold and the polling-hitch
 oracle then require rollback and forward gameplay progress. These controls must prove
 rollback/resimulation, bounded confirmation lag with zero waits/stalls, exact
 state checksum convergence, drained queue age/depth with a non-positive final

--- a/.llm/context.md
+++ b/.llm/context.md
@@ -97,7 +97,7 @@ seeded-netem impaired, and 3,600-frame soak jobs through Signal Fish Server
 0.4.0. It checksum-verifies and builds iproute2 6.6.0 for seeded netem rather
 than relying on the runner's older `tc`. A 20-frame Fortress prediction window
 leaves recovery headroom while scenario oracles still enforce eight-frame
-clean and 12-frame impaired/soak lag bounds. The fixture uses a
+clean, 13-frame impaired, and 12-frame soak lag bounds. The fixture uses a
 peer-independent fixed 18 Hz simulation cadence that preserves elapsed
 deadline debt and catches up by at most one frame per rendered callback, plus
 a bounded causal relay hold, while the polling-hitch oracle requires forward

--- a/.llm/context.md
+++ b/.llm/context.md
@@ -97,7 +97,9 @@ seeded-netem impaired, and 3,600-frame soak jobs through Signal Fish Server
 0.4.0. It checksum-verifies and builds iproute2 6.6.0 for seeded netem rather
 than relying on the runner's older `tc`. A 12-frame Fortress prediction window
 leaves recovery headroom while the clean oracle still enforces eight-frame
-lag. Its deterministic relay hold and polling hitch must prove
+lag. The fixture uses a peer-independent fixed 18 Hz simulation cadence and a
+bounded causal relay hold, while the polling-hitch oracle requires forward
+gameplay progress. These controls must prove
 rollback/resimulation, bounded confirmation lag with zero waits/stalls, exact
 state checksum convergence, drained queue age/depth with a non-positive final
 eight-sample soak age slope, relay/server conservation, and v3 peer departure.

--- a/.llm/context.md
+++ b/.llm/context.md
@@ -92,10 +92,15 @@ caller's `Option` intact. Close polling is idempotent. See
 Godot defaults to adaptive outbound admission: a 50 ms latency target with a
 4 KiB floor, 32 KiB ceiling, and a further native-capacity clamp. A successful Godot send
 transfers ownership immediately; browser buffering is observed separately.
-The blocking Godot workflow runs both the synthetic smoke and a real
-two-process Fortress Rollback session through Signal Fish Server 0.4.0. Its
-deterministic impairment must prove rollback/resimulation, exact state checksum
-convergence, in-sync health, relay/server conservation, and v3 peer departure.
+The blocking Godot workflow builds one official export and runs clean,
+seeded-netem impaired, and 3,600-frame soak jobs through Signal Fish Server
+0.4.0. It checksum-verifies and builds iproute2 6.6.0 for seeded netem rather
+than relying on the runner's older `tc`. A 12-frame Fortress prediction window
+leaves recovery headroom while the clean oracle still enforces eight-frame
+lag. Its deterministic relay hold and polling hitch must prove
+rollback/resimulation, bounded confirmation lag with zero waits/stalls, exact
+state checksum convergence, drained queue age/depth with a non-positive final
+eight-sample soak age slope, relay/server conservation, and v3 peer departure.
 
 ### Client Usage Pattern
 
@@ -182,7 +187,10 @@ capacity accessors, `stats()`, and coherent `snapshot()`. Its default per-poll
 work budget is 64 frames/64 KiB in each direction, and its default close policy
 abandons client-owned queued work. Adaptive backpressure and flush-on-close are
 explicit opt-ins. Use `polling_stats()` for scheduling/queue diagnostics and
-`transport_diagnostics()` for backend buffering/admission diagnostics.
+`queue_age_stats()` for sampled current/peak age of client-owned work; reset the
+age peak after authentication/setup when measuring gameplay. Backend acceptance
+ends queue age but is not peer delivery. Use `transport_diagnostics()` for
+backend buffering/admission diagnostics.
 Use the polling client's read-only `transport()` accessor for Godot's
 zero-expected `admission_watermark_violations()` counter and the separately
 accounted `one_frame_escape_bytes()` empty-buffer exception.

--- a/.llm/context.md
+++ b/.llm/context.md
@@ -95,11 +95,12 @@ transfers ownership immediately; browser buffering is observed separately.
 The blocking Godot workflow builds one official export and runs clean,
 seeded-netem impaired, and 3,600-frame soak jobs through Signal Fish Server
 0.4.0. It checksum-verifies and builds iproute2 6.6.0 for seeded netem rather
-than relying on the runner's older `tc`. A 12-frame Fortress prediction window
-leaves recovery headroom while the clean oracle still enforces eight-frame
-lag. The fixture uses a peer-independent fixed 18 Hz simulation cadence and a
-bounded causal relay hold, while the polling-hitch oracle requires forward
-gameplay progress. These controls must prove
+than relying on the runner's older `tc`. A 20-frame Fortress prediction window
+leaves recovery headroom while scenario oracles still enforce eight-frame
+clean and 12-frame impaired/soak lag bounds. The fixture uses a
+peer-independent fixed 18 Hz simulation cadence and a bounded causal relay
+hold, while the polling-hitch oracle requires forward gameplay progress. These
+controls must prove
 rollback/resimulation, bounded confirmation lag with zero waits/stalls, exact
 state checksum convergence, drained queue age/depth with a non-positive final
 eight-sample soak age slope, relay/server conservation, and v3 peer departure.

--- a/.llm/context.md
+++ b/.llm/context.md
@@ -98,9 +98,10 @@ seeded-netem impaired, and 3,600-frame soak jobs through Signal Fish Server
 than relying on the runner's older `tc`. A 20-frame Fortress prediction window
 leaves recovery headroom while scenario oracles still enforce eight-frame
 clean and 12-frame impaired/soak lag bounds. The fixture uses a
-peer-independent fixed 18 Hz simulation cadence and a bounded causal relay
-hold, while the polling-hitch oracle requires forward gameplay progress. These
-controls must prove
+peer-independent fixed 18 Hz simulation cadence that preserves elapsed
+deadline debt and catches up by at most one frame per rendered callback, plus
+a bounded causal relay hold, while the polling-hitch oracle requires forward
+gameplay progress. These controls must prove
 rollback/resimulation, bounded confirmation lag with zero waits/stalls, exact
 state checksum convergence, drained queue age/depth with a non-positive final
 eight-sample soak age slope, relay/server conservation, and v3 peer departure.

--- a/.llm/context.md
+++ b/.llm/context.md
@@ -100,8 +100,9 @@ leaves recovery headroom while scenario oracles still enforce eight-frame
 clean, 13-frame impaired, and 12-frame soak lag bounds. The fixture uses a
 peer-independent fixed 18 Hz simulation cadence that preserves elapsed
 deadline debt and catches up by at most one frame per rendered callback, plus
-a bounded causal relay hold, while the polling-hitch oracle requires forward
-gameplay progress. These controls must prove
+a one-time causal startup barrier that prevents process-launch order from
+becoming frame advantage. A bounded causal relay hold and the polling-hitch
+oracle then require rollback and forward gameplay progress. These controls must prove
 rollback/resimulation, bounded confirmation lag with zero waits/stalls, exact
 state checksum convergence, drained queue age/depth with a non-positive final
 eight-sample soak age slope, relay/server conservation, and v3 peer departure.

--- a/.llm/skills/async-rust-patterns/SKILL.md
+++ b/.llm/skills/async-rust-patterns/SKILL.md
@@ -153,6 +153,12 @@ The polling client uses a noop waker and calls the methods again on the next
 game-loop tick. A transport may therefore support both models with the same
 state machine.
 
+Polling queue-age telemetry follows client ownership: timestamp on enqueue,
+preserve the timestamp while pre-acceptance `Pending` retains the exact frame,
+and stop counting it as soon as `poll_send` takes the frame. Sample age with
+`Instant::saturating_duration_since` so a regressing injected/test clock cannot
+violate `peak >= current`.
+
 Do not create and immediately drop a readiness future on every poll: dropping
 it may unregister its waker. Retain the future/state across polls or poll the
 underlying primitive directly.

--- a/.llm/skills/ci-configuration/SKILL.md
+++ b/.llm/skills/ci-configuration/SKILL.md
@@ -132,6 +132,12 @@ The project uses `locale = "en-us"` in `.typos.toml`. Use American English spell
 
 Any cargo subcommands sharing the same `target/` directory or Cargo package lock must not be run in parallel in local scripts/hooks. Two problems arise: (1) **Feature-flag conflicts** — different flag combinations (e.g., `--all-features` vs `--no-default-features`) cause constant cache invalidation, each process rebuilding what the other just compiled. (2) **Package-lock contention** — even non-compiling subcommands like `cargo fmt --check` acquire the Cargo package lock; running them in parallel with `cargo clippy` gains nothing because one blocks on the lock while the other holds it, and output becomes interleaved and non-deterministic.
 
+Browser system-test workflows should build/export expensive fixtures once and
+fan out required scenario jobs through an uploaded artifact. Seed network
+impairment explicitly, capture the applied `tc` configuration, and upload logs,
+time series, summaries, and metric snapshots with `if: always()` so a failed
+oracle remains diagnosable.
+
 **Correct pattern (two-phase hooks):** Phase 1 runs non-cargo checks in parallel (typos, shellcheck, markdownlint, etc.). Phase 2 runs cargo commands sequentially to avoid lock contention and cache thrashing. The two hooks differ in Phase 2: the **pre-commit hook** runs `cargo fmt` in the foreground first (fast, no compilation), then backgrounds `cargo clippy` alongside remaining non-cargo checks; the **pre-push hook** runs `cargo clippy` then `cargo test` sequentially (no `cargo fmt`). In CI, matrix strategies give each job its own runner and `target/` directory, so parallel execution across jobs is safe. Enforced by `ci_config_tests.rs::ci_config_validation::install_hooks_pre_push_cargo_commands_must_not_run_in_parallel` and `install_hooks_pre_commit_cargo_fmt_must_run_before_clippy`. Reference: `scripts/install-hooks.sh`.
 
 ### Shell scripts: Comments must match behavior
@@ -284,6 +290,16 @@ Always include a version pin in the `tool:` parameter: `cargo-audit@0.22.1`, not
 ### Nightly clippy may flag different issues than stable
 
 The emscripten WASM target requires nightly, which may introduce lints (e.g., `needless_borrow`) not flagged by stable. Fix code for both when possible; otherwise use `#[allow(clippy::lint_name)]` with a comment.
+
+### Seeded netem requires a seed-capable tc
+
+Ubuntu 24.04's packaged iproute2 6.1 does not parse netem's `seed` option. The
+blocking Godot impaired/soak jobs therefore checksum-verify and build only the
+`lib tc` subdirectories from pinned iproute2 6.6.0. Keep the runner version,
+source version/checksum, parser invocation, receiver-facing ingress filters,
+and `netem.txt` qdisc/filter counters in sync. Removing `seed` makes the
+scenario nondeterministic; reinstalling the distribution package does not fix
+the parser gap.
 
 ## Validation Scripts
 

--- a/.llm/skills/godot-websocket/SKILL.md
+++ b/.llm/skills/godot-websocket/SKILL.md
@@ -143,7 +143,11 @@ Advance simulation on a fixed local cadence that does not consult peer or
 network progress, so process scheduling is controlled without hiding genuine
 Fortress stalls. Preserve elapsed deadline debt and recover by at most one
 simulation frame per rendered callback, preventing permanent process skew
-without allowing multi-frame bursts. Use causal post-advance watermarks to
+without allowing multi-frame bursts. Before initializing those local cadence
+deadlines, use a one-time causal barrier: A observes B at frame zero and B
+observes A's subsequent frame one. Retain and validate both roles' release
+watermarks and local release frames so launch order cannot masquerade as
+gameplay lag. Use causal post-advance watermarks to
 bound the relay hold that forces rollback while both games continue advancing,
 and require the polling hitch window to contain forward simulation progress. Its impairment must
 produce measured rollback/load/resimulation, after which

--- a/.llm/skills/godot-websocket/SKILL.md
+++ b/.llm/skills/godot-websocket/SKILL.md
@@ -144,6 +144,13 @@ both peers must match exact game-state checksums, report in-sync health, drain
 all queues, conserve relay/server counts, and complete an observable v3
 `PlayerLeft` teardown.
 
+The workflow builds/exports once, then runs required clean, seeded bidirectional
+netem, and 3,600-confirmed-frame soak jobs in parallel. Impaired profiles include
+a six-callback polling hitch while gameplay advances. Pure JavaScript validators
+must reject negative controls for checksum, confirmation, conservation, queue
+age, lag/stalls, teardown watermarks, and admission diagnostics. Always retain
+logs, time series, Prometheus snapshots, summaries, and netem configuration.
+
 Web builds must use `godot/api-custom` so bindgen generates 32-bit interface
 types. Point `GODOT4_BIN` at the 4.5 editor, point the target-specific bindgen
 arguments at Emscripten's sysroot, build `std` with the pinned nightly, and

--- a/.llm/skills/godot-websocket/SKILL.md
+++ b/.llm/skills/godot-websocket/SKILL.md
@@ -139,7 +139,12 @@ its stable `SIGNAL_FISH_SMOKE` and `SIGNAL_FISH_FORTRESS` log markers and
 retain browser/server logs on failure. The Fortress scenario launches two
 independent Chromium processes, derives stable handles from sorted Signal Fish
 UUIDs, and runs one polling cycle per rendered callback against a real server.
-Its impairment must produce measured rollback/load/resimulation, after which
+Advance simulation on a fixed local cadence that does not consult peer or
+network progress, so process scheduling is controlled without hiding genuine
+Fortress stalls. Use causal post-advance watermarks to bound the relay hold that
+forces rollback while both games continue advancing, and require the polling
+hitch window to contain forward simulation progress. Its impairment must
+produce measured rollback/load/resimulation, after which
 both peers must match exact game-state checksums, report in-sync health, drain
 all queues, conserve relay/server counts, and complete an observable v3
 `PlayerLeft` teardown.

--- a/.llm/skills/godot-websocket/SKILL.md
+++ b/.llm/skills/godot-websocket/SKILL.md
@@ -144,10 +144,12 @@ network progress, so process scheduling is controlled without hiding genuine
 Fortress stalls. Preserve elapsed deadline debt and recover by at most one
 simulation frame per rendered callback, preventing permanent process skew
 without allowing multi-frame bursts. Before initializing those local cadence
-deadlines, use a one-time causal barrier: A observes B at frame zero and B
-observes A's subsequent frame one. Retain and validate both roles' release
-watermarks and local release frames so launch order cannot masquerade as
-gameplay lag. Use causal post-advance watermarks to
+deadlines, use a one-time proposal/ack/commit barrier with a shared same-host
+wall-clock deadline mapped once to each process's monotonic clock. Retain and
+validate every stage, the exact deadline, local release frame, and release
+lateness so launch order cannot masquerade as gameplay lag. This is a
+fixture-only same-host assumption, not a multiplayer clock-synchronization
+protocol. Use causal post-advance watermarks to
 bound the relay hold that forces rollback while both games continue advancing,
 and require the polling hitch window to contain forward simulation progress. Its impairment must
 produce measured rollback/load/resimulation, after which

--- a/.llm/skills/godot-websocket/SKILL.md
+++ b/.llm/skills/godot-websocket/SKILL.md
@@ -141,9 +141,11 @@ independent Chromium processes, derives stable handles from sorted Signal Fish
 UUIDs, and runs one polling cycle per rendered callback against a real server.
 Advance simulation on a fixed local cadence that does not consult peer or
 network progress, so process scheduling is controlled without hiding genuine
-Fortress stalls. Use causal post-advance watermarks to bound the relay hold that
-forces rollback while both games continue advancing, and require the polling
-hitch window to contain forward simulation progress. Its impairment must
+Fortress stalls. Preserve elapsed deadline debt and recover by at most one
+simulation frame per rendered callback, preventing permanent process skew
+without allowing multi-frame bursts. Use causal post-advance watermarks to
+bound the relay hold that forces rollback while both games continue advancing,
+and require the polling hitch window to contain forward simulation progress. Its impairment must
 produce measured rollback/load/resimulation, after which
 both peers must match exact game-state checksums, report in-sync health, drain
 all queues, conserve relay/server counts, and complete an observable v3

--- a/.llm/skills/public-api-design/SKILL.md
+++ b/.llm/skills/public-api-design/SKILL.md
@@ -272,7 +272,9 @@ close details come from `Transport::close_info()`.
   backlog.
 - **Diagnostics are plain accessors.** `send_capacity()`,
   `max_send_capacity()`, `stats()`, and `snapshot()` return plain data on both
-  clients; keep the common APIs mirrored.
+  clients; keep the common APIs mirrored. Polling-only scheduling telemetry
+  such as `PollingQueueAgeStats` stays on the concrete polling client and is
+  exported from the crate root.
 - `GameDataDelivery::Reliable` preserves the v2 wire by omitting class/key;
   `Latest { key }` and `Volatile` require negotiated v3.
 - Adding `SendBufferFull` to the exhaustive `SignalFishError` is breaking

--- a/.llm/skills/shared-core-drivers/SKILL.md
+++ b/.llm/skills/shared-core-drivers/SKILL.md
@@ -27,7 +27,8 @@ pending transport sends, bounded per-poll send/receive work, scheduling
 diagnostics, and deadline-bounded close progress. Its default close policy
 abandons client-owned queued work; flush-on-close is an explicit option. Never
 wait indefinitely for polling close, and never interpret backend acceptance as
-peer delivery.
+peer delivery. Queue age belongs only to polling-driver client ownership and
+stops at backend acceptance; backend buffering remains transport diagnostics.
 
 Never add protocol interpretation or state mutation directly to a driver. Add
 it to `ClientCore`, then exercise it through both drivers in the parity matrix.

--- a/.llm/skills/testing-async/SKILL.md
+++ b/.llm/skills/testing-async/SKILL.md
@@ -222,6 +222,10 @@ cargo test --test client_tests --all-features
 - Returning `Poll::Pending` without using `cx.waker()` deliberately never
   wakes the async driver. Use this only for mocks meant to stay idle until
   shutdown; transports with later input or send capacity must register/wake.
+- For polling schedulers, use generated transition sequences plus a reference
+  ownership model. Persist shrunken failures and include negative models that
+  duplicate a frame or impose stop-and-wait so the oracle's sensitivity is
+  itself tested.
 
 ## Custom Code Scanners in Tests
 

--- a/.llm/skills/transport-abstraction/SKILL.md
+++ b/.llm/skills/transport-abstraction/SKILL.md
@@ -61,6 +61,9 @@ The caller owns `frame: Option<TransportFrame>` until the transport takes it.
   it.
 - Once the transport calls `frame.take()`, the backend owns the frame. This is
   successful ownership transfer, not peer delivery or a socket-wide drain.
+- Client-owned queue-age telemetry ends at that `frame.take()` boundary. A
+  refusal that leaves the slot intact must preserve the frame's original
+  enqueue timestamp along with its FIFO identity.
 - A transport may return `Ready(Ok(()))` immediately after backend acceptance.
   Never use a socket-wide buffered amount reaching zero as per-frame completion.
 - If a transport returns `Pending` after taking a frame, it must retain all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   accessor for bounded per-poll work, explicit flush-on-close, deadline
   handling, and queue/transport observability; defaults are 64 frames/64 KiB
   per direction and `Abandon` on close.
+- Added `PollingQueueAgeStats`, `SignalFishPollingClient::queue_age_stats()`,
+  and `reset_queue_age_peak()` for sampled current/peak age of the oldest
+  client-owned outbound item, complementing queue-depth diagnostics without
+  counting frames after backend acceptance.
 - Added `GodotWebSocketOptions`, `GodotBackpressurePolicy`,
   `connect_with_options`, and `from_peer_with_options` with adaptive
   latency-targeted admission by default (50 ms, 4 KiB–32 KiB), plus explicit

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,8 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 toml = "1.0"
 # Used by the wire-sample provenance policy test to verify checksums.
 sha2 = "0.11"
+# Generates and shrinks polling-driver scheduler transition sequences.
+proptest = "1.7"
 
 [[example]]
 name = "basic_lobby"

--- a/README.md
+++ b/README.md
@@ -243,6 +243,11 @@ let transport = GodotWebSocketTransport::connect("wss://server/ws")
 let config = SignalFishConfig::new("mb_app_abc123");
 let mut client = SignalFishPollingClient::new(transport, config);
 
+// Reset after authentication/setup, then monitor both queue depth and age.
+client.reset_queue_age_peak();
+let queue_age = client.queue_age_stats();
+assert!(queue_age.current_oldest_queue_age <= queue_age.peak_oldest_queue_age);
+
 // Optional: tune the bounded per-frame work and flush queued commands on close
 // with SignalFishPollingClient::new_with_options(...).
 // Godot admission defaults to an adaptive 50 ms target in the 4-32 KiB range,

--- a/docs/fortress.md
+++ b/docs/fortress.md
@@ -83,9 +83,10 @@ Chromium processes and a real Signal Fish Server 0.4.0. The clean case advances
 600 confirmed frames; the impaired case adds seeded bidirectional 40 ms delay,
 10 ms jitter, 0.2% correlated loss, a 10 Mbit/s rate, and a six-callback polling
 hitch at frame 240; the soak advances 3,600 confirmed frames under the same
-profile. The fixture configures a 12-frame prediction window so the declared
-hitch can recover without a scheduler stall; the clean oracle still caps
-observed confirmation lag at eight frames. Simulation advances on a fixed local
+profile. The fixture configures a 20-frame prediction window so acceptable
+constrained-network lag and the declared hitch can recover without an internal
+scheduler stall; the scenario oracles still cap observed confirmation lag at
+eight clean or 12 impaired/soak frames. Simulation advances on a fixed local
 18 Hz cadence, independent of peer or network progress, so unequal browser CPU
 slices do not become artificial frame advantage and real prediction-window
 stalls remain observable. A bounded relay hold uses causal post-advance frame

--- a/docs/fortress.md
+++ b/docs/fortress.md
@@ -92,9 +92,10 @@ slices do not become artificial frame advantage and real prediction-window
 stalls remain observable. Delayed callbacks retain their elapsed deadline debt
 and recover by at most one simulation frame per rendered callback, preventing
 permanent scheduling skew without allowing a multi-frame burst. A bounded
-one-time barrier admits A after B's frame-zero synchronization packet and B
-after A's causally subsequent frame-one packet, preventing process-start order
-from becoming measured gameplay skew. A bounded relay hold uses causal
+one-time proposal/ack/commit barrier maps a shared deadline to each browser's
+monotonic clock, preventing process-start order from becoming measured gameplay
+skew. This wall-clock assumption is fixture-scoped because CI launches both
+Chromium processes on the same host. A bounded relay hold uses causal
 post-advance frame watermarks to prove the remote peer
 predicted the changed delayed input before release, forcing rollback, state
 load, and resimulation while both games keep advancing. The hitch oracle

--- a/docs/fortress.md
+++ b/docs/fortress.md
@@ -85,8 +85,14 @@ Chromium processes and a real Signal Fish Server 0.4.0. The clean case advances
 hitch at frame 240; the soak advances 3,600 confirmed frames under the same
 profile. The fixture configures a 12-frame prediction window so the declared
 hitch can recover without a scheduler stall; the clean oracle still caps
-observed confirmation lag at eight frames. A deterministic remote-input change
-still forces prediction, rollback, state load, and resimulation. CI builds
+observed confirmation lag at eight frames. Simulation advances on a fixed local
+18 Hz cadence, independent of peer or network progress, so unequal browser CPU
+slices do not become artificial frame advantage and real prediction-window
+stalls remain observable. A bounded relay hold uses causal post-advance frame
+watermarks to prove the remote peer predicted the changed delayed input before
+release, forcing rollback, state load, and resimulation while both games keep
+advancing. The hitch oracle separately requires forward simulation progress
+during its six skipped polling callbacks. CI builds
 the pinned, checksum-verified iproute2 6.6.0 `tc` because the runner's packaged
 version cannot apply a deterministic netem seed.
 

--- a/docs/fortress.md
+++ b/docs/fortress.md
@@ -92,7 +92,10 @@ slices do not become artificial frame advantage and real prediction-window
 stalls remain observable. Delayed callbacks retain their elapsed deadline debt
 and recover by at most one simulation frame per rendered callback, preventing
 permanent scheduling skew without allowing a multi-frame burst. A bounded
-relay hold uses causal post-advance frame watermarks to prove the remote peer
+one-time barrier admits A after B's frame-zero synchronization packet and B
+after A's causally subsequent frame-one packet, preventing process-start order
+from becoming measured gameplay skew. A bounded relay hold uses causal
+post-advance frame watermarks to prove the remote peer
 predicted the changed delayed input before release, forcing rollback, state
 load, and resimulation while both games keep advancing. The hitch oracle
 separately requires forward simulation progress during its six skipped polling

--- a/docs/fortress.md
+++ b/docs/fortress.md
@@ -69,19 +69,31 @@ Drive the integration once from Godot's `_process` callback:
 
 Messages produced in step 3 are offered to the WebSocket on the next rendered
 callback. This ordering preserves the real frame-driven pressure that exposed
-issue #61 while keeping each callback bounded. Inspect `polling_stats()` and
-`transport_diagnostics()` for queue peaks, work-budget exhaustion, admission
-hits, and accepted multi-frame bursts.
+issue #61 while keeping each callback bounded. Inspect `polling_stats()` for
+queue peaks and work-budget exhaustion, and `queue_age_stats()` so a
+stable-depth but increasingly stale queue is visible; reset the age peak when
+measured simulation begins. Inspect `transport_diagnostics()` separately for
+admission hits, backend buffering, and accepted multi-frame bursts.
 
 ## System test
 
-The `Godot Web` workflow starts a real Signal Fish server, launches two
-independent Chromium processes running the official Godot 4.5 no-thread export,
-creates and joins one room, and advances a deterministic two-player Fortress
-game for 600 confirmed frames. A deterministic eight-frame outbound impairment
-forces prediction, rollback, state load, and resimulation. The gate then proves
-matching serialized state checksums, in-sync Fortress health and checksum
-comparisons, exact room/roster identity, relay and server conservation, an
-observable v3 `PlayerLeft` terminal watermark, and zero residual queues. It
-also rejects malformed envelopes, capacity hits, callback stalls, server drops,
-and slow-consumer disconnects, and uploads per-process diagnostics on every run.
+The required `Godot Web` checks reuse one official Godot 4.5 no-thread export
+across clean, impaired, and soak jobs. Every job launches two independent
+Chromium processes and a real Signal Fish Server 0.4.0. The clean case advances
+600 confirmed frames; the impaired case adds seeded bidirectional 40 ms delay,
+10 ms jitter, 0.2% correlated loss, a 10 Mbit/s rate, and a six-callback polling
+hitch at frame 240; the soak advances 3,600 confirmed frames under the same
+profile. The fixture configures a 12-frame prediction window so the declared
+hitch can recover without a scheduler stall; the clean oracle still caps
+observed confirmation lag at eight frames. A deterministic remote-input change
+still forces prediction, rollback, state load, and resimulation. CI builds
+the pinned, checksum-verified iproute2 6.6.0 `tc` because the runner's packaged
+version cannot apply a deterministic netem seed.
+
+The gates require exact checksum convergence, in-sync health, bounded
+confirmation lag, zero waits/stalls, at least two relay messages per simulated
+frame, final queue depth and age of zero, a sampled queue-age peak no greater
+than 500 ms, a non-positive final eight-sample queue-age slope for the soak,
+exact client/server conservation, and an observable v3 `PlayerLeft` terminal
+watermark. Browser/server logs, time series, summaries, Prometheus snapshots,
+and netem seed/configuration are uploaded even on failure.

--- a/docs/fortress.md
+++ b/docs/fortress.md
@@ -86,8 +86,8 @@ hitch at frame 240; the soak advances 3,600 confirmed frames under the same
 profile. The fixture configures a 20-frame prediction window so acceptable
 constrained-network lag and the declared hitch can recover without an internal
 scheduler stall; the scenario oracles still cap observed confirmation lag at
-eight clean or 12 impaired/soak frames. Simulation advances on a fixed local
-18 Hz cadence, independent of peer or network progress, so unequal browser CPU
+eight clean, 13 impaired, or 12 soak frames. Simulation advances on a fixed
+local 18 Hz cadence, independent of peer or network progress, so unequal browser CPU
 slices do not become artificial frame advantage and real prediction-window
 stalls remain observable. Delayed callbacks retain their elapsed deadline debt
 and recover by at most one simulation frame per rendered callback, preventing

--- a/docs/fortress.md
+++ b/docs/fortress.md
@@ -89,11 +89,14 @@ scheduler stall; the scenario oracles still cap observed confirmation lag at
 eight clean or 12 impaired/soak frames. Simulation advances on a fixed local
 18 Hz cadence, independent of peer or network progress, so unequal browser CPU
 slices do not become artificial frame advantage and real prediction-window
-stalls remain observable. A bounded relay hold uses causal post-advance frame
-watermarks to prove the remote peer predicted the changed delayed input before
-release, forcing rollback, state load, and resimulation while both games keep
-advancing. The hitch oracle separately requires forward simulation progress
-during its six skipped polling callbacks. CI builds
+stalls remain observable. Delayed callbacks retain their elapsed deadline debt
+and recover by at most one simulation frame per rendered callback, preventing
+permanent scheduling skew without allowing a multi-frame burst. A bounded
+relay hold uses causal post-advance frame watermarks to prove the remote peer
+predicted the changed delayed input before release, forcing rollback, state
+load, and resimulation while both games keep advancing. The hitch oracle
+separately requires forward simulation progress during its six skipped polling
+callbacks. CI builds
 the pinned, checksum-verified iproute2 6.6.0 `tc` because the runner's packaged
 version cannot apply a deterministic netem seed.
 

--- a/docs/transport.md
+++ b/docs/transport.md
@@ -237,6 +237,8 @@ for event in client.poll() {
 `PollingClientOptions` for other budgets or `PollingClosePolicy::Flush`. Zero
 budgets clamp to one, and one individually oversized frame can consume a poll
 by itself. `polling_stats()` reports client-owned queue/budget/close state;
+`queue_age_stats()` reports the sampled current and peak age of the oldest
+client-owned item, and `reset_queue_age_peak()` excludes earlier setup peaks;
 `transport_diagnostics()` reports backend acceptance and buffering. Queued,
 backend-accepted, backend-buffered, and peer-delivered are distinct stages.
 

--- a/docs/wasm.md
+++ b/docs/wasm.md
@@ -343,6 +343,15 @@ Use `polling_stats()` for client-owned queue depth, budget exhaustion, and
 deadline counters; use `transport_diagnostics()` for backend buffering,
 watermark, acceptance, and capacity counters. Backend acceptance is not peer
 delivery.
+Use `queue_age_stats()` alongside depth to detect a fixed-depth queue whose
+oldest command is becoming progressively stale. The current and peak ages are
+sampled on polls and queue mutations. Authentication/setup time contributes
+until `reset_queue_age_peak()` is called; backend acceptance stops the age
+immediately but does not mean the peer has received the frame.
+[Godot's `WebSocketPeer`](https://docs.godotengine.org/en/stable/classes/class_websocketpeer.html)
+reports its outbound buffer separately, matching the
+[WebSocket `bufferedAmount` contract](https://websockets.spec.whatwg.org/):
+buffering after acceptance is backend-owned, not proof of peer delivery.
 
 ### API reference
 
@@ -379,6 +388,8 @@ environment).
 | `current_room_id()` | `fn current_room_id(&self) -> Option<RoomId>` | The current room ID, if in a room. |
 | `current_room_code()` | `fn current_room_code(&self) -> Option<&str>` | The current room code, if in a room. |
 | `polling_stats()` | `fn polling_stats(&self) -> PollingStats` | Client queue, work-budget, abandonment, and deadline diagnostics. |
+| `queue_age_stats()` | `fn queue_age_stats(&self) -> PollingQueueAgeStats` | Sampled current/peak age of the oldest client-owned outbound item. |
+| `reset_queue_age_peak()` | `fn reset_queue_age_peak(&mut self)` | Refresh current age and reset the sampled peak to it. |
 | `transport_diagnostics()` | `fn transport_diagnostics(&self) -> TransportDiagnostics` | Backend acceptance, buffering, watermark, and capacity diagnostics. |
 
 !!! tip "Comparison with `SignalFishClient`"

--- a/proptest-regressions/polling_client.txt
+++ b/proptest-regressions/polling_client.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc e483522aab041fdbe3a85b7156bc8a8b7efa753eb61202287bc736d65f6d814a # shrinks to operations = [ReceiveBinary(0), Poll], flush_on_close = false

--- a/scripts/godot-e2e-validators.mjs
+++ b/scripts/godot-e2e-validators.mjs
@@ -91,6 +91,9 @@ export function validateFortressPeer(summary, options = {}) {
   if (
     !isNonnegativeNumber(summary?.simulation_elapsed_ms) || summary.simulation_elapsed_ms === 0 ||
     summary.simulation_elapsed_ms >= sessionTimeoutMs ||
+    summary?.simulation_target_fps !== 18 ||
+    !isNonnegativeNumber(summary?.observed_simulation_fps) ||
+    summary.observed_simulation_fps < 12 || summary.observed_simulation_fps > 20 ||
     !isNonnegativeNumber(summary?.max_poll_us) || summary.max_poll_us >= 50_000
   ) errors.push("simulation or callback timing bound failed");
   if (
@@ -125,8 +128,12 @@ export function validateFortressPeer(summary, options = {}) {
     summary?.desync_events !== 0 ||
     summary?.frames_advanced !== summary?.visual_frames + summary?.resimulated_frames
   ) errors.push("integrity, conservation, or admission diagnostics failed");
-  if (options.requireHitch && !summary?.poll_hitch_completed) {
-    errors.push("six-callback polling hitch was not completed");
+  if (
+    options.requireHitch &&
+    (!summary?.poll_hitch_completed || !isNonnegativeInteger(summary?.poll_hitch_frames_advanced) ||
+      summary.poll_hitch_frames_advanced === 0)
+  ) {
+    errors.push("six-callback polling hitch did not preserve gameplay advancement");
   }
   return { ok: errors.length === 0, errors };
 }

--- a/scripts/godot-e2e-validators.mjs
+++ b/scripts/godot-e2e-validators.mjs
@@ -77,7 +77,14 @@ export function validateFortressPeer(summary, options = {}) {
   const sessionTimeoutMs = options.sessionTimeoutMs ?? 40_000;
   const errors = [];
   const decimal = /^\d+$/;
-  const requiredStartupFrame = summary?.role === "a" ? 0 : summary?.role === "b" ? 1 : null;
+  const startupRoleValid = summary?.role === "a"
+    ? summary?.startup_proposal_sent === false && summary?.startup_proposal_received === true &&
+      summary?.startup_ack_sent === true && summary?.startup_ack_received === false &&
+      summary?.startup_commit_sent === false && summary?.startup_commit_received === true
+    : summary?.role === "b" && summary?.startup_proposal_sent === true &&
+      summary?.startup_proposal_received === false && summary?.startup_ack_sent === false &&
+      summary?.startup_ack_received === true && summary?.startup_commit_sent === true &&
+      summary?.startup_commit_received === false;
   if (
     summary?.passed !== true || summary?.target_frames !== targetFrames ||
     summary?.settlement_frame_limit !== targetFrames + settlementFrames ||
@@ -104,12 +111,12 @@ export function validateFortressPeer(summary, options = {}) {
     !isNonnegativeNumber(summary?.max_poll_us) || summary.max_poll_us >= 50_000
   ) errors.push("simulation or callback timing bound failed");
   if (
-    requiredStartupFrame === null || summary?.startup_barrier_completed !== true ||
-    summary?.startup_barrier_required_remote_frame !== requiredStartupFrame ||
+    !startupRoleValid || summary?.startup_barrier_completed !== true ||
     summary?.startup_barrier_release_local_frame !== 0 ||
-    !isNonnegativeInteger(summary?.startup_barrier_release_remote_frame) ||
-    summary.startup_barrier_release_remote_frame < requiredStartupFrame ||
-    !isNonnegativeNumber(summary?.startup_barrier_elapsed_ms)
+    !isNonnegativeInteger(summary?.startup_start_unix_ms) || summary.startup_start_unix_ms === 0 ||
+    !isNonnegativeNumber(summary?.startup_barrier_elapsed_ms) ||
+    !isNonnegativeNumber(summary?.startup_release_lateness_ms) ||
+    summary.startup_release_lateness_ms > 100
   ) errors.push("causal startup barrier failed");
   if (
     summary?.multi_frame_poll !== true ||
@@ -155,6 +162,14 @@ export function validateFortressPeer(summary, options = {}) {
 
 export function validateFortressPair(first, second) {
   const errors = [];
+  if (first?.startup_start_unix_ms !== second?.startup_start_unix_ms) {
+    errors.push("peer startup deadlines diverged");
+  }
+  if (
+    !isNonnegativeNumber(first?.startup_release_lateness_ms) ||
+    !isNonnegativeNumber(second?.startup_release_lateness_ms) ||
+    Math.abs(first.startup_release_lateness_ms - second.startup_release_lateness_ms) > 56
+  ) errors.push("peer startup release phases diverged");
   if (
     first?.target_state_checksum !== second?.target_state_checksum ||
     first?.confirmed_input_checksum !== second?.confirmed_input_checksum

--- a/scripts/godot-e2e-validators.mjs
+++ b/scripts/godot-e2e-validators.mjs
@@ -1,0 +1,164 @@
+export function linearSlope(samples, field) {
+  if (samples.length < 2) return Number.NaN;
+  const meanX = samples.reduce((sum, sample) => sum + sample.elapsed_ms, 0) / samples.length;
+  const meanY = samples.reduce((sum, sample) => sum + sample[field], 0) / samples.length;
+  const numerator = samples.reduce(
+    (sum, sample) => sum + (sample.elapsed_ms - meanX) * (sample[field] - meanY),
+    0,
+  );
+  const denominator = samples.reduce(
+    (sum, sample) => sum + (sample.elapsed_ms - meanX) ** 2,
+    0,
+  );
+  return numerator / Math.max(1, denominator);
+}
+
+export function validateFinalSlope(samples, field) {
+  const finalSamples = samples.slice(-8);
+  const slope = linearSlope(finalSamples, field);
+  return {
+    ok: finalSamples.length === 8 && Number.isFinite(slope) && slope <= 0,
+    slope,
+    samples: finalSamples,
+  };
+}
+
+function isNonnegativeNumber(value) {
+  return Number.isFinite(value) && value >= 0;
+}
+
+function isNonnegativeInteger(value) {
+  return Number.isSafeInteger(value) && value >= 0;
+}
+
+export function validateLoadSummary(summary, samples) {
+  const errors = [];
+  const depth = validateFinalSlope(samples, "command_depth");
+  const age = validateFinalSlope(samples, "current_queue_age_ms");
+  if (summary?.passed !== true) errors.push("fixture summary failed");
+  if (summary?.final_queue_depth !== 0) errors.push("final command queue was not drained");
+  if (summary?.current_queue_age_ms !== 0) errors.push("final queue age was not zero");
+  if (!Number.isFinite(summary?.peak_queue_age_ms) || summary.peak_queue_age_ms > 500) {
+    errors.push("peak queue age exceeded 500 ms");
+  }
+  if (!depth.ok) {
+    errors.push("final command-depth slope was positive or unavailable");
+  }
+  if (!age.ok) {
+    errors.push("final queue-age slope was positive or unavailable");
+  }
+  if (
+    summary?.load_error !== false || !isNonnegativeNumber(summary?.p99_latency_us) ||
+    summary.p99_latency_us > 500_000 || !isNonnegativeNumber(summary?.max_poll_us) ||
+    summary.max_poll_us >= 50_000
+  ) {
+    errors.push("load latency, ordering, or callback bound failed");
+  }
+  if (summary?.buffering_safe !== true || summary?.admission_watermark_violations !== 0) {
+    errors.push("transport admission diagnostics failed");
+  }
+  return { ok: errors.length === 0, errors, depthSlope: depth.slope, ageSlope: age.slope };
+}
+
+export function validateFortressPeer(summary, options = {}) {
+  const targetFrames = options.targetFrames ?? 600;
+  const settlementFrames = options.settlementFrames ?? 20;
+  const lagLimit = options.lagLimit ?? 8;
+  const sessionTimeoutMs = options.sessionTimeoutMs ?? 40_000;
+  const errors = [];
+  const decimal = /^\d+$/;
+  if (
+    summary?.passed !== true || summary?.target_frames !== targetFrames ||
+    summary?.settlement_frame_limit !== targetFrames + settlementFrames ||
+    summary?.session_timeout_ms !== sessionTimeoutMs
+  ) errors.push("state summary schema or scenario bounds failed");
+  if (
+    !isNonnegativeInteger(summary?.game_frame) ||
+    !isNonnegativeInteger(summary?.checksum_through) ||
+    summary?.game_frame < targetFrames ||
+    summary?.game_frame > targetFrames + settlementFrames ||
+    summary?.checksum_through !== targetFrames
+  ) errors.push("target frame was not exactly confirmed");
+  if (
+    !decimal.test(summary?.confirmed_input_checksum ?? "") ||
+    !decimal.test(summary?.target_state_checksum ?? "") ||
+    summary?.game_ready !== true || summary?.sync_in_sync !== true
+  ) errors.push("checksum or synchronization state failed");
+  if (
+    !isNonnegativeNumber(summary?.simulation_elapsed_ms) || summary.simulation_elapsed_ms === 0 ||
+    summary.simulation_elapsed_ms >= sessionTimeoutMs ||
+    !isNonnegativeNumber(summary?.max_poll_us) || summary.max_poll_us >= 50_000
+  ) errors.push("simulation or callback timing bound failed");
+  if (
+    summary?.multi_frame_poll !== true ||
+    !isNonnegativeInteger(summary?.peak_queue_depth) || summary.peak_queue_depth > 64
+  ) {
+    errors.push("multi-frame scheduling or queue-depth bound failed");
+  }
+  if (
+    summary?.queue_depth !== 0 || summary?.current_queue_age_ms !== 0 ||
+    !isNonnegativeNumber(summary?.peak_queue_age_ms) || summary.peak_queue_age_ms > 500 ||
+    summary?.relay_inbound_depth !== 0 ||
+    summary?.relay_outbound_depth !== 0
+  ) errors.push("client or relay queue failed to drain within age bounds");
+  if (
+    !isNonnegativeInteger(summary?.confirmation_lag_current) ||
+    !isNonnegativeInteger(summary?.confirmation_lag_max) ||
+    summary?.confirmation_lag_current > lagLimit || summary?.confirmation_lag_max > lagLimit ||
+    summary?.wait_recommendation_count !== 0 || summary?.stall_count !== 0
+  ) errors.push("gameplay confirmation lag, wait, or stall bound failed");
+  if (
+    !isNonnegativeNumber(summary?.relay_messages_per_simulated_frame) ||
+    summary.relay_messages_per_simulated_frame < 2
+  ) {
+    errors.push("relay message cadence fell below two per simulated frame");
+  }
+  if (
+    summary?.relay_dropped !== 0 || summary?.relay_malformed !== 0 ||
+    summary?.backend_capacity_hits !== 0 || summary?.admission_watermark_violations !== 0 ||
+    summary?.checksums_compared < 10 || summary?.checksums_matched !== summary?.checksums_compared ||
+    summary?.checksums_mismatched !== 0 || summary?.events_discarded !== 0 ||
+    summary?.desync_events !== 0 ||
+    summary?.frames_advanced !== summary?.visual_frames + summary?.resimulated_frames
+  ) errors.push("integrity, conservation, or admission diagnostics failed");
+  if (options.requireHitch && !summary?.poll_hitch_completed) {
+    errors.push("six-callback polling hitch was not completed");
+  }
+  return { ok: errors.length === 0, errors };
+}
+
+export function validateFortressPair(first, second) {
+  const errors = [];
+  if (
+    first?.target_state_checksum !== second?.target_state_checksum ||
+    first?.confirmed_input_checksum !== second?.confirmed_input_checksum
+  ) errors.push("peer checksums diverged");
+  if (
+    first?.local_id !== second?.remote_id || second?.local_id !== first?.remote_id ||
+    first?.relay_encoded !== second?.relay_decoded ||
+    second?.relay_encoded !== first?.relay_decoded
+  ) errors.push("roster or relay delivery conservation failed");
+  if (
+    !second?.impairment_activated || !second?.impairment_released ||
+    first?.rollback_count <= first?.pre_impairment_rollback_count ||
+    first?.resimulated_frames <= first?.pre_impairment_resimulated_frames ||
+    first?.prediction_miss_count <= first?.pre_impairment_prediction_miss_count ||
+    first?.max_rollback_depth < 1 || first?.load_requests <= 0
+  ) errors.push("deterministic rollback proof was absent");
+  if (
+    !first?.peer_left_observed || first?.peer_left_epoch <= 0 || first?.peer_left_final_seq <= 0
+  ) errors.push("terminal teardown watermark was absent");
+  return { ok: errors.length === 0, errors };
+}
+
+export function validateServerConservation(values) {
+  const errors = [];
+  if (
+    values.gameDataForwarded !== values.expectedGameData ||
+    values.reliableAttempted !== values.expectedGameData ||
+    values.reliableDelivered !== values.expectedGameData ||
+    values.deliveryAttempts !== values.deliveryTerminals ||
+    values.harmfulDeltas.length > 0
+  ) errors.push("server delivery conservation failed");
+  return { ok: errors.length === 0, errors };
+}

--- a/scripts/godot-e2e-validators.mjs
+++ b/scripts/godot-e2e-validators.mjs
@@ -77,6 +77,7 @@ export function validateFortressPeer(summary, options = {}) {
   const sessionTimeoutMs = options.sessionTimeoutMs ?? 40_000;
   const errors = [];
   const decimal = /^\d+$/;
+  const requiredStartupFrame = summary?.role === "a" ? 0 : summary?.role === "b" ? 1 : null;
   if (
     summary?.passed !== true || summary?.target_frames !== targetFrames ||
     summary?.settlement_frame_limit !== targetFrames + settlementFrames ||
@@ -102,6 +103,14 @@ export function validateFortressPeer(summary, options = {}) {
     summary.observed_simulation_fps < 12 || summary.observed_simulation_fps > 20 ||
     !isNonnegativeNumber(summary?.max_poll_us) || summary.max_poll_us >= 50_000
   ) errors.push("simulation or callback timing bound failed");
+  if (
+    requiredStartupFrame === null || summary?.startup_barrier_completed !== true ||
+    summary?.startup_barrier_required_remote_frame !== requiredStartupFrame ||
+    summary?.startup_barrier_release_local_frame !== 0 ||
+    !isNonnegativeInteger(summary?.startup_barrier_release_remote_frame) ||
+    summary.startup_barrier_release_remote_frame < requiredStartupFrame ||
+    !isNonnegativeNumber(summary?.startup_barrier_elapsed_ms)
+  ) errors.push("causal startup barrier failed");
   if (
     summary?.multi_frame_poll !== true ||
     !isNonnegativeInteger(summary?.peak_queue_depth) || summary.peak_queue_depth > 64

--- a/scripts/godot-e2e-validators.mjs
+++ b/scripts/godot-e2e-validators.mjs
@@ -39,9 +39,15 @@ export function validateLoadSummary(summary, samples) {
   const errors = [];
   const depth = validateFinalSlope(samples, "command_depth");
   const age = validateFinalSlope(samples, "current_queue_age_ms");
+  const finalSamples = samples.slice(-8);
   if (summary?.passed !== true) errors.push("fixture summary failed");
   if (summary?.final_queue_depth !== 0) errors.push("final command queue was not drained");
   if (summary?.current_queue_age_ms !== 0) errors.push("final queue age was not zero");
+  if (summary?.final_drained_samples !== 8 || finalSamples.length !== 8 ||
+      finalSamples.some((sample) =>
+        sample.command_depth !== 0 || sample.current_queue_age_ms !== 0)) {
+    errors.push("final eight samples were not continuously drained");
+  }
   if (!Number.isFinite(summary?.peak_queue_age_ms) || summary.peak_queue_age_ms > 500) {
     errors.push("peak queue age exceeded 500 ms");
   }

--- a/scripts/godot-e2e-validators.mjs
+++ b/scripts/godot-e2e-validators.mjs
@@ -1,5 +1,9 @@
 export function linearSlope(samples, field) {
   if (samples.length < 2) return Number.NaN;
+  if (samples.some((sample, index) =>
+    !Number.isFinite(sample.elapsed_ms) || !Number.isFinite(sample[field]) ||
+    (index > 0 && sample.elapsed_ms < samples[index - 1].elapsed_ms)
+  )) return Number.NaN;
   const meanX = samples.reduce((sum, sample) => sum + sample.elapsed_ms, 0) / samples.length;
   const meanY = samples.reduce((sum, sample) => sum + sample[field], 0) / samples.length;
   const numerator = samples.reduce(
@@ -10,7 +14,7 @@ export function linearSlope(samples, field) {
     (sum, sample) => sum + (sample.elapsed_ms - meanX) ** 2,
     0,
   );
-  return numerator / Math.max(1, denominator);
+  return denominator > 0 ? numerator / denominator : Number.NaN;
 }
 
 export function validateFinalSlope(samples, field) {

--- a/scripts/run-godot-fortress-e2e.mjs
+++ b/scripts/run-godot-fortress-e2e.mjs
@@ -225,11 +225,7 @@ function assertPeerSummary(peer) {
       `Fortress peer ${peer.role} failed its oracle: ${JSON.stringify({ validation, summary })}`,
     );
   }
-  const finalAgeSamples = peer.samples.slice(-8).map((sample) => ({
-    elapsed_ms: sample.current_frame,
-    queue_age_ms: sample.queue_age_ms,
-  }));
-  const finalAgeValidation = validateFinalSlope(finalAgeSamples, "queue_age_ms");
+  const finalAgeValidation = validateFinalSlope(peer.samples, "queue_age_ms");
   peer.finalAgeSlope = finalAgeValidation.slope;
   if (scenario === "soak" && !finalAgeValidation.ok) {
     throw new Error(
@@ -400,9 +396,10 @@ try {
     writeFile(
       "godot-fortress-timeseries.csv",
       `${[
-        "role,current_frame,confirmed_frame,confirmation_lag,queue_depth,queue_age_ms",
+        "role,elapsed_ms,current_frame,confirmed_frame,confirmation_lag,queue_depth,queue_age_ms",
         ...peers.flatMap((peer) => peer.samples.map((sample) => [
           sample.role,
+          sample.elapsed_ms,
           sample.current_frame,
           sample.confirmed_frame,
           sample.confirmation_lag,

--- a/scripts/run-godot-fortress-e2e.mjs
+++ b/scripts/run-godot-fortress-e2e.mjs
@@ -4,11 +4,35 @@ import { createServer } from "node:http";
 import { extname, isAbsolute, join, normalize, relative, resolve, sep } from "node:path";
 import { pipeline } from "node:stream/promises";
 import { chromium } from "playwright";
+import {
+  validateFinalSlope,
+  validateFortressPair,
+  validateFortressPeer,
+  validateServerConservation,
+} from "./godot-e2e-validators.mjs";
 
-const [exportDirectoryArgument] = process.argv.slice(2);
+const [exportDirectoryArgument, ...scenarioArguments] = process.argv.slice(2);
 if (!exportDirectoryArgument) {
-  throw new Error("usage: node scripts/run-godot-fortress-e2e.mjs <export-directory>");
+  throw new Error(
+    "usage: node scripts/run-godot-fortress-e2e.mjs <export-directory> " +
+    "[--scenario clean|impaired|soak] [--server-url ws://host:port/v2/ws]",
+  );
 }
+function option(name, fallback) {
+  const index = scenarioArguments.indexOf(name);
+  return index >= 0 ? scenarioArguments[index + 1] : fallback;
+}
+const scenario = option("--scenario", "clean");
+if (!["clean", "impaired", "soak"].includes(scenario)) {
+  throw new Error(`unsupported Fortress scenario: ${scenario}`);
+}
+const serverUrl = option("--server-url", "ws://127.0.0.1:3536/v2/ws");
+const serverAddress = new URL(serverUrl);
+const metricsUrl = `http://${serverAddress.host}/metrics/prom`;
+const targetFrames = scenario === "soak" ? 3_600 : 600;
+const lagLimit = scenario === "clean" ? 8 : 12;
+const requireHitch = scenario !== "clean";
+const sessionTimeoutMs = scenario === "soak" ? 240_000 : scenario === "clean" ? 40_000 : 60_000;
 const exportDirectory = await realpath(resolve(exportDirectoryArgument));
 const mimeTypes = new Map([
   [".html", "text/html; charset=utf-8"],
@@ -64,7 +88,7 @@ let runError;
 let passed = false;
 
 async function fetchMetrics() {
-  const response = await fetch("http://127.0.0.1:3536/metrics/prom", {
+  const response = await fetch(metricsUrl, {
     signal: AbortSignal.timeout(5_000),
   });
   if (!response.ok) throw new Error(`metrics request failed with HTTP ${response.status}`);
@@ -125,6 +149,7 @@ async function launchPeer(role, requestedRoomCode) {
     console: [],
     pageErrors: [],
     summary: undefined,
+    samples: [],
   };
   // Register the browser immediately so a newPage/navigation failure cannot
   // leak its process or erase its partial diagnostics.
@@ -145,6 +170,15 @@ async function launchPeer(role, requestedRoomCode) {
         peer.pageErrors.push(`invalid summary JSON: ${error}`);
       }
     }
+    const sampleMarker = "SIGNAL_FISH_FORTRESS sample ";
+    const sampleIndex = line.indexOf(sampleMarker);
+    if (sampleIndex >= 0) {
+      try {
+        peer.samples.push(JSON.parse(line.slice(sampleIndex + sampleMarker.length)));
+      } catch (error) {
+        peer.pageErrors.push(`invalid time-series JSON: ${error}`);
+      }
+    }
   });
   page.on("pageerror", (error) => {
     peer.pageErrors.push(error.message);
@@ -152,6 +186,10 @@ async function launchPeer(role, requestedRoomCode) {
   });
   const query = new URLSearchParams({ fortress_role: role });
   if (requestedRoomCode) query.set("room_code", requestedRoomCode);
+  query.set("server_url", serverUrl);
+  query.set("target_frames", String(targetFrames));
+  query.set("session_timeout_ms", String(sessionTimeoutMs));
+  if (requireHitch) query.set("poll_hitch_frame", "240");
   await page.goto(`http://127.0.0.1:${address.port}/index.html?${query}`, {
     waitUntil: "domcontentloaded",
     timeout: 30_000,
@@ -159,7 +197,12 @@ async function launchPeer(role, requestedRoomCode) {
   return peer;
 }
 
-async function waitFor(peer, predicate, description, timeoutMilliseconds = 60_000) {
+async function waitFor(
+  peer,
+  predicate,
+  description,
+  timeoutMilliseconds = scenario === "soak" ? 300_000 : 90_000,
+) {
   const deadline = Date.now() + timeoutMilliseconds;
   while (Date.now() < deadline) {
     const value = predicate();
@@ -171,36 +214,28 @@ async function waitFor(peer, predicate, description, timeoutMilliseconds = 60_00
 
 function assertPeerSummary(peer) {
   const summary = peer.summary;
-  const decimal = /^\d+$/;
-  if (
-    !summary?.passed || summary.target_frames !== 600 || summary.settlement_frame_limit !== 620 ||
-    summary.session_timeout_ms !== 40_000 ||
-    summary.game_frame < 600 || summary.game_frame > 620 || summary.checksum_through !== 600 ||
-    !decimal.test(summary.confirmed_input_checksum) || !decimal.test(summary.target_state_checksum) ||
-    !summary.game_ready || !summary.sync_in_sync
-  ) {
-    throw new Error(`Fortress peer ${peer.role} failed its state oracle: ${JSON.stringify(summary)}`);
+  const validation = validateFortressPeer(summary, {
+    targetFrames,
+    lagLimit,
+    requireHitch,
+    sessionTimeoutMs,
+  });
+  if (!validation.ok) {
+    throw new Error(
+      `Fortress peer ${peer.role} failed its oracle: ${JSON.stringify({ validation, summary })}`,
+    );
   }
-  if (
-    !Number.isFinite(summary.simulation_elapsed_ms) || summary.simulation_elapsed_ms <= 0 ||
-    summary.simulation_elapsed_ms >= summary.session_timeout_ms || summary.max_poll_us >= 50_000
-  ) {
-    throw new Error(`Fortress peer ${peer.role} missed timing bounds: ${JSON.stringify(summary)}`);
-  }
-  if (
-    !summary.multi_frame_poll || summary.peak_queue_depth > 64 || summary.queue_depth !== 0 ||
-    summary.relay_inbound_depth !== 0 || summary.relay_outbound_depth !== 0
-  ) {
-    throw new Error(`Fortress peer ${peer.role} missed queue assertions: ${JSON.stringify(summary)}`);
-  }
-  if (
-    summary.relay_dropped !== 0 || summary.relay_malformed !== 0 ||
-    summary.backend_capacity_hits !== 0 || summary.checksums_compared < 10 ||
-    summary.checksums_matched !== summary.checksums_compared || summary.checksums_mismatched !== 0 ||
-    summary.events_discarded !== 0 || summary.desync_events !== 0 ||
-    summary.frames_advanced !== summary.visual_frames + summary.resimulated_frames
-  ) {
-    throw new Error(`Fortress peer ${peer.role} reported integrity loss: ${JSON.stringify(summary)}`);
+  const finalAgeSamples = peer.samples.slice(-8).map((sample) => ({
+    elapsed_ms: sample.current_frame,
+    queue_age_ms: sample.queue_age_ms,
+  }));
+  const finalAgeValidation = validateFinalSlope(finalAgeSamples, "queue_age_ms");
+  peer.finalAgeSlope = finalAgeValidation.slope;
+  if (scenario === "soak" && !finalAgeValidation.ok) {
+    throw new Error(
+      `Fortress peer ${peer.role} ended the soak with a positive or unavailable queue-age slope: ` +
+      JSON.stringify(finalAgeValidation),
+    );
   }
   assertPeerDiagnostics(peer);
 }
@@ -246,31 +281,14 @@ try {
   ) {
     throw new Error(`Fortress room/roster mismatch: ${JSON.stringify(peers.map((peer) => peer.summary))}`);
   }
-  if (
-    first.summary.target_state_checksum !== second.summary.target_state_checksum ||
-    first.summary.confirmed_input_checksum !== second.summary.confirmed_input_checksum
-  ) {
-    throw new Error(`Fortress convergence mismatch: ${JSON.stringify(peers.map((peer) => peer.summary))}`);
-  }
-  if (
-    !second.summary.impairment_activated || !second.summary.impairment_released ||
-    first.summary.pre_impairment_rollback_count !== 0 ||
-    first.summary.pre_impairment_resimulated_frames !== 0 ||
-    first.summary.pre_impairment_prediction_miss_count !== 0 ||
-    first.summary.rollback_count <= first.summary.pre_impairment_rollback_count ||
-    first.summary.resimulated_frames <= first.summary.pre_impairment_resimulated_frames ||
-    first.summary.prediction_miss_count <= first.summary.pre_impairment_prediction_miss_count ||
-    first.summary.max_rollback_depth < 4 || first.summary.load_requests <= 0 ||
-    !first.summary.peer_left_observed || first.summary.peer_left_epoch <= 0 ||
-    first.summary.peer_left_final_seq <= 0
-  ) {
-    throw new Error(`Fortress rollback/teardown proof absent: ${JSON.stringify(peers.map((peer) => peer.summary))}`);
-  }
-  if (
-    first.summary.relay_encoded !== second.summary.relay_decoded ||
-    second.summary.relay_encoded !== first.summary.relay_decoded
-  ) {
-    throw new Error(`Fortress relay conservation failed: ${JSON.stringify(peers.map((peer) => peer.summary))}`);
+  const pairValidation = validateFortressPair(first.summary, second.summary);
+  if (!pairValidation.ok) {
+    throw new Error(
+      `Fortress pair oracle failed: ${JSON.stringify({
+        pairValidation,
+        peers: peers.map((peer) => peer.summary),
+      })}`,
+    );
   }
 
   await Promise.all(peers.map((peer) => waitFor(
@@ -314,11 +332,16 @@ try {
   const harmfulDeltas = Object.entries(serverMetricDeltas).filter(
     ([name, delta]) => delta > 0 && /(drop|slow_consumer.*disconnect)/i.test(name),
   );
-  if (
-    gameDataForwarded !== expectedGameData || reliableAttempted !== expectedGameData ||
-    reliableDelivered !== expectedGameData || deliveryAttempts !== deliveryTerminals ||
-    harmfulDeltas.length > 0
-  ) {
+  const conservation = validateServerConservation({
+    expectedGameData,
+    gameDataForwarded,
+    reliableAttempted,
+    reliableDelivered,
+    deliveryAttempts,
+    deliveryTerminals,
+    harmfulDeltas,
+  });
+  if (!conservation.ok) {
     throw new Error(`server delivery conservation failed: ${JSON.stringify({
       expectedGameData,
       gameDataForwarded,
@@ -361,11 +384,32 @@ try {
         peers: peers.map((peer) => ({
           role: peer.role,
           summary: peer.summary ?? null,
+          finalAgeSlope: Number.isFinite(peer.finalAgeSlope) ? peer.finalAgeSlope : null,
           pageErrors: peer.pageErrors,
           consoleTypes: peer.console.map(({ type }) => type),
         })),
         serverMetricDeltas,
+        scenario,
+        serverUrl,
       }, null, 2)}\n`,
+    ),
+    writeFile(
+      "godot-fortress-timeseries.json",
+      `${JSON.stringify(peers.flatMap((peer) => peer.samples), null, 2)}\n`,
+    ),
+    writeFile(
+      "godot-fortress-timeseries.csv",
+      `${[
+        "role,current_frame,confirmed_frame,confirmation_lag,queue_depth,queue_age_ms",
+        ...peers.flatMap((peer) => peer.samples.map((sample) => [
+          sample.role,
+          sample.current_frame,
+          sample.confirmed_frame,
+          sample.confirmation_lag,
+          sample.queue_depth,
+          sample.queue_age_ms,
+        ].join(","))),
+      ].join("\n")}\n`,
     ),
     ...peers.map((peer) =>
       writeFile(`godot-fortress-${peer.role}.log`, `${peer.lines.join("\n")}\n`)

--- a/scripts/run-godot-fortress-e2e.mjs
+++ b/scripts/run-godot-fortress-e2e.mjs
@@ -32,7 +32,7 @@ const metricsUrl = `http://${serverAddress.host}/metrics/prom`;
 const targetFrames = scenario === "soak" ? 3_600 : 600;
 const lagLimit = scenario === "clean" ? 8 : 12;
 const requireHitch = scenario !== "clean";
-const sessionTimeoutMs = scenario === "soak" ? 240_000 : scenario === "clean" ? 40_000 : 60_000;
+const sessionTimeoutMs = scenario === "soak" ? 300_000 : scenario === "clean" ? 60_000 : 90_000;
 const exportDirectory = await realpath(resolve(exportDirectoryArgument));
 const mimeTypes = new Map([
   [".html", "text/html; charset=utf-8"],
@@ -201,7 +201,7 @@ async function waitFor(
   peer,
   predicate,
   description,
-  timeoutMilliseconds = scenario === "soak" ? 300_000 : 90_000,
+  timeoutMilliseconds = scenario === "soak" ? 360_000 : 120_000,
 ) {
   const deadline = Date.now() + timeoutMilliseconds;
   while (Date.now() < deadline) {

--- a/scripts/run-godot-fortress-e2e.mjs
+++ b/scripts/run-godot-fortress-e2e.mjs
@@ -396,13 +396,14 @@ try {
     writeFile(
       "godot-fortress-timeseries.csv",
       `${[
-        "role,elapsed_ms,current_frame,confirmed_frame,confirmation_lag,queue_depth,queue_age_ms",
+        "role,elapsed_ms,current_frame,confirmed_frame,confirmation_lag,confirmation_lag_max,queue_depth,queue_age_ms",
         ...peers.flatMap((peer) => peer.samples.map((sample) => [
           sample.role,
           sample.elapsed_ms,
           sample.current_frame,
           sample.confirmed_frame,
           sample.confirmation_lag,
+          sample.confirmation_lag_max,
           sample.queue_depth,
           sample.queue_age_ms,
         ].join(","))),

--- a/scripts/run-godot-fortress-e2e.mjs
+++ b/scripts/run-godot-fortress-e2e.mjs
@@ -30,7 +30,7 @@ const serverUrl = option("--server-url", "ws://127.0.0.1:3536/v2/ws");
 const serverAddress = new URL(serverUrl);
 const metricsUrl = `http://${serverAddress.host}/metrics/prom`;
 const targetFrames = scenario === "soak" ? 3_600 : 600;
-const lagLimit = scenario === "clean" ? 8 : 12;
+const lagLimit = scenario === "clean" ? 8 : scenario === "soak" ? 12 : 13;
 const requireHitch = scenario !== "clean";
 const sessionTimeoutMs = scenario === "soak" ? 300_000 : scenario === "clean" ? 60_000 : 90_000;
 const exportDirectory = await realpath(resolve(exportDirectoryArgument));

--- a/scripts/run-godot-web-smoke.mjs
+++ b/scripts/run-godot-web-smoke.mjs
@@ -4,6 +4,7 @@ import { createServer } from "node:http";
 import { extname, isAbsolute, join, normalize, relative, resolve, sep } from "node:path";
 import { pipeline } from "node:stream/promises";
 import { chromium } from "playwright";
+import { validateLoadSummary, validateServerConservation } from "./godot-e2e-validators.mjs";
 
 const [exportDirectoryArgument, modeArgument] = process.argv.slice(2);
 if (!exportDirectoryArgument || !modeArgument) {
@@ -180,7 +181,8 @@ async function writeThroughputArtifacts() {
   const report = { loadSummary, samples, serverMetricDeltas: deltas };
   await writeFile("godot-throughput.json", `${JSON.stringify(report, null, 2)}\n`);
   const columns = [
-    "elapsed_ms", "command_depth", "peak_depth", "buffered_bytes",
+    "elapsed_ms", "command_depth", "peak_depth", "current_queue_age_ms",
+    "peak_queue_age_ms", "buffered_bytes",
     "accepted_frames", "received_frames", "accepted_per_second",
     "received_per_second", "offered_frames", "poll_max_us", "poll_work_frames",
     "poll_work_bytes", "poll_receive_frames", "poll_count",
@@ -220,30 +222,12 @@ try {
 
     const summaryLine = consoleLines.find((line) => line.includes("SIGNAL_FISH_SMOKE load-summary "));
     loadSummary = JSON.parse(summaryLine.slice(summaryLine.indexOf("SIGNAL_FISH_SMOKE load-summary ") + 31));
-    if (!loadSummary.passed) {
-      throw new Error(`Godot throughput assertions failed: ${JSON.stringify(loadSummary)}`);
-    }
     const samples = loadSamples();
-    const finalSamples = samples.slice(-8);
-    if (finalSamples.length < 2) {
-      throw new Error("insufficient final throughput samples for queue-depth slope");
-    }
-    const meanX = finalSamples.reduce((sum, sample) => sum + sample.elapsed_ms, 0) /
-      finalSamples.length;
-    const meanY = finalSamples.reduce((sum, sample) => sum + sample.command_depth, 0) /
-      finalSamples.length;
-    const slopeNumerator = finalSamples.reduce(
-      (sum, sample) => sum + (sample.elapsed_ms - meanX) * (sample.command_depth - meanY),
-      0,
-    );
-    const slopeDenominator = finalSamples.reduce(
-      (sum, sample) => sum + (sample.elapsed_ms - meanX) ** 2,
-      0,
-    );
-    const queueDepthSlope = slopeNumerator / Math.max(1, slopeDenominator);
-    loadSummary.queue_depth_slope_per_ms = queueDepthSlope;
-    if (queueDepthSlope > 0) {
-      throw new Error(`positive final command-depth slope: ${queueDepthSlope}`);
+    const loadValidation = validateLoadSummary(loadSummary, samples);
+    loadSummary.queue_depth_slope_per_ms = loadValidation.depthSlope;
+    loadSummary.queue_age_slope_ms_per_ms = loadValidation.ageSlope;
+    if (!loadValidation.ok) {
+      throw new Error(`Godot throughput assertions failed: ${JSON.stringify(loadValidation)}`);
     }
     metricsAfter = await fetchMetrics();
     const deltas = metricDeltas(metricsBefore, metricsAfter);
@@ -286,12 +270,16 @@ try {
       (deltas.signal_fish_websocket_deliveries_enqueued_total ?? 0) +
       (deltas.signal_fish_websocket_deliveries_channel_closed_total ?? 0) +
       (deltas.signal_fish_websocket_deliveries_canceled_total ?? 0);
-    if (
-      gameDataForwarded !== expectedGameData ||
-      reliableAttempted !== expectedGameData ||
-      reliableDelivered !== expectedGameData ||
-      deliveryAttempts !== deliveryTerminals
-    ) {
+    const conservation = validateServerConservation({
+      expectedGameData,
+      gameDataForwarded,
+      reliableAttempted,
+      reliableDelivered,
+      deliveryAttempts,
+      deliveryTerminals,
+      harmfulDeltas,
+    });
+    if (!conservation.ok) {
       throw new Error(`server delivery conservation failed: ${JSON.stringify({
         expectedGameData,
         gameDataForwarded,
@@ -299,6 +287,7 @@ try {
         reliableDelivered,
         deliveryAttempts,
         deliveryTerminals,
+        harmfulDeltas,
       })}`);
     }
 

--- a/scripts/test-godot-e2e-validators.mjs
+++ b/scripts/test-godot-e2e-validators.mjs
@@ -66,6 +66,12 @@ test("Fortress oracle rejects each critical negative control", () => {
   const second = peer("b");
   assert.equal(validateFortressPeer(first).ok, true);
   assert.equal(validateFortressPair(first, second).ok, true);
+  const impairedBoundary = structuredClone(first);
+  impairedBoundary.confirmation_lag_current = 13;
+  impairedBoundary.confirmation_lag_max = 13;
+  assert.equal(validateFortressPeer(impairedBoundary, { lagLimit: 13 }).ok, true);
+  impairedBoundary.confirmation_lag_max = 14;
+  assert.equal(validateFortressPeer(impairedBoundary, { lagLimit: 13 }).ok, false);
 
   for (const [label, mutation] of [
     ["frame confirmation", (value) => { value.checksum_through = 599; }],

--- a/scripts/test-godot-e2e-validators.mjs
+++ b/scripts/test-godot-e2e-validators.mjs
@@ -108,6 +108,12 @@ test("final slope oracle requires eight samples and rejects growth", () => {
   const growing = structuredClone(samples);
   growing.forEach((sample, index) => { sample.queue_age_ms = index; });
   assert.equal(validateFinalSlope(growing, "queue_age_ms").ok, false);
+  const regressingClock = structuredClone(samples);
+  regressingClock[6].elapsed_ms = 2;
+  assert.equal(validateFinalSlope(regressingClock, "queue_age_ms").ok, false);
+  const frozenClock = structuredClone(samples);
+  frozenClock.forEach((sample) => { sample.elapsed_ms = 1; });
+  assert.equal(validateFinalSlope(frozenClock, "queue_age_ms").ok, false);
 });
 
 test("server oracle rejects delivery-count corruption", () => {

--- a/scripts/test-godot-e2e-validators.mjs
+++ b/scripts/test-godot-e2e-validators.mjs
@@ -15,9 +15,12 @@ function peer(role) {
     settlement_frame_limit: 620, session_timeout_ms: 40_000, simulation_elapsed_ms: 20_000,
     simulation_target_fps: 18, observed_simulation_fps: 18,
     startup_barrier_completed: true,
-    startup_barrier_required_remote_frame: role === "a" ? 0 : 1,
-    startup_barrier_release_remote_frame: role === "a" ? 0 : 1,
-    startup_barrier_release_local_frame: 0, startup_barrier_elapsed_ms: 100,
+    startup_start_unix_ms: 1_750_000_000_000,
+    startup_proposal_sent: role === "b", startup_proposal_received: role === "a",
+    startup_ack_sent: role === "a", startup_ack_received: role === "b",
+    startup_commit_sent: role === "b", startup_commit_received: role === "a",
+    startup_barrier_release_local_frame: 0, startup_barrier_elapsed_ms: 2_000,
+    startup_release_lateness_ms: 20,
     max_poll_us: 1_000, multi_frame_poll: true, peak_queue_depth: 4,
     confirmed_input_checksum: "123", target_state_checksum: "456", game_ready: true,
     sync_in_sync: true, queue_depth: 0, current_queue_age_ms: 0, peak_queue_age_ms: 40,
@@ -100,6 +103,10 @@ test("Fortress oracle rejects each critical negative control", () => {
     ["startup completion", (value) => { value.startup_barrier_completed = false; }],
     ["startup local frame", (value) => { value.startup_barrier_release_local_frame = 1; }],
     ["startup elapsed time", (value) => { delete value.startup_barrier_elapsed_ms; }],
+    ["startup proposal receipt", (value) => { value.startup_proposal_received = false; }],
+    ["startup ack send", (value) => { value.startup_ack_sent = false; }],
+    ["startup commit receipt", (value) => { value.startup_commit_received = false; }],
+    ["startup lateness", (value) => { value.startup_release_lateness_ms = 101; }],
     ["simulation cadence", (value) => { value.observed_simulation_fps = 11; }],
     ["queue-depth schema", (value) => { delete value.peak_queue_depth; }],
     ["age schema", (value) => { delete value.peak_queue_age_ms; }],
@@ -112,9 +119,21 @@ test("Fortress oracle rejects each critical negative control", () => {
     assert.equal(validateFortressPeer(corrupted, { requireHitch: true }).ok, false, label);
   }
 
-  const staleCreatorWatermark = structuredClone(second);
-  staleCreatorWatermark.startup_barrier_release_remote_frame = 0;
-  assert.equal(validateFortressPeer(staleCreatorWatermark).ok, false, "B rejects stale A0");
+  const divergentStartup = structuredClone(second);
+  divergentStartup.startup_start_unix_ms += 1;
+  assert.equal(validateFortressPair(first, divergentStartup).ok, false, "startup deadline");
+  const divergentReleasePhase = structuredClone(second);
+  divergentReleasePhase.startup_release_lateness_ms = 80;
+  assert.equal(validateFortressPair(first, divergentReleasePhase).ok, false, "startup phase");
+  for (const [label, field] of [
+    ["proposal send", "startup_proposal_sent"],
+    ["ack receipt", "startup_ack_received"],
+    ["commit send", "startup_commit_sent"],
+  ]) {
+    const corrupted = structuredClone(second);
+    corrupted[field] = false;
+    assert.equal(validateFortressPeer(corrupted).ok, false, label);
+  }
 
   for (const [label, mutation] of [
     ["checksum", (value) => { value.target_state_checksum = "different"; }],

--- a/scripts/test-godot-e2e-validators.mjs
+++ b/scripts/test-godot-e2e-validators.mjs
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  validateFortressPair,
+  validateFortressPeer,
+  validateFinalSlope,
+  validateLoadSummary,
+  validateServerConservation,
+} from "./godot-e2e-validators.mjs";
+
+function peer(role) {
+  return {
+    passed: true, role, target_frames: 600, game_frame: 600, checksum_through: 600,
+    settlement_frame_limit: 620, session_timeout_ms: 40_000, simulation_elapsed_ms: 20_000,
+    max_poll_us: 1_000, multi_frame_poll: true, peak_queue_depth: 4,
+    confirmed_input_checksum: "123", target_state_checksum: "456", game_ready: true,
+    sync_in_sync: true, queue_depth: 0, current_queue_age_ms: 0, peak_queue_age_ms: 40,
+    relay_inbound_depth: 0, relay_outbound_depth: 0, confirmation_lag_current: 0,
+    confirmation_lag_max: 6, wait_recommendation_count: 0, stall_count: 0,
+    relay_messages_per_simulated_frame: 2.5, relay_dropped: 0, relay_malformed: 0,
+    backend_capacity_hits: 0, admission_watermark_violations: 0, checksums_compared: 10,
+    checksums_matched: 10, checksums_mismatched: 0, events_discarded: 0,
+    desync_events: 0, frames_advanced: 610, visual_frames: 600, resimulated_frames: 10,
+    local_id: role === "a" ? "a" : "b", remote_id: role === "a" ? "b" : "a",
+    relay_encoded: 1_500, relay_decoded: 1_500, impairment_activated: true,
+    impairment_released: true, rollback_count: 2, pre_impairment_rollback_count: 0,
+    prediction_miss_count: 2, pre_impairment_prediction_miss_count: 0,
+    pre_impairment_resimulated_frames: 0, max_rollback_depth: 1, load_requests: 2,
+    peer_left_observed: role === "a", peer_left_epoch: role === "a" ? 1 : null,
+    peer_left_final_seq: role === "a" ? 10 : null,
+  };
+}
+
+test("load oracle rejects independently corrupted age and admission fields", () => {
+  const summary = {
+    passed: true, final_queue_depth: 0, current_queue_age_ms: 0, peak_queue_age_ms: 100,
+    load_error: false, p99_latency_us: 100_000, max_poll_us: 1_000, buffering_safe: true,
+    admission_watermark_violations: 0,
+  };
+  const samples = Array.from({ length: 8 }, (_, index) => ({
+    elapsed_ms: index * 10, command_depth: 0, current_queue_age_ms: 0,
+  }));
+  assert.equal(validateLoadSummary(summary, samples).ok, true);
+  for (const [label, mutation] of [
+    ["current age", (value) => { value.current_queue_age_ms = 1; }],
+    ["peak age", (value) => { value.peak_queue_age_ms = 501; }],
+    ["admission", (value) => { value.admission_watermark_violations = 1; }],
+    ["missing latency", (value) => { delete value.p99_latency_us; }],
+    ["missing callback", (value) => { delete value.max_poll_us; }],
+  ]) {
+    const corrupted = structuredClone(summary);
+    mutation(corrupted);
+    assert.equal(validateLoadSummary(corrupted, samples).ok, false, label);
+  }
+  assert.equal(validateLoadSummary(summary, samples.slice(1)).ok, false, "requires eight samples");
+  const staleSamples = structuredClone(samples);
+  staleSamples.forEach((sample, index) => { sample.current_queue_age_ms = index; });
+  assert.equal(validateLoadSummary(summary, staleSamples).ok, false);
+});
+
+test("Fortress oracle rejects each critical negative control", () => {
+  const first = peer("a");
+  const second = peer("b");
+  assert.equal(validateFortressPeer(first).ok, true);
+  assert.equal(validateFortressPair(first, second).ok, true);
+
+  for (const [label, mutation] of [
+    ["frame confirmation", (value) => { value.checksum_through = 599; }],
+    ["current queue age", (value) => { value.current_queue_age_ms = 1; }],
+    ["peak queue age", (value) => { value.peak_queue_age_ms = 501; }],
+    ["current lag", (value) => { value.confirmation_lag_current = 9; }],
+    ["maximum lag", (value) => { value.confirmation_lag_max = 9; }],
+    ["wait", (value) => { value.wait_recommendation_count = 1; }],
+    ["stall", (value) => { value.stall_count = 1; }],
+    ["admission", (value) => { value.admission_watermark_violations = 1; }],
+    ["settlement schema", (value) => { delete value.settlement_frame_limit; }],
+    ["timeout schema", (value) => { delete value.session_timeout_ms; }],
+    ["callback schema", (value) => { delete value.max_poll_us; }],
+    ["queue-depth schema", (value) => { delete value.peak_queue_depth; }],
+    ["age schema", (value) => { delete value.peak_queue_age_ms; }],
+    ["lag schema", (value) => { delete value.confirmation_lag_current; }],
+    ["cadence schema", (value) => { delete value.relay_messages_per_simulated_frame; }],
+  ]) {
+    const corrupted = structuredClone(first);
+    mutation(corrupted);
+    assert.equal(validateFortressPeer(corrupted).ok, false, label);
+  }
+
+  for (const [label, mutation] of [
+    ["checksum", (value) => { value.target_state_checksum = "different"; }],
+    ["delivery count", (value) => { value.relay_decoded -= 1; }],
+    ["teardown watermark", (value) => { value.peer_left_final_seq = 0; }],
+  ]) {
+    const corrupted = structuredClone(first);
+    mutation(corrupted);
+    assert.equal(validateFortressPair(corrupted, second).ok, false, label);
+  }
+});
+
+test("final slope oracle requires eight samples and rejects growth", () => {
+  const samples = Array.from({ length: 8 }, (_, elapsed_ms) => ({
+    elapsed_ms,
+    queue_age_ms: 8 - elapsed_ms,
+  }));
+  assert.equal(validateFinalSlope(samples, "queue_age_ms").ok, true);
+  assert.equal(validateFinalSlope(samples.slice(1), "queue_age_ms").ok, false);
+  const growing = structuredClone(samples);
+  growing.forEach((sample, index) => { sample.queue_age_ms = index; });
+  assert.equal(validateFinalSlope(growing, "queue_age_ms").ok, false);
+});
+
+test("server oracle rejects delivery-count corruption", () => {
+  const values = {
+    expectedGameData: 10, gameDataForwarded: 10, reliableAttempted: 10,
+    reliableDelivered: 10, deliveryAttempts: 10, deliveryTerminals: 10,
+    harmfulDeltas: [],
+  };
+  assert.equal(validateServerConservation(values).ok, true);
+  for (const field of ["gameDataForwarded", "reliableAttempted", "deliveryTerminals"]) {
+    const corrupted = structuredClone(values);
+    corrupted[field] -= 1;
+    assert.equal(validateServerConservation(corrupted).ok, false);
+  }
+});

--- a/scripts/test-godot-e2e-validators.mjs
+++ b/scripts/test-godot-e2e-validators.mjs
@@ -37,6 +37,7 @@ function peer(role) {
 test("load oracle rejects independently corrupted age and admission fields", () => {
   const summary = {
     passed: true, final_queue_depth: 0, current_queue_age_ms: 0, peak_queue_age_ms: 100,
+    final_drained_samples: 8,
     load_error: false, p99_latency_us: 100_000, max_poll_us: 1_000, buffering_safe: true,
     admission_watermark_violations: 0,
   };
@@ -46,6 +47,7 @@ test("load oracle rejects independently corrupted age and admission fields", () 
   assert.equal(validateLoadSummary(summary, samples).ok, true);
   for (const [label, mutation] of [
     ["current age", (value) => { value.current_queue_age_ms = 1; }],
+    ["drained samples", (value) => { value.final_drained_samples = 7; }],
     ["peak age", (value) => { value.peak_queue_age_ms = 501; }],
     ["admission", (value) => { value.admission_watermark_violations = 1; }],
     ["missing latency", (value) => { delete value.p99_latency_us; }],
@@ -59,6 +61,12 @@ test("load oracle rejects independently corrupted age and admission fields", () 
   const staleSamples = structuredClone(samples);
   staleSamples.forEach((sample, index) => { sample.current_queue_age_ms = index; });
   assert.equal(validateLoadSummary(summary, staleSamples).ok, false);
+  const flatButNotDrained = structuredClone(samples);
+  flatButNotDrained.forEach((sample) => {
+    sample.command_depth = 1;
+    sample.current_queue_age_ms = 1;
+  });
+  assert.equal(validateLoadSummary(summary, flatButNotDrained).ok, false);
 });
 
 test("Fortress oracle rejects each critical negative control", () => {

--- a/scripts/test-godot-e2e-validators.mjs
+++ b/scripts/test-godot-e2e-validators.mjs
@@ -13,6 +13,7 @@ function peer(role) {
   return {
     passed: true, role, target_frames: 600, game_frame: 600, checksum_through: 600,
     settlement_frame_limit: 620, session_timeout_ms: 40_000, simulation_elapsed_ms: 20_000,
+    simulation_target_fps: 18, observed_simulation_fps: 18,
     max_poll_us: 1_000, multi_frame_poll: true, peak_queue_depth: 4,
     confirmed_input_checksum: "123", target_state_checksum: "456", game_ready: true,
     sync_in_sync: true, queue_depth: 0, current_queue_age_ms: 0, peak_queue_age_ms: 40,
@@ -29,6 +30,7 @@ function peer(role) {
     pre_impairment_resimulated_frames: 0, max_rollback_depth: 1, load_requests: 2,
     peer_left_observed: role === "a", peer_left_epoch: role === "a" ? 1 : null,
     peer_left_final_seq: role === "a" ? 10 : null,
+    poll_hitch_completed: true, poll_hitch_frames_advanced: 4,
   };
 }
 
@@ -77,14 +79,16 @@ test("Fortress oracle rejects each critical negative control", () => {
     ["settlement schema", (value) => { delete value.settlement_frame_limit; }],
     ["timeout schema", (value) => { delete value.session_timeout_ms; }],
     ["callback schema", (value) => { delete value.max_poll_us; }],
+    ["simulation cadence", (value) => { value.observed_simulation_fps = 11; }],
     ["queue-depth schema", (value) => { delete value.peak_queue_depth; }],
     ["age schema", (value) => { delete value.peak_queue_age_ms; }],
     ["lag schema", (value) => { delete value.confirmation_lag_current; }],
     ["cadence schema", (value) => { delete value.relay_messages_per_simulated_frame; }],
+    ["hitch advancement", (value) => { value.poll_hitch_frames_advanced = 0; }],
   ]) {
     const corrupted = structuredClone(first);
     mutation(corrupted);
-    assert.equal(validateFortressPeer(corrupted).ok, false, label);
+    assert.equal(validateFortressPeer(corrupted, { requireHitch: true }).ok, false, label);
   }
 
   for (const [label, mutation] of [

--- a/scripts/test-godot-e2e-validators.mjs
+++ b/scripts/test-godot-e2e-validators.mjs
@@ -14,6 +14,10 @@ function peer(role) {
     passed: true, role, target_frames: 600, game_frame: 600, checksum_through: 600,
     settlement_frame_limit: 620, session_timeout_ms: 40_000, simulation_elapsed_ms: 20_000,
     simulation_target_fps: 18, observed_simulation_fps: 18,
+    startup_barrier_completed: true,
+    startup_barrier_required_remote_frame: role === "a" ? 0 : 1,
+    startup_barrier_release_remote_frame: role === "a" ? 0 : 1,
+    startup_barrier_release_local_frame: 0, startup_barrier_elapsed_ms: 100,
     max_poll_us: 1_000, multi_frame_poll: true, peak_queue_depth: 4,
     confirmed_input_checksum: "123", target_state_checksum: "456", game_ready: true,
     sync_in_sync: true, queue_depth: 0, current_queue_age_ms: 0, peak_queue_age_ms: 40,
@@ -93,6 +97,9 @@ test("Fortress oracle rejects each critical negative control", () => {
     ["settlement schema", (value) => { delete value.settlement_frame_limit; }],
     ["timeout schema", (value) => { delete value.session_timeout_ms; }],
     ["callback schema", (value) => { delete value.max_poll_us; }],
+    ["startup completion", (value) => { value.startup_barrier_completed = false; }],
+    ["startup local frame", (value) => { value.startup_barrier_release_local_frame = 1; }],
+    ["startup elapsed time", (value) => { delete value.startup_barrier_elapsed_ms; }],
     ["simulation cadence", (value) => { value.observed_simulation_fps = 11; }],
     ["queue-depth schema", (value) => { delete value.peak_queue_depth; }],
     ["age schema", (value) => { delete value.peak_queue_age_ms; }],
@@ -104,6 +111,10 @@ test("Fortress oracle rejects each critical negative control", () => {
     mutation(corrupted);
     assert.equal(validateFortressPeer(corrupted, { requireHitch: true }).ok, false, label);
   }
+
+  const staleCreatorWatermark = structuredClone(second);
+  staleCreatorWatermark.startup_barrier_release_remote_frame = 0;
+  assert.equal(validateFortressPeer(staleCreatorWatermark).ok, false, "B rejects stale A0");
 
   for (const [label, mutation] of [
     ["checksum", (value) => { value.target_state_checksum = "different"; }],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,8 +156,8 @@ pub mod polling_client;
 
 #[cfg(feature = "polling-client")]
 pub use polling_client::{
-    PollingClientOptions, PollingClosePolicy, PollingStats, PollingWorkBudget,
-    SignalFishPollingClient,
+    PollingClientOptions, PollingClosePolicy, PollingQueueAgeStats, PollingStats,
+    PollingWorkBudget, SignalFishPollingClient,
 };
 
 #[cfg(feature = "mesh")]

--- a/src/polling_client.rs
+++ b/src/polling_client.rs
@@ -105,6 +105,28 @@ pub struct PollingStats {
     pub close_deadline_expirations: u64,
 }
 
+/// Sampled age of the oldest client-owned outbound command or frame.
+///
+/// Authentication and other setup commands contribute to these values until
+/// [`SignalFishPollingClient::reset_queue_age_peak`] is called. The age stops
+/// when the transport accepts ownership of a frame; transport acceptance is
+/// not peer delivery, and backend-owned buffering is reported separately by
+/// [`SignalFishPollingClient::transport_diagnostics`].
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct PollingQueueAgeStats {
+    /// Age of the oldest client-owned item at the latest sample.
+    pub current_oldest_queue_age: Duration,
+    /// Highest sampled age of the oldest client-owned item since construction
+    /// or the latest peak reset.
+    pub peak_oldest_queue_age: Duration,
+}
+
+#[derive(Debug)]
+struct QueuedCommand {
+    command: PollingCommand,
+    enqueued_at: Instant,
+}
+
 #[derive(Debug, Clone, Copy)]
 enum ClosePhase {
     Open,
@@ -162,7 +184,7 @@ enum ClosePhase {
 /// ```
 pub struct SignalFishPollingClient<T: Transport> {
     transport: T,
-    cmd_queue: VecDeque<PollingCommand>,
+    cmd_queue: VecDeque<QueuedCommand>,
     /// Maximum number of queued commands before sends fail fast with
     /// [`SignalFishError::SendBufferFull`]. Mirrors the async client's
     /// bounded command channel.
@@ -170,9 +192,11 @@ pub struct SignalFishPollingClient<T: Transport> {
     core: ClientCore,
     options: PollingClientOptions,
     polling_stats: PollingStats,
+    queue_age_stats: PollingQueueAgeStats,
     shutdown_timeout: Duration,
     started: bool,
     pending_frame: Option<TransportFrame>,
+    pending_frame_enqueued_at: Option<Instant>,
     /// The transport accepted the current frame and is still completing it.
     /// While true, poll with `None` and do not dequeue a replacement frame.
     send_in_flight: bool,
@@ -209,8 +233,12 @@ impl<T: Transport> SignalFishPollingClient<T> {
             .is_some_and(|transports| transports.contains(&TransportKind::WebRtc));
         let auth_msg = ClientCore::authenticate(&config);
 
+        let now = Instant::now();
         let mut cmd_queue = VecDeque::new();
-        cmd_queue.push_back(auth_msg);
+        cmd_queue.push_back(QueuedCommand {
+            command: auth_msg,
+            enqueued_at: now,
+        });
 
         let shutdown_timeout = config.shutdown_timeout;
         let mut client = Self {
@@ -228,16 +256,18 @@ impl<T: Transport> SignalFishPollingClient<T> {
                 peak_queue_depth: 1,
                 ..PollingStats::default()
             },
+            queue_age_stats: PollingQueueAgeStats::default(),
             shutdown_timeout,
             started: false,
             pending_frame: None,
+            pending_frame_enqueued_at: None,
             send_in_flight: false,
             pending_frame_is_game_data: false,
             in_flight_is_game_data: false,
             pending_inbound: None,
             close_phase: ClosePhase::Open,
         };
-        client.refresh_queue_depth();
+        client.refresh_queue_diagnostics_at(now);
         client
     }
 
@@ -277,6 +307,7 @@ impl<T: Transport> SignalFishPollingClient<T> {
 
     fn poll_at(&mut self, now: Instant) -> Vec<SignalFishEvent> {
         let mut events = Vec::new();
+        self.refresh_queue_diagnostics_at(now);
 
         // Create a noop waker to poll transport futures synchronously.
         let waker = std::task::Waker::noop();
@@ -292,7 +323,7 @@ impl<T: Transport> SignalFishPollingClient<T> {
             return events;
         }
 
-        if let Err(error) = self.drive_outbound(&mut cx) {
+        if let Err(error) = self.drive_outbound(&mut cx, now) {
             error!(%error, "transport send failed");
             self.handle_disconnect_at(
                 &mut events,
@@ -689,6 +720,22 @@ impl<T: Transport> SignalFishPollingClient<T> {
         self.polling_stats
     }
 
+    /// Return the latest sampled client-owned queue-age diagnostics.
+    ///
+    /// Queue age is sampled on every poll and queue mutation. Empty queues
+    /// report zero. Backend acceptance ends client ownership immediately; use
+    /// [`transport_diagnostics`](Self::transport_diagnostics) for buffering
+    /// after that boundary.
+    pub fn queue_age_stats(&self) -> PollingQueueAgeStats {
+        self.queue_age_stats
+    }
+
+    /// Refresh the current oldest client-owned queue age and reset its peak to
+    /// that sampled value.
+    pub fn reset_queue_age_peak(&mut self) {
+        self.reset_queue_age_peak_at(Instant::now());
+    }
+
     /// Return backend-owned transport buffering and admission diagnostics.
     pub fn transport_diagnostics(&self) -> TransportDiagnostics {
         self.transport.diagnostics()
@@ -730,7 +777,7 @@ impl<T: Transport> SignalFishPollingClient<T> {
         let _ = self.core.disconnect(Some("client closed".into()));
         self.close_phase = match self.options.close_policy {
             PollingClosePolicy::Abandon => {
-                self.abandon_client_owned(false);
+                self.abandon_client_owned(false, now);
                 if self.send_in_flight {
                     ClosePhase::Flushing { started_at: now }
                 } else {
@@ -750,10 +797,10 @@ impl<T: Transport> SignalFishPollingClient<T> {
 
     fn queue_operation(&mut self, operation: ClientOperation) -> Result<()> {
         let command = self.core.prepare(operation)?;
-        self.queue_command(command)
+        self.queue_command_at(command, Instant::now())
     }
 
-    fn queue_command(&mut self, command: PollingCommand) -> Result<()> {
+    fn queue_command_at(&mut self, command: PollingCommand, now: Instant) -> Result<()> {
         if !self.core.is_connected() {
             return Err(SignalFishError::NotConnected);
         }
@@ -766,14 +813,18 @@ impl<T: Transport> SignalFishPollingClient<T> {
                 capacity: self.command_capacity,
             });
         }
-        self.cmd_queue.push_back(command);
-        self.refresh_queue_depth();
+        self.cmd_queue.push_back(QueuedCommand {
+            command,
+            enqueued_at: now,
+        });
+        self.refresh_queue_diagnostics_at(now);
         Ok(())
     }
 
     fn drive_outbound(
         &mut self,
         cx: &mut std::task::Context<'_>,
+        now: Instant,
     ) -> std::result::Result<(), SignalFishError> {
         if self.send_in_flight {
             let mut no_frame = None;
@@ -799,20 +850,16 @@ impl<T: Transport> SignalFishPollingClient<T> {
         let mut sent_bytes = 0usize;
         loop {
             if self.pending_frame.is_none() {
-                let Some(command) = self.cmd_queue.pop_front() else {
+                let Some(queued) = self.cmd_queue.pop_front() else {
                     break;
                 };
-                match command {
+                self.pending_frame_enqueued_at = Some(queued.enqueued_at);
+                match queued.command {
                     PollingCommand::Message(message) => {
-                        let json = match serde_json::to_string(&message) {
-                            Ok(json) => json,
-                            Err(error) => {
-                                error!(%error, "failed to serialize ClientMessage");
-                                self.polling_stats.abandoned_commands =
-                                    self.polling_stats.abandoned_commands.saturating_add(1);
-                                self.refresh_queue_depth();
-                                continue;
-                            }
+                        let Some(json) =
+                            self.finish_serialization_at(serde_json::to_string(&message), now)
+                        else {
+                            continue;
                         };
                         self.pending_frame_is_game_data =
                             matches!(message, ClientMessage::GameData { .. });
@@ -823,7 +870,7 @@ impl<T: Transport> SignalFishPollingClient<T> {
                         self.pending_frame = Some(TransportFrame::Binary(payload));
                     }
                 }
-                self.refresh_queue_depth();
+                self.refresh_queue_diagnostics_at(now);
             }
 
             let frame_bytes = self
@@ -843,9 +890,10 @@ impl<T: Transport> SignalFishPollingClient<T> {
             let result = self.transport.poll_send(cx, &mut self.pending_frame);
             let transferred = self.pending_frame.is_none();
             if transferred {
+                self.pending_frame_enqueued_at = None;
                 sent_frames = sent_frames.saturating_add(1);
                 sent_bytes = next_bytes.unwrap_or(usize::MAX);
-                self.refresh_queue_depth();
+                self.refresh_queue_diagnostics_at(now);
             }
             match result {
                 std::task::Poll::Ready(Ok(())) => {
@@ -890,7 +938,7 @@ impl<T: Transport> SignalFishPollingClient<T> {
             ClosePhase::Open | ClosePhase::Closed => return,
         };
         if now.saturating_duration_since(started_at) >= self.shutdown_timeout {
-            self.abandon_client_owned(true);
+            self.abandon_client_owned(true, now);
             self.transport.abort();
             self.polling_stats.close_deadline_expirations = self
                 .polling_stats
@@ -904,9 +952,9 @@ impl<T: Transport> SignalFishPollingClient<T> {
         self.drain_closing_inbound(cx);
 
         if matches!(self.close_phase, ClosePhase::Flushing { .. }) {
-            if let Err(error) = self.drive_outbound(cx) {
+            if let Err(error) = self.drive_outbound(cx, now) {
                 error!(%error, "queued send failed while flushing close");
-                self.abandon_client_owned(false);
+                self.abandon_client_owned(false, now);
                 self.close_phase = ClosePhase::Closing { started_at };
             } else if !self.has_outbound_work() {
                 self.close_phase = ClosePhase::Closing { started_at };
@@ -975,7 +1023,7 @@ impl<T: Transport> SignalFishPollingClient<T> {
         cx: &mut std::task::Context<'_>,
         now: Instant,
     ) {
-        self.abandon_client_owned(false);
+        self.abandon_client_owned(false, now);
         self.pending_inbound = None;
         self.close_phase = if self.send_in_flight {
             ClosePhase::Flushing { started_at: now }
@@ -990,7 +1038,7 @@ impl<T: Transport> SignalFishPollingClient<T> {
         self.send_in_flight || self.pending_frame.is_some() || !self.cmd_queue.is_empty()
     }
 
-    fn abandon_client_owned(&mut self, include_in_flight: bool) {
+    fn abandon_client_owned(&mut self, include_in_flight: bool, now: Instant) {
         let mut abandoned = self.cmd_queue.len();
         abandoned = abandoned.saturating_add(usize::from(self.pending_frame.is_some()));
         if include_in_flight {
@@ -1000,15 +1048,38 @@ impl<T: Transport> SignalFishPollingClient<T> {
         }
         self.cmd_queue.clear();
         self.pending_frame = None;
+        self.pending_frame_enqueued_at = None;
         self.pending_frame_is_game_data = false;
         self.polling_stats.abandoned_commands = self
             .polling_stats
             .abandoned_commands
             .saturating_add(u64::try_from(abandoned).unwrap_or(u64::MAX));
-        self.refresh_queue_depth();
+        self.refresh_queue_diagnostics_at(now);
     }
 
-    fn refresh_queue_depth(&mut self) {
+    fn record_serialization_failure_at(&mut self, now: Instant) {
+        self.polling_stats.abandoned_commands =
+            self.polling_stats.abandoned_commands.saturating_add(1);
+        self.pending_frame_enqueued_at = None;
+        self.refresh_queue_diagnostics_at(now);
+    }
+
+    fn finish_serialization_at(
+        &mut self,
+        result: serde_json::Result<String>,
+        now: Instant,
+    ) -> Option<String> {
+        match result {
+            Ok(json) => Some(json),
+            Err(error) => {
+                error!(%error, "failed to serialize ClientMessage");
+                self.record_serialization_failure_at(now);
+                None
+            }
+        }
+    }
+
+    fn refresh_queue_diagnostics_at(&mut self, now: Instant) {
         let depth = self
             .cmd_queue
             .len()
@@ -1018,6 +1089,21 @@ impl<T: Transport> SignalFishPollingClient<T> {
             .polling_stats
             .peak_queue_depth
             .max(self.polling_stats.current_queue_depth);
+
+        let oldest = self
+            .pending_frame_enqueued_at
+            .or_else(|| self.cmd_queue.front().map(|queued| queued.enqueued_at));
+        let current = oldest.map_or(Duration::ZERO, |enqueued_at| {
+            now.saturating_duration_since(enqueued_at)
+        });
+        self.queue_age_stats.current_oldest_queue_age = current;
+        self.queue_age_stats.peak_oldest_queue_age =
+            self.queue_age_stats.peak_oldest_queue_age.max(current);
+    }
+
+    fn reset_queue_age_peak_at(&mut self, now: Instant) {
+        self.refresh_queue_diagnostics_at(now);
+        self.queue_age_stats.peak_oldest_queue_age = self.queue_age_stats.current_oldest_queue_age;
     }
 }
 
@@ -1154,6 +1240,8 @@ impl<T: Transport> crate::client_api::SignalFishClientApi for SignalFishPollingC
 )]
 mod tests {
     use std::collections::VecDeque;
+
+    use proptest::{prop_assert, prop_assert_eq};
 
     use super::*;
     use crate::protocol::ServerMessage;
@@ -1309,6 +1397,18 @@ mod tests {
 
     fn default_config() -> SignalFishConfig {
         SignalFishConfig::new("test_app_id")
+    }
+
+    fn enqueue_direct<T: Transport>(
+        client: &mut SignalFishPollingClient<T>,
+        command: PollingCommand,
+    ) {
+        let now = Instant::now();
+        client.cmd_queue.push_back(QueuedCommand {
+            command,
+            enqueued_at: now,
+        });
+        client.refresh_queue_diagnostics_at(now);
     }
 
     fn accountability_prefix(player_id: PlayerId) -> Vec<TransportFrame> {
@@ -3751,6 +3851,180 @@ mod tests {
     }
 
     #[test]
+    fn constant_depth_can_have_positive_oldest_queue_age_slope() {
+        let allow = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let transport = TogglePendingSendTransport {
+            allow,
+            sent: Vec::new(),
+            _sent_binary: Vec::new(),
+        };
+        let mut client = SignalFishPollingClient::new(transport, default_config());
+        let base = Instant::now();
+        client
+            .cmd_queue
+            .front_mut()
+            .expect("Authenticate should be queued")
+            .enqueued_at = base;
+
+        let _ = client.poll_at(base);
+        let first_depth = client.polling_stats().current_queue_depth;
+        let first_age = client.queue_age_stats().current_oldest_queue_age;
+        let _ = client.poll_at(base + Duration::from_millis(40));
+        let second_depth = client.polling_stats().current_queue_depth;
+        let second_age = client.queue_age_stats().current_oldest_queue_age;
+
+        assert_eq!(second_depth, first_depth);
+        assert!(second_age > first_age);
+        assert_eq!(second_age, Duration::from_millis(40));
+    }
+
+    #[test]
+    fn refused_frame_retains_fifo_identity_and_ages_until_acceptance() {
+        let allow = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let transport = TogglePendingSendTransport {
+            allow: std::sync::Arc::clone(&allow),
+            sent: Vec::new(),
+            _sent_binary: Vec::new(),
+        };
+        let mut client = SignalFishPollingClient::new(transport, default_config());
+        let base = Instant::now();
+        client
+            .cmd_queue
+            .front_mut()
+            .expect("Authenticate should be queued")
+            .enqueued_at = base;
+
+        let _ = client.poll_at(base + Duration::from_millis(10));
+        let refused = client
+            .pending_frame
+            .clone()
+            .expect("refused frame should remain client-owned");
+        let refused_at = client.pending_frame_enqueued_at;
+        let _ = client.poll_at(base + Duration::from_millis(25));
+
+        assert_eq!(client.pending_frame.as_ref(), Some(&refused));
+        assert_eq!(client.pending_frame_enqueued_at, refused_at);
+        assert_eq!(
+            client.queue_age_stats().current_oldest_queue_age,
+            Duration::from_millis(25)
+        );
+
+        allow.store(true, std::sync::atomic::Ordering::Release);
+        let _ = client.poll_at(base + Duration::from_millis(30));
+
+        assert!(client.pending_frame.is_none());
+        assert!(client.pending_frame_enqueued_at.is_none());
+        assert_eq!(
+            client.queue_age_stats().current_oldest_queue_age,
+            Duration::ZERO
+        );
+        assert_eq!(
+            client.queue_age_stats().peak_oldest_queue_age,
+            Duration::from_millis(30)
+        );
+        assert_eq!(client.transport.sent.len(), 1);
+    }
+
+    #[test]
+    fn queue_age_peak_reset_clock_regression_and_close_preserve_invariants() {
+        let allow = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let transport = TogglePendingSendTransport {
+            allow,
+            sent: Vec::new(),
+            _sent_binary: Vec::new(),
+        };
+        let mut client = SignalFishPollingClient::new(transport, default_config());
+        let base = Instant::now();
+        client
+            .cmd_queue
+            .front_mut()
+            .expect("Authenticate should be queued")
+            .enqueued_at = base;
+
+        let _ = client.poll_at(base + Duration::from_millis(50));
+        client.reset_queue_age_peak_at(base + Duration::from_millis(20));
+        let regressed = client.queue_age_stats();
+        assert_eq!(
+            regressed.current_oldest_queue_age,
+            Duration::from_millis(20)
+        );
+        assert_eq!(
+            regressed.peak_oldest_queue_age,
+            regressed.current_oldest_queue_age
+        );
+
+        let _ = client.poll_at(base - Duration::from_millis(1));
+        let regressed = client.queue_age_stats();
+        assert_eq!(regressed.current_oldest_queue_age, Duration::ZERO);
+        assert_eq!(regressed.peak_oldest_queue_age, Duration::from_millis(20));
+
+        client.close_at(base + Duration::from_millis(60));
+        let drained = client.queue_age_stats();
+        assert_eq!(drained.current_oldest_queue_age, Duration::ZERO);
+        assert_eq!(drained.peak_oldest_queue_age, Duration::from_millis(20));
+    }
+
+    #[test]
+    fn serialization_failure_cleanup_stops_queue_age_and_preserves_peak() {
+        let mut client = SignalFishPollingClient::new(MockTransport::new(), default_config());
+        let base = Instant::now();
+        let queued = client
+            .cmd_queue
+            .pop_front()
+            .expect("Authenticate should be queued");
+        let _ = queued;
+        client.pending_frame_enqueued_at = Some(base);
+        client.refresh_queue_diagnostics_at(base + Duration::from_millis(10));
+
+        let serialization_error = serde_json::from_str::<serde_json::Value>("{")
+            .expect_err("the injected malformed JSON should fail");
+        assert!(client
+            .finish_serialization_at(Err(serialization_error), base + Duration::from_millis(20),)
+            .is_none());
+
+        let age = client.queue_age_stats();
+        assert_eq!(age.current_oldest_queue_age, Duration::ZERO);
+        assert_eq!(age.peak_oldest_queue_age, Duration::from_millis(10));
+        assert_eq!(client.polling_stats().abandoned_commands, 1);
+
+        // `ClientMessage` contains only JSON-representable SDK and
+        // `serde_json::Value` fields, so safe public inputs cannot construct a
+        // failing message. Inject an error into the same result transition
+        // used by `drive_outbound` instead.
+    }
+
+    #[test]
+    fn backend_accepted_pending_frame_stops_contributing_to_queue_age() {
+        let transport = AcceptedPendingSendTransport {
+            retained: None,
+            sent: Vec::new(),
+            replacement_seen: false,
+            peer_closes_on_recv: false,
+        };
+        let mut client = SignalFishPollingClient::new(transport, default_config());
+        let base = Instant::now();
+        client
+            .cmd_queue
+            .front_mut()
+            .expect("Authenticate should be queued")
+            .enqueued_at = base;
+
+        let _ = client.poll_at(base + Duration::from_millis(25));
+
+        assert!(client.send_in_flight, "backend should retain Authenticate");
+        assert!(client.pending_frame.is_none());
+        assert_eq!(
+            client.queue_age_stats().current_oldest_queue_age,
+            Duration::ZERO,
+            "backend ownership must stop client queue age even while completion is pending"
+        );
+        assert_eq!(
+            client.queue_age_stats().peak_oldest_queue_age,
+            Duration::from_millis(25)
+        );
+    }
+
+    #[test]
     fn accepted_pending_send_completes_before_dequeuing_replacement() {
         let transport = AcceptedPendingSendTransport {
             retained: None,
@@ -3790,17 +4064,10 @@ mod tests {
     fn one_poll_transfers_multiple_text_and_binary_frames() {
         let transport = RecordingFrameTransport::default();
         let mut client = SignalFishPollingClient::new(transport, default_config());
-        client
-            .cmd_queue
-            .push_back(PollingCommand::Message(ClientMessage::Ping));
-        client
-            .cmd_queue
-            .push_back(PollingCommand::Binary(vec![1, 2, 3]));
-        client
-            .cmd_queue
-            .push_back(PollingCommand::Message(ClientMessage::Ping));
-        client.cmd_queue.push_back(PollingCommand::Binary(vec![4]));
-        client.refresh_queue_depth();
+        enqueue_direct(&mut client, PollingCommand::Message(ClientMessage::Ping));
+        enqueue_direct(&mut client, PollingCommand::Binary(vec![1, 2, 3]));
+        enqueue_direct(&mut client, PollingCommand::Message(ClientMessage::Ping));
+        enqueue_direct(&mut client, PollingCommand::Binary(vec![4]));
 
         let _ = client.poll();
 
@@ -3835,11 +4102,8 @@ mod tests {
         let mut client =
             SignalFishPollingClient::new_with_options(transport, default_config(), options);
         for _ in 0..5 {
-            client
-                .cmd_queue
-                .push_back(PollingCommand::Message(ClientMessage::Ping));
+            enqueue_direct(&mut client, PollingCommand::Message(ClientMessage::Ping));
         }
-        client.refresh_queue_depth();
 
         let _ = client.poll();
         assert_eq!(client.transport.sent.len(), 3);
@@ -3866,10 +4130,7 @@ mod tests {
         let mut client =
             SignalFishPollingClient::new_with_options(transport, default_config(), options);
         let _ = client.poll();
-        client
-            .cmd_queue
-            .push_back(PollingCommand::Binary(vec![7; 32]));
-        client.refresh_queue_depth();
+        enqueue_direct(&mut client, PollingCommand::Binary(vec![7; 32]));
 
         let _ = client.poll();
         assert_eq!(client.transport.sent.len(), 2);
@@ -3895,11 +4156,8 @@ mod tests {
             SignalFishPollingClient::new_with_options(transport, default_config(), options);
         let _ = client.poll();
         for byte in [1, 2, 3] {
-            client
-                .cmd_queue
-                .push_back(PollingCommand::Binary(vec![byte; 4]));
+            enqueue_direct(&mut client, PollingCommand::Binary(vec![byte; 4]));
         }
-        client.refresh_queue_depth();
 
         let _ = client.poll();
         assert_eq!(client.transport.sent.len(), 2);
@@ -4100,16 +4358,25 @@ mod tests {
     fn abandon_close_discards_queued_work_and_starts_close() {
         let transport = RecordingFrameTransport::default();
         let mut client = SignalFishPollingClient::new(transport, default_config());
-        client
-            .cmd_queue
-            .push_back(PollingCommand::Message(ClientMessage::Ping));
-        client.refresh_queue_depth();
+        enqueue_direct(&mut client, PollingCommand::Message(ClientMessage::Ping));
+        let base = Instant::now();
+        for queued in &mut client.cmd_queue {
+            queued.enqueued_at = base;
+        }
+        client.refresh_queue_diagnostics_at(base + Duration::from_millis(15));
 
-        client.close();
+        client.close_at(base + Duration::from_millis(20));
 
         assert_eq!(client.transport.sent.len(), 0);
         assert_eq!(client.transport.close_calls, 1);
         assert_eq!(client.polling_stats().abandoned_commands, 2);
+        assert_eq!(
+            client.queue_age_stats(),
+            PollingQueueAgeStats {
+                current_oldest_queue_age: Duration::ZERO,
+                peak_oldest_queue_age: Duration::from_millis(15),
+            }
+        );
         assert!(!client.is_closing());
         assert!(matches!(client.ping(), Err(SignalFishError::NotConnected)));
     }
@@ -4128,6 +4395,14 @@ mod tests {
 
         assert!(client.pending_frame.is_none());
         assert_eq!(client.polling_stats().abandoned_commands, 1);
+        assert_eq!(
+            client.queue_age_stats().current_oldest_queue_age,
+            Duration::ZERO
+        );
+        assert!(
+            client.queue_age_stats().peak_oldest_queue_age
+                >= client.queue_age_stats().current_oldest_queue_age
+        );
         assert_eq!(client.transport.close_calls, 1);
         assert!(!client.is_closing());
     }
@@ -4141,10 +4416,7 @@ mod tests {
         let transport = RecordingFrameTransport::default();
         let mut client =
             SignalFishPollingClient::new_with_options(transport, default_config(), options);
-        client
-            .cmd_queue
-            .push_back(PollingCommand::Message(ClientMessage::Ping));
-        client.refresh_queue_depth();
+        enqueue_direct(&mut client, PollingCommand::Message(ClientMessage::Ping));
 
         client.close();
 
@@ -4208,11 +4480,8 @@ mod tests {
             let config = default_config().with_shutdown_timeout(Duration::from_millis(10));
             let mut client = SignalFishPollingClient::new_with_options(transport, config, options);
             for _ in 0..4 {
-                client
-                    .cmd_queue
-                    .push_back(PollingCommand::Message(ClientMessage::Ping));
+                enqueue_direct(&mut client, PollingCommand::Message(ClientMessage::Ping));
             }
-            client.refresh_queue_depth();
             let started_at = Instant::now();
 
             let _ = client.poll_at(started_at);
@@ -4715,5 +4984,808 @@ mod tests {
             matches!(join_result, Err(SignalFishError::NotConnected)),
             "expected NotConnected after close(), got: {join_result:?}"
         );
+    }
+
+    // ── H. Model-based scheduler verification ─────────────────────
+
+    #[derive(Debug, Clone)]
+    enum SchedulerOperation {
+        EnqueueText,
+        EnqueueBinary,
+        Poll,
+        SetReady(bool),
+        RefuseBeforeAcceptance,
+        PendingAfterAcceptance(bool),
+        CapacityRecovery,
+        SetCloseReady(bool),
+        ReceiveText,
+        ReceiveBinary,
+        AdvanceClock(u8),
+        Close,
+        Abort,
+    }
+
+    fn scheduler_operations() -> impl proptest::strategy::Strategy<Value = Vec<SchedulerOperation>>
+    {
+        use proptest::prelude::*;
+
+        prop::collection::vec(
+            prop_oneof![
+                5 => Just(SchedulerOperation::EnqueueText),
+                5 => Just(SchedulerOperation::EnqueueBinary),
+                8 => Just(SchedulerOperation::Poll),
+                1 => any::<bool>().prop_map(SchedulerOperation::SetReady),
+                2 => Just(SchedulerOperation::RefuseBeforeAcceptance),
+                2 => any::<bool>().prop_map(SchedulerOperation::PendingAfterAcceptance),
+                2 => Just(SchedulerOperation::CapacityRecovery),
+                1 => any::<bool>().prop_map(SchedulerOperation::SetCloseReady),
+                2 => Just(SchedulerOperation::ReceiveText),
+                2 => Just(SchedulerOperation::ReceiveBinary),
+                3 => (0u8..=20).prop_map(SchedulerOperation::AdvanceClock),
+                1 => Just(SchedulerOperation::Close),
+                1 => Just(SchedulerOperation::Abort),
+            ],
+            1..96,
+        )
+        .prop_map(|mut operations| {
+            // Every generated close/refusal/in-flight state gets an explicit
+            // recovery suffix. The driver must remain stuck until these
+            // transitions occur, then finish in finite polls.
+            operations.push(SchedulerOperation::CapacityRecovery);
+            operations.push(SchedulerOperation::PendingAfterAcceptance(false));
+            operations.push(SchedulerOperation::SetCloseReady(true));
+            operations.extend((0..8).map(|_| SchedulerOperation::Poll));
+            operations
+        })
+    }
+
+    fn scheduler_budgets() -> impl proptest::strategy::Strategy<Value = PollingWorkBudget> {
+        use proptest::prelude::*;
+
+        (1usize..=4, 1usize..=160, 1usize..=4, 1usize..=160).prop_map(
+            |(send_frames, send_bytes, receive_frames, receive_bytes)| PollingWorkBudget {
+                send_frames,
+                send_bytes,
+                receive_frames,
+                receive_bytes,
+            },
+        )
+    }
+
+    #[derive(Default)]
+    struct SchedulerTransport {
+        ready: bool,
+        accept: bool,
+        pending_after_acceptance: bool,
+        complete_retained: bool,
+        close_ready: bool,
+        retained: Option<TransportFrame>,
+        accepted: Vec<TransportFrame>,
+        incoming: VecDeque<TransportFrame>,
+        replacement_seen: bool,
+        close_calls: u64,
+        abort_calls: u64,
+    }
+
+    impl Transport for SchedulerTransport {
+        fn poll_send(
+            &mut self,
+            _cx: &mut std::task::Context<'_>,
+            frame: &mut Option<TransportFrame>,
+        ) -> std::task::Poll<std::result::Result<(), SignalFishError>> {
+            if self.retained.is_some() {
+                self.replacement_seen |= frame.is_some();
+                if !self.complete_retained {
+                    return std::task::Poll::Pending;
+                }
+                let retained = self
+                    .retained
+                    .take()
+                    .expect("retained frame was checked immediately above");
+                let _ = retained;
+                return std::task::Poll::Ready(Ok(()));
+            }
+            if !self.accept {
+                return std::task::Poll::Pending;
+            }
+            let Some(accepted) = frame.take() else {
+                return std::task::Poll::Ready(Ok(()));
+            };
+            self.accepted.push(accepted.clone());
+            if self.pending_after_acceptance {
+                self.retained = Some(accepted);
+                std::task::Poll::Pending
+            } else {
+                std::task::Poll::Ready(Ok(()))
+            }
+        }
+
+        fn poll_recv(
+            &mut self,
+            _cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<Option<std::result::Result<TransportFrame, SignalFishError>>> {
+            self.incoming
+                .pop_front()
+                .map_or(std::task::Poll::Pending, |frame| {
+                    std::task::Poll::Ready(Some(Ok(frame)))
+                })
+        }
+
+        fn poll_close(
+            &mut self,
+            _cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<std::result::Result<(), SignalFishError>> {
+            self.close_calls = self.close_calls.saturating_add(1);
+            if self.close_ready {
+                std::task::Poll::Ready(Ok(()))
+            } else {
+                std::task::Poll::Pending
+            }
+        }
+
+        fn abort(&mut self) {
+            self.abort_calls = self.abort_calls.saturating_add(1);
+            self.retained = None;
+        }
+
+        fn is_ready(&self) -> bool {
+            self.ready
+        }
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum SchedulerReceiveIdentity {
+        Text(u64),
+        Binary(u64),
+    }
+
+    #[derive(Debug, Clone)]
+    struct SchedulerInbound {
+        frame: TransportFrame,
+        identity: SchedulerReceiveIdentity,
+    }
+
+    #[derive(Default)]
+    struct SchedulerModel {
+        commands: VecDeque<(TransportFrame, Instant)>,
+        pending: Option<(TransportFrame, Instant)>,
+        backend_in_flight: Option<TransportFrame>,
+        accepted: Vec<TransportFrame>,
+        incoming: VecDeque<SchedulerInbound>,
+        current_age: Duration,
+        peak_age: Duration,
+        connected_emitted: bool,
+        abandoned: u64,
+        close_started_at: Option<Instant>,
+        close_calls: u64,
+        abort_calls: u64,
+        close_deadline_expirations: u64,
+        closed: bool,
+    }
+
+    impl SchedulerModel {
+        fn sample_age(&mut self, now: Instant) {
+            let oldest = self
+                .pending
+                .as_ref()
+                .map(|(_, enqueued_at)| *enqueued_at)
+                .or_else(|| self.commands.front().map(|(_, enqueued_at)| *enqueued_at));
+            self.current_age = oldest.map_or(Duration::ZERO, |enqueued_at| {
+                now.saturating_duration_since(enqueued_at)
+            });
+            self.peak_age = self.peak_age.max(self.current_age);
+        }
+
+        fn client_owned_depth(&self) -> usize {
+            self.commands
+                .len()
+                .saturating_add(usize::from(self.pending.is_some()))
+        }
+
+        fn all_outbound_depth(&self) -> usize {
+            self.client_owned_depth()
+                .saturating_add(usize::from(self.backend_in_flight.is_some()))
+        }
+
+        fn abandon_client_owned(&mut self, include_in_flight: bool, now: Instant) -> usize {
+            let mut abandoned = self.client_owned_depth();
+            self.commands.clear();
+            self.pending = None;
+            if include_in_flight {
+                abandoned =
+                    abandoned.saturating_add(usize::from(self.backend_in_flight.take().is_some()));
+            }
+            self.sample_age(now);
+            abandoned
+        }
+
+        fn stage_pending(&mut self, now: Instant) {
+            if self.pending.is_none() {
+                self.pending = self.commands.pop_front();
+                if self.pending.is_some() {
+                    self.sample_age(now);
+                }
+            }
+        }
+
+        fn is_open(&self) -> bool {
+            self.close_started_at.is_none() && !self.closed
+        }
+
+        fn is_closing(&self) -> bool {
+            self.close_started_at.is_some() && !self.closed
+        }
+    }
+
+    fn scheduler_text(id: u64) -> (PollingCommand, TransportFrame) {
+        let message = ClientMessage::GameData {
+            data: serde_json::json!({ "scheduler_id": id }),
+            class: None,
+            key: None,
+        };
+        let frame = TransportFrame::Text(
+            serde_json::to_string(&message).expect("scheduler text frame should serialize"),
+        );
+        (PollingCommand::Message(message), frame)
+    }
+
+    fn scheduler_binary(id: u64) -> (PollingCommand, TransportFrame) {
+        let mut bytes = vec![0x42];
+        bytes.extend_from_slice(&id.to_be_bytes());
+        (
+            PollingCommand::Binary(bytes.clone()),
+            TransportFrame::Binary(bytes),
+        )
+    }
+
+    fn scheduler_inbound(id: u64, binary: bool) -> SchedulerInbound {
+        if binary {
+            let frame = crate::protocol::V2BinaryGameDataFrame {
+                from_player: uuid::Uuid::from_u128(0xfeed),
+                encoding: GameDataEncoding::MessagePack,
+                payload: id.to_be_bytes().to_vec(),
+            };
+            SchedulerInbound {
+                frame: TransportFrame::Binary(
+                    rmp_serde::to_vec_named(&frame)
+                        .expect("scheduler binary receive frame should serialize"),
+                ),
+                identity: SchedulerReceiveIdentity::Binary(id),
+            }
+        } else {
+            SchedulerInbound {
+                frame: TransportFrame::Text(
+                    serde_json::to_string(&ServerMessage::Error {
+                        message: format!("scheduler-receive-{id}"),
+                        error_code: None,
+                    })
+                    .expect("scheduler Error frame should serialize"),
+                ),
+                identity: SchedulerReceiveIdentity::Text(id),
+            }
+        }
+    }
+
+    fn scheduler_event_identity(event: &SignalFishEvent) -> Option<SchedulerReceiveIdentity> {
+        match event {
+            SignalFishEvent::Error { message, .. } => message
+                .strip_prefix("scheduler-receive-")?
+                .parse()
+                .ok()
+                .map(SchedulerReceiveIdentity::Text),
+            SignalFishEvent::GameDataBinary { payload, .. } => {
+                let bytes: [u8; 8] = payload.as_slice().try_into().ok()?;
+                Some(SchedulerReceiveIdentity::Binary(u64::from_be_bytes(bytes)))
+            }
+            _ => None,
+        }
+    }
+
+    fn declarative_admission_count(
+        model: &SchedulerModel,
+        accept: bool,
+        pending_after_acceptance: bool,
+        budget: PollingWorkBudget,
+    ) -> usize {
+        if !accept {
+            return 0;
+        }
+        let candidates = model
+            .pending
+            .iter()
+            .map(|(frame, _)| frame)
+            .chain(model.commands.iter().map(|(frame, _)| frame));
+        let mut count = 0usize;
+        let mut bytes = 0usize;
+        for frame in candidates {
+            let next_bytes = bytes.saturating_add(frame_payload_len(frame));
+            if count >= budget.send_frames || (count > 0 && next_bytes > budget.send_bytes) {
+                break;
+            }
+            count = count.saturating_add(1);
+            bytes = next_bytes;
+            if pending_after_acceptance {
+                break;
+            }
+        }
+        count
+    }
+
+    fn drive_scheduler_model(
+        model: &mut SchedulerModel,
+        now: Instant,
+        accept: bool,
+        pending_after_acceptance: bool,
+        complete_retained: bool,
+        budget: PollingWorkBudget,
+    ) -> Vec<TransportFrame> {
+        if model.backend_in_flight.is_some() {
+            if !complete_retained {
+                return Vec::new();
+            }
+            model.backend_in_flight = None;
+        }
+
+        model.stage_pending(now);
+        let admission_count =
+            declarative_admission_count(model, accept, pending_after_acceptance, budget);
+        let mut accepted = Vec::new();
+        let mut bytes = 0usize;
+        for index in 0..admission_count {
+            let (frame, _) = model
+                .pending
+                .take()
+                .expect("declarative admission selected an available frame");
+            model.accepted.push(frame.clone());
+            accepted.push(frame.clone());
+            bytes = bytes.saturating_add(frame_payload_len(&frame));
+            model.sample_age(now);
+            if pending_after_acceptance {
+                model.backend_in_flight = Some(frame);
+            } else if index + 1 < admission_count {
+                model.stage_pending(now);
+            }
+        }
+
+        // The driver stages the next FIFO frame before discovering that it
+        // would exceed a non-exact byte budget. Exact frame/byte exhaustion
+        // stops at the queue boundary instead.
+        if !pending_after_acceptance
+            && accepted.len() < budget.send_frames
+            && bytes < budget.send_bytes
+        {
+            model.stage_pending(now);
+        }
+        accepted
+    }
+
+    #[derive(Clone, Copy)]
+    struct SchedulerTransportState {
+        accept: bool,
+        pending_after_acceptance: bool,
+        complete_retained: bool,
+        close_ready: bool,
+    }
+
+    fn scheduler_transport_state(
+        client: &SignalFishPollingClient<SchedulerTransport>,
+    ) -> SchedulerTransportState {
+        SchedulerTransportState {
+            accept: client.transport.accept,
+            pending_after_acceptance: client.transport.pending_after_acceptance,
+            complete_retained: client.transport.complete_retained,
+            close_ready: client.transport.close_ready,
+        }
+    }
+
+    fn drive_model_close_tick(
+        model: &mut SchedulerModel,
+        now: Instant,
+        transport: SchedulerTransportState,
+        budget: PollingWorkBudget,
+    ) -> Vec<TransportFrame> {
+        let accepted = drive_scheduler_model(
+            model,
+            now,
+            transport.accept,
+            transport.pending_after_acceptance,
+            transport.complete_retained,
+            budget,
+        );
+        if model.all_outbound_depth() == 0 {
+            model.close_calls = model.close_calls.saturating_add(1);
+            if transport.close_ready {
+                model.closed = true;
+            }
+        }
+        accepted
+    }
+
+    fn start_model_close(
+        model: &mut SchedulerModel,
+        now: Instant,
+        flush_on_close: bool,
+        transport: SchedulerTransportState,
+        budget: PollingWorkBudget,
+    ) -> Vec<TransportFrame> {
+        if !model.is_open() {
+            return Vec::new();
+        }
+        model.close_started_at = Some(now);
+        if !flush_on_close {
+            let abandoned = model.abandon_client_owned(false, now);
+            model.abandoned = model
+                .abandoned
+                .saturating_add(u64::try_from(abandoned).unwrap_or(u64::MAX));
+        }
+        drive_model_close_tick(model, now, transport, budget)
+    }
+
+    fn poll_model_close(
+        model: &mut SchedulerModel,
+        now: Instant,
+        transport: SchedulerTransportState,
+        budget: PollingWorkBudget,
+    ) -> Vec<TransportFrame> {
+        model.sample_age(now);
+        let started_at = model
+            .close_started_at
+            .expect("closing model should retain its start time");
+        if now.saturating_duration_since(started_at) >= Duration::from_millis(50) {
+            let abandoned = model.abandon_client_owned(true, now);
+            model.abandoned = model
+                .abandoned
+                .saturating_add(u64::try_from(abandoned).unwrap_or(u64::MAX));
+            model.abort_calls = model.abort_calls.saturating_add(1);
+            model.close_deadline_expirations = model.close_deadline_expirations.saturating_add(1);
+            model.closed = true;
+            Vec::new()
+        } else {
+            drive_model_close_tick(model, now, transport, budget)
+        }
+    }
+
+    fn drive_scheduler_receive_model(
+        model: &mut SchedulerModel,
+        budget: PollingWorkBudget,
+    ) -> Vec<SchedulerInbound> {
+        let mut processed = Vec::new();
+        let mut frames = 0usize;
+        let mut bytes = 0usize;
+        while let Some(inbound) = model.incoming.front() {
+            let next_bytes = bytes.checked_add(frame_payload_len(&inbound.frame));
+            if frames > 0
+                && (frames >= budget.receive_frames
+                    || next_bytes.is_none_or(|next| next > budget.receive_bytes))
+            {
+                break;
+            }
+            let inbound = model
+                .incoming
+                .pop_front()
+                .expect("model receive front was just checked");
+            frames = frames.saturating_add(1);
+            bytes = next_bytes.unwrap_or(usize::MAX);
+            processed.push(inbound);
+        }
+        processed
+    }
+
+    fn scheduler_batch_within_budget(
+        batch: &[TransportFrame],
+        frame_limit: usize,
+        byte_limit: usize,
+    ) -> bool {
+        let bytes = batch.iter().fold(0usize, |total, frame| {
+            total.saturating_add(frame_payload_len(frame))
+        });
+        batch.len() <= frame_limit && (bytes <= byte_limit || batch.len() == 1)
+    }
+
+    fn scheduler_transition_matches(
+        expected: &[TransportFrame],
+        observed: &[TransportFrame],
+        budget: PollingWorkBudget,
+    ) -> bool {
+        expected == observed
+            && scheduler_batch_within_budget(observed, budget.send_frames, budget.send_bytes)
+    }
+
+    #[test]
+    fn scheduler_oracle_rejects_stop_and_wait_and_duplication_models() {
+        let budget = PollingWorkBudget {
+            send_frames: 2,
+            send_bytes: 8,
+            ..PollingWorkBudget::default()
+        };
+        let now = Instant::now();
+        let first = TransportFrame::Binary(vec![1; 4]);
+        let second = TransportFrame::Binary(vec![2; 4]);
+        let mut model = SchedulerModel::default();
+        model.commands.push_back((first.clone(), now));
+        model.commands.push_back((second.clone(), now));
+        let expected = drive_scheduler_model(&mut model, now, true, false, true, budget);
+
+        let stop_and_wait = vec![first.clone()];
+        let duplication = vec![first.clone(), first, second];
+        assert!(scheduler_transition_matches(&expected, &expected, budget));
+        assert!(!scheduler_transition_matches(
+            &expected,
+            &stop_and_wait,
+            budget
+        ));
+        assert!(!scheduler_transition_matches(
+            &expected,
+            &duplication,
+            budget
+        ));
+    }
+
+    proptest::proptest! {
+        #![proptest_config(proptest::test_runner::Config {
+            cases: 128,
+            failure_persistence: Some(Box::new(
+                proptest::test_runner::FileFailurePersistence::SourceParallel(
+                    "proptest-regressions",
+                ),
+            )),
+            ..proptest::test_runner::Config::default()
+        })]
+
+        #[test]
+        fn polling_scheduler_matches_reference_model(
+            operations in scheduler_operations(),
+            flush_on_close in proptest::bool::ANY,
+            budget in scheduler_budgets(),
+            command_capacity in 1usize..=6,
+        ) {
+            let options = PollingClientOptions {
+                work_budget: budget,
+                close_policy: if flush_on_close {
+                    PollingClosePolicy::Flush
+                } else {
+                    PollingClosePolicy::Abandon
+                },
+            };
+            let mut config = default_config()
+                .with_command_channel_capacity(command_capacity)
+                .with_shutdown_timeout(Duration::from_millis(50));
+            config.game_data_format = Some(GameDataEncoding::MessagePack);
+            let transport = SchedulerTransport {
+                ready: false,
+                accept: true,
+                complete_retained: true,
+                close_ready: true,
+                ..SchedulerTransport::default()
+            };
+            let mut client = SignalFishPollingClient::new_with_options(transport, config, options);
+            let mut now = Instant::now();
+            let startup_events = client.poll_at(now);
+            prop_assert!(!startup_events
+                .iter()
+                .any(|event| matches!(event, SignalFishEvent::Connected)));
+            client.transport.accepted.clear();
+            client.reset_queue_age_peak_at(now);
+            let mut model = SchedulerModel::default();
+            let mut next_outbound_id = 1u64;
+            let mut next_receive_id = 1u64;
+
+            for operation in operations {
+                if model.closed {
+                    prop_assert!(matches!(
+                        client.queue_command_at(PollingCommand::Binary(vec![0]), now),
+                        Err(SignalFishError::NotConnected)
+                    ));
+                    continue;
+                }
+                match operation {
+                    operation @ (SchedulerOperation::EnqueueText
+                    | SchedulerOperation::EnqueueBinary) => {
+                        let id = next_outbound_id;
+                        next_outbound_id = next_outbound_id.saturating_add(1);
+                        let (command, frame) = match operation {
+                            SchedulerOperation::EnqueueText => scheduler_text(id),
+                            SchedulerOperation::EnqueueBinary => scheduler_binary(id),
+                            _ => unreachable!("enqueue alternatives were matched above"),
+                        };
+                        if model.is_closing() {
+                            prop_assert!(matches!(
+                                client.queue_command_at(command, now),
+                                Err(SignalFishError::NotConnected)
+                            ));
+                        } else {
+                            let expected_full = model.commands.len() >= command_capacity;
+                            let result = client.queue_command_at(command, now);
+                            if expected_full {
+                                match result {
+                                    Err(SignalFishError::SendBufferFull { capacity }) => {
+                                        prop_assert_eq!(capacity, command_capacity);
+                                    }
+                                    other => prop_assert!(
+                                        false,
+                                        "full scheduler queue returned {other:?}"
+                                    ),
+                                }
+                            } else {
+                                prop_assert!(result.is_ok());
+                                model.commands.push_back((frame, now));
+                                model.sample_age(now);
+                            }
+                        }
+                    }
+                    SchedulerOperation::Poll => {
+                        let was_open = model.is_open();
+                        let transport_state = scheduler_transport_state(&client);
+                        let accepted_before = client.transport.accepted.len();
+                        let events = client.poll_at(now);
+                        let expected_accepted = if was_open {
+                            model.sample_age(now);
+                            drive_scheduler_model(
+                                &mut model,
+                                now,
+                                transport_state.accept,
+                                transport_state.pending_after_acceptance,
+                                transport_state.complete_retained,
+                                budget,
+                            )
+                        } else {
+                            poll_model_close(&mut model, now, transport_state, budget)
+                        };
+                        let actual_accepted = &client.transport.accepted[accepted_before..];
+                        prop_assert!(scheduler_transition_matches(
+                            &expected_accepted,
+                            actual_accepted,
+                            budget
+                        ));
+
+                        let should_connect =
+                            was_open && client.transport.ready && !model.connected_emitted;
+                        let connected_count = events
+                            .iter()
+                            .filter(|event| matches!(event, SignalFishEvent::Connected))
+                            .count();
+                        prop_assert_eq!(connected_count, usize::from(should_connect));
+                        if should_connect {
+                            model.connected_emitted = true;
+                        }
+
+                        let expected_inbound = if was_open {
+                            drive_scheduler_receive_model(&mut model, budget)
+                        } else {
+                            Vec::new()
+                        };
+                        let actual_inbound = events
+                            .iter()
+                            .filter_map(scheduler_event_identity)
+                            .collect::<Vec<_>>();
+                        let expected_identities = expected_inbound
+                            .iter()
+                            .map(|inbound| inbound.identity)
+                            .collect::<Vec<_>>();
+                        prop_assert_eq!(&actual_inbound, &expected_identities);
+                        let processed_frames = expected_inbound
+                            .iter()
+                            .map(|inbound| inbound.frame.clone())
+                            .collect::<Vec<_>>();
+                        prop_assert!(scheduler_batch_within_budget(
+                            &processed_frames,
+                            budget.receive_frames,
+                            budget.receive_bytes,
+                        ));
+                    }
+                    SchedulerOperation::SetReady(ready) => client.transport.ready = ready,
+                    SchedulerOperation::RefuseBeforeAcceptance => client.transport.accept = false,
+                    SchedulerOperation::PendingAfterAcceptance(pending) => {
+                        client.transport.pending_after_acceptance = pending;
+                        if pending {
+                            client.transport.complete_retained = false;
+                        }
+                    }
+                    SchedulerOperation::CapacityRecovery => {
+                        client.transport.accept = true;
+                        client.transport.complete_retained = true;
+                    }
+                    SchedulerOperation::SetCloseReady(ready) => {
+                        client.transport.close_ready = ready;
+                    }
+                    operation @ (SchedulerOperation::ReceiveText
+                    | SchedulerOperation::ReceiveBinary) => {
+                        let inbound = scheduler_inbound(
+                            next_receive_id,
+                            matches!(operation, SchedulerOperation::ReceiveBinary),
+                        );
+                        next_receive_id = next_receive_id.saturating_add(1);
+                        client.transport.incoming.push_back(inbound.frame.clone());
+                        model.incoming.push_back(inbound);
+                    }
+                    SchedulerOperation::AdvanceClock(milliseconds) => {
+                        now += Duration::from_millis(u64::from(milliseconds));
+                    }
+                    SchedulerOperation::Close => {
+                        let transport_state = scheduler_transport_state(&client);
+                        let accepted_before = client.transport.accepted.len();
+                        let expected = start_model_close(
+                            &mut model,
+                            now,
+                            flush_on_close,
+                            transport_state,
+                            budget,
+                        );
+                        client.close_at(now);
+                        let actual = &client.transport.accepted[accepted_before..];
+                        prop_assert!(scheduler_transition_matches(&expected, actual, budget));
+                    }
+                    SchedulerOperation::Abort => {
+                        client.transport.accept = false;
+                        client.transport.complete_retained = false;
+                        client.transport.close_ready = false;
+                        let transport_state = SchedulerTransportState {
+                            accept: false,
+                            pending_after_acceptance: client.transport.pending_after_acceptance,
+                            complete_retained: false,
+                            close_ready: false,
+                        };
+                        if model.is_open() {
+                            let accepted_before = client.transport.accepted.len();
+                            let expected = start_model_close(
+                                &mut model,
+                                now,
+                                flush_on_close,
+                                transport_state,
+                                budget,
+                            );
+                            client.close_at(now);
+                            let actual = &client.transport.accepted[accepted_before..];
+                            prop_assert!(scheduler_transition_matches(&expected, actual, budget));
+                        }
+                        let deadline = model
+                            .close_started_at
+                            .expect("abort operation should start close")
+                            + Duration::from_millis(50);
+                        now = now.max(deadline);
+                        let expected = poll_model_close(&mut model, now, transport_state, budget);
+                        prop_assert!(expected.is_empty());
+                        let _ = client.poll_at(now);
+                    }
+                }
+
+                prop_assert!(client.cmd_queue.len() <= command_capacity);
+                prop_assert!(!client.transport.replacement_seen);
+                prop_assert_eq!(
+                    client.polling_stats.current_queue_depth,
+                    u64::try_from(model.client_owned_depth())
+                        .unwrap_or(u64::MAX),
+                );
+                prop_assert_eq!(
+                    client.queue_age_stats.current_oldest_queue_age,
+                    model.current_age
+                );
+                prop_assert_eq!(
+                    client.queue_age_stats.peak_oldest_queue_age,
+                    model.peak_age
+                );
+                prop_assert_eq!(client.polling_stats.abandoned_commands, model.abandoned);
+                prop_assert_eq!(client.transport.close_calls, model.close_calls);
+                prop_assert_eq!(client.transport.abort_calls, model.abort_calls);
+                prop_assert_eq!(
+                    client.polling_stats.close_deadline_expirations,
+                    model.close_deadline_expirations
+                );
+                prop_assert_eq!(client.is_closing(), model.is_closing());
+                prop_assert_eq!(&client.transport.accepted, &model.accepted);
+                if model.closed {
+                    prop_assert!(!client.is_closing());
+                    prop_assert_eq!(client.polling_stats.current_queue_depth, 0);
+                    prop_assert_eq!(model.current_age, Duration::ZERO);
+                    prop_assert!(matches!(
+                        client.queue_command_at(PollingCommand::Binary(vec![0]), now),
+                        Err(SignalFishError::NotConnected)
+                    ));
+                    break;
+                }
+            }
+            prop_assert!(!model.is_closing(), "recovery suffix must finish close");
+            prop_assert!(!client.is_closing(), "driver must finish after recovery suffix");
+        }
     }
 }

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -40,8 +40,10 @@ mod godot_issue_61_policy {
             .expect("Fortress dependency uses a simple exact version");
 
         assert_eq!(fortress, "=0.10.0");
-        assert!(fortress_fixture.contains("with_max_prediction_window(12)"));
+        assert!(fortress_fixture.contains("const PREDICTION_WINDOW_FRAMES: usize = 20;"));
+        assert!(fortress_fixture.contains("with_max_prediction_window(PREDICTION_WINDOW_FRAMES)"));
         assert!(fortress_runner.contains("scenario === \"soak\" ? 3_600 : 600"));
+        assert!(fortress_runner.contains("scenario === \"clean\" ? 8 : 12"));
         assert!(fortress_runner.contains("finalAgeValidation.ok"));
         assert!(
             workflow.contains("SERVER_VERSION: \"0.4.0\"")

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -43,7 +43,8 @@ mod godot_issue_61_policy {
         assert!(fortress_fixture.contains("const PREDICTION_WINDOW_FRAMES: usize = 20;"));
         assert!(fortress_fixture.contains("with_max_prediction_window(PREDICTION_WINDOW_FRAMES)"));
         assert!(fortress_runner.contains("scenario === \"soak\" ? 3_600 : 600"));
-        assert!(fortress_runner.contains("scenario === \"clean\" ? 8 : 12"));
+        assert!(fortress_runner
+            .contains("scenario === \"clean\" ? 8 : scenario === \"soak\" ? 12 : 13"));
         assert!(fortress_runner.contains("finalAgeValidation.ok"));
         assert!(
             workflow.contains("SERVER_VERSION: \"0.4.0\"")

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -31,6 +31,8 @@ mod godot_issue_61_policy {
     fn fixture_and_workflow_pin_the_fortress_system_scenario() {
         let workflow = read_project_file(".github/workflows/godot-web.yml");
         let fixture = read_project_file("tests/godot-web-smoke/Cargo.toml");
+        let fortress_fixture = read_project_file("tests/godot-web-smoke/src/fortress.rs");
+        let fortress_runner = read_project_file("scripts/run-godot-fortress-e2e.mjs");
         let fixture: toml::Value =
             toml::from_str(&fixture).expect("fixture manifest is valid TOML");
         let fortress = fixture["dependencies"]["fortress-rollback"]
@@ -38,17 +40,56 @@ mod godot_issue_61_policy {
             .expect("Fortress dependency uses a simple exact version");
 
         assert_eq!(fortress, "=0.10.0");
+        assert!(fortress_fixture.contains("with_max_prediction_window(12)"));
+        assert!(fortress_runner.contains("scenario === \"soak\" ? 3_600 : 600"));
+        assert!(fortress_runner.contains("finalAgeValidation.ok"));
         assert!(
             workflow.contains("SERVER_VERSION: \"0.4.0\"")
                 && workflow.contains("run-godot-fortress-e2e.mjs")
+                && workflow.contains("scenario: clean")
+                && workflow.contains("scenario: impaired")
+                && workflow.contains("scenario: soak")
+                && workflow.contains("delay 40ms 10ms")
+                && workflow.contains("loss random 0.2% 25%")
+                && workflow.contains("rate 10mbit")
+                && workflow.contains("NETEM_SEED: \"6101\"")
+                && workflow.contains("IPROUTE2_VERSION: \"6.6.0\"")
+                && workflow.contains("sha256sum --check")
+                && workflow.contains("actions/download-artifact@v7.0.0")
                 && workflow.contains("--locked")
         );
+        assert_eq!(workflow.matches("runs-on: ubuntu-24.04").count(), 2);
+        assert_eq!(workflow.matches("name: godot-web-export").count(), 2);
+        for required in [
+            "needs: build-export",
+            "fail-fast: false",
+            "if: always()",
+            "qdisc add dev veth-host handle ffff: ingress",
+            "qdisc add dev veth-server handle ffff: ingress",
+            "filter show dev veth-host parent ffff:",
+            "filter show dev veth-server parent ffff:",
+        ] {
+            assert!(
+                workflow.contains(required),
+                "Godot CI must retain {required}"
+            );
+        }
+        assert!(!workflow.contains("continue-on-error"));
         for artifact in [
+            "browser.log",
+            "server.log",
+            "godot-throughput.json",
+            "godot-throughput.csv",
+            "metrics-before.prom",
+            "metrics-after.prom",
             "godot-fortress-summary.json",
+            "godot-fortress-timeseries.json",
+            "godot-fortress-timeseries.csv",
             "godot-fortress-a.log",
             "godot-fortress-b.log",
             "fortress-metrics-before.prom",
             "fortress-metrics-after.prom",
+            "netem.txt",
         ] {
             assert!(
                 workflow.contains(artifact),

--- a/tests/godot-web-smoke/README.md
+++ b/tests/godot-web-smoke/README.md
@@ -13,8 +13,8 @@ rendered callback, then runs two JSON clients at 136 offered frames/second each
 for 16 seconds. It records queue depth, Godot/browser buffering, acceptance and
 receipt counts, poll duration, and end-to-end timestamp latency. The browser
 gate requires exact reliable receipt, bounded/finally drained client queues, a
-non-positive final queue slope, p99 latency at most
-500 ms, and every `poll()` below 50 ms. CI always uploads JSON/CSV time series
+non-positive final queue slope over eight consecutive 250 ms drained samples,
+p99 latency at most 500 ms, and every `poll()` below 50 ms. CI always uploads JSON/CSV time series
 and before/after `/metrics/prom` snapshots; browser/server logs are retained on
 failure. The transport wrapper also requires zero contemporaneous adaptive
 watermark violations and reports empty-buffer single-frame escape bytes
@@ -51,7 +51,8 @@ simulation frame per rendered callback. The gate requires both clients to
 confirm 600 frames within the scenario timeout, settle in sync with matching
 state, and drain every relay and SDK queue,
 conserve every client/server delivery, and cross-check the exact room and
-player IDs. Player B
+player IDs. Confirmation lag is capped at eight clean, 13 impaired, and 12 soak
+frames. Player B
 then closes first; player A must observe its nonzero v3 `PlayerLeft` epoch and
 final sequence before closing. Malformed packets, relay loss, desynchronization,
 backend-capacity refusals, server drops, and slow consumers all fail the run.

--- a/tests/godot-web-smoke/README.md
+++ b/tests/godot-web-smoke/README.md
@@ -48,8 +48,9 @@ changed input. The bounded hold deterministically forces A to roll back, load
 state, and resimulate after release. Both peers advance on an independent fixed
 18 Hz cadence, preserving elapsed deadline debt and recovering by at most one
 simulation frame per rendered callback. Before those independent clocks begin,
-A must observe B's frame-zero synchronization packet and B must observe A's
-causally subsequent frame-one packet; the summary retains the release evidence.
+B proposes a future same-host wall-clock deadline and the peers exchange an
+exact proposal/ack/commit handshake. Each browser maps that deadline once to
+its monotonic clock; the summary retains every stage and release lateness.
 The gate requires both clients to
 confirm 600 frames within the scenario timeout, settle in sync with matching
 state, and drain every relay and SDK queue,

--- a/tests/godot-web-smoke/README.md
+++ b/tests/godot-web-smoke/README.md
@@ -46,9 +46,10 @@ changes its delayed input at frame 120 and holds its outbound relay until
 player A's causal post-advance watermark proves that A predicted through the
 changed input. The bounded hold deterministically forces A to roll back, load
 state, and resimulate after release. Both peers advance on an independent fixed
-18 Hz cadence. The gate requires both clients to confirm 600 frames within the
-scenario timeout, settle in sync with matching state, and drain every relay and
-SDK queue,
+18 Hz cadence, preserving elapsed deadline debt and recovering by at most one
+simulation frame per rendered callback. The gate requires both clients to
+confirm 600 frames within the scenario timeout, settle in sync with matching
+state, and drain every relay and SDK queue,
 conserve every client/server delivery, and cross-check the exact room and
 player IDs. Player B
 then closes first; player A must observe its nonzero v3 `PlayerLeft` epoch and

--- a/tests/godot-web-smoke/README.md
+++ b/tests/godot-web-smoke/README.md
@@ -47,7 +47,10 @@ player A's causal post-advance watermark proves that A predicted through the
 changed input. The bounded hold deterministically forces A to roll back, load
 state, and resimulate after release. Both peers advance on an independent fixed
 18 Hz cadence, preserving elapsed deadline debt and recovering by at most one
-simulation frame per rendered callback. The gate requires both clients to
+simulation frame per rendered callback. Before those independent clocks begin,
+A must observe B's frame-zero synchronization packet and B must observe A's
+causally subsequent frame-one packet; the summary retains the release evidence.
+The gate requires both clients to
 confirm 600 frames within the scenario timeout, settle in sync with matching
 state, and drain every relay and SDK queue,
 conserve every client/server delivery, and cross-check the exact room and

--- a/tests/godot-web-smoke/README.md
+++ b/tests/godot-web-smoke/README.md
@@ -42,10 +42,13 @@ joins the exact room code reported by A.
 Each rendered callback polls Signal Fish exactly once, pumps a bounded relay
 queue into Fortress, supplies deterministic local input, advances rollback,
 and records both confirmed-input and serialized game-state checksums. Player B
-holds its outbound relay for frames 120 through 127, deterministically forcing
-player A to predict, roll back, load state, and resimulate after release. The
-gate requires both clients to confirm 600 frames within a 40-second wall-clock
-guard, settle in sync with matching state, drain every relay and SDK queue,
+changes its delayed input at frame 120 and holds its outbound relay until
+player A's causal post-advance watermark proves that A predicted through the
+changed input. The bounded hold deterministically forces A to roll back, load
+state, and resimulate after release. Both peers advance on an independent fixed
+18 Hz cadence. The gate requires both clients to confirm 600 frames within the
+scenario timeout, settle in sync with matching state, and drain every relay and
+SDK queue,
 conserve every client/server delivery, and cross-check the exact room and
 player IDs. Player B
 then closes first; player A must observe its nonzero v3 `PlayerLeft` epoch and

--- a/tests/godot-web-smoke/project/custom_shell.html
+++ b/tests/godot-web-smoke/project/custom_shell.html
@@ -18,11 +18,21 @@
     const query = new URLSearchParams(window.location.search);
     const role = query.get("fortress_role");
     const roomCode = query.get("room_code");
-    const args = [];
+    const userArgs = [];
     if (role) {
-      args.push("--", "--fortress-role", role);
-      if (roomCode) args.push("--room-code", roomCode);
+      userArgs.push("--fortress-role", role);
+      if (roomCode) userArgs.push("--room-code", roomCode);
     }
+    for (const [queryName, argumentName] of [
+      ["server_url", "--server-url"],
+      ["target_frames", "--target-frames"],
+      ["session_timeout_ms", "--session-timeout-ms"],
+      ["poll_hitch_frame", "--poll-hitch-frame"],
+    ]) {
+      const value = query.get(queryName);
+      if (value) userArgs.push(argumentName, value);
+    }
+    const args = userArgs.length > 0 ? ["--", ...userArgs] : [];
     const config = $GODOT_CONFIG;
     config.onExit = (code) => {
       console.log("SIGNAL_FISH_SHELL game-complete", code);

--- a/tests/godot-web-smoke/src/fortress.rs
+++ b/tests/godot-web-smoke/src/fortress.rs
@@ -24,6 +24,10 @@ const DEFAULT_TARGET_FRAMES: i32 = 600;
 const SETTLEMENT_FRAMES: i32 = 20;
 const MAX_RELAY_QUEUE: usize = 256;
 const IMPAIRMENT_START_FRAME: i32 = 120;
+const INPUT_DELAY_FRAMES: i32 = 2;
+const IMPAIRMENT_MAX_HOLD_FRAMES: i32 = 8;
+const SIMULATION_FPS: usize = 18;
+const RELAY_ENVELOPE_MAGIC: &[u8; 4] = b"SFF1";
 // GitHub's shared runners have measured at roughly 23 rendered frames/second
 // under two independent Chromium/Godot processes. Keep a generous wall-clock
 // guard while the frame/checksum/queue oracles remain exact.
@@ -65,6 +69,8 @@ struct RelayQueues {
     retries: u64,
     peak_inbound: usize,
     peak_outbound: usize,
+    local_frame: Option<i32>,
+    remote_frame: Option<i32>,
 }
 
 #[derive(Clone)]
@@ -81,9 +87,11 @@ impl NonBlockingSocket<PlayerId> for RelaySocket {
         }
         match encode(message) {
             Ok(encoded) => {
-                let mut payload = Vec::with_capacity(16usize.saturating_add(encoded.len()));
-                payload.extend_from_slice(destination.as_bytes());
-                payload.extend_from_slice(&encoded);
+                let payload = encode_relay_envelope(
+                    destination.as_bytes(),
+                    queues.local_frame.unwrap_or(Frame::NULL.as_i32()),
+                    &encoded,
+                );
                 queues.outbound.push_back((*destination, payload));
                 queues.encoded = queues.encoded.saturating_add(1);
                 queues.peak_outbound = queues.peak_outbound.max(queues.outbound.len());
@@ -106,6 +114,7 @@ pub(super) struct FortressScenario {
     poll_hitch_frame: Option<i32>,
     poll_hitch_callbacks_remaining: u8,
     poll_hitch_completed: bool,
+    poll_hitch_frames_advanced: u64,
     joined_room_code: Option<String>,
     client: Option<Client>,
     local_id: Option<PlayerId>,
@@ -125,6 +134,7 @@ pub(super) struct FortressScenario {
     target_state_checksum: Option<u128>,
     started: Option<Instant>,
     simulation_elapsed_ms: Option<u128>,
+    next_advance_at: Option<Instant>,
     game_ready: bool,
     max_poll_us: u64,
     last_time_series_frame: i32,
@@ -197,6 +207,7 @@ impl FortressScenario {
             poll_hitch_frame,
             poll_hitch_callbacks_remaining: u8::from(poll_hitch_frame.is_some()) * 6,
             poll_hitch_completed: false,
+            poll_hitch_frames_advanced: 0,
             joined_room_code: None,
             client,
             local_id: None,
@@ -216,6 +227,7 @@ impl FortressScenario {
             target_state_checksum: None,
             started: None,
             simulation_elapsed_ms: None,
+            next_advance_at: None,
             game_ready: false,
             max_poll_us: 0,
             last_time_series_frame: -60,
@@ -243,7 +255,8 @@ impl FortressScenario {
         if self.completed {
             return true;
         }
-        let events = if self.should_skip_poll_for_hitch() {
+        let skipped_poll_for_hitch = self.should_skip_poll_for_hitch();
+        let events = if skipped_poll_for_hitch {
             Vec::new()
         } else {
             self.poll_client_once()
@@ -254,7 +267,24 @@ impl FortressScenario {
         if self.fatal.is_none() && !self.closing_success {
             self.start_session_if_ready();
             if !(self.game_ready && self.peer_left_observed) {
+                let advances_before = self.advance_requests;
+                let visual_frames_before = self
+                    .session
+                    .as_ref()
+                    .map_or(0, |session| session.metrics().visual_frames);
                 self.drive_session();
+                if skipped_poll_for_hitch {
+                    let visual_frames_after = self
+                        .session
+                        .as_ref()
+                        .map_or(visual_frames_before, |session| {
+                            session.metrics().visual_frames
+                        });
+                    self.poll_hitch_frames_advanced = self
+                        .poll_hitch_frames_advanced
+                        .saturating_add(visual_frames_after.saturating_sub(visual_frames_before));
+                }
+                debug_assert!(self.advance_requests >= advances_before);
             }
             self.stop_game_session_if_ready();
             self.drain_post_ready_relay();
@@ -396,7 +426,7 @@ impl FortressScenario {
             && seq.is_some_and(|value| value > 0)
             && epoch.is_some_and(|value| value > 0)
             && valid_sender;
-        let Some((destination, encoded)) = payload.split_at_checked(16) else {
+        let Some((destination, advertised_frame, encoded)) = decode_relay_envelope(&payload) else {
             self.note_malformed();
             return;
         };
@@ -408,6 +438,14 @@ impl FortressScenario {
             let ignored = self.relay.borrow().ignored_nonlocal.saturating_add(1);
             self.relay.borrow_mut().ignored_nonlocal = ignored;
             return;
+        }
+        {
+            let mut queues = self.relay.borrow_mut();
+            queues.remote_frame = Some(
+                queues
+                    .remote_frame
+                    .map_or(advertised_frame, |current| current.max(advertised_frame)),
+            );
         }
         match decode_message(encoded) {
             Ok((message, consumed)) if consumed == encoded.len() => {
@@ -456,8 +494,8 @@ impl FortressScenario {
         let remote_handle = PlayerHandle::new(remote_index);
         let builder = SessionBuilder::<TestConfig>::new()
             .with_num_players(2)
-            .and_then(|builder| builder.with_fps(60))
-            .and_then(|builder| builder.with_input_delay(2))
+            .and_then(|builder| builder.with_fps(SIMULATION_FPS))
+            .and_then(|builder| builder.with_input_delay(INPUT_DELAY_FRAMES as usize))
             // Leave enough prediction headroom for the declared six-callback
             // hitch on top of the constrained-network round trip. Scenario
             // oracles still enforce the tighter clean/impaired lag limits.
@@ -494,6 +532,7 @@ impl FortressScenario {
         let Some(session) = &mut self.session else {
             return;
         };
+        self.relay.borrow_mut().local_frame = Some(session.current_frame().as_i32());
         session.poll_remote_clients();
         let confirmed = session.confirmed_frame().as_i32().min(self.target_frames);
         while self.checksum_through < confirmed {
@@ -582,7 +621,13 @@ impl FortressScenario {
         // session entered Running first. Receiving one valid Fortress packet
         // proves the independently launched peer is also pumping the session,
         // removing process-start skew from gameplay-lag measurements.
-        if self.relay.borrow().decoded == 0 {
+        if self.relay.borrow().decoded == 0
+            || self
+                .relay
+                .borrow()
+                .remote_frame
+                .is_none_or(|remote| remote < 0)
+        {
             return;
         }
 
@@ -611,16 +656,37 @@ impl FortressScenario {
         if current >= IMPAIRMENT_START_FRAME && self.pre_impairment_metrics.is_none() {
             self.pre_impairment_metrics = Some(session.metrics());
         }
+        if self.role == "b" && !self.impairment_activated && current >= IMPAIRMENT_START_FRAME {
+            // Align at the switch boundary before changing B's delayed input.
+            // This setup synchronization does not pace measured steady-state
+            // gameplay and is bounded by the session timeout/oracles.
+            if self
+                .relay
+                .borrow()
+                .remote_frame
+                .is_none_or(|remote| remote < IMPAIRMENT_START_FRAME)
+            {
+                return;
+            }
+            self.impairment_activated = true;
+        }
+        let now = Instant::now();
+        if !simulation_advance_due(now, &mut self.next_advance_at) {
+            return;
+        }
         if current < self.settlement_frame_limit {
             let Some(local_handle) = self.local_handle else {
                 self.fatal = Some("missing local Fortress handle".to_string());
                 return;
             };
+            // The input packet produced by this advance causally proves the
+            // advertised post-advance watermark at the receiving peer.
+            self.relay.borrow_mut().local_frame = Some(current.saturating_add(1));
             // Prediction stays exactly correct before the switch. Player B's
             // value change makes A's last-value prediction wrong, so the later
             // nonzero rollback delta is causally tied to that remote input.
             let input = TestInput {
-                value: u32::from(self.role == "b" && current >= IMPAIRMENT_START_FRAME),
+                value: u32::from(self.role == "b" && self.impairment_activated),
             };
             if let Err(error) = session.add_local_input(local_handle, input) {
                 self.fatal = Some(format!("add_local_input failed: {error}"));
@@ -704,11 +770,27 @@ impl FortressScenario {
             .session
             .as_ref()
             .map_or(0, |session| session.current_frame().as_i32());
-        if self.role == "b" && !self.impairment_activated && current_frame >= IMPAIRMENT_START_FRAME
-        {
-            // Changing B's input invalidates A's prior prediction. Keep relay
-            // delivery live so this rollback proof does not manufacture lag.
-            self.impairment_activated = true;
+        if self.role == "b" && self.impairment_activated && !self.impairment_released {
+            let predicted_through = IMPAIRMENT_START_FRAME
+                .saturating_add(INPUT_DELAY_FRAMES)
+                .saturating_add(1);
+            // Retain B's FIFO until A's causal post-advance watermark proves
+            // it simulated the changed delayed-input frame speculatively.
+            if self
+                .relay
+                .borrow()
+                .remote_frame
+                .is_none_or(|remote| remote < predicted_through)
+            {
+                if current_frame
+                    >= IMPAIRMENT_START_FRAME.saturating_add(IMPAIRMENT_MAX_HOLD_FRAMES)
+                {
+                    self.fatal = Some(
+                        "deterministic rollback relay hold exceeded its frame bound".to_string(),
+                    );
+                }
+                return;
+            }
             self.impairment_released = true;
         }
         let Some(client) = &mut self.client else {
@@ -862,6 +944,12 @@ impl FortressScenario {
             queues.encoded.saturating_add(queues.decoded) as f64
                 / metrics.visual_frames.max(1) as f64
         });
+        let observed_simulation_fps = self
+            .simulation_elapsed_ms
+            .filter(|elapsed| *elapsed > 0)
+            .map_or(0.0, |elapsed| {
+                self.target_frames.max(0) as f64 * 1_000.0 / elapsed as f64
+            });
         let invariant_passed = self.game_ready
             && self.target_state_checksum.is_some()
             && final_inbound_depth == 0
@@ -897,6 +985,8 @@ impl FortressScenario {
             "checksum_through": self.checksum_through,
             "speculative_value": self.game.value,
             "simulation_elapsed_ms": self.simulation_elapsed_ms,
+            "simulation_target_fps": SIMULATION_FPS,
+            "observed_simulation_fps": observed_simulation_fps,
             "total_elapsed_ms": total_elapsed_ms,
             "max_poll_us": self.max_poll_us,
             "multi_frame_poll": self.multi_frame_poll,
@@ -947,6 +1037,7 @@ impl FortressScenario {
             "impairment_released": self.impairment_released,
             "poll_hitch_frame": self.poll_hitch_frame,
             "poll_hitch_completed": self.poll_hitch_completed,
+            "poll_hitch_frames_advanced": self.poll_hitch_frames_advanced,
             "peer_left_observed": self.peer_left_observed,
             "peer_left_epoch": self.peer_left_epoch,
             "peer_left_final_seq": self.peer_left_final_seq,
@@ -972,7 +1063,103 @@ impl FortressScenario {
     }
 }
 
+fn simulation_frame_period() -> std::time::Duration {
+    std::time::Duration::from_nanos(1_000_000_000 / SIMULATION_FPS as u64)
+}
+
+fn simulation_advance_due(now: Instant, next_advance_at: &mut Option<Instant>) -> bool {
+    let period = simulation_frame_period();
+    let Some(deadline) = next_advance_at else {
+        *next_advance_at = now.checked_add(period);
+        return true;
+    };
+    if now < *deadline {
+        return false;
+    }
+    let scheduled = deadline.checked_add(period).unwrap_or(now);
+    // Preserve the absolute cadence under ordinary callback jitter, but bound
+    // recovery after a long suspension to one immediate catch-up callback.
+    *deadline = scheduled.max(now);
+    true
+}
+
+fn encode_relay_envelope(destination: &[u8; 16], advertised_frame: i32, encoded: &[u8]) -> Vec<u8> {
+    let mut payload = Vec::with_capacity(
+        destination
+            .len()
+            .saturating_add(RELAY_ENVELOPE_MAGIC.len())
+            .saturating_add(std::mem::size_of::<i32>())
+            .saturating_add(encoded.len()),
+    );
+    payload.extend_from_slice(destination);
+    payload.extend_from_slice(RELAY_ENVELOPE_MAGIC);
+    payload.extend_from_slice(&advertised_frame.to_le_bytes());
+    payload.extend_from_slice(encoded);
+    payload
+}
+
+fn decode_relay_envelope(payload: &[u8]) -> Option<(&[u8], i32, &[u8])> {
+    let (destination, remainder) = payload.split_at_checked(16)?;
+    let (header, encoded) = remainder.split_at_checked(8)?;
+    if header.get(..4)? != RELAY_ENVELOPE_MAGIC {
+        return None;
+    }
+    let advertised_frame = i32::from_le_bytes(header.get(4..8)?.try_into().ok()?);
+    Some((destination, advertised_frame, encoded))
+}
+
 fn argument(args: &[String], name: &str) -> Option<String> {
     args.windows(2)
         .find_map(|pair| (pair.first().map(String::as_str) == Some(name)).then(|| pair[1].clone()))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{Duration, Instant};
+
+    use super::{
+        decode_relay_envelope, encode_relay_envelope, simulation_advance_due,
+        simulation_frame_period,
+    };
+
+    #[test]
+    fn fixed_cadence_preserves_deadlines_and_bounds_long_pause_recovery() {
+        let start = Instant::now();
+        let period = simulation_frame_period();
+        let mut deadline = None;
+
+        assert!(simulation_advance_due(start, &mut deadline));
+        assert!(!simulation_advance_due(
+            start + Duration::from_millis(40),
+            &mut deadline
+        ));
+        assert!(simulation_advance_due(
+            start + Duration::from_millis(60),
+            &mut deadline
+        ));
+        assert_eq!(deadline, start.checked_add(period.saturating_mul(2)));
+
+        let after_pause = start + Duration::from_secs(5);
+        assert!(simulation_advance_due(after_pause, &mut deadline));
+        assert_eq!(deadline, Some(after_pause));
+    }
+
+    #[test]
+    fn relay_envelope_round_trips_frame_watermark_and_rejects_corruption() {
+        let destination = [7; 16];
+        let encoded = [1, 2, 3, 4];
+        let payload = encode_relay_envelope(&destination, 123, &encoded);
+
+        assert_eq!(
+            decode_relay_envelope(&payload),
+            Some((destination.as_slice(), 123, encoded.as_slice()))
+        );
+        assert_eq!(decode_relay_envelope(&payload[..20]), None);
+
+        let mut corrupt = payload;
+        if let Some(byte) = corrupt.get_mut(16) {
+            *byte ^= 0xff;
+        }
+        assert_eq!(decode_relay_envelope(&corrupt), None);
+    }
 }

--- a/tests/godot-web-smoke/src/fortress.rs
+++ b/tests/godot-web-smoke/src/fortress.rs
@@ -20,15 +20,14 @@ use signal_fish_client::{
 const SERVER_URL: &str = "ws://127.0.0.1:3536/v2/ws";
 const APP_ID: &str = "e2e-test-app";
 const GAME_NAME: &str = "godot-fortress-issue-61";
-const TARGET_FRAMES: i32 = 600;
-const SETTLEMENT_FRAME_LIMIT: i32 = TARGET_FRAMES + 20;
+const DEFAULT_TARGET_FRAMES: i32 = 600;
+const SETTLEMENT_FRAMES: i32 = 20;
 const MAX_RELAY_QUEUE: usize = 256;
 const IMPAIRMENT_START_FRAME: i32 = 120;
-const IMPAIRMENT_END_FRAME: i32 = 128;
 // GitHub's shared runners have measured at roughly 23 rendered frames/second
 // under two independent Chromium/Godot processes. Keep a generous wall-clock
 // guard while the frame/checksum/queue oracles remain exact.
-const SESSION_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(40);
+const DEFAULT_SESSION_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(40);
 const TEARDOWN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
 type Client = SignalFishPollingClient<GodotWebSocketTransport>;
@@ -101,6 +100,12 @@ impl NonBlockingSocket<PlayerId> for RelaySocket {
 pub(super) struct FortressScenario {
     role: String,
     requested_room_code: Option<String>,
+    target_frames: i32,
+    settlement_frame_limit: i32,
+    session_timeout: std::time::Duration,
+    poll_hitch_frame: Option<i32>,
+    poll_hitch_callbacks_remaining: u8,
+    poll_hitch_completed: bool,
     joined_room_code: Option<String>,
     client: Option<Client>,
     local_id: Option<PlayerId>,
@@ -122,6 +127,7 @@ pub(super) struct FortressScenario {
     simulation_elapsed_ms: Option<u128>,
     game_ready: bool,
     max_poll_us: u64,
+    last_time_series_frame: i32,
     last_accepted: u64,
     multi_frame_poll: bool,
     completed: bool,
@@ -145,6 +151,19 @@ impl FortressScenario {
     pub(super) fn from_user_args(args: &[String]) -> Option<Self> {
         let role = argument(args, "--fortress-role")?;
         let requested_room_code = argument(args, "--room-code");
+        let target_frames = argument(args, "--target-frames")
+            .and_then(|value| value.parse::<i32>().ok())
+            .filter(|value| *value > 0)
+            .unwrap_or(DEFAULT_TARGET_FRAMES);
+        let settlement_frame_limit = target_frames.saturating_add(SETTLEMENT_FRAMES);
+        let session_timeout = argument(args, "--session-timeout-ms")
+            .and_then(|value| value.parse::<u64>().ok())
+            .map(std::time::Duration::from_millis)
+            .unwrap_or(DEFAULT_SESSION_TIMEOUT);
+        let poll_hitch_frame = argument(args, "--poll-hitch-frame")
+            .and_then(|value| value.parse::<i32>().ok())
+            .filter(|value| *value >= 0);
+        let server_url = argument(args, "--server-url").unwrap_or_else(|| SERVER_URL.into());
         let configuration_error = match (role.as_str(), requested_room_code.as_ref()) {
             ("a", None) | ("b", Some(_)) => None,
             ("a", Some(_)) => Some("role a must create a room without --room-code".to_string()),
@@ -155,7 +174,7 @@ impl FortressScenario {
             godot_error!("SIGNAL_FISH_FORTRESS startup-error {error}");
             (None, Some(error))
         } else {
-            match GodotWebSocketTransport::connect(SERVER_URL) {
+            match GodotWebSocketTransport::connect(&server_url) {
                 Ok(transport) => {
                     let mut config = SignalFishConfig::new(APP_ID).enable_v3();
                     config.platform = Some(format!("godot-fortress-{role}"));
@@ -172,6 +191,12 @@ impl FortressScenario {
         Some(Self {
             role,
             requested_room_code,
+            target_frames,
+            settlement_frame_limit,
+            session_timeout,
+            poll_hitch_frame,
+            poll_hitch_callbacks_remaining: u8::from(poll_hitch_frame.is_some()) * 6,
+            poll_hitch_completed: false,
             joined_room_code: None,
             client,
             local_id: None,
@@ -193,6 +218,7 @@ impl FortressScenario {
             simulation_elapsed_ms: None,
             game_ready: false,
             max_poll_us: 0,
+            last_time_series_frame: -60,
             last_accepted: 0,
             multi_frame_poll: false,
             completed: false,
@@ -217,7 +243,11 @@ impl FortressScenario {
         if self.completed {
             return true;
         }
-        let events = self.poll_client_once();
+        let events = if self.should_skip_poll_for_hitch() {
+            Vec::new()
+        } else {
+            self.poll_client_once()
+        };
         for event in events {
             self.handle_event(event);
         }
@@ -252,6 +282,24 @@ impl FortressScenario {
         self.multi_frame_poll |= accepted.saturating_sub(self.last_accepted) > 1;
         self.last_accepted = accepted;
         events
+    }
+
+    fn should_skip_poll_for_hitch(&mut self) -> bool {
+        let Some(hitch_frame) = self.poll_hitch_frame else {
+            return false;
+        };
+        let current_frame = self
+            .session
+            .as_ref()
+            .map_or(-1, |session| session.current_frame().as_i32());
+        if current_frame < hitch_frame || self.poll_hitch_callbacks_remaining == 0 {
+            return false;
+        }
+        self.poll_hitch_callbacks_remaining = self.poll_hitch_callbacks_remaining.saturating_sub(1);
+        if self.poll_hitch_callbacks_remaining == 0 {
+            self.poll_hitch_completed = true;
+        }
+        true
     }
 
     fn handle_event(&mut self, event: SignalFishEvent) {
@@ -410,6 +458,10 @@ impl FortressScenario {
             .with_num_players(2)
             .and_then(|builder| builder.with_fps(60))
             .and_then(|builder| builder.with_input_delay(2))
+            // Leave enough prediction headroom for the declared six-callback
+            // hitch on top of the constrained-network round trip. Scenario
+            // oracles still enforce the tighter clean/impaired lag limits.
+            .map(|builder| builder.with_max_prediction_window(12))
             .and_then(|builder| builder.add_player(PlayerType::Local, local_handle))
             .and_then(|builder| builder.add_player(PlayerType::Remote(remote_id), remote_handle))
             .map(|builder| {
@@ -426,6 +478,9 @@ impl FortressScenario {
                 self.remote_handle = Some(remote_handle);
                 self.remote_id = Some(remote_id);
                 self.started = Some(Instant::now());
+                if let Some(client) = &mut self.client {
+                    client.reset_queue_age_peak();
+                }
                 godot_print!(
                     "SIGNAL_FISH_FORTRESS session-created role={} local_handle={local_index}",
                     self.role
@@ -440,7 +495,7 @@ impl FortressScenario {
             return;
         };
         session.poll_remote_clients();
-        let confirmed = session.confirmed_frame().as_i32().min(TARGET_FRAMES);
+        let confirmed = session.confirmed_frame().as_i32().min(self.target_frames);
         while self.checksum_through < confirmed {
             let frame = self.checksum_through.saturating_add(1);
             match session.confirmed_inputs_for_frame(Frame::new(frame)) {
@@ -478,12 +533,36 @@ impl FortressScenario {
             }
         }
         let metrics = session.metrics();
+        let sample_frame = session.current_frame().as_i32();
+        if sample_frame >= self.last_time_series_frame.saturating_add(60) {
+            self.last_time_series_frame = sample_frame;
+            let queue_depth = self
+                .client
+                .as_ref()
+                .map_or(0, |client| client.polling_stats().current_queue_depth);
+            let queue_age_ms = self.client.as_ref().map_or(0.0, |client| {
+                client
+                    .queue_age_stats()
+                    .current_oldest_queue_age
+                    .as_secs_f64()
+                    * 1_000.0
+            });
+            let sample = serde_json::json!({
+                "role": self.role,
+                "current_frame": sample_frame,
+                "confirmed_frame": session.confirmed_frame().as_i32(),
+                "confirmation_lag": metrics.confirmation_lag_current,
+                "queue_depth": queue_depth,
+                "queue_age_ms": queue_age_ms,
+            });
+            godot_print!("SIGNAL_FISH_FORTRESS sample {sample}");
+        }
         let sync_health = self
             .remote_handle
             .and_then(|handle| session.sync_health(handle));
         if self
             .started
-            .is_some_and(|started| started.elapsed() >= SESSION_TIMEOUT)
+            .is_some_and(|started| started.elapsed() >= self.session_timeout)
         {
             self.fatal = Some(format!(
                 "Fortress settlement timed out: confirmed={} checksum_through={} target_checksum={} sync_health={sync_health:?} checks={}",
@@ -498,8 +577,16 @@ impl FortressScenario {
             return;
         }
 
-        let target_is_confirmed = session.confirmed_frame().as_i32() >= TARGET_FRAMES
-            && self.checksum_through >= TARGET_FRAMES;
+        // Do not let the first browser advance merely because its local
+        // session entered Running first. Receiving one valid Fortress packet
+        // proves the independently launched peer is also pumping the session,
+        // removing process-start skew from gameplay-lag measurements.
+        if self.relay.borrow().decoded == 0 {
+            return;
+        }
+
+        let target_is_confirmed = session.confirmed_frame().as_i32() >= self.target_frames
+            && self.checksum_through >= self.target_frames;
         if target_is_confirmed && !self.target_confirmed {
             self.target_confirmed = true;
             self.simulation_elapsed_ms = self.started.map(|started| started.elapsed().as_millis());
@@ -523,15 +610,14 @@ impl FortressScenario {
         if current >= IMPAIRMENT_START_FRAME && self.pre_impairment_metrics.is_none() {
             self.pre_impairment_metrics = Some(session.metrics());
         }
-        if current < SETTLEMENT_FRAME_LIMIT {
+        if current < self.settlement_frame_limit {
             let Some(local_handle) = self.local_handle else {
                 self.fatal = Some("missing local Fortress handle".to_string());
                 return;
             };
-            // Prediction stays exactly correct before the impairment. Player
-            // B changes its value at the same frame its outbound relay is
-            // withheld, so the later nonzero rollback delta is causally tied
-            // to reintegrating those delayed inputs.
+            // Prediction stays exactly correct before the switch. Player B's
+            // value change makes A's last-value prediction wrong, so the later
+            // nonzero rollback delta is causally tied to that remote input.
             let input = TestInput {
                 value: u32::from(self.role == "b" && current >= IMPAIRMENT_START_FRAME),
             };
@@ -568,7 +654,7 @@ impl FortressScenario {
                                     return;
                                 }
                                 self.save_requests = self.save_requests.saturating_add(1);
-                                if frame.as_i32() == TARGET_FRAMES {
+                                if frame.as_i32() == self.target_frames {
                                     self.target_state_checksum = Some(checksum);
                                 }
                             }
@@ -617,13 +703,11 @@ impl FortressScenario {
             .session
             .as_ref()
             .map_or(0, |session| session.current_frame().as_i32());
-        if self.role == "b"
-            && (IMPAIRMENT_START_FRAME..IMPAIRMENT_END_FRAME).contains(&current_frame)
+        if self.role == "b" && !self.impairment_activated && current_frame >= IMPAIRMENT_START_FRAME
         {
+            // Changing B's input invalidates A's prior prediction. Keep relay
+            // delivery live so this rollback proof does not manufacture lag.
             self.impairment_activated = true;
-            return;
-        }
-        if self.role == "b" && self.impairment_activated && current_frame >= IMPAIRMENT_END_FRAME {
             self.impairment_released = true;
         }
         let Some(client) = &mut self.client else {
@@ -751,27 +835,50 @@ impl FortressScenario {
                     == Some(SyncHealth::InSync)
             });
         let polling = self.client.as_ref().map(|client| client.polling_stats());
+        let queue_age = self.client.as_ref().map(|client| client.queue_age_stats());
         let transport = self
             .client
             .as_ref()
             .map(|client| client.transport_diagnostics());
+        let admission_watermark_violations = self.client.as_ref().map_or(0, |client| {
+            client.transport().admission_watermark_violations()
+        });
         let total_elapsed_ms = self
             .started
             .map_or(0, |started| started.elapsed().as_millis());
         let final_inbound_depth = queues.inbound.len();
         let final_outbound_depth = queues.outbound.len();
         let queue_depth = polling.map_or(0, |stats| stats.current_queue_depth);
+        let current_queue_age = queue_age.map_or(std::time::Duration::ZERO, |stats| {
+            stats.current_oldest_queue_age
+        });
+        let peak_queue_age = queue_age.map_or(std::time::Duration::ZERO, |stats| {
+            stats.peak_oldest_queue_age
+        });
         let checksums_mismatched = metrics.map_or(0, |metrics| metrics.checksums_mismatched);
         let events_discarded = metrics.map_or(0, |metrics| metrics.events_discarded_total);
+        let relay_messages_per_simulated_frame = metrics.map_or(0.0, |metrics| {
+            queues.encoded.saturating_add(queues.decoded) as f64
+                / metrics.visual_frames.max(1) as f64
+        });
         let invariant_passed = self.game_ready
             && self.target_state_checksum.is_some()
             && final_inbound_depth == 0
             && final_outbound_depth == 0
             && queue_depth == 0
+            && current_queue_age == std::time::Duration::ZERO
+            && peak_queue_age <= std::time::Duration::from_millis(500)
             && queues.dropped == 0
             && queues.malformed == 0
             && checksums_mismatched == 0
-            && events_discarded == 0;
+            && events_discarded == 0
+            && metrics.is_some_and(|metrics| {
+                metrics.confirmation_lag_current <= 12
+                    && metrics.confirmation_lag_max <= 12
+                    && metrics.stall_count == 0
+                    && metrics.wait_recommendations == 0
+            })
+            && relay_messages_per_simulated_frame >= 2.0;
         let summary = serde_json::json!({
             "passed": passed && self.fatal.is_none() && invariant_passed,
             "role": self.role,
@@ -779,9 +886,9 @@ impl FortressScenario {
             "joined_room_code": self.joined_room_code,
             "local_id": self.local_id.map(|id| id.to_string()),
             "remote_id": self.remote_id.map(|id| id.to_string()),
-            "target_frames": TARGET_FRAMES,
-            "settlement_frame_limit": SETTLEMENT_FRAME_LIMIT,
-            "session_timeout_ms": SESSION_TIMEOUT.as_millis(),
+            "target_frames": self.target_frames,
+            "settlement_frame_limit": self.settlement_frame_limit,
+            "session_timeout_ms": self.session_timeout.as_millis(),
             "game_frame": self.game.frame,
             // Preserve exact integer values when the browser runner parses JSON.
             "confirmed_input_checksum": self.confirmed_checksum.to_string(),
@@ -801,6 +908,9 @@ impl FortressScenario {
             "max_rollback_depth": metrics.map_or(0, |metrics| metrics.max_rollback_depth),
             "prediction_miss_count": metrics.map_or(0, |metrics| metrics.prediction_miss_count),
             "stall_count": metrics.map_or(0, |metrics| metrics.stall_count),
+            "wait_recommendation_count": metrics.map_or(0, |metrics| metrics.wait_recommendations),
+            "confirmation_lag_current": metrics.map_or(0, |metrics| metrics.confirmation_lag_current),
+            "confirmation_lag_max": metrics.map_or(0, |metrics| metrics.confirmation_lag_max),
             "checksums_compared": metrics.map_or(0, |metrics| metrics.checksums_compared),
             "checksums_matched": metrics.map_or(0, |metrics| metrics.checksums_matched),
             "checksums_mismatched": checksums_mismatched,
@@ -825,16 +935,32 @@ impl FortressScenario {
             "relay_outbound_depth": final_outbound_depth,
             "queue_depth": queue_depth,
             "peak_queue_depth": polling.map_or(0, |stats| stats.peak_queue_depth),
+            "current_queue_age_ms": current_queue_age.as_secs_f64() * 1_000.0,
+            "peak_queue_age_ms": peak_queue_age.as_secs_f64() * 1_000.0,
+            "relay_messages_per_simulated_frame": relay_messages_per_simulated_frame,
             "accepted_frames": transport.map_or(0, |stats| stats.accepted_frames),
             "watermark_hits": transport.map_or(0, |stats| stats.watermark_hits),
             "backend_capacity_hits": transport.map_or(0, |stats| stats.backend_capacity_hits),
+            "admission_watermark_violations": admission_watermark_violations,
             "impairment_activated": self.impairment_activated,
             "impairment_released": self.impairment_released,
+            "poll_hitch_frame": self.poll_hitch_frame,
+            "poll_hitch_completed": self.poll_hitch_completed,
             "peer_left_observed": self.peer_left_observed,
             "peer_left_epoch": self.peer_left_epoch,
             "peer_left_final_seq": self.peer_left_final_seq,
             "fatal": self.fatal,
         });
+        let final_sample = serde_json::json!({
+            "role": self.role,
+            "current_frame": self.game.frame,
+            "confirmed_frame": self.checksum_through,
+            "confirmation_lag": metrics.map_or(0, |metrics| metrics.confirmation_lag_current),
+            "queue_depth": queue_depth,
+            "queue_age_ms": current_queue_age.as_secs_f64() * 1_000.0,
+            "final": true,
+        });
+        godot_print!("SIGNAL_FISH_FORTRESS sample {final_sample}");
         if summary["passed"].as_bool() == Some(true) {
             godot_print!("SIGNAL_FISH_FORTRESS summary {summary}");
         } else {

--- a/tests/godot-web-smoke/src/fortress.rs
+++ b/tests/godot-web-smoke/src/fortress.rs
@@ -549,6 +549,7 @@ impl FortressScenario {
             });
             let sample = serde_json::json!({
                 "role": self.role,
+                "elapsed_ms": self.started.map_or(0, |started| started.elapsed().as_millis()),
                 "current_frame": sample_frame,
                 "confirmed_frame": session.confirmed_frame().as_i32(),
                 "confirmation_lag": metrics.confirmation_lag_current,
@@ -953,6 +954,7 @@ impl FortressScenario {
         });
         let final_sample = serde_json::json!({
             "role": self.role,
+            "elapsed_ms": total_elapsed_ms,
             "current_frame": self.game.frame,
             "confirmed_frame": self.checksum_through,
             "confirmation_lag": metrics.map_or(0, |metrics| metrics.confirmation_lag_current),

--- a/tests/godot-web-smoke/src/fortress.rs
+++ b/tests/godot-web-smoke/src/fortress.rs
@@ -139,6 +139,10 @@ pub(super) struct FortressScenario {
     started: Option<Instant>,
     simulation_elapsed_ms: Option<u128>,
     next_advance_at: Option<Instant>,
+    startup_barrier_completed: bool,
+    startup_barrier_release_remote_frame: Option<i32>,
+    startup_barrier_release_local_frame: Option<i32>,
+    startup_barrier_elapsed_ms: Option<u128>,
     game_ready: bool,
     max_poll_us: u64,
     last_time_series_frame: i32,
@@ -232,6 +236,10 @@ impl FortressScenario {
             started: None,
             simulation_elapsed_ms: None,
             next_advance_at: None,
+            startup_barrier_completed: false,
+            startup_barrier_release_remote_frame: None,
+            startup_barrier_release_local_frame: None,
+            startup_barrier_elapsed_ms: None,
             game_ready: false,
             max_poll_us: 0,
             last_time_series_frame: -60,
@@ -597,6 +605,7 @@ impl FortressScenario {
                 "current_frame": sample_frame,
                 "confirmed_frame": session.confirmed_frame().as_i32(),
                 "confirmation_lag": metrics.confirmation_lag_current,
+                "confirmation_lag_max": metrics.confirmation_lag_max,
                 "queue_depth": queue_depth,
                 "queue_age_ms": queue_age_ms,
             });
@@ -622,18 +631,25 @@ impl FortressScenario {
             return;
         }
 
-        // Do not let the first browser advance merely because its local
-        // session entered Running first. Receiving one valid Fortress packet
-        // proves the independently launched peer is also pumping the session,
-        // removing process-start skew from gameplay-lag measurements.
-        if self.relay.borrow().decoded == 0
-            || self
-                .relay
-                .borrow()
-                .remote_frame
-                .is_none_or(|remote| remote < 0)
-        {
+        // Do not let the creator's earlier process start become permanent
+        // gameplay skew. Both sessions emit frame-zero synchronization
+        // packets before advancing. A may advance after observing B at frame
+        // zero; B waits for A's causally later frame-one packet. This one-time
+        // barrier proves A observed B before either peer begins independent
+        // fixed-cadence gameplay.
+        let (decoded, remote_frame) = {
+            let relay = self.relay.borrow();
+            (relay.decoded, relay.remote_frame)
+        };
+        if decoded == 0 || !startup_remote_frame_ready(&self.role, remote_frame) {
             return;
+        }
+        if !self.startup_barrier_completed {
+            self.startup_barrier_completed = true;
+            self.startup_barrier_release_remote_frame = remote_frame;
+            self.startup_barrier_release_local_frame = Some(session.current_frame().as_i32());
+            self.startup_barrier_elapsed_ms =
+                self.started.map(|started| started.elapsed().as_millis());
         }
 
         let target_is_confirmed = session.confirmed_frame().as_i32() >= self.target_frames
@@ -960,8 +976,12 @@ impl FortressScenario {
             self.target_frames,
             self.settlement_frame_limit,
         );
+        let startup_barrier_valid = self.startup_barrier_completed
+            && self.startup_barrier_release_local_frame == Some(0)
+            && startup_remote_frame_ready(&self.role, self.startup_barrier_release_remote_frame);
         let invariant_passed = self.game_ready
             && self.target_state_checksum.is_some()
+            && startup_barrier_valid
             && final_inbound_depth == 0
             && final_outbound_depth == 0
             && queue_depth == 0
@@ -998,6 +1018,11 @@ impl FortressScenario {
             "simulation_target_fps": SIMULATION_FPS,
             "observed_simulation_fps": observed_simulation_fps,
             "total_elapsed_ms": total_elapsed_ms,
+            "startup_barrier_completed": self.startup_barrier_completed,
+            "startup_barrier_required_remote_frame": startup_required_remote_frame(&self.role),
+            "startup_barrier_release_remote_frame": self.startup_barrier_release_remote_frame,
+            "startup_barrier_release_local_frame": self.startup_barrier_release_local_frame,
+            "startup_barrier_elapsed_ms": self.startup_barrier_elapsed_ms,
             "max_poll_us": self.max_poll_us,
             "multi_frame_poll": self.multi_frame_poll,
             "game_ready": self.game_ready,
@@ -1059,6 +1084,7 @@ impl FortressScenario {
             "current_frame": self.game.frame,
             "confirmed_frame": self.checksum_through,
             "confirmation_lag": metrics.map_or(0, |metrics| metrics.confirmation_lag_current),
+            "confirmation_lag_max": metrics.map_or(0, |metrics| metrics.confirmation_lag_max),
             "queue_depth": queue_depth,
             "queue_age_ms": current_queue_age.as_secs_f64() * 1_000.0,
             "final": true,
@@ -1091,6 +1117,20 @@ fn scenario_lag_limit(
     } else {
         CLEAN_LAG_LIMIT
     }
+}
+
+fn startup_required_remote_frame(role: &str) -> Option<i32> {
+    match role {
+        "a" => Some(0),
+        "b" => Some(1),
+        _ => None,
+    }
+}
+
+fn startup_remote_frame_ready(role: &str, remote_frame: Option<i32>) -> bool {
+    startup_required_remote_frame(role)
+        .zip(remote_frame)
+        .is_some_and(|(required, observed)| observed >= required)
 }
 
 fn simulation_advance_due(now: Instant, next_advance_at: &mut Option<Instant>) -> bool {
@@ -1146,8 +1186,20 @@ mod tests {
 
     use super::{
         decode_relay_envelope, encode_relay_envelope, scenario_lag_limit, simulation_advance_due,
-        simulation_frame_period,
+        simulation_frame_period, startup_remote_frame_ready,
     };
+
+    #[test]
+    fn startup_barrier_causally_orders_the_independent_peer_cadences() {
+        assert!(!startup_remote_frame_ready("a", None));
+        assert!(!startup_remote_frame_ready("a", Some(-1)));
+        assert!(startup_remote_frame_ready("a", Some(0)));
+
+        assert!(!startup_remote_frame_ready("b", Some(0)));
+        assert!(startup_remote_frame_ready("b", Some(1)));
+        assert!(startup_remote_frame_ready("b", Some(2)));
+        assert!(!startup_remote_frame_ready("unexpected", Some(i32::MAX)));
+    }
 
     #[test]
     fn fixed_cadence_preserves_deadline_debt_and_bounds_each_recovery_callback() {

--- a/tests/godot-web-smoke/src/fortress.rs
+++ b/tests/godot-web-smoke/src/fortress.rs
@@ -26,6 +26,7 @@ const MAX_RELAY_QUEUE: usize = 256;
 const IMPAIRMENT_START_FRAME: i32 = 120;
 const INPUT_DELAY_FRAMES: i32 = 2;
 const IMPAIRMENT_MAX_HOLD_FRAMES: i32 = 8;
+const PREDICTION_WINDOW_FRAMES: usize = 20;
 const SIMULATION_FPS: usize = 18;
 const RELAY_ENVELOPE_MAGIC: &[u8; 4] = b"SFF1";
 // GitHub's shared runners have measured at roughly 23 rendered frames/second
@@ -496,10 +497,11 @@ impl FortressScenario {
             .with_num_players(2)
             .and_then(|builder| builder.with_fps(SIMULATION_FPS))
             .and_then(|builder| builder.with_input_delay(INPUT_DELAY_FRAMES as usize))
-            // Leave enough prediction headroom for the declared six-callback
-            // hitch on top of the constrained-network round trip. Scenario
-            // oracles still enforce the tighter clean/impaired lag limits.
-            .map(|builder| builder.with_max_prediction_window(12))
+            // Keep Fortress's internal stop threshold above the declared
+            // constrained-network lag limit. Scenario oracles independently
+            // enforce tighter clean/impaired bounds, so acceptable lag does
+            // not manufacture a wait or stall by exhausting this window.
+            .map(|builder| builder.with_max_prediction_window(PREDICTION_WINDOW_FRAMES))
             .and_then(|builder| builder.add_player(PlayerType::Local, local_handle))
             .and_then(|builder| builder.add_player(PlayerType::Remote(remote_id), remote_handle))
             .map(|builder| {

--- a/tests/godot-web-smoke/src/fortress.rs
+++ b/tests/godot-web-smoke/src/fortress.rs
@@ -1090,9 +1090,10 @@ fn simulation_advance_due(now: Instant, next_advance_at: &mut Option<Instant>) -
         return false;
     }
     let scheduled = deadline.checked_add(period).unwrap_or(now);
-    // Preserve the absolute cadence under ordinary callback jitter, but bound
-    // recovery after a long suspension to one immediate catch-up callback.
-    *deadline = scheduled.max(now);
+    // Preserve elapsed deadline debt so a delayed browser process can catch
+    // up instead of retaining permanent frame advantage. The caller invokes
+    // this once per rendered callback, bounding recovery to one frame there.
+    *deadline = scheduled;
     true
 }
 
@@ -1131,12 +1132,12 @@ mod tests {
     use std::time::{Duration, Instant};
 
     use super::{
-        decode_relay_envelope, encode_relay_envelope, simulation_advance_due,
-        simulation_frame_period, scenario_lag_limit,
+        decode_relay_envelope, encode_relay_envelope, scenario_lag_limit, simulation_advance_due,
+        simulation_frame_period,
     };
 
     #[test]
-    fn fixed_cadence_preserves_deadlines_and_bounds_long_pause_recovery() {
+    fn fixed_cadence_preserves_deadline_debt_and_bounds_each_recovery_callback() {
         let start = Instant::now();
         let period = simulation_frame_period();
         let mut deadline = None;
@@ -1154,7 +1155,13 @@ mod tests {
 
         let after_pause = start + Duration::from_secs(5);
         assert!(simulation_advance_due(after_pause, &mut deadline));
-        assert_eq!(deadline, Some(after_pause));
+        assert_eq!(deadline, start.checked_add(period.saturating_mul(3)));
+        assert!(deadline.is_some_and(|deadline| deadline < after_pause));
+
+        // Each invocation advances exactly one deadline even while overdue;
+        // the rendered-callback caller therefore cannot burst several frames.
+        assert!(simulation_advance_due(after_pause, &mut deadline));
+        assert_eq!(deadline, start.checked_add(period.saturating_mul(4)));
     }
 
     #[test]

--- a/tests/godot-web-smoke/src/fortress.rs
+++ b/tests/godot-web-smoke/src/fortress.rs
@@ -1,7 +1,7 @@
 use std::cell::RefCell;
 use std::collections::VecDeque;
 use std::rc::Rc;
-use std::time::Instant;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use fortress_rollback::network::codec::{decode_message, encode};
 use fortress_rollback::{
@@ -32,6 +32,13 @@ const SOAK_LAG_LIMIT: u64 = 12;
 const PREDICTION_WINDOW_FRAMES: usize = 20;
 const SIMULATION_FPS: usize = 18;
 const RELAY_ENVELOPE_MAGIC: &[u8; 4] = b"SFF1";
+const STARTUP_ENVELOPE_MAGIC: &[u8; 4] = b"SFS1";
+const STARTUP_LEAD_MS: u64 = 2_000;
+const STARTUP_MAX_LEAD: Duration = Duration::from_secs(3);
+const STARTUP_MIN_PROPOSAL_LEAD: Duration = Duration::from_millis(1_250);
+const STARTUP_MIN_ACK_LEAD: Duration = Duration::from_millis(750);
+const STARTUP_MIN_COMMIT_LEAD: Duration = Duration::from_millis(250);
+const STARTUP_TIMEOUT: Duration = Duration::from_secs(5);
 // GitHub's shared runners have measured at roughly 23 rendered frames/second
 // under two independent Chromium/Godot processes. Keep a generous wall-clock
 // guard while the frame/checksum/queue oracles remain exact.
@@ -58,6 +65,51 @@ impl Config for TestConfig {
     type Input = TestInput;
     type State = TestState;
     type Address = PlayerId;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StartupControl {
+    Proposal { start_unix_ms: u64 },
+    Ack { start_unix_ms: u64 },
+    Commit { start_unix_ms: u64 },
+}
+
+impl StartupControl {
+    fn start_unix_ms(self) -> u64 {
+        match self {
+            Self::Proposal { start_unix_ms }
+            | Self::Ack { start_unix_ms }
+            | Self::Commit { start_unix_ms } => start_unix_ms,
+        }
+    }
+}
+
+fn startup_control_allowed(
+    role: &str,
+    control: StartupControl,
+    expected_start_unix_ms: Option<u64>,
+    proposal_sent: bool,
+    ack_sent: bool,
+) -> bool {
+    let exact_deadline = expected_start_unix_ms == Some(control.start_unix_ms());
+    match (role, control) {
+        ("a", StartupControl::Proposal { .. }) => {
+            expected_start_unix_ms.is_none() || exact_deadline
+        }
+        ("a", StartupControl::Commit { .. }) => ack_sent && exact_deadline,
+        ("b", StartupControl::Ack { .. }) => proposal_sent && exact_deadline,
+        _ => false,
+    }
+}
+
+fn startup_control_lead_valid(
+    deadline: Option<Instant>,
+    now: Instant,
+    minimum_lead: Duration,
+    already_received: bool,
+) -> bool {
+    already_received
+        || deadline.is_some_and(|deadline| deadline.saturating_duration_since(now) >= minimum_lead)
 }
 
 #[derive(Default)]
@@ -136,13 +188,22 @@ pub(super) struct FortressScenario {
     checksum_through: i32,
     confirmed_checksum: u64,
     target_state_checksum: Option<u128>,
+    startup_started_at: Option<Instant>,
     started: Option<Instant>,
     simulation_elapsed_ms: Option<u128>,
     next_advance_at: Option<Instant>,
     startup_barrier_completed: bool,
-    startup_barrier_release_remote_frame: Option<i32>,
+    startup_start_unix_ms: Option<u64>,
+    startup_start_at: Option<Instant>,
+    startup_proposal_sent: bool,
+    startup_proposal_received: bool,
+    startup_ack_sent: bool,
+    startup_ack_received: bool,
+    startup_commit_sent: bool,
+    startup_commit_received: bool,
     startup_barrier_release_local_frame: Option<i32>,
     startup_barrier_elapsed_ms: Option<u128>,
+    startup_release_lateness_ms: Option<u128>,
     game_ready: bool,
     max_poll_us: u64,
     last_time_series_frame: i32,
@@ -233,13 +294,22 @@ impl FortressScenario {
             checksum_through: -1,
             confirmed_checksum: 0,
             target_state_checksum: None,
+            startup_started_at: None,
             started: None,
             simulation_elapsed_ms: None,
             next_advance_at: None,
             startup_barrier_completed: false,
-            startup_barrier_release_remote_frame: None,
+            startup_start_unix_ms: None,
+            startup_start_at: None,
+            startup_proposal_sent: false,
+            startup_proposal_received: false,
+            startup_ack_sent: false,
+            startup_ack_received: false,
+            startup_commit_sent: false,
+            startup_commit_received: false,
             startup_barrier_release_local_frame: None,
             startup_barrier_elapsed_ms: None,
+            startup_release_lateness_ms: None,
             game_ready: false,
             max_poll_us: 0,
             last_time_series_frame: -60,
@@ -438,14 +508,30 @@ impl FortressScenario {
             && seq.is_some_and(|value| value > 0)
             && epoch.is_some_and(|value| value > 0)
             && valid_sender;
-        let Some((destination, advertised_frame, encoded)) = decode_relay_envelope(&payload) else {
-            self.note_malformed();
-            return;
-        };
         if !valid_envelope {
             self.note_malformed();
             return;
         }
+        if let Some((destination, control)) = decode_startup_envelope(&payload) {
+            if destination != local_id.as_bytes() {
+                let ignored = self.relay.borrow().ignored_nonlocal.saturating_add(1);
+                self.relay.borrow_mut().ignored_nonlocal = ignored;
+                return;
+            }
+            let mut relay = self.relay.borrow_mut();
+            relay.decoded = relay.decoded.saturating_add(1);
+            drop(relay);
+            if self.remote_id != Some(sender) {
+                self.fail("startup control did not originate from the session peer".to_string());
+                return;
+            }
+            self.handle_startup_control(control);
+            return;
+        }
+        let Some((destination, advertised_frame, encoded)) = decode_relay_envelope(&payload) else {
+            self.note_malformed();
+            return;
+        };
         if destination != local_id.as_bytes() {
             let ignored = self.relay.borrow().ignored_nonlocal.saturating_add(1);
             self.relay.borrow_mut().ignored_nonlocal = ignored;
@@ -471,6 +557,80 @@ impl FortressScenario {
                 }
             }
             _ => self.note_malformed(),
+        }
+    }
+
+    fn handle_startup_control(&mut self, control: StartupControl) {
+        let start_unix_ms = control.start_unix_ms();
+        if !startup_control_allowed(
+            &self.role,
+            control,
+            self.startup_start_unix_ms,
+            self.startup_proposal_sent,
+            self.startup_ack_sent,
+        ) {
+            self.fail(format!(
+                "unexpected startup control for role {}: {control:?}",
+                self.role
+            ));
+            return;
+        }
+        match (&*self.role, control) {
+            ("a", StartupControl::Proposal { .. }) => {
+                if self.startup_start_at.is_none() {
+                    match instant_for_unix_ms(start_unix_ms) {
+                        Some(deadline) => {
+                            let remaining = deadline.saturating_duration_since(Instant::now());
+                            if !(STARTUP_MIN_PROPOSAL_LEAD..=STARTUP_MAX_LEAD).contains(&remaining)
+                            {
+                                self.fail(
+                                    "startup proposal has an unsafe deadline lead".to_string(),
+                                );
+                                return;
+                            }
+                            self.startup_start_unix_ms = Some(start_unix_ms);
+                            self.startup_start_at = Some(deadline);
+                        }
+                        None => {
+                            self.fail("startup proposal arrived after its deadline".to_string());
+                            return;
+                        }
+                    }
+                }
+                self.startup_proposal_received = true;
+            }
+            ("a", StartupControl::Commit { .. })
+                if self.startup_ack_sent && self.startup_start_unix_ms == Some(start_unix_ms) =>
+            {
+                if !startup_control_lead_valid(
+                    self.startup_start_at,
+                    Instant::now(),
+                    STARTUP_MIN_COMMIT_LEAD,
+                    self.startup_commit_received,
+                ) {
+                    self.fail("startup commit arrived too near its common deadline".to_string());
+                    return;
+                }
+                self.startup_commit_received = true;
+            }
+            ("b", StartupControl::Ack { .. })
+                if self.startup_proposal_sent
+                    && self.startup_start_unix_ms == Some(start_unix_ms) =>
+            {
+                if !startup_control_lead_valid(
+                    self.startup_start_at,
+                    Instant::now(),
+                    STARTUP_MIN_ACK_LEAD,
+                    self.startup_ack_received,
+                ) {
+                    self.fail(
+                        "startup acknowledgement arrived too near its common deadline".to_string(),
+                    );
+                    return;
+                }
+                self.startup_ack_received = true;
+            }
+            _ => self.fail("startup control admission mismatch".to_string()),
         }
     }
 
@@ -528,10 +688,7 @@ impl FortressScenario {
                 self.local_handle = Some(local_handle);
                 self.remote_handle = Some(remote_handle);
                 self.remote_id = Some(remote_id);
-                self.started = Some(Instant::now());
-                if let Some(client) = &mut self.client {
-                    client.reset_queue_age_peak();
-                }
+                self.startup_started_at = Some(Instant::now());
                 godot_print!(
                     "SIGNAL_FISH_FORTRESS session-created role={} local_handle={local_index}",
                     self.role
@@ -627,29 +784,126 @@ impl FortressScenario {
             ));
             return;
         }
+        let now = Instant::now();
+        if !self.startup_barrier_completed
+            && self
+                .startup_started_at
+                .is_some_and(|started| started.elapsed() >= STARTUP_TIMEOUT)
+        {
+            self.fatal = Some("causal startup handshake timed out".to_string());
+            return;
+        }
         if session.current_state() != SessionState::Running {
             return;
         }
-
-        // Do not let the creator's earlier process start become permanent
-        // gameplay skew. Both sessions emit frame-zero synchronization
-        // packets before advancing. A may advance after observing B at frame
-        // zero; B waits for A's causally later frame-one packet. This one-time
-        // barrier proves A observed B before either peer begins independent
-        // fixed-cadence gameplay.
-        let (decoded, remote_frame) = {
-            let relay = self.relay.borrow();
-            (relay.decoded, relay.remote_frame)
-        };
-        if decoded == 0 || !startup_remote_frame_ready(&self.role, remote_frame) {
+        if self.role == "b" && !self.startup_proposal_sent {
+            let Some(start_unix_ms) =
+                unix_time_millis().and_then(|now_ms| now_ms.checked_add(STARTUP_LEAD_MS))
+            else {
+                self.fatal = Some("system clock cannot represent startup deadline".to_string());
+                return;
+            };
+            let Some(start_at) = instant_for_unix_ms(start_unix_ms) else {
+                self.fatal = Some("startup deadline cannot be mapped monotonically".to_string());
+                return;
+            };
+            let Some(remote_id) = self.remote_id else {
+                self.fatal = Some("missing remote player for startup proposal".to_string());
+                return;
+            };
+            let control = StartupControl::Proposal { start_unix_ms };
+            if !queue_startup_control(&self.relay, remote_id, control) {
+                self.fatal = Some("startup proposal exceeded the relay queue bound".to_string());
+                return;
+            }
+            self.startup_start_unix_ms = Some(start_unix_ms);
+            self.startup_start_at = Some(start_at);
+            self.startup_proposal_sent = true;
             return;
         }
+        if self.role == "a" && self.startup_proposal_received && !self.startup_ack_sent {
+            let (Some(remote_id), Some(start_unix_ms), Some(start_at)) = (
+                self.remote_id,
+                self.startup_start_unix_ms,
+                self.startup_start_at,
+            ) else {
+                self.fatal = Some("startup proposal state is incomplete".to_string());
+                return;
+            };
+            if now >= start_at {
+                self.fatal = Some("startup proposal left no time for acknowledgement".to_string());
+                return;
+            }
+            if !queue_startup_control(
+                &self.relay,
+                remote_id,
+                StartupControl::Ack { start_unix_ms },
+            ) {
+                self.fatal =
+                    Some("startup acknowledgement exceeded the relay queue bound".to_string());
+                return;
+            }
+            self.startup_ack_sent = true;
+            return;
+        }
+        if self.role == "b" && self.startup_ack_received && !self.startup_commit_sent {
+            let (Some(remote_id), Some(start_unix_ms), Some(start_at)) = (
+                self.remote_id,
+                self.startup_start_unix_ms,
+                self.startup_start_at,
+            ) else {
+                self.fatal = Some("startup acknowledgement state is incomplete".to_string());
+                return;
+            };
+            if now >= start_at {
+                self.fatal = Some("startup acknowledgement missed the common deadline".to_string());
+                return;
+            }
+            if !queue_startup_control(
+                &self.relay,
+                remote_id,
+                StartupControl::Commit { start_unix_ms },
+            ) {
+                self.fatal = Some("startup commit exceeded the relay queue bound".to_string());
+                return;
+            }
+            self.startup_commit_sent = true;
+            return;
+        }
+        let startup_handshake_ready = match &*self.role {
+            "a" => self.startup_ack_sent && self.startup_commit_received,
+            "b" => {
+                self.startup_proposal_sent && self.startup_ack_received && self.startup_commit_sent
+            }
+            _ => false,
+        };
+        match startup_release_due(now, self.startup_start_at, startup_handshake_ready) {
+            Ok(false) => return,
+            Ok(true) => {}
+            Err(message) => {
+                self.fatal = Some(format!("{message} for role {}", self.role));
+                return;
+            }
+        }
+        let Some(start_at) = self.startup_start_at else {
+            self.fatal = Some("startup release lost the common deadline".to_string());
+            return;
+        };
         if !self.startup_barrier_completed {
             self.startup_barrier_completed = true;
-            self.startup_barrier_release_remote_frame = remote_frame;
             self.startup_barrier_release_local_frame = Some(session.current_frame().as_i32());
-            self.startup_barrier_elapsed_ms =
-                self.started.map(|started| started.elapsed().as_millis());
+            self.startup_barrier_elapsed_ms = self
+                .startup_started_at
+                .map(|started| started.elapsed().as_millis());
+            self.startup_release_lateness_ms =
+                Some(now.saturating_duration_since(start_at).as_millis());
+            self.started = Some(now);
+            // Anchor both independent cadence schedules to the same mapped
+            // deadline rather than each browser's first later callback.
+            self.next_advance_at = Some(start_at);
+            if let Some(client) = &mut self.client {
+                client.reset_queue_age_peak();
+            }
         }
 
         let target_is_confirmed = session.confirmed_frame().as_i32() >= self.target_frames
@@ -691,7 +945,6 @@ impl FortressScenario {
             }
             self.impairment_activated = true;
         }
-        let now = Instant::now();
         if !simulation_advance_due(now, &mut self.next_advance_at) {
             return;
         }
@@ -978,7 +1231,24 @@ impl FortressScenario {
         );
         let startup_barrier_valid = self.startup_barrier_completed
             && self.startup_barrier_release_local_frame == Some(0)
-            && startup_remote_frame_ready(&self.role, self.startup_barrier_release_remote_frame);
+            && self.startup_start_unix_ms.is_some_and(|value| value > 0)
+            && self.startup_barrier_elapsed_ms.is_some()
+            && self
+                .startup_release_lateness_ms
+                .is_some_and(|value| value <= 100)
+            && match &*self.role {
+                "a" => {
+                    self.startup_proposal_received
+                        && self.startup_ack_sent
+                        && self.startup_commit_received
+                }
+                "b" => {
+                    self.startup_proposal_sent
+                        && self.startup_ack_received
+                        && self.startup_commit_sent
+                }
+                _ => false,
+            };
         let invariant_passed = self.game_ready
             && self.target_state_checksum.is_some()
             && startup_barrier_valid
@@ -1019,10 +1289,16 @@ impl FortressScenario {
             "observed_simulation_fps": observed_simulation_fps,
             "total_elapsed_ms": total_elapsed_ms,
             "startup_barrier_completed": self.startup_barrier_completed,
-            "startup_barrier_required_remote_frame": startup_required_remote_frame(&self.role),
-            "startup_barrier_release_remote_frame": self.startup_barrier_release_remote_frame,
+            "startup_start_unix_ms": self.startup_start_unix_ms,
+            "startup_proposal_sent": self.startup_proposal_sent,
+            "startup_proposal_received": self.startup_proposal_received,
+            "startup_ack_sent": self.startup_ack_sent,
+            "startup_ack_received": self.startup_ack_received,
+            "startup_commit_sent": self.startup_commit_sent,
+            "startup_commit_received": self.startup_commit_received,
             "startup_barrier_release_local_frame": self.startup_barrier_release_local_frame,
             "startup_barrier_elapsed_ms": self.startup_barrier_elapsed_ms,
+            "startup_release_lateness_ms": self.startup_release_lateness_ms,
             "max_poll_us": self.max_poll_us,
             "multi_frame_poll": self.multi_frame_poll,
             "game_ready": self.game_ready,
@@ -1119,20 +1395,6 @@ fn scenario_lag_limit(
     }
 }
 
-fn startup_required_remote_frame(role: &str) -> Option<i32> {
-    match role {
-        "a" => Some(0),
-        "b" => Some(1),
-        _ => None,
-    }
-}
-
-fn startup_remote_frame_ready(role: &str, remote_frame: Option<i32>) -> bool {
-    startup_required_remote_frame(role)
-        .zip(remote_frame)
-        .is_some_and(|(required, observed)| observed >= required)
-}
-
 fn simulation_advance_due(now: Instant, next_advance_at: &mut Option<Instant>) -> bool {
     let period = simulation_frame_period();
     let Some(deadline) = next_advance_at else {
@@ -1148,6 +1410,92 @@ fn simulation_advance_due(now: Instant, next_advance_at: &mut Option<Instant>) -
     // this once per rendered callback, bounding recovery to one frame there.
     *deadline = scheduled;
     true
+}
+
+fn unix_time_millis() -> Option<u64> {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .and_then(|elapsed| u64::try_from(elapsed.as_millis()).ok())
+}
+
+fn instant_for_unix_ms(start_unix_ms: u64) -> Option<Instant> {
+    let remaining_ms = start_unix_ms.checked_sub(unix_time_millis()?)?;
+    if remaining_ms == 0 {
+        return None;
+    }
+    Instant::now().checked_add(Duration::from_millis(remaining_ms))
+}
+
+fn startup_release_due(
+    now: Instant,
+    start_at: Option<Instant>,
+    handshake_ready: bool,
+) -> Result<bool, &'static str> {
+    let Some(start_at) = start_at else {
+        return if handshake_ready {
+            Err("startup handshake omitted the common deadline")
+        } else {
+            Ok(false)
+        };
+    };
+    if !handshake_ready {
+        return if now >= start_at {
+            Err("startup handshake was incomplete at the common deadline")
+        } else {
+            Ok(false)
+        };
+    }
+    Ok(now >= start_at)
+}
+
+fn queue_startup_control(
+    relay: &Rc<RefCell<RelayQueues>>,
+    remote_id: PlayerId,
+    control: StartupControl,
+) -> bool {
+    let payload = encode_startup_envelope(remote_id.as_bytes(), control);
+    let mut queues = relay.borrow_mut();
+    if queues.outbound.len() >= MAX_RELAY_QUEUE {
+        queues.dropped = queues.dropped.saturating_add(1);
+        return false;
+    }
+    queues.outbound.push_back((remote_id, payload));
+    queues.encoded = queues.encoded.saturating_add(1);
+    queues.peak_outbound = queues.peak_outbound.max(queues.outbound.len());
+    true
+}
+
+fn encode_startup_envelope(destination: &[u8; 16], control: StartupControl) -> Vec<u8> {
+    let kind = match control {
+        StartupControl::Proposal { .. } => 1,
+        StartupControl::Ack { .. } => 2,
+        StartupControl::Commit { .. } => 3,
+    };
+    let mut payload = Vec::with_capacity(29);
+    payload.extend_from_slice(destination);
+    payload.extend_from_slice(STARTUP_ENVELOPE_MAGIC);
+    payload.push(kind);
+    payload.extend_from_slice(&control.start_unix_ms().to_le_bytes());
+    payload
+}
+
+fn decode_startup_envelope(payload: &[u8]) -> Option<(&[u8], StartupControl)> {
+    let (destination, header) = payload.split_at_checked(16)?;
+    if header.len() != 13 || header.get(..4)? != STARTUP_ENVELOPE_MAGIC {
+        return None;
+    }
+    let start_unix_ms = u64::from_le_bytes(header.get(5..13)?.try_into().ok()?);
+    if start_unix_ms == 0 {
+        return None;
+    }
+    let control = match *header.get(4)? {
+        1 => StartupControl::Proposal { start_unix_ms },
+        2 => StartupControl::Ack { start_unix_ms },
+        3 => StartupControl::Commit { start_unix_ms },
+        _ => return None,
+    };
+    Some((destination, control))
 }
 
 fn encode_relay_envelope(destination: &[u8; 16], advertised_frame: i32, encoded: &[u8]) -> Vec<u8> {
@@ -1185,20 +1533,117 @@ mod tests {
     use std::time::{Duration, Instant};
 
     use super::{
-        decode_relay_envelope, encode_relay_envelope, scenario_lag_limit, simulation_advance_due,
-        simulation_frame_period, startup_remote_frame_ready,
+        decode_relay_envelope, decode_startup_envelope, encode_relay_envelope,
+        encode_startup_envelope, scenario_lag_limit, simulation_advance_due,
+        simulation_frame_period, startup_control_allowed, startup_control_lead_valid,
+        startup_release_due, StartupControl,
     };
 
     #[test]
-    fn startup_barrier_causally_orders_the_independent_peer_cadences() {
-        assert!(!startup_remote_frame_ready("a", None));
-        assert!(!startup_remote_frame_ready("a", Some(-1)));
-        assert!(startup_remote_frame_ready("a", Some(0)));
+    fn startup_envelope_round_trips_deadline_controls_and_rejects_corruption() {
+        let destination = [9; 16];
+        for control in [
+            StartupControl::Proposal {
+                start_unix_ms: 123_456,
+            },
+            StartupControl::Ack {
+                start_unix_ms: 123_456,
+            },
+            StartupControl::Commit {
+                start_unix_ms: 123_456,
+            },
+        ] {
+            let payload = encode_startup_envelope(&destination, control);
+            assert_eq!(
+                decode_startup_envelope(&payload),
+                Some((destination.as_slice(), control))
+            );
+        }
 
-        assert!(!startup_remote_frame_ready("b", Some(0)));
-        assert!(startup_remote_frame_ready("b", Some(1)));
-        assert!(startup_remote_frame_ready("b", Some(2)));
-        assert!(!startup_remote_frame_ready("unexpected", Some(i32::MAX)));
+        let mut invalid_kind = encode_startup_envelope(
+            &destination,
+            StartupControl::Proposal {
+                start_unix_ms: 123_456,
+            },
+        );
+        invalid_kind[20] = u8::MAX;
+        assert_eq!(decode_startup_envelope(&invalid_kind), None);
+        assert_eq!(decode_startup_envelope(&invalid_kind[..28]), None);
+    }
+
+    #[test]
+    fn startup_transition_gate_rejects_wrong_stage_timestamp_and_missed_deadline() {
+        let start = Instant::now();
+        let proposal = StartupControl::Proposal { start_unix_ms: 100 };
+        let ack = StartupControl::Ack { start_unix_ms: 100 };
+        let commit = StartupControl::Commit { start_unix_ms: 100 };
+
+        assert!(startup_control_allowed("a", proposal, None, false, false));
+        assert!(startup_control_allowed(
+            "a",
+            proposal,
+            Some(100),
+            false,
+            true
+        ));
+        assert!(!startup_control_allowed(
+            "a",
+            StartupControl::Proposal { start_unix_ms: 101 },
+            Some(100),
+            false,
+            true
+        ));
+        assert!(!startup_control_allowed(
+            "a",
+            commit,
+            Some(100),
+            false,
+            false
+        ));
+        assert!(startup_control_allowed("a", commit, Some(100), false, true));
+        assert!(startup_control_allowed("b", ack, Some(100), true, false));
+        assert!(!startup_control_allowed(
+            "b",
+            StartupControl::Ack { start_unix_ms: 101 },
+            Some(100),
+            true,
+            false
+        ));
+        assert!(!startup_control_allowed(
+            "b",
+            proposal,
+            Some(100),
+            true,
+            false
+        ));
+
+        assert_eq!(
+            startup_release_due(start, Some(start), false),
+            Err("startup handshake was incomplete at the common deadline")
+        );
+        assert_eq!(startup_release_due(start, Some(start), true), Ok(true));
+        assert_eq!(
+            startup_release_due(start, Some(start + Duration::from_millis(1)), false),
+            Ok(false)
+        );
+        assert_eq!(
+            startup_release_due(start, None, true),
+            Err("startup handshake omitted the common deadline")
+        );
+
+        let after_deadline = start + Duration::from_millis(1);
+        assert!(!startup_control_lead_valid(
+            Some(start),
+            after_deadline,
+            Duration::from_millis(250),
+            false
+        ));
+        assert!(startup_control_lead_valid(
+            Some(start),
+            after_deadline,
+            Duration::from_millis(250),
+            true
+        ));
     }
 
     #[test]

--- a/tests/godot-web-smoke/src/fortress.rs
+++ b/tests/godot-web-smoke/src/fortress.rs
@@ -26,6 +26,8 @@ const MAX_RELAY_QUEUE: usize = 256;
 const IMPAIRMENT_START_FRAME: i32 = 120;
 const INPUT_DELAY_FRAMES: i32 = 2;
 const IMPAIRMENT_MAX_HOLD_FRAMES: i32 = 8;
+const CLEAN_LAG_LIMIT: u64 = 8;
+const IMPAIRED_LAG_LIMIT: u64 = 12;
 const PREDICTION_WINDOW_FRAMES: usize = 20;
 const SIMULATION_FPS: usize = 18;
 const RELAY_ENVELOPE_MAGIC: &[u8; 4] = b"SFF1";
@@ -952,6 +954,7 @@ impl FortressScenario {
             .map_or(0.0, |elapsed| {
                 self.target_frames.max(0) as f64 * 1_000.0 / elapsed as f64
             });
+        let lag_limit = scenario_lag_limit(self.poll_hitch_frame, self.settlement_frame_limit);
         let invariant_passed = self.game_ready
             && self.target_state_checksum.is_some()
             && final_inbound_depth == 0
@@ -964,8 +967,8 @@ impl FortressScenario {
             && checksums_mismatched == 0
             && events_discarded == 0
             && metrics.is_some_and(|metrics| {
-                metrics.confirmation_lag_current <= 12
-                    && metrics.confirmation_lag_max <= 12
+                metrics.confirmation_lag_current <= lag_limit
+                    && metrics.confirmation_lag_max <= lag_limit
                     && metrics.stall_count == 0
                     && metrics.wait_recommendations == 0
             })
@@ -1069,6 +1072,14 @@ fn simulation_frame_period() -> std::time::Duration {
     std::time::Duration::from_nanos(1_000_000_000 / SIMULATION_FPS as u64)
 }
 
+fn scenario_lag_limit(poll_hitch_frame: Option<i32>, settlement_frame_limit: i32) -> u64 {
+    if poll_hitch_frame.is_some_and(|frame| (0..settlement_frame_limit).contains(&frame)) {
+        IMPAIRED_LAG_LIMIT
+    } else {
+        CLEAN_LAG_LIMIT
+    }
+}
+
 fn simulation_advance_due(now: Instant, next_advance_at: &mut Option<Instant>) -> bool {
     let period = simulation_frame_period();
     let Some(deadline) = next_advance_at else {
@@ -1121,7 +1132,7 @@ mod tests {
 
     use super::{
         decode_relay_envelope, encode_relay_envelope, simulation_advance_due,
-        simulation_frame_period,
+        simulation_frame_period, scenario_lag_limit,
     };
 
     #[test]
@@ -1144,6 +1155,14 @@ mod tests {
         let after_pause = start + Duration::from_secs(5);
         assert!(simulation_advance_due(after_pause, &mut deadline));
         assert_eq!(deadline, Some(after_pause));
+    }
+
+    #[test]
+    fn clean_and_impaired_self_oracles_use_the_runner_lag_limits() {
+        assert_eq!(scenario_lag_limit(None, 620), 8);
+        assert_eq!(scenario_lag_limit(Some(240), 620), 12);
+        assert_eq!(scenario_lag_limit(Some(-1), 620), 8);
+        assert_eq!(scenario_lag_limit(Some(620), 620), 8);
     }
 
     #[test]

--- a/tests/godot-web-smoke/src/fortress.rs
+++ b/tests/godot-web-smoke/src/fortress.rs
@@ -27,7 +27,8 @@ const IMPAIRMENT_START_FRAME: i32 = 120;
 const INPUT_DELAY_FRAMES: i32 = 2;
 const IMPAIRMENT_MAX_HOLD_FRAMES: i32 = 8;
 const CLEAN_LAG_LIMIT: u64 = 8;
-const IMPAIRED_LAG_LIMIT: u64 = 12;
+const IMPAIRED_LAG_LIMIT: u64 = 13;
+const SOAK_LAG_LIMIT: u64 = 12;
 const PREDICTION_WINDOW_FRAMES: usize = 20;
 const SIMULATION_FPS: usize = 18;
 const RELAY_ENVELOPE_MAGIC: &[u8; 4] = b"SFF1";
@@ -954,7 +955,11 @@ impl FortressScenario {
             .map_or(0.0, |elapsed| {
                 self.target_frames.max(0) as f64 * 1_000.0 / elapsed as f64
             });
-        let lag_limit = scenario_lag_limit(self.poll_hitch_frame, self.settlement_frame_limit);
+        let lag_limit = scenario_lag_limit(
+            self.poll_hitch_frame,
+            self.target_frames,
+            self.settlement_frame_limit,
+        );
         let invariant_passed = self.game_ready
             && self.target_state_checksum.is_some()
             && final_inbound_depth == 0
@@ -1072,9 +1077,17 @@ fn simulation_frame_period() -> std::time::Duration {
     std::time::Duration::from_nanos(1_000_000_000 / SIMULATION_FPS as u64)
 }
 
-fn scenario_lag_limit(poll_hitch_frame: Option<i32>, settlement_frame_limit: i32) -> u64 {
+fn scenario_lag_limit(
+    poll_hitch_frame: Option<i32>,
+    target_frames: i32,
+    settlement_frame_limit: i32,
+) -> u64 {
     if poll_hitch_frame.is_some_and(|frame| (0..settlement_frame_limit).contains(&frame)) {
-        IMPAIRED_LAG_LIMIT
+        if target_frames > DEFAULT_TARGET_FRAMES {
+            SOAK_LAG_LIMIT
+        } else {
+            IMPAIRED_LAG_LIMIT
+        }
     } else {
         CLEAN_LAG_LIMIT
     }
@@ -1166,10 +1179,11 @@ mod tests {
 
     #[test]
     fn clean_and_impaired_self_oracles_use_the_runner_lag_limits() {
-        assert_eq!(scenario_lag_limit(None, 620), 8);
-        assert_eq!(scenario_lag_limit(Some(240), 620), 12);
-        assert_eq!(scenario_lag_limit(Some(-1), 620), 8);
-        assert_eq!(scenario_lag_limit(Some(620), 620), 8);
+        assert_eq!(scenario_lag_limit(None, 600, 620), 8);
+        assert_eq!(scenario_lag_limit(Some(240), 600, 620), 13);
+        assert_eq!(scenario_lag_limit(Some(240), 3_600, 3_620), 12);
+        assert_eq!(scenario_lag_limit(Some(-1), 600, 620), 8);
+        assert_eq!(scenario_lag_limit(Some(620), 600, 620), 8);
     }
 
     #[test]

--- a/tests/godot-web-smoke/src/lib.rs
+++ b/tests/godot-web-smoke/src/lib.rs
@@ -18,6 +18,8 @@ const LOAD_SECONDS: u64 = 16;
 const LOAD_RATE_PER_CLIENT: u64 = 136;
 const LOAD_TARGET_PER_CLIENT: u64 = LOAD_SECONDS * LOAD_RATE_PER_CLIENT;
 const LOAD_MAX_QUEUE_DEPTH_PER_CLIENT: u64 = 32;
+const FINAL_DRAIN_SAMPLES: u8 = 8;
+const FINAL_DRAIN_OBSERVATION_TIMEOUT: Duration = Duration::from_secs(3);
 
 type Client = SignalFishPollingClient<GodotWebSocketTransport>;
 
@@ -84,6 +86,8 @@ struct SmokePair {
     last_latency_us: u64,
     sample_last_accepted: u64,
     sample_last_received: u64,
+    final_drained_samples: u8,
+    final_drain_started_at: Option<Instant>,
     max_poll_work_frames: u64,
     max_poll_work_bytes: u64,
     max_poll_receive_frames: u64,
@@ -132,6 +136,8 @@ impl SmokePair {
             last_latency_us: 0,
             sample_last_accepted: 0,
             sample_last_received: 0,
+            final_drained_samples: 0,
+            final_drain_started_at: None,
             max_poll_work_frames: 0,
             max_poll_work_bytes: 0,
             max_poll_receive_frames: 0,
@@ -215,6 +221,8 @@ impl SmokePair {
                 self.sample_last_accepted =
                     self.last_accepted_a.saturating_add(self.last_accepted_b);
                 self.sample_last_received = 0;
+                self.final_drained_samples = 0;
+                self.final_drain_started_at = None;
                 self.max_poll_work_frames = 0;
                 self.max_poll_work_bytes = 0;
                 self.max_poll_receive_frames = 0;
@@ -415,15 +423,15 @@ impl SmokePair {
         let (current_depth, _, _, _) =
             aggregate_diagnostics(self.first.as_ref(), self.second.as_ref());
         self.peak_aggregate_depth = self.peak_aggregate_depth.max(current_depth);
+        let load_received = elapsed >= Duration::from_secs(LOAD_SECONDS)
+            && self.offered_a == LOAD_TARGET_PER_CLIENT
+            && self.offered_b == LOAD_TARGET_PER_CLIENT
+            && self.received_a == LOAD_TARGET_PER_CLIENT
+            && self.received_b == LOAD_TARGET_PER_CLIENT;
 
         if self
             .last_sample_at
             .is_none_or(|last| now.saturating_duration_since(last) >= Duration::from_millis(250))
-            || (elapsed >= Duration::from_secs(LOAD_SECONDS)
-                && self.offered_a == LOAD_TARGET_PER_CLIENT
-                && self.offered_b == LOAD_TARGET_PER_CLIENT
-                && self.received_a == LOAD_TARGET_PER_CLIENT
-                && self.received_b == LOAD_TARGET_PER_CLIENT)
         {
             let last_sample_at = self.last_sample_at.unwrap_or(now);
             self.last_sample_at = Some(now);
@@ -471,6 +479,15 @@ impl SmokePair {
                 "latest_latency_us": self.last_latency_us,
             });
             godot_print!("SIGNAL_FISH_LOAD sample {sample}");
+            if load_received && queue_depth == 0 && current_queue_age == Duration::ZERO {
+                if self.final_drained_samples == 0 {
+                    self.final_drain_started_at = Some(now);
+                }
+                self.final_drained_samples = self.final_drained_samples.saturating_add(1);
+            } else {
+                self.final_drained_samples = 0;
+                self.final_drain_started_at = None;
+            }
             self.sample_last_accepted = accepted;
             self.sample_last_received = received;
             self.max_poll_work_frames = 0;
@@ -486,15 +503,14 @@ impl SmokePair {
                 .second
                 .as_ref()
                 .is_none_or(|client| client.polling_stats().current_queue_depth == 0);
-        if elapsed >= Duration::from_secs(LOAD_SECONDS)
-            && self.offered_a == LOAD_TARGET_PER_CLIENT
-            && self.offered_b == LOAD_TARGET_PER_CLIENT
-            && self.received_a == LOAD_TARGET_PER_CLIENT
-            && self.received_b == LOAD_TARGET_PER_CLIENT
-            && queues_empty
-        {
+        if load_received && queues_empty && self.final_drained_samples >= FINAL_DRAIN_SAMPLES {
             self.finish_load();
-        } else if elapsed >= Duration::from_secs(LOAD_SECONDS + 5) {
+        } else if (self.final_drain_started_at.is_none()
+            && elapsed >= Duration::from_secs(LOAD_SECONDS + 5))
+            || self.final_drain_started_at.is_some_and(|started| {
+                now.saturating_duration_since(started) >= FINAL_DRAIN_OBSERVATION_TIMEOUT
+            })
+        {
             godot_error!(
                 "SIGNAL_FISH_SMOKE load-drain-error offered={}/{} received={}/{}",
                 self.offered_a,

--- a/tests/godot-web-smoke/src/lib.rs
+++ b/tests/godot-web-smoke/src/lib.rs
@@ -52,6 +52,7 @@ impl PairKind {
 
 struct SmokePair {
     kind: PairKind,
+    server_url: String,
     first: Option<Client>,
     second: Option<Client>,
     room_code: Option<String>,
@@ -96,10 +97,11 @@ struct SmokePair {
 }
 
 impl SmokePair {
-    fn new(kind: PairKind) -> Self {
+    fn new(kind: PairKind, server_url: &str) -> Self {
         Self {
             kind,
-            first: connect_client(kind, "a"),
+            server_url: server_url.to_string(),
+            first: connect_client(kind, "a", server_url),
             second: None,
             room_code: None,
             relay_sent: false,
@@ -169,7 +171,7 @@ impl SmokePair {
         }
 
         if self.second.is_none() && self.room_code.is_some() {
-            self.second = connect_client(self.kind, "b");
+            self.second = connect_client(self.kind, "b", &self.server_url);
         }
 
         let second_events = poll_measured(
@@ -217,6 +219,12 @@ impl SmokePair {
                 self.max_poll_work_bytes = 0;
                 self.max_poll_receive_frames = 0;
                 self.poll_count = 0;
+                if let Some(client) = &mut self.first {
+                    client.reset_queue_age_peak();
+                }
+                if let Some(client) = &mut self.second {
+                    client.reset_queue_age_peak();
+                }
                 godot_print!("SIGNAL_FISH_SMOKE load-started");
             }
             self.drive_load();
@@ -421,6 +429,8 @@ impl SmokePair {
             self.last_sample_at = Some(now);
             let (queue_depth, peak_depth, buffered, accepted) =
                 aggregate_diagnostics(self.first.as_ref(), self.second.as_ref());
+            let (current_queue_age, peak_queue_age) =
+                aggregate_queue_age(self.first.as_ref(), self.second.as_ref());
             self.peak_aggregate_depth = self.peak_aggregate_depth.max(queue_depth);
             let (send_budget_exhaustions, receive_budget_exhaustions) =
                 aggregate_budget_exhaustions(self.first.as_ref(), self.second.as_ref());
@@ -443,6 +453,8 @@ impl SmokePair {
                 "elapsed_ms": elapsed.as_millis(),
                 "command_depth": queue_depth,
                 "peak_depth": peak_depth,
+                "current_queue_age_ms": current_queue_age.as_secs_f64() * 1_000.0,
+                "peak_queue_age_ms": peak_queue_age.as_secs_f64() * 1_000.0,
                 "buffered_bytes": buffered,
                 "accepted_frames": accepted,
                 "received_frames": received,
@@ -546,6 +558,8 @@ impl SmokePair {
             .unwrap_or(u64::MAX);
         let (queue_depth, peak_depth, buffered, accepted) =
             aggregate_diagnostics(self.first.as_ref(), self.second.as_ref());
+        let (current_queue_age, peak_queue_age) =
+            aggregate_queue_age(self.first.as_ref(), self.second.as_ref());
         let admission_hits = [self.first.as_ref(), self.second.as_ref()]
             .into_iter()
             .flatten()
@@ -558,12 +572,11 @@ impl SmokePair {
             .fold(0u64, u64::saturating_add);
         let (own_violations, own_escape_bytes, own_within_ceiling) =
             aggregate_godot_admission(self.first.as_ref(), self.second.as_ref());
-        let admission_violations = own_violations
-            .saturating_add(self.other_pair_admission_violations);
-        let one_frame_escape_bytes = own_escape_bytes
-            .saturating_add(self.other_pair_one_frame_escape_bytes);
-        let within_absolute_ceiling =
-            own_within_ceiling && self.other_pair_within_absolute_ceiling;
+        let admission_violations =
+            own_violations.saturating_add(self.other_pair_admission_violations);
+        let one_frame_escape_bytes =
+            own_escape_bytes.saturating_add(self.other_pair_one_frame_escape_bytes);
+        let within_absolute_ceiling = own_within_ceiling && self.other_pair_within_absolute_ceiling;
         let buffering_safe = within_absolute_ceiling && admission_violations == 0;
         let per_client_peak_depth = [self.first.as_ref(), self.second.as_ref()]
             .map(|client| client.map_or(0, |client| client.polling_stats().peak_queue_depth));
@@ -572,6 +585,8 @@ impl SmokePair {
             && self.received_a == LOAD_TARGET_PER_CLIENT
             && self.received_b == LOAD_TARGET_PER_CLIENT
             && queue_depth == 0
+            && current_queue_age == Duration::ZERO
+            && peak_queue_age <= Duration::from_millis(500)
             && self.peak_aggregate_depth <= 64
             && per_client_peak_depth.into_iter().all(|depth| depth <= 64)
             && self.multi_frame_poll
@@ -595,6 +610,8 @@ impl SmokePair {
             "received_per_client": [self.received_a, self.received_b],
             "final_queue_depth": queue_depth,
             "peak_queue_depth": peak_depth,
+            "current_queue_age_ms": current_queue_age.as_secs_f64() * 1_000.0,
+            "peak_queue_age_ms": peak_queue_age.as_secs_f64() * 1_000.0,
             "peak_aggregate_queue_depth": self.peak_aggregate_depth,
             "per_client_peak_queue_depth": per_client_peak_depth,
             "buffered_bytes": buffered,
@@ -682,10 +699,11 @@ impl INode for SignalFishSmoke {
             .collect::<Vec<_>>();
         let fortress = FortressScenario::from_user_args(&args);
         let regular_smoke = fortress.is_none();
+        let server_url = user_argument(&args, "--server-url").unwrap_or_else(|| SERVER_URL.into());
         Self {
             base,
-            json: regular_smoke.then(|| SmokePair::new(PairKind::Json)),
-            binary: regular_smoke.then(|| SmokePair::new(PairKind::Binary)),
+            json: regular_smoke.then(|| SmokePair::new(PairKind::Json, &server_url)),
+            binary: regular_smoke.then(|| SmokePair::new(PairKind::Binary, &server_url)),
             fortress,
             complete: false,
         }
@@ -826,10 +844,20 @@ fn aggregate_diagnostics(first: Option<&Client>, second: Option<&Client>) -> (u6
     )
 }
 
-fn aggregate_godot_admission(
-    first: Option<&Client>,
-    second: Option<&Client>,
-) -> (u64, u64, bool) {
+fn aggregate_queue_age(first: Option<&Client>, second: Option<&Client>) -> (Duration, Duration) {
+    [first, second].into_iter().flatten().fold(
+        (Duration::ZERO, Duration::ZERO),
+        |(current, peak), client| {
+            let age = client.queue_age_stats();
+            (
+                current.max(age.current_oldest_queue_age),
+                peak.max(age.peak_oldest_queue_age),
+            )
+        },
+    )
+}
+
+fn aggregate_godot_admission(first: Option<&Client>, second: Option<&Client>) -> (u64, u64, bool) {
     [first, second].into_iter().flatten().fold(
         (0u64, 0u64, true),
         |(violations, escape_bytes, within_ceiling), client| {
@@ -857,8 +885,8 @@ fn default_adaptive_ceiling_bytes() -> Option<u64> {
     }
 }
 
-fn connect_client(kind: PairKind, suffix: &str) -> Option<Client> {
-    match GodotWebSocketTransport::connect(SERVER_URL) {
+fn connect_client(kind: PairKind, suffix: &str, server_url: &str) -> Option<Client> {
+    match GodotWebSocketTransport::connect(server_url) {
         Ok(transport) => {
             let mut config = SignalFishConfig::new(APP_ID).enable_v3();
             config.platform = Some(format!("godot-smoke-{}-{suffix}", kind.label()));
@@ -870,6 +898,11 @@ fn connect_client(kind: PairKind, suffix: &str) -> Option<Client> {
             None
         }
     }
+}
+
+fn user_argument(args: &[String], name: &str) -> Option<String> {
+    args.windows(2)
+        .find_map(|pair| (pair.first().map(String::as_str) == Some(name)).then(|| pair[1].clone()))
 }
 
 fn close_client(client: &mut Option<Client>) {

--- a/tests/godot-web-smoke/src/lib.rs
+++ b/tests/godot-web-smoke/src/lib.rs
@@ -518,6 +518,7 @@ impl SmokePair {
                 self.received_a,
                 self.received_b
             );
+            self.load_error = true;
             self.finish_load();
         }
     }
@@ -600,6 +601,7 @@ impl SmokePair {
             && self.offered_b == LOAD_TARGET_PER_CLIENT
             && self.received_a == LOAD_TARGET_PER_CLIENT
             && self.received_b == LOAD_TARGET_PER_CLIENT
+            && self.final_drained_samples >= FINAL_DRAIN_SAMPLES
             && queue_depth == 0
             && current_queue_age == Duration::ZERO
             && peak_queue_age <= Duration::from_millis(500)
@@ -628,6 +630,7 @@ impl SmokePair {
             "peak_queue_depth": peak_depth,
             "current_queue_age_ms": current_queue_age.as_secs_f64() * 1_000.0,
             "peak_queue_age_ms": peak_queue_age.as_secs_f64() * 1_000.0,
+            "final_drained_samples": self.final_drained_samples,
             "peak_aggregate_queue_depth": self.peak_aggregate_depth,
             "per_client_peak_queue_depth": per_client_peak_depth,
             "buffered_bytes": buffered,


### PR DESCRIPTION
## Summary

- add sampled current/peak age telemetry for the oldest client-owned polling command, with explicit ownership/reset semantics
- add model-based scheduler verification across budgets, refusal, retained sends, receive ordering, close, abort, and clock transitions
- strengthen Godot synthetic-load and Fortress gameplay oracles with lag, queue-age, cadence, conservation, hitch, and teardown checks plus deterministic negative controls
- split Godot browser CI into shared export plus required clean, seeded impaired-network, and 3,600-frame soak scenarios with complete evidence retention

## Why

Queue depth alone cannot detect a fixed-depth queue whose oldest command grows progressively stale. The existing browser/Fortress test also proved eventual checksum convergence, but did not independently reject growing gameplay lag, stalls, stale queues, or conservation/oracle corruption.

## Implementation notes

- queue age ends at backend ownership transfer; transport buffering remains separately observable
- authentication/setup contributes until `reset_queue_age_peak()`
- gameplay starts through a sender-scoped proposal/ack/commit handshake on an exact same-host deadline; missing stages fail at that deadline, peer release phases stay within one 18 Hz period, and steady-state play advances independently while a bounded causal relay hold proves rollback
- clean, impaired, and soak runs fail above 8, 13, and 12 frames of confirmation lag respectively; impaired jobs build checksum-pinned iproute2 6.6.0 so seeded netem is available on Ubuntu 24.04

## Local validation

- `cargo fmt && cargo clippy --all-targets --all-features -- -D warnings && cargo test --all-features`
- standalone Godot fixture Clippy and tests
- official Godot 4.5/Emscripten web builds and exports
- full local clean Fortress + synthetic-load + raw-Emscripten-negative browser scenario
- Node oracle mutation tests
- 191 CI policy tests, workflow/action/yaml/shell lint, test-quality checks
- strict MkDocs and warning-denied rustdoc
- `cargo semver-checks check-release --baseline-rev origin/main` (196 pass, 49 skip)

The impaired/soak network-namespace lanes require the privileged GitHub runner and are expected to provide the blocking runtime proof in this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the polling client's outbound path and expands privileged CI (netem, matrix jobs); behavior is heavily tested but E2E and scheduler changes affect release confidence for Godot/web.
> 
> **Overview**
> Adds **client-owned queue-age diagnostics** on `SignalFishPollingClient` (`PollingQueueAgeStats`, `queue_age_stats()`, `reset_queue_age_peak()`), with age stopping at transport acceptance and **proptest** reference-model coverage of the polling scheduler (FIFO, budgets, close/abort).
> 
> **Godot Web CI** is split into a shared **build/export** job and parallel **clean / impaired / soak** browser matrix jobs. Impaired/soak lanes use **checksum-pinned iproute2 6.6.0** for **seeded bidirectional netem**; evidence uploads are **`if: always()`**. Shared **JS validators** and stricter Fortress/smoke oracles enforce confirmation lag caps, queue-age slopes, startup barrier, polling hitch, and server conservation—not just checksum convergence.
> 
> Docs, changelog, `.gitignore`, and CI policy tests are updated to match the new APIs and workflow shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ccb091341f65445e2a46f40a688a84c9a9b65787. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->