### PR TITLE
Harden issue #61 documentation and agent guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -21,6 +21,14 @@ Use version tags in workflow `uses:` references, not commit hashes.
 - Use: `owner/action@vN` or `owner/action@vN.N.N`
 - Exception: `dtolnay/rust-toolchain@stable|nightly|beta`
 
+## GitHub Tool Order
+
+For every GitHub operation, follow
+`.llm/skills/github-operations/SKILL.md`: prefer the VS Code GitHub
+connector/extension first, use local `git` second, and use GitHub CLI (`gh`)
+only as the final fallback. Missing `gh` authentication does not block a
+connector- or `git`-capable workflow.
+
 ## Skills
 
 Focused Agent Skills live in `.llm/skills/<name>/SKILL.md`; the generated
@@ -28,4 +36,4 @@ Focused Agent Skills live in `.llm/skills/<name>/SKILL.md`; the generated
 description, read its complete `SKILL.md` before acting and resolve relative
 resources from that skill directory.
 
-Key skills: `async-rust-patterns`, `transport-abstraction`, `websocket-client`, `error-handling`, `serde-patterns`, `testing-async`, `public-api-design`, `tracing-instrumentation`, `crate-publishing`.
+Key skills: `async-rust-patterns`, `transport-abstraction`, `websocket-client`, `error-handling`, `serde-patterns`, `testing-async`, `public-api-design`, `tracing-instrumentation`, `crate-publishing`, `github-operations`.

--- a/.llm/context.md
+++ b/.llm/context.md
@@ -30,6 +30,14 @@ Run this before every commit. All three steps must pass with zero warnings.
 Use the manual **Prepare Release** and **Release** workflows; see
 `skills/release-recovery/SKILL.md` and `docs/releasing.md` for fail-closed recovery.
 
+## GitHub Tool Order
+
+For every GitHub operation, follow
+`skills/github-operations/SKILL.md`: prefer the VS Code GitHub
+connector/extension first, use local `git` second, and use GitHub CLI (`gh`)
+only as the final fallback. Missing `gh` authentication does not block a
+connector- or `git`-capable workflow.
+
 ## CI/CD Action Reference Policy
 
 Use `owner/action@vN.N.N` (preferred) or `@vN`, not commit hashes. Exceptions:
@@ -51,7 +59,7 @@ Only add `CHANGELOG.md` entries for user-visible changes.
 | `src/protocol/binary.rs` | Strict physical MessagePack envelope decoders for v2/v3 binary game data |
 | `src/accountability.rs` | Server-0.4.0-derived delivery-accountability state machine |
 | `src/signal.rs` | `PeerSignal` — typed, matchbox-compatible WebRTC signal (protocol v3) |
-| `src/error_codes.rs` | `ErrorCode` enum — 50 variants from server |
+| `src/error_codes.rs` | `ErrorCode` enum — 52 variants from server |
 | `src/error.rs` | `SignalFishError` error type |
 | `src/event.rs` | `SignalFishEvent` high-level event stream |
 | `src/client_core.rs` | Shared command construction, decoding, accountability, state, events, and statistics |

--- a/.llm/skills/github-operations/SKILL.md
+++ b/.llm/skills/github-operations/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: github-operations
+description: Route repository-hosted GitHub work through the VS Code GitHub connector or extension, local git, and gh in strict preference order. Use when working with issues, pull requests, reviews, checks, Actions, branches, commits, pushes, releases, or any other GitHub operation.
+---
+
+# GitHub Operations
+
+Use this order for every GitHub operation:
+
+1. **VS Code GitHub connector/extension** -- use the connected GitHub tools for
+   hosted repository state and actions whenever they expose the required
+   capability. This includes issue and pull-request reads or writes, reviews,
+   comments, workflow runs, checks, artifacts, merges, releases, and remote
+   branch/ref operations.
+2. **Local `git`** -- use it when the connector/extension does not operate on
+   the local checkout, or when the required operation is inherently Git-native:
+   inspect or change the worktree/index, create commits, compare history, manage
+   local branches, fetch, or push through an already configured remote.
+3. **GitHub CLI (`gh`)** -- use it only when neither the connector/extension nor
+   local `git` exposes the required capability.
+
+Do not probe or require `gh` authentication unless a concrete last-resort
+operation actually needs `gh`. A missing or unauthenticated `gh` executable is
+not a blocker while the connector/extension or local `git` can complete the
+workflow.
+
+Before falling back, identify the unavailable capability. Keep hosted and local
+state aligned by resolving the repository from `git remote`, the branch from
+the checkout, and the exact commit SHA. Re-read hosted state through the
+connector/extension after each write that affects a pull request, workflow, or
+deployment.
+
+Preserve normal write safety at every layer: inspect the target and current
+state first, stage only intended files, avoid force updates unless explicitly
+authorized, and confirm the result after mutation.

--- a/.llm/skills/index.md
+++ b/.llm/skills/index.md
@@ -48,6 +48,10 @@ Preserve lifecycle event timing across async and polling clients. Use when chang
 
 Implement and review safe native or WebAssembly FFI boundaries. Use when changing C type mappings, struct layout,...
 
+### [GitHub Operations](github-operations/SKILL.md)
+
+Route repository-hosted GitHub work through the VS Code GitHub connector or extension, local git, and gh in strict...
+
 ### [Godot 4.5 WebSocket Transport](godot-websocket/SKILL.md)
 
 Maintain the Godot 4.5 WebSocketPeer transport. Use when changing Godot native or web GDExtension networking, polling...

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,14 @@ Use version tags in workflow `uses:` references, not commit hashes.
 - Use: `owner/action@vN` or `owner/action@vN.N.N`
 - Exception: `dtolnay/rust-toolchain@stable|nightly|beta`
 
+## GitHub Tool Order
+
+For every GitHub operation, follow
+`.llm/skills/github-operations/SKILL.md`: prefer the VS Code GitHub
+connector/extension first, use local `git` second, and use GitHub CLI (`gh`)
+only as the final fallback. Missing `gh` authentication does not block a
+connector- or `git`-capable workflow.
+
 ## Changelog Policy
 
 For any user-visible change, update `CHANGELOG.md` in the same PR under
@@ -33,4 +41,4 @@ Focused Agent Skills live in `.llm/skills/<name>/SKILL.md`; the generated
 description, read its complete `SKILL.md` before acting and resolve relative
 resources from that skill directory.
 
-Key skills: `async-rust-patterns`, `shared-core-drivers`, `transport-abstraction`, `websocket-client`, `error-handling`, `serde-patterns`, `testing-async`, `public-api-design`, `tracing-instrumentation`, `crate-publishing`, `changelog-discipline`, `keep-a-changelog-format`.
+Key skills: `async-rust-patterns`, `shared-core-drivers`, `transport-abstraction`, `websocket-client`, `error-handling`, `serde-patterns`, `testing-async`, `public-api-design`, `tracing-instrumentation`, `crate-publishing`, `github-operations`, `changelog-discipline`, `keep-a-changelog-format`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a Godot 4.5 + Fortress Rollback integration guide and a published
   `llms.txt` usage index for discovering current SDK documentation.
 
+### Changed
+
+- Changed repository agent guidance to prefer the VS Code GitHub
+  connector/extension for hosted operations, then local `git`, with GitHub CLI
+  (`gh`) reserved for the final fallback.
+
 ### Fixed
 
 - Fixed the Emscripten WebSocket transport consuming a queued frame while the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,14 @@ cargo fmt && cargo clippy --all-targets --all-features -- -D warnings && cargo t
 
 Run this before every commit. All three steps must pass with zero warnings.
 
+## GitHub Tool Order
+
+For every GitHub operation, follow
+`.llm/skills/github-operations/SKILL.md`: prefer the VS Code GitHub
+connector/extension first, use local `git` second, and use GitHub CLI (`gh`)
+only as the final fallback. Missing `gh` authentication does not block a
+connector- or `git`-capable workflow.
+
 ## Skills
 
 Focused Agent Skills live in `.llm/skills/<name>/SKILL.md`; the generated
@@ -21,4 +29,4 @@ Focused Agent Skills live in `.llm/skills/<name>/SKILL.md`; the generated
 description, read its complete `SKILL.md` before acting and resolve relative
 resources from that skill directory.
 
-Key skills: `async-rust-patterns`, `transport-abstraction`, `websocket-client`, `error-handling`, `serde-patterns`, `testing-async`, `public-api-design`, `tracing-instrumentation`, `crate-publishing`, `ci-configuration`, `markdown-and-doc-validation`.
+Key skills: `async-rust-patterns`, `transport-abstraction`, `websocket-client`, `error-handling`, `serde-patterns`, `testing-async`, `public-api-design`, `tracing-instrumentation`, `crate-publishing`, `github-operations`, `ci-configuration`, `markdown-and-doc-validation`.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,10 @@
   </a>
 </p>
 
-Transport-agnostic async Rust client for the **Signal Fish** multiplayer signaling protocol. Connect to a Signal Fish server over any bidirectional transport, authenticate, join rooms, and receive strongly-typed events — all through a simple channel-based API.
+Transport-agnostic Rust client SDK for the **Signal Fish** multiplayer
+signaling protocol. Choose the Tokio background driver or the caller-driven
+polling client to connect over any bidirectional transport, authenticate, join
+rooms, and receive strongly typed events.
 
 ---
 
@@ -45,7 +48,8 @@ Transport-agnostic async Rust client for the **Signal Fish** multiplayer signali
 - **Wire-compatible** — protocol types are conformance-tested against the server's published wire samples and error-code registry; undecodable frames surface as a typed `DecodeFailed` event
 - **Protocol support: v2 relay + server 0.4.0 v3** — opt-in v3 adds classified delivery, accountability, binary frames, reconnect tokens, graceful drain, and WebRTC mesh signaling; the default remains byte-identical to v2. Use `enable_v3()` for relay-only support or `enable_mesh()` with a WebRTC driver.
 - **Feature-gated WebSocket transport** — the default `transport-websocket` feature provides a ready-to-use `WebSocketTransport`
-- **Event-driven** — receive typed `SignalFishEvent`s via a Tokio MPSC channel
+- **Typed events for both drivers** — receive `SignalFishEvent`s through the
+  async driver's bounded Tokio MPSC channel or directly from each polling call
 - **Structured errors** — typed client errors, server error codes, decode failures, and categorized protocol-accountability violations
 - **Full protocol coverage** — typed v2/v3 messages and events, including strict physical MessagePack envelopes
 - **No silent loss while receivers remain active** — event delivery uses backpressure, and the bounded send queue surfaces congestion as `SignalFishError::SendBufferFull` instead of buffering without bound; receiver/handle drop and shutdown remain explicit terminal boundaries, while `stats()` counters make relay-path loss observable

--- a/docs/client.md
+++ b/docs/client.md
@@ -419,7 +419,7 @@ Synchronous diagnostics for the outgoing command queue and game-data traffic:
 | `stats()` | `fn stats(&self) -> ClientStats` | Cumulative game-data traffic counters. |
 
 `ClientStats` (re-exported at the crate root) carries `game_data_sent`
-(`GameData` messages written to the transport), `game_data_received`
+(`GameData` messages whose frames the transport accepted), `game_data_received`
 (`GameData`/`GameDataBinary` messages read off the transport and accepted by
 the protocol-accountability layer —
 counted at **receipt**, not at delivery to your event loop, so a consumer
@@ -769,9 +769,10 @@ All accessors are **synchronous** (no async, no mutex):
 | `transport()` | `&T` | Read-only access to transport-specific diagnostics; I/O remains driven by `poll()`. |
 
 !!! note "No async accessors"
-    Unlike `SignalFishClient`, all `SignalFishPollingClient` accessors are
-    plain `&self` methods — no `.await` needed. This is because the polling
-    client is single-threaded and owns its state directly.
+    Unlike `SignalFishClient`, polling diagnostics and state access require no
+    `.await`: read-only accessors take `&self`, while
+    `reset_queue_age_peak()` takes `&mut self` because it resets sampled state.
+    The polling client owns its state directly and uses no mutex.
 
 ---
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -153,12 +153,13 @@ once). See the [Mesh Guide](mesh-guide.md).
 
 ---
 
-## Event-Driven Architecture
+## Typed Event Architecture
 
-All server responses arrive as `SignalFishEvent` variants on a **bounded
+Both drivers convert server responses into `SignalFishEvent` variants. The
+async `SignalFishClient` delivers them on a **bounded
 `mpsc::Receiver<SignalFishEvent>`** (default capacity 256, configurable via
-`SignalFishConfig::event_channel_capacity`). Your application consumes
-them in an async loop:
+`SignalFishConfig::event_channel_capacity`), which an application consumes in
+an async loop:
 
 ```rust,ignore
 let config = SignalFishConfig::new("mb_app_abc123");
@@ -183,6 +184,10 @@ while let Some(event) = events.recv().await {
     }
 }
 ```
+
+`SignalFishPollingClient::poll()` returns the events decoded during that
+bounded polling cycle directly as a `Vec<SignalFishEvent>`; it does not create
+an event channel.
 
 ### Synthetic vs. Server Events
 
@@ -289,9 +294,10 @@ Because the client applies backpressure instead of dropping events on
 overflow, loss elsewhere becomes observable. `stats()`
 returns [`ClientStats`](client.md) with cumulative `game_data_sent` /
 `game_data_received` / `messages_undecodable` counters (they survive
-disconnects): exchange or log them across peers, and a persistent
-sent-vs-received deficit points at the relay path or a peer — not at this
-client. Pace high-rate streams with
+disconnects): exchange or log them across peers, account for the explicit
+terminal and quarantine boundaries above, and use any remaining persistent
+sent-vs-received deficit to investigate the relay path or a peer. Pace
+high-rate streams with
 `send_game_data_reliable` instead of guessing at sleep durations — but drain
 events from a separate task while awaiting it: the queue only drains while
 the transport loop runs, and the loop pauses when the event channel is full,
@@ -430,7 +436,7 @@ directly from client methods as `Result<(), SignalFishError>`.
 
 ### Server-Side: `ErrorCode`
 
-`ErrorCode` is a 50-variant enum that arrives inside events. The server sends
+`ErrorCode` is a 52-variant enum that arrives inside events. The server sends
 these as `SCREAMING_SNAKE_CASE` strings (e.g., `"ROOM_NOT_FOUND"`).
 
 ```rust,ignore

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -73,7 +73,7 @@ fn try_join(client: &mut SignalFishClient) {
 
 ## `ErrorCode`
 
-`ErrorCode` is a protocol-level enum with **50 variants** representing
+`ErrorCode` is a protocol-level enum with **52 variants** representing
 structured error codes returned by the Signal Fish server. It derives `Debug`,
 `Clone`, `PartialEq`, `Eq`, `Serialize`, and `Deserialize`.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,9 @@ description: "Signal Fish Client SDK — A transport-agnostic Rust client SDK fo
 
 - :material-swap-horizontal: **Transport-Agnostic** — Plug in any transport that implements the `Transport` trait; swap WebSocket for TCP, QUIC, or a test loopback without changing your game code.
 - :material-lightning-bolt: **Async or Frame-Driven** — Use the Tokio background driver or the synchronous polling client. Command admission is bounded and explicit in both.
-- :material-message-flash: **Event-Driven Architecture** — All server responses are delivered as strongly-typed `SignalFishEvent` variants on a bounded `mpsc` channel — just `match` in a loop.
+- :material-message-flash: **Typed Event Architecture** — The async driver
+  delivers strongly typed `SignalFishEvent` variants on a bounded `mpsc`
+  channel; the polling driver returns them directly from each `poll()` call.
 - :material-lan: **Protocol v2 relay + v3 mesh** — v3 WebRTC mesh signaling is opt-in and a default client keeps the v2 authentication wire shape; game start is now an explicit `start_game()` request. See [Protocol Versioning](protocol-versioning.md) and the [Mesh Guide](mesh-guide.md).
 - :material-web: **WebSocket Built-In** — `WebSocketTransport` ships out of the box (enabled by default via the `transport-websocket` feature) so you can connect in one line.
 - :material-refresh: **Reconnection Support** — Gracefully handle disconnects and reconnect to your session without losing context.

--- a/scripts/pre-commit-llm.py
+++ b/scripts/pre-commit-llm.py
@@ -26,6 +26,13 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 LLM_DIR = REPO_ROOT / ".llm"
 SKILLS_DIR = LLM_DIR / "skills"
 INDEX_FILE = SKILLS_DIR / "index.md"
+GITHUB_GUIDANCE_FILES = (
+    Path("AGENTS.md"),
+    Path("CLAUDE.md"),
+    Path(".github/copilot-instructions.md"),
+    Path(".llm/context.md"),
+    Path(".llm/skills/github-operations/SKILL.md"),
+)
 
 
 def path_for_bash(path: Path, cwd: Optional[Path] = None) -> str:
@@ -71,6 +78,74 @@ def validate_plain_python_annotation_syntax() -> List[str]:
                         f"  {path_for_bash(path, REPO_ROOT)}:{lineno}: "
                         f"{description}: {line.strip()}"
                     )
+    return errors
+
+
+def validate_github_tool_order(repo_root: Path = REPO_ROOT) -> List[str]:
+    """Enforce connector, git, then gh ordering in every LLM entry point."""
+    errors = []
+    patterns = (
+        re.compile(r"VS Code GitHub\s+connector/extension", re.IGNORECASE),
+        re.compile(r"local\s+`git`", re.IGNORECASE),
+        re.compile(r"GitHub CLI\s+\(`gh`\)", re.IGNORECASE),
+    )
+
+    for relative_path in GITHUB_GUIDANCE_FILES:
+        path = repo_root / relative_path
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as e:
+            errors.append(f"  {relative_path.as_posix()}: could not read: {e}")
+            continue
+
+        marker = (
+            "# GitHub Operations"
+            if relative_path.name == "SKILL.md"
+            else "## GitHub Tool Order"
+        )
+        marker_index = text.find(marker)
+        if marker_index == -1:
+            errors.append(
+                f"  {relative_path.as_posix()}: missing `{marker}` section"
+            )
+            continue
+
+        section = text[marker_index + len(marker):]
+        next_heading = re.search(r"\n#{1,2} ", section)
+        if next_heading is not None:
+            section = section[:next_heading.start()]
+
+        matches = [pattern.search(section) for pattern in patterns]
+        missing = [
+            label
+            for label, match in zip(("connector/extension", "local git", "gh"), matches)
+            if match is None
+        ]
+        if missing:
+            errors.append(
+                f"  {relative_path.as_posix()}: GitHub tool-order section is "
+                f"missing {', '.join(missing)}"
+            )
+            continue
+
+        positions = [match.start() for match in matches if match is not None]
+        if positions != sorted(positions) or len(set(positions)) != len(positions):
+            errors.append(
+                f"  {relative_path.as_posix()}: GitHub tools must appear in "
+                "connector/extension -> local git -> gh order"
+            )
+
+        lower_section = section.lower()
+        if "final fallback" not in lower_section and "only when neither" not in lower_section:
+            errors.append(
+                f"  {relative_path.as_posix()}: must state that gh is the final fallback"
+            )
+
+        if relative_path.name != "SKILL.md" and "github-operations/SKILL.md" not in section:
+            errors.append(
+                f"  {relative_path.as_posix()}: must route to the github-operations skill"
+            )
+
     return errors
 
 
@@ -973,10 +1048,13 @@ def main() -> int:
     # 12. Validate required changelog Added entries for public APIs (blocking)
     changelog_added_api_errors = validate_changelog_added_api_entries()
 
-    # 13. Validate Python syntax compatibility for plain `python3` entrypoints
+    # 13. Validate GitHub tool preference in every LLM guidance entry point
+    github_tool_order_errors = validate_github_tool_order()
+
+    # 14. Validate Python syntax compatibility for plain `python3` entrypoints
     python_syntax_errors = validate_plain_python_annotation_syntax()
 
-    # 14. Advisory: warn about absolute guarantee language in doc comments
+    # 15. Advisory: warn about absolute guarantee language in doc comments
     guarantee_warnings = warn_absolute_guarantee_language()
     if guarantee_warnings:
         print(
@@ -994,7 +1072,7 @@ def main() -> int:
             file=sys.stderr,
         )
 
-    # 15. Report all collected errors together
+    # 16. Report all collected errors together
     error_sections = [
         (
             version_sync_errors,
@@ -1045,6 +1123,11 @@ def main() -> int:
             changelog_added_api_errors,
             "required changelog public API additions are missing:",
             "Document required user-visible public APIs under a `### Added` section in CHANGELOG.md.",
+        ),
+        (
+            github_tool_order_errors,
+            "GitHub tool-order guidance is inconsistent:",
+            "Keep every LLM entry point ordered as VS Code GitHub connector/extension, local git, then gh as the final fallback.",
         ),
         (
             python_syntax_errors,

--- a/scripts/test_pre_commit_llm.py
+++ b/scripts/test_pre_commit_llm.py
@@ -33,6 +33,7 @@ sync_crate_version_references = _mod.sync_crate_version_references
 warn_absolute_guarantee_language = _mod.warn_absolute_guarantee_language
 path_for_bash = _mod.path_for_bash
 validate_plain_python_annotation_syntax = _mod.validate_plain_python_annotation_syntax
+validate_github_tool_order = _mod.validate_github_tool_order
 
 
 # ===================================================================
@@ -85,6 +86,62 @@ def test_plain_python_entrypoints_avoid_modern_annotation_syntax():
                     violations.append(f"{path.name}:{lineno}: {description}: {line.strip()}")
 
     assert violations == []
+
+
+def _write_github_guidance_fixture(repo_root, tool_order):
+    """Create all repository-owned LLM guidance surfaces for policy tests."""
+    entrypoint_section = """\
+## GitHub Tool Order
+
+Follow `.llm/skills/github-operations/SKILL.md`: {tool_order}. Use `gh` only
+as the final fallback.
+"""
+    for relative in (
+        "AGENTS.md",
+        "CLAUDE.md",
+        ".github/copilot-instructions.md",
+        ".llm/context.md",
+    ):
+        path = repo_root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(entrypoint_section.format(tool_order=tool_order), encoding="utf-8")
+
+    skill = repo_root / ".llm/skills/github-operations/SKILL.md"
+    skill.parent.mkdir(parents=True, exist_ok=True)
+    skill.write_text(
+        "# GitHub Operations\n\n"
+        + tool_order
+        + ". Use GitHub CLI (`gh`) only when neither prior tool works.\n",
+        encoding="utf-8",
+    )
+
+
+def test_github_tool_order_is_consistent_in_repository_guidance():
+    """Current repository guidance must keep the connector-first policy."""
+    assert validate_github_tool_order() == []
+
+
+def test_github_tool_order_validator_accepts_connector_git_gh(tmp_path):
+    """The canonical connector, git, gh ordering is accepted everywhere."""
+    _write_github_guidance_fixture(
+        tmp_path,
+        "VS Code GitHub connector/extension, local `git`, GitHub CLI (`gh`)",
+    )
+
+    assert validate_github_tool_order(tmp_path) == []
+
+
+def test_github_tool_order_validator_rejects_gh_before_git(tmp_path):
+    """A guidance regression that promotes gh ahead of git must fail."""
+    _write_github_guidance_fixture(
+        tmp_path,
+        "VS Code GitHub connector/extension, GitHub CLI (`gh`), local `git`",
+    )
+
+    errors = validate_github_tool_order(tmp_path)
+
+    assert len(errors) == 5
+    assert all("connector/extension -> local git -> gh order" in error for error in errors)
 
 
 # ===================================================================

--- a/src/client.rs
+++ b/src/client.rs
@@ -476,18 +476,18 @@ impl JoinRoomParams {
 /// Returned by [`SignalFishClient::stats`] and
 /// [`SignalFishPollingClient::stats`](crate::polling_client::SignalFishPollingClient::stats).
 ///
-/// The client itself never drops game data (events are delivered with
-/// backpressure and refused sends return
-/// [`SendBufferFull`](crate::SignalFishError::SendBufferFull)), so these
-/// counters make loss *elsewhere* observable: exchange or log them across
-/// peers, and a persistent sent-vs-received deficit points at the relay
-/// path or a peer — not at this client.
+/// During normal operation, async event-channel overflow applies backpressure,
+/// polling work remains queued across bounded cycles, and refused sends return
+/// [`SendBufferFull`](crate::SignalFishError::SendBufferFull). Exchange or log
+/// these counters across peers to locate a persistent deficit after accounting
+/// for explicit terminal boundaries (shutdown, handle/receiver drop, or
+/// disconnect) and protocol quarantine.
 ///
 /// Counters are cumulative for the lifetime of the client (they survive
 /// room changes and disconnection).
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct ClientStats {
-    /// `GameData` messages successfully written to the transport.
+    /// `GameData` messages whose frames the transport accepted from the client.
     pub game_data_sent: u64,
     /// `GameData`/`GameDataBinary` messages received from the server.
     ///
@@ -496,8 +496,8 @@ pub struct ClientStats {
     /// the relay-path deficit diagnostic needs — it measures the wire, so a
     /// consumer that stops draining events (or a terminal abort racing the
     /// last deliveries) cannot masquerade as relay loss. In steady state
-    /// receipt and delivery are identical because events are not dropped on
-    /// overflow.
+    /// normal-operation receipt and delivery remain aligned across async
+    /// backpressure or bounded polling cycles.
     pub game_data_received: u64,
     /// Inbound frames that failed to decode into a `ServerMessage`.
     ///

--- a/src/event.rs
+++ b/src/event.rs
@@ -93,13 +93,14 @@ pub enum SignalFishEvent {
     /// an otherwise-known message), a proxy injecting non-protocol frames,
     /// or payload corruption.
     ///
-    /// Every undecodable frame produces exactly one `DecodeFailed` event
-    /// (no coalescing), delivered with backpressure like any other event
-    /// (never dropped merely because the consumer is behind; see the delivery
-    /// guarantees on [`SignalFishClient`](crate::SignalFishClient)), and
-    /// increments the `messages_undecodable` counter in
+    /// Every undecodable frame processed during normal operation produces
+    /// exactly one `DecodeFailed` event (no coalescing) and increments the
+    /// `messages_undecodable` counter in
     /// [`ClientStats`](crate::ClientStats). Steady growth of that counter
-    /// means protocol drift (upgrade this SDK) or a corrupting middlebox.
+    /// means protocol drift (upgrade this SDK) or a corrupting middlebox. The
+    /// async driver delivers the event with channel backpressure; the polling
+    /// driver returns it from the current bounded polling cycle. Explicit
+    /// shutdown/close boundaries retain their documented delivery caveats.
     DecodeFailed {
         /// The wire `type` tag, when the frame was valid JSON with one.
         ///

--- a/src/polling_client.rs
+++ b/src/polling_client.rs
@@ -10,9 +10,11 @@
 //! [`poll()`](SignalFishPollingClient::poll) once per frame from the game
 //! loop; no background task or runtime is required.
 //!
-//! Delivery guarantees match the async client: incoming events are returned
-//! from `poll()` without loss, and outgoing commands go through a bounded
-//! queue that fails fast with
+//! During normal operation, ready inbound frames are retained across bounded
+//! polling cycles and returned as events rather than dropped for overflow.
+//! Calling `close` clears session state and intentionally drains any late
+//! inbound transport frames without emitting application events. Outgoing
+//! commands go through a bounded queue that fails fast with
 //! [`SendBufferFull`](crate::error::SignalFishError::SendBufferFull) instead
 //! of growing without bound when the transport is congested.
 

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -4089,6 +4089,70 @@ mod llm_index_validation {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Module: github_tool_order_policy
+// ─────────────────────────────────────────────────────────────────────────────
+
+mod github_tool_order_policy {
+    use super::*;
+
+    const GUIDANCE_FILES: [(&str, &str); 5] = [
+        ("AGENTS.md", "## GitHub Tool Order"),
+        ("CLAUDE.md", "## GitHub Tool Order"),
+        (".github/copilot-instructions.md", "## GitHub Tool Order"),
+        (".llm/context.md", "## GitHub Tool Order"),
+        (
+            ".llm/skills/github-operations/SKILL.md",
+            "# GitHub Operations",
+        ),
+    ];
+
+    #[test]
+    fn all_llm_guidance_prefers_connector_then_git_then_gh() {
+        for (path, marker) in GUIDANCE_FILES {
+            let contents = read_project_file(path);
+            let section = contents
+                .split_once(marker)
+                .map(|(_, tail)| tail)
+                .unwrap_or_else(|| panic!("{path} must contain a `{marker}` section"));
+
+            let connector = section.find("VS Code GitHub").unwrap_or_else(|| {
+                panic!("{path} must name the VS Code GitHub connector/extension")
+            });
+            let git = [section.find("local `git`"), section.find("Local `git`")]
+                .into_iter()
+                .flatten()
+                .min()
+                .unwrap_or_else(|| panic!("{path} must name local git"));
+            let gh = section
+                .find("GitHub CLI (`gh`)")
+                .unwrap_or_else(|| panic!("{path} must name GitHub CLI (`gh`)"));
+
+            assert!(
+                connector < git && git < gh,
+                "{path} must order GitHub tools as connector/extension -> local git -> gh"
+            );
+            assert!(
+                section.contains("final fallback") || section.contains("only when neither"),
+                "{path} must state that gh is the final fallback"
+            );
+
+            if path != ".llm/skills/github-operations/SKILL.md" {
+                assert!(
+                    section.contains("github-operations/SKILL.md"),
+                    "{path} must route agents to the github-operations skill"
+                );
+            }
+        }
+
+        let index = read_project_file(".llm/skills/index.md");
+        assert!(
+            index.contains("[GitHub Operations](github-operations/SKILL.md)"),
+            "the generated skills index must expose github-operations"
+        );
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Module: markdown_policy_validation
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/tests/error_code_conformance_tests.rs
+++ b/tests/error_code_conformance_tests.rs
@@ -266,6 +266,48 @@ fn client_and_spec_error_code_counts_match() {
 }
 
 #[test]
+fn public_documentation_covers_every_error_code_variant_and_current_count() {
+    let codes = all_client_error_codes();
+    for code in &codes {
+        exhaustiveness_guard(code);
+    }
+
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let errors_path = root.join("docs/errors.md");
+    let errors = std::fs::read_to_string(&errors_path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", errors_path.display()));
+    let concepts_path = root.join("docs/concepts.md");
+    let concepts = std::fs::read_to_string(&concepts_path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", concepts_path.display()));
+    let context_path = root.join(".llm/context.md");
+    let context = std::fs::read_to_string(&context_path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", context_path.display()));
+
+    let count = codes.len();
+    assert!(
+        errors.contains(&format!("**{count} variants**")),
+        "docs/errors.md must report the source-derived ErrorCode variant count ({count})"
+    );
+    assert!(
+        concepts.contains(&format!("`ErrorCode` is a {count}-variant enum")),
+        "docs/concepts.md must report the source-derived ErrorCode variant count ({count})"
+    );
+    assert!(
+        context.contains(&format!("`ErrorCode` enum — {count} variants from server")),
+        ".llm/context.md must report the source-derived ErrorCode variant count ({count})"
+    );
+
+    for code in &codes {
+        let variant = format!("{code:?}");
+        let table_cell = format!("| `{variant}` |");
+        assert!(
+            errors.contains(&table_cell),
+            "docs/errors.md must document ErrorCode::{variant} in its variant tables"
+        );
+    }
+}
+
+#[test]
 fn spec_error_code_extraction_finds_a_plausible_count() {
     let tokens = extract_spec_error_tokens();
     assert!(


### PR DESCRIPTION
## Summary

- correct public Markdown and Rust documentation that overstated async-channel, delivery, and polling-close guarantees
- update the documented server `ErrorCode` count to 52 and enforce the count plus complete variant coverage in CI
- add connector-first GitHub guidance across AGENTS, Claude, Copilot, and canonical LLM context
- add a focused `github-operations` skill plus local-hook and Rust CI guards for connector → `git` → `gh` ordering

## Why

The completion audit following #61 found documentation drift even though the transport fix and its browser/system regressions were already merged. In particular, several pages described only the async driver, called transport acceptance a write/delivery guarantee, or reported the old 50-variant error-code count.

The repository guidance also treated unauthenticated `gh` as a blocker despite the VS Code GitHub connector and configured Git remote being able to complete the workflow.

## Impact

Consumers get documentation aligned with current async and polling behavior. Contributors and coding agents consistently use the VS Code GitHub connector/extension first, local `git` second, and `gh` only as a final fallback.

## Validation

- `cargo fmt && cargo clippy --all-targets --all-features -- -D warnings && cargo test --all-features`
- `bash scripts/check-docs-rendering.sh`
- `npx --yes markdownlint-cli2@0.17.2 "**/*.md"`
- `typos --config .typos.toml`
- `uv run --with pytest python -m pytest scripts/test_pre_commit_llm.py -q` (114 passed)
- pre-commit hook: 14/14 checks passed
- pre-push hook: 6/6 checks passed

Follow-up completion hardening for #61.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to documentation, agent guidance, and validation tests; no production client protocol or transport logic is modified in this diff.
> 
> **Overview**
> This PR tightens **public and agent-facing documentation** so it matches how the async and polling drivers actually behave, and it standardizes **how contributors and coding agents use GitHub**.
> 
> **Documentation and rustdoc** no longer imply universal lossless delivery or that transport acceptance equals peer delivery. Copy now distinguishes the Tokio **mpsc** path from **`SignalFishPollingClient::poll()`** return values, documents **shutdown/close/quarantine** as explicit boundaries, and reframes **`ClientStats`** (including **`game_data_sent`** as transport acceptance). **`ErrorCode`** is updated from **50 to 52** variants across docs and **`.llm/context.md`**, with a new conformance test that enforces the live count and **every variant** in **`docs/errors.md`**.
> 
> **Contributor/agent workflow** adds **`github-operations`** (VS Code GitHub connector/extension → local **`git`** → **`gh`** last; missing **`gh` auth** is not a blocker). That policy is wired into **AGENTS**, **CLAUDE**, **Copilot**, and context, indexed in skills, noted in **CHANGELOG**, and enforced by **`scripts/pre-commit-llm.py`**, Python tests, and **`ci_config_tests`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 266792daf2182a65f9e1d1750bc51c31bbc5b31d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->