### PR TITLE
ci: harden workspace release automation

### DIFF
--- a/.github/required-checks.json
+++ b/.github/required-checks.json
@@ -1,0 +1,24 @@
+{
+  "required_checks": [
+    { "workflow": "CI", "file": "ci.yml", "job": "CI Required" },
+    { "workflow": "Coverage", "file": "coverage.yml", "job": "Coverage Required" },
+    { "workflow": "Docs Validation", "file": "docs-validation.yml", "job": "Docs Validation Required" },
+    { "workflow": "Examples Validation", "file": "examples-validation.yml", "job": "Examples Validation Required" },
+    { "workflow": "Godot Web", "file": "godot-web.yml", "job": "Godot Web Required" },
+    { "workflow": "No Panics", "file": "no-panics.yml", "job": "No Panics Required" },
+    { "workflow": "Security", "file": "security-supply-chain.yml", "job": "Security Required" },
+    { "workflow": "Semver Checks", "file": "semver-checks.yml", "job": "Semver Required" },
+    { "workflow": "Unused Deps", "file": "unused-deps.yml", "job": "Unused Deps Required" },
+    { "workflow": "WASM", "file": "wasm.yml", "job": "WASM Required" },
+    { "workflow": "Workflow Lint", "file": "workflow-lint.yml", "job": "Workflow Lint Required" }
+  ],
+  "repository_rules": {
+    "enforcement": "active",
+    "include": ["~DEFAULT_BRANCH"],
+    "required_approving_review_count": 1,
+    "dismiss_stale_reviews_on_push": true,
+    "required_review_thread_resolution": true,
+    "strict_required_status_checks_policy": true,
+    "forbid_bypass_actors": true
+  }
+}

--- a/.github/required-checks.json
+++ b/.github/required-checks.json
@@ -18,7 +18,6 @@
     "required_approving_review_count": 1,
     "dismiss_stale_reviews_on_push": true,
     "required_review_thread_resolution": true,
-    "strict_required_status_checks_policy": true,
-    "forbid_bypass_actors": true
+    "strict_required_status_checks_policy": true
   }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,8 @@ jobs:
           toolchain: 1.96.1
       - name: Cache Cargo artifacts
         uses: Swatinem/rust-cache@v2.9.1
+      - name: Generate workspace lockfile for packaging
+        run: bash scripts/cargo-retry.sh +1.96.1 generate-lockfile
       - name: Create isolated core package tree
         run: |
           core_dir="$RUNNER_TEMP/signal-fish-core-msrv"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
+  RELEASE_RUST: "1.96.1"
   # Deny warnings in CI for doc builds
   RUSTDOCFLAGS: "-D warnings"
 
@@ -235,6 +236,8 @@ jobs:
         uses: actions/checkout@v7.0.0
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RELEASE_RUST }}
       - name: Cache Cargo artifacts
         uses: Swatinem/rust-cache@v2.9.1
       - name: Run publish dry-run
@@ -245,7 +248,7 @@ jobs:
           for package in "${packages[@]}"; do
             package_args+=(-p "$package")
           done
-          cargo publish --dry-run "${package_args[@]}"
+          cargo +"${RELEASE_RUST}" publish --dry-run "${package_args[@]}"
 
   required:
     name: CI Required

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,10 +131,14 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.0
-      - name: Install Rust toolchain
+      - name: Install MSRV Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 1.87.0
+      - name: Install packaging Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.96.1
       - name: Cache Cargo artifacts
         uses: Swatinem/rust-cache@v2.9.1
       - name: Create isolated core package tree
@@ -142,28 +146,20 @@ jobs:
           core_dir="$RUNNER_TEMP/signal-fish-core-msrv"
           core_version=$(python3 scripts/release.py package-version)
           mkdir -p "$core_dir"
-          git archive HEAD | tar -x -C "$core_dir"
-          awk -v version="$core_version" '
-            /^\[workspace\]$/ { exit }
-            /^version\.workspace = true$/ {
-              printf "version = \"%s\"\n", version
-              next
-            }
-            { print }
-          ' Cargo.toml > "$core_dir/Cargo.toml"
-      - name: Generate isolated core lockfile
-        run: bash scripts/cargo-retry.sh generate-lockfile --manifest-path "$RUNNER_TEMP/signal-fish-core-msrv/Cargo.toml"
+          cargo +1.96.1 package --locked --package signal-fish-client --no-verify
+          tar -xzf "target/package/signal-fish-client-${core_version}.crate" \
+            --strip-components=1 -C "$core_dir"
       - name: Verify isolated core metadata has no Godot packages
         run: |
-          cargo metadata --locked --format-version 1 \
+          cargo +1.87.0 metadata --locked --format-version 1 \
             --manifest-path "$RUNNER_TEMP/signal-fish-core-msrv/Cargo.toml" \
             > "$RUNNER_TEMP/core-metadata.json"
           python3 -c 'import json,sys; data=json.load(open(sys.argv[1])); assert all(not p["name"].startswith("godot") for p in data["packages"])' \
             "$RUNNER_TEMP/core-metadata.json"
-      - name: Build isolated core with MSRV
-        run: cargo build --locked --manifest-path "$RUNNER_TEMP/signal-fish-core-msrv/Cargo.toml" --all-features
-      - name: Test isolated core with MSRV
-        run: cargo test --locked --manifest-path "$RUNNER_TEMP/signal-fish-core-msrv/Cargo.toml" --all-features
+      - name: Compile isolated core tests with MSRV
+        run: cargo +1.87.0 test --locked --manifest-path "$RUNNER_TEMP/signal-fish-core-msrv/Cargo.toml" --all-features --no-run
+      - name: Test isolated core library with MSRV
+        run: cargo +1.87.0 test --locked --manifest-path "$RUNNER_TEMP/signal-fish-core-msrv/Cargo.toml" --all-features --lib
 
   # ──────────────────────────────────────────────────────────────
   # Adapter MSRV — godot-rust 0.5 requires a newer compiler than core

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,7 +233,27 @@ jobs:
         uses: Swatinem/rust-cache@v2.9.1
       - name: Run publish dry-run
         run: |
-          cargo publish --dry-run -p signal-fish-client
-          core_path=$(pwd)
-          cargo package --no-verify -p signal-fish-client-godot \
-            --config "patch.crates-io.signal-fish-client.path='$core_path'"
+          python3 scripts/release.py workspace-plan > "$RUNNER_TEMP/workspace-plan.json"
+          mapfile -t packages < <(jq -r '.packages[].name' "$RUNNER_TEMP/workspace-plan.json")
+          package_args=()
+          for package in "${packages[@]}"; do
+            package_args+=(-p "$package")
+          done
+          cargo publish --dry-run "${package_args[@]}"
+
+  required:
+    name: CI Required
+    if: ${{ always() }}
+    needs: [fmt, spell-check, clippy, test, msrv, adapter-msrv, doc, deny, publish-dry-run]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Require every CI job
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          failures=$(jq -r 'to_entries[] | select(.value.result != "success") | "\(.key)=\(.value.result)"' <<< "$NEEDS_JSON")
+          if [ -n "$failures" ]; then
+            printf '::error::Required jobs did not succeed:\n%s\n' "$failures"
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,9 +140,17 @@ jobs:
       - name: Create isolated core package tree
         run: |
           core_dir="$RUNNER_TEMP/signal-fish-core-msrv"
+          core_version=$(python3 scripts/release.py package-version)
           mkdir -p "$core_dir"
           git archive HEAD | tar -x -C "$core_dir"
-          awk '/^\[workspace\]$/ { exit } { print }' Cargo.toml > "$core_dir/Cargo.toml"
+          awk -v version="$core_version" '
+            /^\[workspace\]$/ { exit }
+            /^version\.workspace = true$/ {
+              printf "version = \"%s\"\n", version
+              next
+            }
+            { print }
+          ' Cargo.toml > "$core_dir/Cargo.toml"
       - name: Generate isolated core lockfile
         run: bash scripts/cargo-retry.sh generate-lockfile --manifest-path "$RUNNER_TEMP/signal-fish-core-msrv/Cargo.toml"
       - name: Verify isolated core metadata has no Godot packages

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -85,3 +85,20 @@ jobs:
         # Measured at 93.70% after the issue #61 regression expansion. Keep a
         # little platform/toolchain rounding headroom while preventing drift.
         run: cargo llvm-cov report --summary-only --fail-under-lines 93
+
+  required:
+    name: Coverage Required
+    if: ${{ always() }}
+    needs: [coverage]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Require coverage
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          failures=$(jq -r 'to_entries[] | select(.value.result != "success") | "\(.key)=\(.value.result)"' <<< "$NEEDS_JSON")
+          if [ -n "$failures" ]; then
+            printf '::error::Required jobs did not succeed:\n%s\n' "$failures"
+            exit 1
+          fi

--- a/.github/workflows/docs-validation.yml
+++ b/.github/workflows/docs-validation.yml
@@ -1,7 +1,7 @@
 # Docs validation pipeline for signal-fish-client
 #
-# Runs on every push to main and on all pull requests that touch
-# markdown files, documentation config, or this workflow itself.
+# Runs on every push to main and on all pull requests so its stable aggregate
+# gate reports on every protected-branch candidate.
 # Jobs: markdownlint, link-check, rendering-check
 #
 # Spell checking (typos) lives in ci.yml instead: typos scans the whole
@@ -14,31 +14,7 @@ name: Docs Validation
 on:
   push:
     branches: [main]
-    paths:
-      - "**/*.md"
-      - "docs/**"
-      - ".markdownlint.json"
-      - ".markdownlint-cli2.jsonc"
-      - ".lychee.toml"
-      - "mkdocs.yml"
-      - "hooks/**"
-      - "llms.txt"
-      - "requirements-docs.txt"
-      - "scripts/check-docs-rendering.sh"
-      - ".github/workflows/docs-validation.yml"
   pull_request:
-    paths:
-      - "**/*.md"
-      - "docs/**"
-      - ".markdownlint.json"
-      - ".markdownlint-cli2.jsonc"
-      - ".lychee.toml"
-      - "mkdocs.yml"
-      - "hooks/**"
-      - "llms.txt"
-      - "requirements-docs.txt"
-      - "scripts/check-docs-rendering.sh"
-      - ".github/workflows/docs-validation.yml"
 
 permissions:
   contents: read
@@ -116,3 +92,20 @@ jobs:
 
       - name: Run docs rendering check
         run: bash scripts/check-docs-rendering.sh
+
+  required:
+    name: Docs Validation Required
+    if: ${{ always() }}
+    needs: [markdownlint, link-check, rendering-check]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Require every docs validation job
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          failures=$(jq -r 'to_entries[] | select(.value.result != "success") | "\(.key)=\(.value.result)"' <<< "$NEEDS_JSON")
+          if [ -n "$failures" ]; then
+            printf '::error::Required jobs did not succeed:\n%s\n' "$failures"
+            exit 1
+          fi

--- a/.github/workflows/examples-validation.yml
+++ b/.github/workflows/examples-validation.yml
@@ -85,3 +85,20 @@ jobs:
 
       - name: Extract and compile Rust snippets from markdown
         run: bash scripts/extract-rust-snippets.sh
+
+  required:
+    name: Examples Validation Required
+    if: ${{ always() }}
+    needs: [doc-tests, examples, snippet-check]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Require every examples validation job
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          failures=$(jq -r 'to_entries[] | select(.value.result != "success") | "\(.key)=\(.value.result)"' <<< "$NEEDS_JSON")
+          if [ -n "$failures" ]; then
+            printf '::error::Required jobs did not succeed:\n%s\n' "$failures"
+            exit 1
+          fi

--- a/.github/workflows/godot-web.yml
+++ b/.github/workflows/godot-web.yml
@@ -352,3 +352,20 @@ jobs:
             fortress-metrics-before.prom
             fortress-metrics-after.prom
           if-no-files-found: warn
+
+  required:
+    name: Godot Web Required
+    if: ${{ always() }}
+    needs: [build-export, browser-scenarios]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Require every Godot web job
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          failures=$(jq -r 'to_entries[] | select(.value.result != "success") | "\(.key)=\(.value.result)"' <<< "$NEEDS_JSON")
+          if [ -n "$failures" ]; then
+            printf '::error::Required jobs did not succeed:\n%s\n' "$failures"
+            exit 1
+          fi

--- a/.github/workflows/no-panics.yml
+++ b/.github/workflows/no-panics.yml
@@ -44,3 +44,20 @@ jobs:
 
       - name: Run panic-free policy check
         run: bash scripts/check-no-panics.sh
+
+  required:
+    name: No Panics Required
+    if: ${{ always() }}
+    needs: [panic-free-policy]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Require panic-free policy
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          failures=$(jq -r 'to_entries[] | select(.value.result != "success") | "\(.key)=\(.value.result)"' <<< "$NEEDS_JSON")
+          if [ -n "$failures" ]; then
+            printf '::error::Required jobs did not succeed:\n%s\n' "$failures"
+            exit 1
+          fi

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -141,7 +141,9 @@ jobs:
           fi
           {
             printf 'Automated release preparation for %s.\n\n' "$VERSION"
-            printf '%s\n' 'GitHub holds workflows triggered by this app-free automation for maintainer approval. Select **Approve workflows to run**, then merge only after every required check and review is green.'
+            printf '%s\n' \
+              'GitHub holds workflows triggered by this app-free automation for maintainer approval.' \
+              'Select **Approve workflows to run**, then merge only after every required check and review is green.'
           } > "$RUNNER_TEMP/release-pr.md"
           gh pr create \
             --base "$DEFAULT_BRANCH" \

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -112,7 +112,7 @@ jobs:
         run: |
           git switch -c "$BRANCH"
           git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add --update
           git diff --cached --check
           if git diff --cached --quiet; then

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -75,6 +75,8 @@ jobs:
         with:
           client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Checkout default-branch HEAD
         uses: actions/checkout@v7.0.0

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -29,9 +29,12 @@ concurrency:
   group: prepare-release
   cancel-in-progress: false
 
+env:
+  RELEASE_RUST: "1.96.1"
+
 jobs:
   prepare:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
       - name: Require the default branch
@@ -43,6 +46,27 @@ jobs:
             printf '::error::Prepare Release must run from %s, not %s.\n' "$DEFAULT_BRANCH" "$REF_NAME"
             exit 1
           fi
+
+      - name: Preflight release-app configuration
+        if: ${{ !inputs.dry_run }}
+        env:
+          CLIENT_ID: ${{ vars.RELEASE_APP_CLIENT_ID }}
+          PRIVATE_KEY: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+        run: |
+          if [ -z "$CLIENT_ID" ]; then
+            printf '::error::Repository variable RELEASE_APP_CLIENT_ID is not configured. See docs/releasing.md.\n'
+            exit 1
+          fi
+          if [ -z "$PRIVATE_KEY" ]; then
+            printf '::error::Repository secret RELEASE_APP_PRIVATE_KEY is not configured. See docs/releasing.md.\n'
+            exit 1
+          fi
+          case "$PRIVATE_KEY" in
+            *"BEGIN"*"PRIVATE KEY"*"END"*"PRIVATE KEY"*) ;;
+            *)
+              printf '::error::RELEASE_APP_PRIVATE_KEY is not a PEM private key. See docs/releasing.md.\n'
+              exit 1 ;;
+          esac
 
       - name: Create release-app token
         id: app-token
@@ -59,16 +83,19 @@ jobs:
           token: ${{ steps.app-token.outputs.token || github.token }}
           fetch-depth: 0
 
-      - name: Install Rust
+      - name: Install pinned release Rust
         uses: dtolnay/rust-toolchain@stable
         with:
+          toolchain: ${{ env.RELEASE_RUST }}
           components: rustfmt, clippy
 
       - name: Cache Cargo artifacts
         uses: Swatinem/rust-cache@v2.9.1
 
       - name: Test release tooling
-        run: python3 -m unittest scripts/test_release.py
+        run: >-
+          python3 -m unittest scripts/test_release.py scripts/test_required_checks.py
+          scripts/test_audit_repository_rules.py
 
       - name: Prepare release files
         id: version
@@ -87,13 +114,16 @@ jobs:
       - name: Run mandatory verification
         run: cargo fmt --all -- --check && cargo clippy --workspace --all-targets --all-features -- -D warnings && cargo test --workspace --all-features
 
-      - name: Verify package and documentation
+      - name: Verify every publishable package and documentation
         run: |
-          cargo package --allow-dirty -p signal-fish-client
-          core_path=$(pwd)
-          cargo package --allow-dirty --no-verify -p signal-fish-client-godot \
-            --config "patch.crates-io.signal-fish-client.path='$core_path'"
-          cargo publish --dry-run --allow-dirty -p signal-fish-client
+          python3 scripts/release.py workspace-plan > "$RUNNER_TEMP/workspace-plan.json"
+          mapfile -t packages < <(jq -r '.packages[].name' "$RUNNER_TEMP/workspace-plan.json")
+          package_args=()
+          for package in "${packages[@]}"; do
+            package_args+=(-p "$package")
+          done
+          cargo package --allow-dirty "${package_args[@]}"
+          cargo publish --dry-run --allow-dirty "${package_args[@]}"
           rustup toolchain install nightly --profile minimal
           bash scripts/check-docsrs.sh
 
@@ -111,12 +141,12 @@ jobs:
           git switch -c "$BRANCH"
           git config user.name "signal-fish-release[bot]"
           git config user.email "signal-fish-release[bot]@users.noreply.github.com"
-          git add Cargo.toml crates/signal-fish-client-godot/Cargo.toml \
-            README.md CHANGELOG.md docs .llm tests/compatibility.toml \
-            tests/godot-compat-min/Cargo.lock \
-            tests/godot-web-smoke/Cargo.lock \
-            tests/server-spec/PROVENANCE.toml \
-            tests/wire-samples/PROVENANCE.toml
+          git add --update
+          git diff --cached --check
+          if git diff --cached --quiet; then
+            printf '::error::Release preparation produced no tracked changes.\n'
+            exit 1
+          fi
           subject="chore: prepare release ${VERSION}"
           if [ "$BREAKING" = true ]; then
             subject="chore!: prepare release ${VERSION}"

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -111,8 +111,8 @@ jobs:
           BREAKING: ${{ inputs.breaking }}
         run: |
           git switch -c "$BRANCH"
-          git config user.name "signal-fish-release[bot]"
-          git config user.email "signal-fish-release[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
           git add --update
           git diff --cached --check
           if git diff --cached --quiet; then

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -23,7 +23,8 @@ on:
         type: boolean
 
 permissions:
-  contents: read
+  contents: write
+  pull-requests: write
 
 concurrency:
   group: prepare-release
@@ -47,43 +48,12 @@ jobs:
             exit 1
           fi
 
-      - name: Preflight release-app configuration
-        if: ${{ !inputs.dry_run }}
-        env:
-          CLIENT_ID: ${{ vars.RELEASE_APP_CLIENT_ID }}
-          PRIVATE_KEY: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
-        run: |
-          if [ -z "$CLIENT_ID" ]; then
-            printf '::error::Repository variable RELEASE_APP_CLIENT_ID is not configured. See docs/releasing.md.\n'
-            exit 1
-          fi
-          if [ -z "$PRIVATE_KEY" ]; then
-            printf '::error::Repository secret RELEASE_APP_PRIVATE_KEY is not configured. See docs/releasing.md.\n'
-            exit 1
-          fi
-          case "$PRIVATE_KEY" in
-            *"BEGIN"*"PRIVATE KEY"*"END"*"PRIVATE KEY"*) ;;
-            *)
-              printf '::error::RELEASE_APP_PRIVATE_KEY is not a PEM private key. See docs/releasing.md.\n'
-              exit 1 ;;
-          esac
-
-      - name: Create release-app token
-        id: app-token
-        if: ${{ !inputs.dry_run }}
-        uses: actions/create-github-app-token@v3.2.0
-        with:
-          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
-          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
-          permission-contents: write
-          permission-pull-requests: write
-
       - name: Checkout default-branch HEAD
         uses: actions/checkout@v7.0.0
         with:
           ref: ${{ github.event.repository.default_branch }}
-          token: ${{ steps.app-token.outputs.token || github.token }}
           fetch-depth: 0
+          persist-credentials: true
 
       - name: Install pinned release Rust
         uses: dtolnay/rust-toolchain@stable
@@ -159,7 +129,7 @@ jobs:
       - name: Open release pull request
         if: ${{ !inputs.dry_run }}
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ github.token }}
           BRANCH: ${{ steps.version.outputs.branch }}
           VERSION: ${{ steps.version.outputs.version }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
@@ -169,8 +139,12 @@ jobs:
           if [ "$BREAKING" = true ]; then
             title="chore!: prepare release ${VERSION}"
           fi
+          {
+            printf 'Automated release preparation for %s.\n\n' "$VERSION"
+            printf '%s\n' 'GitHub holds workflows triggered by this app-free automation for maintainer approval. Select **Approve workflows to run**, then merge only after every required check and review is green.'
+          } > "$RUNNER_TEMP/release-pr.md"
           gh pr create \
             --base "$DEFAULT_BRANCH" \
             --head "$BRANCH" \
             --title "$title" \
-            --body "Automated release preparation for \`${VERSION}\`. Merge only after every required check and review is green."
+            --body-file "$RUNNER_TEMP/release-pr.md"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,11 +2,6 @@ name: Release
 
 on:
   workflow_dispatch:
-    inputs:
-      version:
-        description: Release version in strict X.Y.Z form
-        required: true
-        type: string
 
 permissions:
   contents: write
@@ -21,25 +16,21 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
+  RELEASE_RUST: "1.96.1"
   RUSTDOCFLAGS: "-D warnings"
 
 jobs:
   release:
     name: Release publication
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 45
     environment: crates-io
     steps:
-      - name: Validate strict version input
+      - name: Require the default branch
         env:
-          VERSION: ${{ inputs.version }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           REF_NAME: ${{ github.ref_name }}
         run: |
-          if ! printf '%s\n' "$VERSION" | grep -qE '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'; then
-            printf '::error::Invalid version %s; expected strict X.Y.Z.\n' "$VERSION"
-            exit 1
-          fi
           if [ "$REF_NAME" != "$DEFAULT_BRANCH" ]; then
             printf '::error::Release must run from %s, not %s.\n' "$DEFAULT_BRANCH" "$REF_NAME"
             exit 1
@@ -52,12 +43,11 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
-      - name: Verify default-branch HEAD and successful checks
+      - name: Verify default-branch HEAD and required checks
         env:
           GH_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-          RUN_ID: ${{ github.run_id }}
         run: |
           remote_sha=$(gh api "repos/${REPOSITORY}/branches/${DEFAULT_BRANCH}" --jq '.commit.sha')
           local_sha=$(git rev-parse HEAD)
@@ -65,33 +55,16 @@ jobs:
             printf '::error::Checked-out SHA %s is not default-branch HEAD %s.\n' "$local_sha" "$remote_sha"
             exit 1
           fi
-          current_run="/actions/runs/${RUN_ID}/"
-          checks=$(
-            gh api --paginate \
-              "repos/${REPOSITORY}/commits/${local_sha}/check-runs?filter=latest&per_page=100" \
-              --jq "[.check_runs[] | select(
-                ((.details_url // \"\") | contains(\"${current_run}\")) | not)] | length" |
-              awk '{ total += $1 } END { print total + 0 }'
-          )
-          failures=$(
-            gh api --paginate \
-              "repos/${REPOSITORY}/commits/${local_sha}/check-runs?filter=latest&per_page=100" \
-              --jq "[.check_runs[] | select(
-                ((.details_url // \"\") | contains(\"${current_run}\")) | not) | select(
-                  .status != \"completed\" or
-                  (.conclusion != \"success\" and
-                   .conclusion != \"neutral\" and
-                   .conclusion != \"skipped\"))] | length" |
-              awk '{ total += $1 } END { print total + 0 }'
-          )
-          if [ "$checks" -eq 0 ] || [ "$failures" -ne 0 ]; then
-            printf '::error::Default-branch HEAD has %s check runs and %s non-successful runs.\n' "$checks" "$failures"
-            exit 1
-          fi
+          gh api "repos/${REPOSITORY}/commits/${local_sha}/check-runs?filter=latest&per_page=100" \
+            > "$RUNNER_TEMP/check-runs.json"
+          python3 scripts/check-required-checks.py \
+            --check-runs "$RUNNER_TEMP/check-runs.json" \
+            --policy .github/required-checks.json
 
-      - name: Install Rust
+      - name: Install pinned release Rust
         uses: dtolnay/rust-toolchain@stable
         with:
+          toolchain: ${{ env.RELEASE_RUST }}
           components: rustfmt, clippy
 
       - name: Cache Cargo artifacts
@@ -102,129 +75,82 @@ jobs:
         with:
           tool: cargo-cyclonedx@0.5.7,cargo-semver-checks@0.46.0
 
-      - name: Validate release files
+      - name: Derive and validate release metadata
         id: release-metadata
-        env:
-          VERSION: ${{ inputs.version }}
         run: |
-          cargo_version=$(python3 scripts/release.py package-version)
-          if [ "$VERSION" != "$cargo_version" ]; then
-            printf '::error::Input %s does not match Cargo.toml %s.\n' "$VERSION" "$cargo_version"
+          python3 scripts/release.py workspace-plan > "$RUNNER_TEMP/workspace-plan.json"
+          version=$(jq -r '.version' "$RUNNER_TEMP/workspace-plan.json")
+          if ! grep -qF "## [${version}] - " CHANGELOG.md; then
+            printf '::error::CHANGELOG.md has no dated %s section.\n' "$version"
             exit 1
           fi
-          adapter_version=$(python3 scripts/release.py package-version \
-            --manifest crates/signal-fish-client-godot/Cargo.toml)
-          if [ "$VERSION" != "$adapter_version" ]; then
-            printf '::error::Input %s does not match adapter Cargo.toml %s.\n' \
-              "$VERSION" "$adapter_version"
-            exit 1
-          fi
-          if ! grep -qF "version = \"=${VERSION}\"" \
-            crates/signal-fish-client-godot/Cargo.toml; then
-            printf '::error::Adapter does not require core exactly at =%s.\n' "$VERSION"
-            exit 1
-          fi
-          if ! grep -qF "## [${VERSION}] - " CHANGELOG.md; then
-            printf '::error::CHANGELOG.md has no dated %s section.\n' "$VERSION"
-            exit 1
-          fi
-          release_type=$(python3 scripts/release.py semver-policy "$VERSION")
-          printf 'release_type=%s\n' "$release_type" >> "$GITHUB_OUTPUT"
-          python3 -m unittest scripts/test_release.py
+          release_type=$(python3 scripts/release.py semver-policy "$version")
+          {
+            printf 'version=%s\n' "$version"
+            printf 'release_type=%s\n' "$release_type"
+          } >> "$GITHUB_OUTPUT"
+          python3 -m unittest scripts/test_release.py scripts/test_required_checks.py \
+            scripts/test_audit_repository_rules.py
 
       - name: Run complete release verification
         env:
           RELEASE_TYPE: ${{ steps.release-metadata.outputs.release_type }}
+          VERSION: ${{ steps.release-metadata.outputs.version }}
         run: |
           cargo fmt --all -- --check
           cargo clippy --workspace --all-targets --all-features -- -D warnings
           cargo test --workspace --all-features
-          cargo semver-checks check-release --package signal-fish-client \
-            --release-type "$RELEASE_TYPE"
-          previous=$(python3 scripts/release.py previous-version "${{ inputs.version }}")
-          adapter_baseline=$(python3 scripts/release.py registry-checksum \
-            signal-fish-client-godot "$previous")
-          if [ "$adapter_baseline" = "UNPUBLISHED" ]; then
-            echo "Skipping adapter semver baseline for its first release."
-          else
-            cargo semver-checks check-release --package signal-fish-client-godot \
-              --release-type "$RELEASE_TYPE"
-          fi
+          previous=$(python3 scripts/release.py previous-version "$VERSION")
+          while IFS= read -r package; do
+            baseline=$(python3 scripts/release.py registry-checksum "$package" "$previous")
+            if [ "$baseline" = "UNPUBLISHED" ]; then
+              printf 'Skipping %s semver baseline for its first release.\n' "$package"
+            else
+              cargo semver-checks check-release --package "$package" \
+                --release-type "$RELEASE_TYPE"
+            fi
+          done < <(jq -r '.packages[].name' "$RUNNER_TEMP/workspace-plan.json")
           rustup toolchain install nightly --profile minimal
           bash scripts/check-docsrs.sh
-          cargo publish --dry-run -p signal-fish-client
 
-      - name: Build release artifacts
-        id: artifact
+      - name: Build reproducible release assets
         env:
-          VERSION: ${{ inputs.version }}
+          VERSION: ${{ steps.release-metadata.outputs.version }}
         run: |
-          cargo package -p signal-fish-client
-          core_path=$(pwd)
-          cargo package --no-verify -p signal-fish-client-godot \
-            --config "patch.crates-io.signal-fish-client.path='$core_path'"
+          mapfile -t packages < <(jq -r '.packages[].name' "$RUNNER_TEMP/workspace-plan.json")
+          package_args=()
+          for package in "${packages[@]}"; do
+            package_args+=(-p "$package")
+          done
+          cargo package "${package_args[@]}"
           cargo cyclonedx --format json --workspace
+
           asset_dir="$RUNNER_TEMP/release-assets"
           mkdir -p "$asset_dir"
-          core_crate="target/package/signal-fish-client-${VERSION}.crate"
-          adapter_crate="target/package/signal-fish-client-godot-${VERSION}.crate"
-          mapfile -t sboms < <(find . -type f -name '*.cdx.json' -not -path './target/*' -print)
-          if [ "${#sboms[@]}" -ne 2 ]; then
-            printf '::error::Expected two CycloneDX JSON files, found %s.\n' "${#sboms[@]}"
-            exit 1
-          fi
-          cp "$core_crate" "$adapter_crate" "$asset_dir/"
-          for sbom in "${sboms[@]}"; do
-            case "$sbom" in
-              *signal-fish-client-godot.cdx.json)
-                mv "$sbom" "$asset_dir/signal-fish-client-godot-${VERSION}.cdx.json" ;;
-              *signal-fish-client.cdx.json)
-                mv "$sbom" "$asset_dir/signal-fish-client-${VERSION}.cdx.json" ;;
-              *)
-                printf '::error::Unexpected CycloneDX file %s.\n' "$sbom"
-                exit 1 ;;
-            esac
+          : > "$asset_dir/SHA256SUMS"
+          for package in "${packages[@]}"; do
+            crate="target/package/${package}-${VERSION}.crate"
+            cp "$crate" "$asset_dir/"
+            checksum=$(python3 scripts/release.py checksum "$crate")
+            printf '%s  %s\n' "$checksum" "${package}-${VERSION}.crate" \
+              >> "$asset_dir/SHA256SUMS"
+
+            mapfile -t sboms < <(
+              find . -type f -name "${package}.cdx.json" -not -path './target/*' -print
+            )
+            if [ "${#sboms[@]}" -ne 1 ]; then
+              printf '::error::Expected one CycloneDX file for %s, found %s.\n' \
+                "$package" "${#sboms[@]}"
+              exit 1
+            fi
+            mv "${sboms[0]}" "$asset_dir/${package}-${VERSION}.cdx.json"
           done
-          core_checksum=$(python3 scripts/release.py checksum "$core_crate")
-          adapter_checksum=$(python3 scripts/release.py checksum "$adapter_crate")
-          {
-            printf '%s  %s\n' "$core_checksum" "signal-fish-client-${VERSION}.crate"
-            printf '%s  %s\n' "$adapter_checksum" "signal-fish-client-godot-${VERSION}.crate"
-          } > "$asset_dir/SHA256SUMS"
 
-          verify_dir="$RUNNER_TEMP/packaged-consumer"
-          mkdir -p "$verify_dir/core" "$verify_dir/adapter" "$verify_dir/consumer/src"
-          tar -xzf "$core_crate" -C "$verify_dir/core" --strip-components=1
-          tar -xzf "$adapter_crate" -C "$verify_dir/adapter" --strip-components=1
-          cat > "$verify_dir/consumer/Cargo.toml" <<EOF
-          [package]
-          name = "signal-fish-packaged-adapter-check"
-          version = "0.0.0"
-          edition = "2021"
-          publish = false
-
-          [dependencies]
-          signal-fish-client-godot = { path = "$verify_dir/adapter" }
-
-          [patch.crates-io]
-          signal-fish-client = { path = "$verify_dir/core" }
-          EOF
-          printf 'fn main() {}\n' > "$verify_dir/consumer/src/main.rs"
-          cargo check --manifest-path "$verify_dir/consumer/Cargo.toml"
-          {
-            printf 'core_crate=%s\n' "$core_crate"
-            printf 'core_checksum=%s\n' "$core_checksum"
-            printf 'adapter_crate=%s\n' "$adapter_crate"
-            printf 'adapter_checksum=%s\n' "$adapter_checksum"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Validate recovery state
+      - name: Validate fail-closed recovery state
         id: state
         env:
           GH_TOKEN: ${{ github.token }}
-          VERSION: ${{ inputs.version }}
-          CORE_CHECKSUM: ${{ steps.artifact.outputs.core_checksum }}
-          ADAPTER_CHECKSUM: ${{ steps.artifact.outputs.adapter_checksum }}
+          VERSION: ${{ steps.release-metadata.outputs.version }}
           REPOSITORY: ${{ github.repository }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
@@ -245,70 +171,89 @@ jobs:
             printf '::error::Existing tag %s targets %s, not %s.\n' "$tag" "$tag_sha" "$head_sha"
             exit 1
           fi
-          core_registry=$(python3 scripts/release.py registry-checksum signal-fish-client "$VERSION")
-          adapter_registry=$(python3 scripts/release.py registry-checksum signal-fish-client-godot "$VERSION")
-          if [ "$core_registry" != "UNPUBLISHED" ] && [ "$core_registry" != "$CORE_CHECKSUM" ]; then
-            printf '::error::Published core checksum does not match the reproduced package.\n'
-            exit 1
-          fi
-          if [ "$adapter_registry" != "UNPUBLISHED" ] && [ "$adapter_registry" != "$ADAPTER_CHECKSUM" ]; then
-            printf '::error::Published adapter checksum does not match the reproduced package.\n'
-            exit 1
-          fi
-          if [ "$core_registry" = "UNPUBLISHED" ] && [ "$adapter_registry" != "UNPUBLISHED" ]; then
-            printf '::error::Adapter is published while its exact core version is absent.\n'
-            exit 1
-          fi
           if gh release view "$tag" >/dev/null 2>&1 && [ -z "$tag_sha" ]; then
-            printf '::error::GitHub release %s exists without a matching local tag.\n' "$tag"
+            printf '::error::GitHub release %s exists without a matching tag.\n' "$tag"
             exit 1
           fi
+
+          python3 scripts/release.py registry-plan \
+            --artifacts-dir "$RUNNER_TEMP/release-assets" \
+            > "$RUNNER_TEMP/registry-plan.json"
+          pending_count=$(jq '.pending | length' "$RUNNER_TEMP/registry-plan.json")
           tag_exists=$([ -n "$tag_sha" ] && printf true || printf false)
-          core_published=$([ "$core_registry" != "UNPUBLISHED" ] && printf true || printf false)
-          adapter_published=$([ "$adapter_registry" != "UNPUBLISHED" ] && printf true || printf false)
           release_exists=$(gh release view "$tag" >/dev/null 2>&1 && printf true || printf false)
           {
+            printf 'pending_count=%s\n' "$pending_count"
             printf 'tag_exists=%s\n' "$tag_exists"
-            printf 'core_published=%s\n' "$core_published"
-            printf 'adapter_published=%s\n' "$adapter_published"
             printf 'release_exists=%s\n' "$release_exists"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Create annotated tag
-        if: steps.state.outputs.tag_exists != 'true'
+      - name: Preflight crates.io publishing token
+        if: steps.state.outputs.pending_count != '0'
         env:
-          VERSION: ${{ inputs.version }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a "v${VERSION}" -m "Release ${VERSION}"
-          git push origin "v${VERSION}"
+          if [ -z "$CARGO_REGISTRY_TOKEN" ]; then
+            printf '::error::Environment secret CRATES_IO_TOKEN is not configured. See docs/releasing.md.\n'
+            exit 1
+          fi
+
+      - name: Dry-run every unpublished crate
+        if: steps.state.outputs.pending_count != '0'
+        run: |
+          mapfile -t pending < <(jq -r '.pending[]' "$RUNNER_TEMP/registry-plan.json")
+          publish_args=()
+          for package in "${pending[@]}"; do
+            publish_args+=(-p "$package")
+          done
+          cargo publish --dry-run "${publish_args[@]}"
 
       - name: Attest package provenance
         uses: actions/attest@v4.2.0
         with:
           subject-path: ${{ runner.temp }}/release-assets/*.crate
 
-      - name: Publish core to crates.io
-        if: steps.state.outputs.core_published != 'true'
+      - name: Create annotated tag
+        if: steps.state.outputs.tag_exists != 'true'
+        env:
+          VERSION: ${{ steps.release-metadata.outputs.version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "v${VERSION}" -m "Release ${VERSION}"
+          git push origin "v${VERSION}"
+
+      - name: Publish every unpublished crate
+        if: steps.state.outputs.pending_count != '0'
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
-        run: cargo publish -p signal-fish-client
+        run: |
+          mapfile -t pending < <(jq -r '.pending[]' "$RUNNER_TEMP/registry-plan.json")
+          publish_args=()
+          for package in "${pending[@]}"; do
+            publish_args+=(-p "$package")
+          done
+          cargo publish "${publish_args[@]}"
 
-      - name: Wait for core visibility and verify checksum
-        env:
-          VERSION: ${{ inputs.version }}
-          CHECKSUM: ${{ steps.artifact.outputs.core_checksum }}
+      - name: Wait for crates.io and verify every checksum
         run: |
           attempt=1
           while [ "$attempt" -le 30 ]; do
-            registry_checksum=$(python3 scripts/release.py registry-checksum signal-fish-client "$VERSION")
-            if [ "$registry_checksum" = "$CHECKSUM" ]; then
+            missing=0
+            while IFS=$'\t' read -r package version checksum; do
+              registry_checksum=$(python3 scripts/release.py registry-checksum "$package" "$version")
+              if [ "$registry_checksum" = "$checksum" ]; then
+                continue
+              fi
+              if [ "$registry_checksum" != "UNPUBLISHED" ]; then
+                printf '::error::Registry checksum for %s %s does not match.\n' "$package" "$version"
+                exit 1
+              fi
+              missing=1
+            done < <(jq -r '.packages[] | [.name, .version, .checksum] | @tsv' \
+              "$RUNNER_TEMP/registry-plan.json")
+            if [ "$missing" -eq 0 ]; then
               exit 0
-            fi
-            if [ "$registry_checksum" != "UNPUBLISHED" ]; then
-              printf '::error::Registry checksum changed to an unexpected value.\n'
-              exit 1
             fi
             sleep 10
             attempt=$((attempt + 1))
@@ -316,42 +261,9 @@ jobs:
           printf '::error::Timed out waiting for crates.io visibility.\n'
           exit 1
 
-      - name: Dry-run and publish adapter to crates.io
-        if: steps.state.outputs.adapter_published != 'true'
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
-        run: |
-          core_path=$(pwd)
-          cargo publish --dry-run --no-verify -p signal-fish-client-godot \
-            --config "patch.crates-io.signal-fish-client.path='$core_path'"
-          cargo publish --no-verify -p signal-fish-client-godot \
-            --config "patch.crates-io.signal-fish-client.path='$core_path'"
-
-      - name: Wait for adapter visibility and verify checksum
-        env:
-          VERSION: ${{ inputs.version }}
-          CHECKSUM: ${{ steps.artifact.outputs.adapter_checksum }}
-        run: |
-          attempt=1
-          while [ "$attempt" -le 30 ]; do
-            registry_checksum=$(python3 scripts/release.py registry-checksum \
-              signal-fish-client-godot "$VERSION")
-            if [ "$registry_checksum" = "$CHECKSUM" ]; then
-              exit 0
-            fi
-            if [ "$registry_checksum" != "UNPUBLISHED" ]; then
-              printf '::error::Adapter registry checksum changed unexpectedly.\n'
-              exit 1
-            fi
-            sleep 10
-            attempt=$((attempt + 1))
-          done
-          printf '::error::Timed out waiting for adapter crates.io visibility.\n'
-          exit 1
-
       - name: Extract release notes
         env:
-          VERSION: ${{ inputs.version }}
+          VERSION: ${{ steps.release-metadata.outputs.version }}
         run: |
           awk -v version="$VERSION" '
             $0 ~ "^## \\[" version "\\]" { found=1; next }
@@ -367,7 +279,7 @@ jobs:
         if: steps.state.outputs.release_exists != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
-          VERSION: ${{ inputs.version }}
+          VERSION: ${{ steps.release-metadata.outputs.version }}
         run: |
           gh release create "v${VERSION}" \
             "$RUNNER_TEMP"/release-assets/*.crate \
@@ -381,7 +293,7 @@ jobs:
         if: steps.state.outputs.release_exists == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
-          VERSION: ${{ inputs.version }}
+          VERSION: ${{ steps.release-metadata.outputs.version }}
         run: |
           gh release upload "v${VERSION}" \
             "$RUNNER_TEMP"/release-assets/*.crate \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,7 +55,8 @@ jobs:
             printf '::error::Checked-out SHA %s is not default-branch HEAD %s.\n' "$local_sha" "$remote_sha"
             exit 1
           fi
-          gh api "repos/${REPOSITORY}/commits/${local_sha}/check-runs?filter=latest&per_page=100" \
+          gh api --paginate --slurp \
+            "repos/${REPOSITORY}/commits/${local_sha}/check-runs?filter=latest&per_page=100" \
             > "$RUNNER_TEMP/check-runs.json"
           python3 scripts/check-required-checks.py \
             --check-runs "$RUNNER_TEMP/check-runs.json" \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -225,7 +225,7 @@ jobs:
           VERSION: ${{ steps.release-metadata.outputs.version }}
         run: |
           git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag -a "v${VERSION}" -m "Release ${VERSION}"
           git push origin "v${VERSION}"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -207,7 +207,12 @@ jobs:
           for package in "${pending[@]}"; do
             publish_args+=(-p "$package")
           done
-          cargo publish --dry-run "${publish_args[@]}"
+          resume_args=()
+          if jq -e '.resume_requires_no_verify' "$RUNNER_TEMP/registry-plan.json" >/dev/null; then
+            printf 'Using --no-verify because an internal dependency is already checksum-matched on crates.io.\n'
+            resume_args+=(--no-verify)
+          fi
+          cargo publish --dry-run "${resume_args[@]}" "${publish_args[@]}"
 
       - name: Attest package provenance
         uses: actions/attest@v4.2.0
@@ -234,7 +239,12 @@ jobs:
           for package in "${pending[@]}"; do
             publish_args+=(-p "$package")
           done
-          cargo publish "${publish_args[@]}"
+          resume_args=()
+          if jq -e '.resume_requires_no_verify' "$RUNNER_TEMP/registry-plan.json" >/dev/null; then
+            printf 'Using --no-verify because an internal dependency is already checksum-matched on crates.io.\n'
+            resume_args+=(--no-verify)
+          fi
+          cargo publish "${resume_args[@]}" "${publish_args[@]}"
 
       - name: Wait for crates.io and verify every checksum
         run: |

--- a/.github/workflows/repository-policy.yml
+++ b/.github/workflows/repository-policy.yml
@@ -1,0 +1,28 @@
+name: Repository Policy
+
+on:
+  schedule:
+    - cron: "17 7 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: repository-policy
+  cancel-in-progress: false
+
+jobs:
+  audit:
+    name: Audit default-branch rules
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7.0.0
+
+      - name: Test policy audit
+        run: python3 -m unittest scripts/test_audit_repository_rules.py scripts/test_required_checks.py
+
+      - name: Audit live repository rulesets
+        run: python3 scripts/audit-repository-rules.py

--- a/.github/workflows/repository-policy.yml
+++ b/.github/workflows/repository-policy.yml
@@ -24,5 +24,25 @@ jobs:
       - name: Test policy audit
         run: python3 -m unittest scripts/test_audit_repository_rules.py scripts/test_required_checks.py
 
+      - name: Preflight policy-app configuration
+        env:
+          CLIENT_ID: ${{ vars.RELEASE_APP_CLIENT_ID }}
+          PRIVATE_KEY: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+        run: |
+          if [ -z "$CLIENT_ID" ] || [ -z "$PRIVATE_KEY" ]; then
+            printf '::error::Repository Policy requires RELEASE_APP_CLIENT_ID and RELEASE_APP_PRIVATE_KEY. See docs/releasing.md.\n'
+            exit 1
+          fi
+
+      - name: Create policy-audit token
+        id: app-token
+        uses: actions/create-github-app-token@v3.2.0
+        with:
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          permission-administration: read
+
       - name: Audit live repository rulesets
         run: python3 scripts/audit-repository-rules.py
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/repository-policy.yml
+++ b/.github/workflows/repository-policy.yml
@@ -24,25 +24,7 @@ jobs:
       - name: Test policy audit
         run: python3 -m unittest scripts/test_audit_repository_rules.py scripts/test_required_checks.py
 
-      - name: Preflight policy-app configuration
-        env:
-          CLIENT_ID: ${{ vars.RELEASE_APP_CLIENT_ID }}
-          PRIVATE_KEY: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
-        run: |
-          if [ -z "$CLIENT_ID" ] || [ -z "$PRIVATE_KEY" ]; then
-            printf '::error::Repository Policy requires RELEASE_APP_CLIENT_ID and RELEASE_APP_PRIVATE_KEY. See docs/releasing.md.\n'
-            exit 1
-          fi
-
-      - name: Create policy-audit token
-        id: app-token
-        uses: actions/create-github-app-token@v3.2.0
-        with:
-          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
-          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
-          permission-administration: read
-
       - name: Audit live repository rulesets
         run: python3 scripts/audit-repository-rules.py
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/security-supply-chain.yml
+++ b/.github/workflows/security-supply-chain.yml
@@ -122,3 +122,20 @@ jobs:
           path: ./**/*.cdx.json
           if-no-files-found: error
           retention-days: 90
+
+  required:
+    name: Security Required
+    if: ${{ always() }}
+    needs: [cargo-audit, sbom]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Require every PR security job
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          failures=$(jq -r 'to_entries[] | select(.value.result != "success") | "\(.key)=\(.value.result)"' <<< "$NEEDS_JSON")
+          if [ -n "$failures" ]; then
+            printf '::error::Required jobs did not succeed:\n%s\n' "$failures"
+            exit 1
+          fi

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -64,19 +64,6 @@ jobs:
       - name: Generate lockfile
         run: bash scripts/cargo-retry.sh generate-lockfile
 
-      - name: Check if adapter package exists on base branch
-        id: check-base-adapter
-        if: github.event_name == 'pull_request'
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        run: |
-          if git show "$BASE_SHA":crates/signal-fish-client-godot/Cargo.toml >/dev/null 2>&1; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-            echo "Skipping adapter semver check: package does not exist on base branch"
-          fi
-
       - name: Classify PR release type
         id: pr-release-type
         if: github.event_name == 'pull_request'
@@ -90,62 +77,57 @@ jobs:
             echo "release-type=auto" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Check semver compliance (PR — against base branch)
-        if: github.event_name == 'pull_request' && steps.pr-release-type.outputs.release-type == 'auto'
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        run: cargo semver-checks check-release --package signal-fish-client --baseline-rev "$BASE_SHA"
-
-      - name: Check intentional breaking API change (PR — against base branch)
-        if: github.event_name == 'pull_request' && steps.pr-release-type.outputs.release-type == 'major'
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        run: cargo semver-checks check-release --package signal-fish-client --baseline-rev "$BASE_SHA" --release-type major
-
-      - name: Check adapter semver compliance (PR — against base branch)
-        if: github.event_name == 'pull_request' && steps.check-base-adapter.outputs.exists == 'true'
+      - name: Check every publishable crate against the PR base
+        if: github.event_name == 'pull_request'
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           RELEASE_TYPE: ${{ steps.pr-release-type.outputs.release-type }}
         run: |
-          args=()
-          if [ "$RELEASE_TYPE" = major ]; then
-            args+=(--release-type major)
-          fi
-          cargo semver-checks check-release --package signal-fish-client-godot \
-            --baseline-rev "$BASE_SHA" "${args[@]}"
+          python3 scripts/release.py workspace-plan > "$RUNNER_TEMP/workspace-plan.json"
+          while IFS=$'\t' read -r package manifest; do
+            if ! git cat-file -e "${BASE_SHA}:${manifest}" 2>/dev/null; then
+              printf 'Skipping %s: package does not exist on the base branch.\n' "$package"
+              continue
+            fi
+            args=(--package "$package" --baseline-rev "$BASE_SHA")
+            if [ "$RELEASE_TYPE" = major ]; then
+              args+=(--release-type major)
+            fi
+            cargo semver-checks check-release "${args[@]}"
+          done < <(jq -r '.packages[] | [.name, .manifest_path] | @tsv' \
+            "$RUNNER_TEMP/workspace-plan.json")
 
-      - name: Check which crates are published on crates.io
-        id: check-published
+      - name: Check every published crate against crates.io
         if: github.event_name == 'push'
         run: |
-          if ! search_output="$(CARGO_TERM_COLOR=never bash scripts/cargo-retry.sh search signal-fish-client --limit 1 2>&1)"; then
-            echo "::error::Could not query crates.io for signal-fish-client."
-            printf '%s\n' "$search_output"
+          python3 scripts/release.py workspace-plan > "$RUNNER_TEMP/workspace-plan.json"
+          while IFS= read -r package; do
+            if ! search_output="$(
+              CARGO_TERM_COLOR=never bash scripts/cargo-retry.sh search "$package" --limit 1 2>&1
+            )"; then
+              printf '::error::Could not query crates.io for %s.\n%s\n' "$package" "$search_output"
+              exit 1
+            fi
+            if printf '%s\n' "$search_output" | grep -qF "${package} ="; then
+              cargo semver-checks check-release --package "$package"
+            else
+              printf 'Skipping %s: no crates.io baseline exists.\n' "$package"
+            fi
+          done < <(jq -r '.packages[].name' "$RUNNER_TEMP/workspace-plan.json")
+
+  required:
+    name: Semver Required
+    if: ${{ always() }}
+    needs: [semver-checks]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Require semantic-version compatibility
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          failures=$(jq -r 'to_entries[] | select(.value.result != "success") | "\(.key)=\(.value.result)"' <<< "$NEEDS_JSON")
+          if [ -n "$failures" ]; then
+            printf '::error::Required jobs did not succeed:\n%s\n' "$failures"
             exit 1
           fi
-
-          if printf '%s\n' "$search_output" | grep -q '^signal-fish-client '; then
-            echo "core=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "core=false" >> "$GITHUB_OUTPUT"
-          fi
-          if ! adapter_search="$(CARGO_TERM_COLOR=never bash scripts/cargo-retry.sh search signal-fish-client-godot --limit 1 2>&1)"; then
-            echo "::error::Could not query crates.io for signal-fish-client-godot."
-            printf '%s\n' "$adapter_search"
-            exit 1
-          fi
-          if printf '%s\n' "$adapter_search" | grep -q '^signal-fish-client-godot '; then
-            echo "adapter=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "adapter=false" >> "$GITHUB_OUTPUT"
-            echo "Adapter not yet published — skipping its first-release baseline"
-          fi
-
-      - name: Check semver compliance (push — against crates.io)
-        if: github.event_name == 'push' && steps.check-published.outputs.core == 'true'
-        run: cargo semver-checks check-release --package signal-fish-client
-
-      - name: Check adapter semver compliance (push — against crates.io)
-        if: github.event_name == 'push' && steps.check-published.outputs.adapter == 'true'
-        run: cargo semver-checks check-release --package signal-fish-client-godot

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -108,7 +108,7 @@ jobs:
               printf '::error::Could not query crates.io for %s.\n%s\n' "$package" "$search_output"
               exit 1
             fi
-            if printf '%s\n' "$search_output" | grep -qF "${package} ="; then
+            if printf '%s\n' "$search_output" | grep -q "^${package} ="; then
               cargo semver-checks check-release --package "$package"
             else
               printf 'Skipping %s: no crates.io baseline exists.\n' "$package"

--- a/.github/workflows/unused-deps.yml
+++ b/.github/workflows/unused-deps.yml
@@ -97,3 +97,20 @@ jobs:
 
       - name: Run cargo udeps
         run: cargo +nightly udeps --all-targets --all-features
+
+  required:
+    name: Unused Deps Required
+    if: ${{ always() }}
+    needs: [cargo-machete]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Require cargo-machete
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          failures=$(jq -r 'to_entries[] | select(.value.result != "success") | "\(.key)=\(.value.result)"' <<< "$NEEDS_JSON")
+          if [ -n "$failures" ]; then
+            printf '::error::Required jobs did not succeed:\n%s\n' "$failures"
+            exit 1
+          fi

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -101,3 +101,20 @@ jobs:
           --no-default-features
           --features transport-websocket-emscripten
           -- -D warnings
+
+  required:
+    name: WASM Required
+    if: ${{ always() }}
+    needs: [wasm, emscripten]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Require every WASM job
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          failures=$(jq -r 'to_entries[] | select(.value.result != "success") | "\(.key)=\(.value.result)"' <<< "$NEEDS_JSON")
+          if [ -n "$failures" ]; then
+            printf '::error::Required jobs did not succeed:\n%s\n' "$failures"
+            exit 1
+          fi

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -1,7 +1,7 @@
 # Workflow lint and hygiene checks for signal-fish-client
 #
-# Runs on every push to main and on all pull requests that touch
-# workflow files, shell scripts, devcontainer config, or this workflow itself.
+# Runs on every push to main and on all pull requests so its stable aggregate
+# gate reports on every protected-branch candidate.
 # Jobs: actionlint — workflow syntax, yamllint — YAML style, shellcheck — shell scripts,
 #        devcontainer-compat — cross-platform devcontainer validation
 #
@@ -12,23 +12,7 @@ name: Workflow Lint
 on:
   push:
     branches: [main]
-    paths:
-      - ".github/workflows/**"
-      - ".github/*.yml"
-      - ".github/*.yaml"
-      - "scripts/*.sh"
-      - ".devcontainer/scripts/*.sh"
-      - ".yamllint.yml"
-      - ".devcontainer/**"
   pull_request:
-    paths:
-      - ".github/workflows/**"
-      - ".github/*.yml"
-      - ".github/*.yaml"
-      - "scripts/*.sh"
-      - ".devcontainer/scripts/*.sh"
-      - ".yamllint.yml"
-      - ".devcontainer/**"
 
 permissions:
   contents: read
@@ -112,3 +96,20 @@ jobs:
 
       - name: Check devcontainer Dockerfile
         run: docker buildx build --check -f .devcontainer/Dockerfile .
+
+  required:
+    name: Workflow Lint Required
+    if: ${{ always() }}
+    needs: [actionlint, yamllint, shellcheck, devcontainer-compat]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Require every workflow lint job
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          failures=$(jq -r 'to_entries[] | select(.value.result != "success") | "\(.key)=\(.value.result)"' <<< "$NEEDS_JSON")
+          if [ -n "$failures" ]; then
+            printf '::error::Required jobs did not succeed:\n%s\n' "$failures"
+            exit 1
+          fi

--- a/.llm/context.md
+++ b/.llm/context.md
@@ -29,8 +29,17 @@ Run this before every commit. All three steps must pass with zero warnings.
 ## Release Automation
 
 Use the manual **Prepare Release** and **Release** workflows. They prepare,
-reproduce, attest, and publish both crates at one version, core first and the
-adapter second; see `skills/release-recovery/SKILL.md` and `docs/releasing.md`.
+reproduce, attest, and publish every crates.io-publishable workspace member at
+the single `[workspace.package].version`. `scripts/release.py workspace-plan`
+discovers members with Cargo metadata and orders internal dependencies; Release
+has no version input and resumes only checksum-identical partial publication.
+Release jobs pin Rust 1.96.1 and Ubuntu 24.04. See
+`skills/release-recovery/SKILL.md` and `docs/releasing.md`.
+
+Every blocking workflow runs on PR and default-branch SHAs and ends in a
+uniquely named aggregate `Required` job. The names and desired rules live in
+`.github/required-checks.json`; the scheduled Repository Policy workflow audits
+GitHub for drift. Path filters must not suppress a configured required gate.
 
 ## GitHub Tool Order
 
@@ -243,7 +252,8 @@ accounted `one_frame_escape_bytes()` empty-buffer exception.
 
 The core manifest must never depend on `godot` or expose godot-rust types.
 `signal-fish-client-godot` depends exactly on the same core version with
-`default-features = false` and `polling-client`, and declares
+an inherited workspace dependency, `default-features = false`, and
+`polling-client`, and declares
 `godot = ">=0.4.5, <0.6"` with no-thread WASM and lazy-function-table support.
 Its minimum 0.4.5 and latest 0.5.4 standalone fixtures must each lock exactly
 one `godot` and one version of every `godot-*` family crate.

--- a/.llm/context.md
+++ b/.llm/context.md
@@ -39,8 +39,10 @@ Release jobs pin Rust 1.96.1 and Ubuntu 24.04. See
 Every blocking workflow runs on PR and default-branch SHAs and ends in a
 uniquely named aggregate `Required` job. The names and desired rules live in
 `.github/required-checks.json`; the scheduled Repository Policy workflow audits
-GitHub for drift with a short-lived release-App token scoped to Administration
-read. Live ruleset audits must never rely on anonymous public API responses.
+GitHub for visible drift with its authenticated built-in `GITHUB_TOKEN`.
+GitHub hides ruleset bypass actors from workflow tokens, so maintainers verify
+an empty bypass list in the ruleset UI. Prepare Release also uses only
+`GITHUB_TOKEN`; maintainers approve the resulting PR workflows before they run.
 Path filters must not suppress a configured required gate.
 
 ## GitHub Tool Order

--- a/.llm/context.md
+++ b/.llm/context.md
@@ -39,7 +39,9 @@ Release jobs pin Rust 1.96.1 and Ubuntu 24.04. See
 Every blocking workflow runs on PR and default-branch SHAs and ends in a
 uniquely named aggregate `Required` job. The names and desired rules live in
 `.github/required-checks.json`; the scheduled Repository Policy workflow audits
-GitHub for drift. Path filters must not suppress a configured required gate.
+GitHub for drift with a short-lived release-App token scoped to Administration
+read. Live ruleset audits must never rely on anonymous public API responses.
+Path filters must not suppress a configured required gate.
 
 ## GitHub Tool Order
 

--- a/.llm/skills/ci-configuration/SKILL.md
+++ b/.llm/skills/ci-configuration/SKILL.md
@@ -39,7 +39,9 @@ verify the exact default-branch SHA rather than only the pre-merge PR head.
 default-branch rules. Keep gate names unique and stable. Update the config, the
 workflow gate, and `required_check_policy` tests together. The scheduled
 Repository Policy workflow detects live GitHub ruleset drift; do not add bypass
-actors to make a failing gate mergeable.
+actors to make a failing gate mergeable. Live ruleset reads must use the
+release App's explicitly scoped Administration-read token; unauthenticated
+public API responses are not an adequate policy audit.
 
 ### lychee: TOML vs CLI syntax
 

--- a/.llm/skills/ci-configuration/SKILL.md
+++ b/.llm/skills/ci-configuration/SKILL.md
@@ -25,6 +25,22 @@ Reference for CI/CD tool configuration, common pitfalls, identifier boundary mat
 
 Use `uses: owner/action@vN` (or `@vN.N.N`) and do not use commit-SHA refs. Only `dtolnay/rust-toolchain` may use channels (`@stable`, `@nightly`, `@beta`); policy is enforced by `scripts/check-workflows.sh` and `tests/ci_config_tests.rs`.
 
+### Required checks need aggregate gates
+
+GitHub can merge a PR when individual matrix jobs are not the stable contexts
+named in branch policy, and a required path-filtered workflow may never report
+a check. Every blocking workflow therefore runs on every PR and default-branch
+push, and ends with a uniquely named aggregate gate. The gate uses
+`if: always()`, declares every blocking job in `needs`, and fails unless every
+dependency result is `success`. Running on the push is necessary so Release can
+verify the exact default-branch SHA rather than only the pre-merge PR head.
+
+`.github/required-checks.json` is the canonical list of gate names and desired
+default-branch rules. Keep gate names unique and stable. Update the config, the
+workflow gate, and `required_check_policy` tests together. The scheduled
+Repository Policy workflow detects live GitHub ruleset drift; do not add bypass
+actors to make a failing gate mergeable.
+
 ### lychee: TOML vs CLI syntax
 
 The lychee link checker has different syntax for TOML config vs CLI flags.

--- a/.llm/skills/ci-configuration/SKILL.md
+++ b/.llm/skills/ci-configuration/SKILL.md
@@ -42,7 +42,9 @@ Repository Policy workflow detects live GitHub ruleset drift; do not add bypass
 actors to make a failing gate mergeable. Live ruleset reads use the workflow's
 authenticated built-in `GITHUB_TOKEN`. GitHub hides bypass actors from workflow
 tokens, so the operator runbook requires manual verification of an empty bypass
-list and the automated policy must not claim it checked that hidden field.
+list and the automated policy must not claim it checked that hidden field. One
+applicable ruleset must satisfy the complete checked-in policy; never combine
+partial guarantees from separate rulesets into a passing audit.
 
 ### Workspace MSRV isolation
 

--- a/.llm/skills/ci-configuration/SKILL.md
+++ b/.llm/skills/ci-configuration/SKILL.md
@@ -39,9 +39,10 @@ verify the exact default-branch SHA rather than only the pre-merge PR head.
 default-branch rules. Keep gate names unique and stable. Update the config, the
 workflow gate, and `required_check_policy` tests together. The scheduled
 Repository Policy workflow detects live GitHub ruleset drift; do not add bypass
-actors to make a failing gate mergeable. Live ruleset reads must use the
-release App's explicitly scoped Administration-read token; unauthenticated
-public API responses are not an adequate policy audit.
+actors to make a failing gate mergeable. Live ruleset reads use the workflow's
+authenticated built-in `GITHUB_TOKEN`. GitHub hides bypass actors from workflow
+tokens, so the operator runbook requires manual verification of an empty bypass
+list and the automated policy must not claim it checked that hidden field.
 
 ### Workspace MSRV isolation
 

--- a/.llm/skills/ci-configuration/SKILL.md
+++ b/.llm/skills/ci-configuration/SKILL.md
@@ -43,6 +43,18 @@ actors to make a failing gate mergeable. Live ruleset reads must use the
 release App's explicitly scoped Administration-read token; unauthenticated
 public API responses are not an adequate policy audit.
 
+### Workspace MSRV isolation
+
+The core MSRV job must test Cargo's actual publishable `.crate` artifact. Do
+not recreate a standalone manifest by truncating or rewriting workspace TOML;
+that diverges from Cargo normalization and breaks inherited fields. Package
+with pinned release Cargo, extract the artifact, compile every packaged test
+target with `--no-run` under the core MSRV, and execute the package-independent
+library tests with `--lib`. Repository-policy tests that require `.github`,
+`.llm`, or sibling crates must stay excluded from `package.include`. Keep
+`isolated_core_msrv_uses_the_publishable_package_artifact` and the package
+exclusion policy test in sync with this workflow.
+
 ### lychee: TOML vs CLI syntax
 
 The lychee link checker has different syntax for TOML config vs CLI flags.

--- a/.llm/skills/crate-publishing/SKILL.md
+++ b/.llm/skills/crate-publishing/SKILL.md
@@ -64,6 +64,9 @@ signal-fish-client = { workspace = true, default-features = false, features = ["
 ```
 
 Never publish mismatched versions or a non-exact adapter-to-core requirement.
+Internal publishable dependencies must inherit with `workspace = true`; an
+inline exact version can look correct in Cargo metadata while becoming stale
+when the workspace version is prepared.
 
 - `keywords`: max 5, lowercase, hyphenated — used for crates.io search
 - `categories`: must be from the official crates.io category list

--- a/.llm/skills/crate-publishing/SKILL.md
+++ b/.llm/skills/crate-publishing/SKILL.md
@@ -13,7 +13,8 @@ publishing of the core and Godot adapter crates.
 ```toml
 [package]
 name = "signal-fish-client"
-version = "0.8.0"
+version.workspace = true
+publish = ["crates-io"]
 edition = "2021"
 rust-version = "1.87.0"          # MSRV — enforced by cargo
 license = "MIT"                   # SPDX identifier
@@ -37,18 +38,29 @@ include = [
 ]
 ```
 
-The adapter manifest uses the same package version, Rust 1.94.0, its own
-docs.rs URL, and an exact core requirement:
+The workspace owns the lockstep version and exact internal requirement:
+
+```toml
+[workspace.package]
+version = "0.8.0"
+
+[workspace.dependencies]
+signal-fish-client = { version = "=0.8.0", path = ".", default-features = false }
+```
+
+The adapter inherits that version and dependency, uses Rust 1.94.0, and has its
+own docs.rs URL:
 
 ```toml
 [package]
 name = "signal-fish-client-godot"
-version = "0.8.0"
+version.workspace = true
+publish = ["crates-io"]
 rust-version = "1.94.0"
 
 [dependencies]
 godot = { version = ">=0.4.5, <0.6", features = ["experimental-wasm", "experimental-wasm-nothreads", "lazy-function-tables"] }
-signal-fish-client = { version = "=0.8.0", default-features = false, features = ["polling-client"] }
+signal-fish-client = { workspace = true, default-features = false, features = ["polling-client"] }
 ```
 
 Never publish mismatched versions or a non-exact adapter-to-core requirement.
@@ -147,79 +159,49 @@ cargo fmt && cargo clippy --workspace --all-targets --all-features -- -D warning
 # 2. Check deny policies
 cargo deny check
 
-# 3. Verify what will be published
-cargo package --list -p signal-fish-client
-cargo package --list -p signal-fish-client-godot
+# 3. Inspect the discovered dependency-first publication plan
+python3 scripts/release.py workspace-plan
 
-# 4. Dry-run core. Adapter dry-run follows core registry visibility.
-cargo publish --dry-run --allow-dirty -p signal-fish-client
+# 4. Package and dry-run all planned crates together (Rust 1.96.1)
+cargo package -p signal-fish-client -p signal-fish-client-godot
+cargo publish --dry-run -p signal-fish-client -p signal-fish-client-godot
 
 # 5. Check docs build cleanly (stable + docs.rs nightly simulation)
 cargo doc --all-features --no-deps
 bash scripts/check-docsrs.sh
 
-# 6. Verify version in Cargo.toml matches tag
-grep '^version' Cargo.toml
+# 6. Verify the derived version and registry recovery plan
+python3 scripts/release.py package-version
 ```
 
-Before publication, reproduce both `.crate` files. Package the adapter with
-`--no-verify`, extract both archives into a temporary consumer, and use
-`[patch.crates-io]` to point its exact core requirement at the extracted core
-package. This verifies packaged contents without depending on an unpublished
-registry version. Publish core first and wait for its exact crates.io checksum;
-only then dry-run and publish the adapter. Attach both crates, checksums, SBOMs,
-and attestations to one tag and GitHub Release.
+Cargo 1.90+ can package and publish multiple interdependent workspace members.
+The workflows pin Rust 1.96.1, derive package arguments from `workspace-plan`,
+and do not carry a special-case local patch for the adapter. Before publication,
+`registry-plan` reproduces every `.crate`, verifies already-published checksums,
+and returns only absent packages in dependency order. Attach every crate,
+checksum, SBOM, and attestation to one tag and GitHub Release.
 
 ## CI Publishing Workflow
 
-Example GitHub Actions workflow (`.github/workflows/publish.yml`):
-
-```yaml
-name: Publish
-
-on:
-  push:
-    tags:
-      - 'v*'
-
-jobs:
-  publish:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: dtolnay/rust-toolchain@stable
-
-      - name: Run tests
-        run: cargo test --workspace --all-features
-
-      - name: Check deny
-        uses: EmbarkStudios/cargo-deny-action@v2
-
-      - name: Publish to crates.io
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo publish
-```
+`.github/workflows/publish.yml` is manual-only, derives its version from the
+workspace, requires the protected `crates-io` environment, and treats the tag
+as an output rather than a trigger. Do not add a version input or tag-push
+publication path.
 
 ## Versioning Workflow
 
 ```shell
-# Bump version (0.1.0 → 0.2.0)
-# 1. Update version in ALL locations (see checklist below)
-# 2. Update CHANGELOG.md (user-visible changes only; exclude internal tooling/test/CI details)
-# 3. Commit: "chore: release 0.2.0"
-# 4. Tag: git tag -s v0.2.0 -m "Release 0.2.0"
-# 5. Push: git push && git push --tags
-# CI then publishes automatically
+# Preview and prepare a lockstep release.
+python3 scripts/release.py prepare minor
+# In normal operations, dispatch Prepare Release instead; it creates the PR.
 ```
 
 ### Version bump checklist
 
 A version bump must update **all** references, not just `Cargo.toml`:
 
-- `Cargo.toml` and `crates/signal-fish-client-godot/Cargo.toml` (`version`)
-- the adapter's exact `signal-fish-client` requirement
+- `Cargo.toml` (`[workspace.package].version` and exact workspace requirements)
+- every publishable member continues to set `version.workspace = true`
 - root and standalone fixture lockfile path-package versions
 - `README.md` (dependency snippet, badge if present)
 - `docs/getting-started.md` (dependency snippets)

--- a/.llm/skills/crate-publishing/SKILL.md
+++ b/.llm/skills/crate-publishing/SKILL.md
@@ -67,6 +67,9 @@ Never publish mismatched versions or a non-exact adapter-to-core requirement.
 Internal publishable dependencies must inherit with `workspace = true`; an
 inline exact version can look correct in Cargo metadata while becoming stale
 when the workspace version is prepared.
+The release plan keeps each workspace dependency key separate from its real
+package name so a renamed entry is bumped by its manifest key and published by
+its crates.io name.
 
 - `keywords`: max 5, lowercase, hyphenated — used for crates.io search
 - `categories`: must be from the official crates.io category list

--- a/.llm/skills/crate-publishing/SKILL.md
+++ b/.llm/skills/crate-publishing/SKILL.md
@@ -73,7 +73,8 @@ its crates.io name.
 
 - `keywords`: max 5, lowercase, hyphenated — used for crates.io search
 - `categories`: must be from the official crates.io category list
-- `include`: excludes `.llm/`, `scripts/`, `.github/`, target from the published package
+- `include`: excludes `.llm/`, `scripts/`, `.github/`, target, and any
+  repository-policy test that reads those paths from the published package
 - `homepage`: project website / user guide (GitHub Pages URL)
 - `documentation`: API reference (docs.rs URL)
 - `.llm/context.md` must list **both** URLs separately so that LLM

--- a/.llm/skills/release-recovery/SKILL.md
+++ b/.llm/skills/release-recovery/SKILL.md
@@ -70,8 +70,9 @@ error; stop and investigate.
 
 ## Repository configuration
 
-The release App needs Contents and Pull requests read/write access. Store its
-client ID in `RELEASE_APP_CLIENT_ID` and PEM key in
+The release App needs Contents and Pull requests read/write access plus
+Administration read access for authenticated ruleset audits. Store its client
+ID in `RELEASE_APP_CLIENT_ID` and PEM key in
 `RELEASE_APP_PRIVATE_KEY`. The prepare preflight diagnoses either missing value.
 
 The protected `crates-io` environment holds `CRATES_IO_TOKEN`. Bootstrap new
@@ -80,5 +81,6 @@ workspace crates with a token limited to `signal-fish-client*` and
 publication.
 
 Default-branch rules must match `.github/required-checks.json`. The weekly
-Repository Policy workflow detects drift. See `docs/releasing.md` for the
-operator runbook.
+Repository Policy workflow detects drift with an App token explicitly scoped to
+Administration read. Never make live audit requests anonymously. See
+`docs/releasing.md` for the operator runbook.

--- a/.llm/skills/release-recovery/SKILL.md
+++ b/.llm/skills/release-recovery/SKILL.md
@@ -64,7 +64,10 @@ artifact.
 `registry-plan` classifies each package as `unpublished` or
 `published-matching`. It rejects a checksum mismatch and rejects any published
 dependent whose internal dependency is absent. A rerun skips matching packages
-and publishes only the dependency-ordered absent set.
+and publishes only the dependency-ordered absent set. When a pending dependent
+has a checksum-matched published dependency, the plan enables `--no-verify`
+only for that resume invocation; the full workspace tests and reproducible
+package build have already passed, and this avoids crates.io sparse-index lag.
 
 An existing tag must target current default-branch HEAD. An existing GitHub
 Release must have that tag. A mismatch is an integrity incident, not a retryable

--- a/.llm/skills/release-recovery/SKILL.md
+++ b/.llm/skills/release-recovery/SKILL.md
@@ -5,82 +5,80 @@ description: Operate and recover the two-stage Signal Fish release process. Use 
 
 # Release Preparation and Recovery
 
-Reference for the two-stage 0.8+ release automation and fail-closed recovery
-for the lockstep core and Godot adapter crates.
+Reference for lockstep, workspace-discovered publication and fail-closed
+recovery.
 
 ## Workflow split
 
-`.github/workflows/prepare-release.yml` is the reversible stage. It runs only
-by manual dispatch from the default branch, accepts a `major`, `minor`, or
-`patch` bump, a deliberate breaking-release marker, and supports a dry run. A
-repository GitHub App creates the
-`release/X.Y.Z` branch and pull request so ordinary CI triggers on the generated
-change.
+`.github/workflows/prepare-release.yml` is reversible. Manual dispatch from the
+default branch accepts a version bump, deliberate breaking marker, and dry-run
+mode. A repository GitHub App creates `release/X.Y.Z` and its pull request so
+all normal PR workflows run.
 
-`.github/workflows/publish.yml` is the irreversible stage. It runs only by
-manual dispatch from the default branch, accepts strict `X.Y.Z`, and uses the
-protected `crates-io` environment. Never add a tag-push trigger: a tag is an
-output of a verified release, not permission to publish.
+`.github/workflows/publish.yml` is irreversible. It is manual-only, has no
+version input, derives the version from the merged workspace, and uses the
+protected `crates-io` environment. A tag is an output, never a publish trigger.
 
-## Preparation invariants
+## Workspace and preparation invariants
 
-Use `python3 scripts/release.py prepare <major|minor|patch>`. The script:
+`[workspace.package].version` is authoritative. Every crates.io-publishable
+member uses `version.workspace = true` and `publish = ["crates-io"]`. Internal
+publishable dependencies inherit an exact `=X.Y.Z` requirement from
+`[workspace.dependencies]`.
 
-- Requires a clean worktree.
-- Calculates the next version without prerelease or build metadata.
-- Updates both package versions, the adapter's exact core requirement,
-  lockfiles, dependency snippets, SDK examples, LLM references, the
-  compatibility marker, and provenance dates.
-- Moves non-empty `[Unreleased]` content into a dated release section and
-  updates compare links.
-- Persists intentional major or pre-1.0 breaking-minor policy so release-time
-  semver checks distinguish it from ordinary minor and patch releases.
-- Fails when an expected reference is absent instead of producing a partial
-  release bump.
+`python3 scripts/release.py workspace-plan` uses `cargo metadata` to discover
+eligible members, reject version or dependency-policy drift, reject cycles and
+dependencies on non-publishable workspace crates, and return a deterministic
+dependency-first plan.
 
-Update `scripts/test_release.py` whenever the version-reference inventory or
-workflow invariants change.
+`python3 scripts/release.py prepare <major|minor|patch>` validates the complete
+inventory before writing, changes the shared version and exact requirements,
+updates locks, documentation, compatibility and provenance markers, and cuts a
+non-empty changelog release. Update `scripts/test_release.py` when a release
+invariant changes.
 
 ## Publishing order
 
 The release workflow must retain this order:
 
-1. Verify strict input, default-branch HEAD, and successful check runs.
-2. Match Cargo and the dated changelog section.
-3. Run formatting, Clippy, tests, semver checks, docs.rs simulation, packaging,
-   and publish dry-run.
-4. Reproduce both `.crate` files, one SHA-256 manifest, and both CycloneDX SBOMs.
-5. Revalidate default-branch HEAD, then validate all existing tag, GitHub
-   Release, and crates.io state.
-6. Create the annotated tag if absent.
-7. Attest both packages; publish core if absent and wait for its checksum.
-8. Dry-run and publish the adapter if absent, then wait for its checksum.
-9. Create the GitHub Release or repair all matching assets.
+1. Verify default-branch HEAD and every check in
+   `.github/required-checks.json`.
+2. Derive the workspace plan and version; validate the dated changelog.
+3. Run formatting, Clippy, tests, per-crate semver checks, and docs.rs checks.
+4. Package every planned crate together with pinned Rust 1.96.1; create each
+   SBOM and the SHA-256 manifest.
+5. Revalidate HEAD, tag, GitHub Release, and exact crates.io checksums.
+6. Require the crates.io token and dry-run only the unpublished plan.
+7. Attest packages, create the tag if absent, and publish pending crates in
+   dependency order.
+8. Wait for and verify every checksum, then create or repair the GitHub Release.
 
-Crates.io versions cannot be overwritten. Never move an existing release tag,
-delete state automatically, or publish before package reproduction and dry-run.
+Never move a tag, overwrite a crate version, delete release state
+automatically, or publish bytes that differ from the locally reproduced
+artifact.
 
 ## Allowed recovery states
 
-A rerun may proceed when an existing tag targets the current default-branch
-SHA and each existing registry package has the exact reproduced checksum. Core
-may already match while the adapter remains unpublished; the rerun resumes at
-adapter dry-run/publication. An existing GitHub Release must have the matching
-tag.
+`registry-plan` classifies each package as `unpublished` or
+`published-matching`. It rejects a checksum mismatch and rejects any published
+dependent whose internal dependency is absent. A rerun skips matching packages
+and publishes only the dependency-ordered absent set.
 
-Any mismatched SHA or checksum is an integrity failure, not a transient CI
-failure. Stop and investigate. Recovery may skip an already-matching publish
-and upload both reproduced crates, checksum manifest, and SBOMs to the matching
-GitHub Release with replacement enabled. A mismatch for either crate stops the
-entire run.
+An existing tag must target current default-branch HEAD. An existing GitHub
+Release must have that tag. A mismatch is an integrity incident, not a retryable
+error; stop and investigate.
 
 ## Repository configuration
 
-The release GitHub App needs only Contents and Pull requests read/write access.
-Store its client ID in `RELEASE_APP_CLIENT_ID` and private key in
-`RELEASE_APP_PRIVATE_KEY`. Store the crate-scoped token as `CRATES_IO_TOKEN` in
-the protected `crates-io` environment, with required reviewers and a default
-branch deployment restriction. The token must be authorized for both packages,
-including first publication of `signal-fish-client-godot`.
+The release App needs Contents and Pull requests read/write access. Store its
+client ID in `RELEASE_APP_CLIENT_ID` and PEM key in
+`RELEASE_APP_PRIVATE_KEY`. The prepare preflight diagnoses either missing value.
 
-See `docs/releasing.md` for the operator-facing runbook.
+The protected `crates-io` environment holds `CRATES_IO_TOKEN`. Bootstrap new
+workspace crates with a token limited to `signal-fish-client*` and
+`publish-new` plus `publish-update`; rotate to `publish-update` after the first
+publication.
+
+Default-branch rules must match `.github/required-checks.json`. The weekly
+Repository Policy workflow detects drift. See `docs/releasing.md` for the
+operator runbook.

--- a/.llm/skills/release-recovery/SKILL.md
+++ b/.llm/skills/release-recovery/SKILL.md
@@ -12,8 +12,9 @@ recovery.
 
 `.github/workflows/prepare-release.yml` is reversible. Manual dispatch from the
 default branch accepts a version bump, deliberate breaking marker, and dry-run
-mode. A repository GitHub App creates `release/X.Y.Z` and its pull request so
-all normal PR workflows run.
+mode. Its built-in `GITHUB_TOKEN` creates `release/X.Y.Z` and its pull request.
+GitHub holds the resulting PR workflows for a maintainer to select **Approve
+workflows to run**; this approval is required before normal checks execute.
 
 `.github/workflows/publish.yml` is irreversible. It is manual-only, has no
 version input, derives the version from the merged workspace, and uses the
@@ -75,10 +76,10 @@ error; stop and investigate.
 
 ## Repository configuration
 
-The release App needs Contents and Pull requests read/write access plus
-Administration read access for authenticated ruleset audits. Store its client
-ID in `RELEASE_APP_CLIENT_ID` and PEM key in
-`RELEASE_APP_PRIVATE_KEY`. The prepare preflight diagnoses either missing value.
+Enable **Allow GitHub Actions to create and approve pull requests** in the
+repository's Actions settings. Prepare Release requests Contents and Pull
+requests write access for its built-in `GITHUB_TOKEN`; no App, personal access
+token, repository variable, or release secret is required.
 
 The protected `crates-io` environment holds `CRATES_IO_TOKEN`. Bootstrap new
 workspace crates with a token limited to `signal-fish-client*` and
@@ -86,6 +87,7 @@ workspace crates with a token limited to `signal-fish-client*` and
 publication.
 
 Default-branch rules must match `.github/required-checks.json`. The weekly
-Repository Policy workflow detects drift with an App token explicitly scoped to
-Administration read. Never make live audit requests anonymously. See
-`docs/releasing.md` for the operator runbook.
+Repository Policy workflow detects visible drift with its authenticated
+`GITHUB_TOKEN`. GitHub does not expose bypass actors to workflow tokens, so
+verify an empty bypass list in the ruleset UI during setup and ownership
+reviews. See `docs/releasing.md` for the operator runbook.

--- a/.llm/skills/release-recovery/SKILL.md
+++ b/.llm/skills/release-recovery/SKILL.md
@@ -29,7 +29,9 @@ publishable dependencies inherit an exact `=X.Y.Z` requirement from
 `python3 scripts/release.py workspace-plan` uses `cargo metadata` to discover
 eligible members, reject version or dependency-policy drift, reject cycles and
 dependencies on non-publishable workspace crates, and return a deterministic
-dependency-first plan.
+dependency-first plan. It also reads each member manifest to require
+`workspace = true`; metadata's resolved exact requirement alone cannot prove
+that preparation will update the member on the next version bump.
 
 `python3 scripts/release.py prepare <major|minor|patch>` validates the complete
 inventory before writing, changes the shared version and exact requirements,

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "signal-fish-client"
-version = "0.8.0"
+version.workspace = true
+publish = ["crates-io"]
 edition = "2021"
 license = "MIT"
 authors = ["Ambiguous Interactive <eli@theambiguous.co>"]
@@ -113,3 +114,9 @@ indexing_slicing = "deny"
 [workspace]
 members = ["crates/signal-fish-client-godot"]
 resolver = "2"
+
+[workspace.package]
+version = "0.8.0"
+
+[workspace.dependencies]
+signal-fish-client = { version = "=0.8.0", path = ".", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ include = [
     "/tests/**",
     "!/tests/ci_config_tests.rs",
     "!/tests/godot_adapter_policy_tests.rs",
+    "!/tests/shared_core_policy_tests.rs",
     "/Cargo.toml",
     "/LICENSE",
     "/README.md",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ include = [
     "/src/**",
     "/examples/**",
     "/tests/**",
+    "!/tests/ci_config_tests.rs",
     "!/tests/godot_adapter_policy_tests.rs",
     "/Cargo.toml",
     "/LICENSE",

--- a/crates/signal-fish-client-godot/Cargo.toml
+++ b/crates/signal-fish-client-godot/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "signal-fish-client-godot"
-version = "0.8.0"
+version.workspace = true
+publish = ["crates-io"]
 edition = "2021"
 license = "MIT"
 authors = ["Ambiguous Interactive <eli@theambiguous.co>"]
@@ -16,7 +17,7 @@ include = ["/src/**", "/Cargo.toml", "/README.md", "/LICENSE"]
 
 [dependencies]
 godot = { version = ">=0.4.5, <0.6", features = ["experimental-wasm", "experimental-wasm-nothreads", "lazy-function-tables"] }
-signal-fish-client = { version = "=0.8.0", path = "../..", default-features = false, features = ["polling-client"] }
+signal-fish-client = { workspace = true, default-features = false, features = ["polling-client"] }
 tracing = "0.1"
 
 [package.metadata.docs.rs]

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -6,16 +6,17 @@ manual, protected, and fail-closed.
 
 ## One-time repository setup
 
-Create and install a GitHub App with repository **Contents: read and write**,
-**Pull requests: read and write**, and **Administration: read** permissions.
-The administration permission lets the scheduled policy audit inspect complete
-ruleset configuration using an authenticated, least-privilege token. Store its client ID as the
-`RELEASE_APP_CLIENT_ID` repository variable and its PEM private key as the
-`RELEASE_APP_PRIVATE_KEY` repository secret. These names and value types are
-exact: the prepare workflow reports a specific setup error before token
-generation when either is absent or malformed. An App token is used because
-events created with `GITHUB_TOKEN` do not reliably start the full PR workflow
-set.
+In **Settings > Actions > General > Workflow permissions**, enable **Allow
+GitHub Actions to create and approve pull requests**. Prepare Release uses only
+the run's built-in `GITHUB_TOKEN`, explicitly scoped to **Contents: write** and
+**Pull requests: write**. It requires no GitHub App, personal access token,
+repository variable, or release secret.
+
+GitHub places workflows triggered by a pull request created with
+`GITHUB_TOKEN` into an approval-required state. After Prepare Release opens the
+pull request, a maintainer with write access must select **Approve workflows to
+run**. This manual approval is the deliberate app-free replacement for an App
+token that could trigger checks automatically.
 
 Configure the protected `crates-io` environment with required reviewers, a
 default-branch deployment restriction, and a `CRATES_IO_TOKEN` secret. For the
@@ -32,10 +33,15 @@ requires:
 - every job named in `.github/required-checks.json`;
 - deletion and non-fast-forward protections.
 
-The weekly **Repository Policy** workflow audits the live rulesets against this
-checked-in policy with a short-lived release-App token. For a local live audit,
-set `GH_TOKEN` to a token with repository Administration read permission, then
-run `python3 scripts/audit-repository-rules.py`. Offline fixture audits with
+The weekly **Repository Policy** workflow audits the live, publicly readable
+ruleset fields against this checked-in policy using its built-in authenticated
+`GITHUB_TOKEN`. GitHub returns `bypass_actors` only to credentials with write
+access to the ruleset, which workflow tokens cannot request. Verify in the
+ruleset UI that **Bypass list** is empty during initial setup and repository
+ownership reviews; the workflow intentionally does not claim to automate that
+hidden check. For a local live audit, set `GH_TOKEN` to an authenticated token
+with repository Metadata read access, then run
+`python3 scripts/audit-repository-rules.py`. Offline fixture audits with
 `--rulesets FILE` do not require a token.
 
 ## Prepare a release
@@ -44,9 +50,10 @@ run `python3 scripts/audit-repository-rules.py`. Offline fixture audits with
 2. Select `major`, `minor`, or `patch`. Enable `breaking` only for an
    intentional major release or pre-1.0 breaking minor release.
 3. Inspect the generated diff and validation output.
-4. Run it again with `dry_run` disabled. The GitHub App creates
+4. Run it again with `dry_run` disabled. The built-in token creates
    `release/X.Y.Z` and opens the preparation pull request.
-5. Merge only after every aggregate required check, review, and thread is
+5. Open the pull request and select **Approve workflows to run**.
+6. Merge only after every aggregate required check, review, and thread is
    green.
 
 The workspace owns one version at `[workspace.package].version`; publishable

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -96,7 +96,9 @@ Matching registry packages are skipped, absent packages are resumed, and an
 existing matching GitHub Release has its assets repaired. A tag mismatch,
 checksum mismatch, impossible dependency state, missing required check, or a
 default-branch move stops the run. Never delete or move release state to make a
-rerun pass.
+rerun pass. If only a dependent remains unpublished, the rerun uses
+`--no-verify` after full workspace verification and exact dependency checksum
+matching so crates.io sparse-index propagation cannot strand recovery.
 
 After success, confirm crates.io and docs.rs show every planned package and
 verify each downloaded crate attestation:

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,80 +1,99 @@
 # Release Operations
 
-Signal Fish Client releases use two manually dispatched workflows. The split
-keeps ordinary version-file changes reviewable before the irreversible
-crates.io publish.
+Signal Fish Client uses separate preparation and publication workflows. The
+preparation stage is reversible and reviewable; the publication stage is
+manual, protected, and fail-closed.
 
 ## One-time repository setup
 
 Create and install a GitHub App with repository **Contents: read and write** and
-**Pull requests: read and write** permissions. Add its client ID as the
-`RELEASE_APP_CLIENT_ID` repository variable and its private key as the
-`RELEASE_APP_PRIVATE_KEY` repository secret. The App token is required because
-branches and pull requests created with the normal workflow token do not
-reliably trigger the repository's full CI policy.
+**Pull requests: read and write** permissions. Store its client ID as the
+`RELEASE_APP_CLIENT_ID` repository variable and its PEM private key as the
+`RELEASE_APP_PRIVATE_KEY` repository secret. These names and value types are
+exact: the prepare workflow reports a specific setup error before token
+generation when either is absent or malformed. An App token is used because
+events created with `GITHUB_TOKEN` do not reliably start the full PR workflow
+set.
 
-Configure the protected `crates-io` environment with required reviewers and a
-`CRATES_IO_TOKEN` secret authorized for both `signal-fish-client` and
-`signal-fish-client-godot`, including first publication of the adapter.
-Restrict the environment to the default branch. Artifact attestations also
-require GitHub Actions and attestations to be enabled in repository settings.
+Configure the protected `crates-io` environment with required reviewers, a
+default-branch deployment restriction, and a `CRATES_IO_TOKEN` secret. For the
+first adapter release, create a crates.io token scoped to the
+`signal-fish-client*` crate pattern with both `publish-new` and
+`publish-update`. After every crate has been published once, rotate it to
+`publish-update` only. Artifact attestations must also be enabled.
+
+Protect the default branch with an active ruleset that has no bypass actors and
+requires:
+
+- pull requests, one approval, stale-review dismissal, and resolved threads;
+- a branch updated with its base before merging;
+- every job named in `.github/required-checks.json`;
+- deletion and non-fast-forward protections.
+
+The weekly **Repository Policy** workflow audits the live rulesets against this
+checked-in policy. Run `python3 scripts/audit-repository-rules.py` for the same
+read-only audit.
 
 ## Prepare a release
 
-1. Run **Prepare Release** from the default branch.
-2. Select `major`, `minor`, or `patch` and leave `dry_run` enabled first. Enable
-   `breaking` only for an intentional major release or pre-1.0 breaking minor
-   release; this persists the stricter semver-checks policy in the changelog.
+1. Run **Prepare Release** from the default branch with `dry_run` enabled.
+2. Select `major`, `minor`, or `patch`. Enable `breaking` only for an
+   intentional major release or pre-1.0 breaking minor release.
 3. Inspect the generated diff and validation output.
-4. Run it again with `dry_run` disabled. The workflow creates
-   `release/X.Y.Z`, updates both package versions, the adapter's exact core
-   requirement, fixture locks, and every provenance marker, cuts the changelog,
-   and opens a pull request.
-5. Review and merge only after all required CI and reviewer feedback is green.
+4. Run it again with `dry_run` disabled. The GitHub App creates
+   `release/X.Y.Z` and opens the preparation pull request.
+5. Merge only after every aggregate required check, review, and thread is
+   green.
 
-Preparation fails if the default branch is not selected, the worktree is not
-clean, a version reference is missing, or `[Unreleased]` has no content. The
-underlying deterministic command is:
+The workspace owns one version at `[workspace.package].version`; publishable
+members set `version.workspace = true`. Preparation discovers crates through
+`cargo metadata`, updates that version and exact internal workspace
+requirements, then updates locks, documentation references, provenance, and
+the changelog. It fails before writing if the workspace graph, inventory, or
+`[Unreleased]` section is invalid.
 
 ```sh
+python3 scripts/release.py workspace-plan
 python3 scripts/release.py prepare minor
 ```
 
 ## Publish a release
 
-Run **Release** from the default branch and enter the strict `X.Y.Z` version
-from the merged preparation pull request. After the protected-environment
-approval, the workflow verifies default-branch HEAD and its checks, package and
-changelog versions, the full Rust suite, docs.rs compatibility, semver policy,
-and the core `cargo publish --dry-run`. The first adapter release has no semver
-baseline; every later release checks both crates.
+Run **Release** from the default branch. It has no version input: the workflow
+derives the strict lockstep version and dependency-first package order from the
+merged workspace. The protected-environment approval is the authorization to
+publish.
 
-The workflow then reproduces both `.crate` files, verifies the packaged adapter
-against the extracted packaged core through `[patch.crates-io]`, creates both
-CycloneDX SBOMs and one checksum manifest, and creates the annotated `vX.Y.Z`
-tag. It attests both packages, publishes core first, waits for its exact
-registry checksum, then dry-runs and publishes the adapter and waits for its
-checksum. One GitHub Release carries both crates and both SBOMs.
+The workflow verifies default-branch HEAD and all configured aggregate checks,
+runs the complete Rust, semver, and docs.rs suites, and uses Cargo's
+multi-package support to package every crates.io-publishable workspace member.
+It creates one `.crate` and CycloneDX SBOM per discovered package plus one
+checksum manifest. The release jobs use pinned Rust 1.96.1 and Ubuntu 24.04 so
+multi-package behavior cannot drift with `stable` or `ubuntu-latest`.
+
+Before mutation, `registry-plan` queries every exact crate version. It publishes
+only absent packages, in dependency order, and verifies every resulting
+registry checksum. One annotated tag, attestation set, and GitHub Release cover
+the whole workspace release.
 
 ## Recovery rules
 
-Re-run **Release** with the same version after a transient failure. Recovery is
-allowed only when every existing artifact agrees with the current
-default-branch commit:
+Re-run **Release** after a transient failure; do not enter or change a version.
+A rerun proceeds only when:
 
-- An existing tag must target the current SHA.
-- Each existing crates.io package must have the exact checksum of its locally
-  reproduced package. A matching core with an unpublished adapter is a valid
-  recovery state; the rerun resumes with the adapter.
-- An existing GitHub Release must have the matching tag.
+- an existing tag targets the current default-branch SHA;
+- every published crate checksum equals the locally reproduced `.crate`;
+- a published dependent never has an unpublished internal dependency;
+- any existing GitHub Release has the matching tag.
 
-The workflow fails closed on any mismatch. It never overwrites a crate version;
-when registry publication already matches, it skips that crate and repairs only
-the GitHub Release assets. If a tag or either registry checksum points
-elsewhere, stop and investigate rather than deleting or moving release state.
+Matching registry packages are skipped, absent packages are resumed, and an
+existing matching GitHub Release has its assets repaired. A tag mismatch,
+checksum mismatch, impossible dependency state, missing required check, or a
+default-branch move stops the run. Never delete or move release state to make a
+rerun pass.
 
-After success, confirm the version and assets on crates.io and GitHub, confirm
-docs.rs built the same version, and verify the package attestation with:
+After success, confirm crates.io and docs.rs show every planned package and
+verify each downloaded crate attestation:
 
 ```sh
 gh attestation verify signal-fish-client-X.Y.Z.crate \

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -6,8 +6,10 @@ manual, protected, and fail-closed.
 
 ## One-time repository setup
 
-Create and install a GitHub App with repository **Contents: read and write** and
-**Pull requests: read and write** permissions. Store its client ID as the
+Create and install a GitHub App with repository **Contents: read and write**,
+**Pull requests: read and write**, and **Administration: read** permissions.
+The administration permission lets the scheduled policy audit inspect complete
+ruleset configuration using an authenticated, least-privilege token. Store its client ID as the
 `RELEASE_APP_CLIENT_ID` repository variable and its PEM private key as the
 `RELEASE_APP_PRIVATE_KEY` repository secret. These names and value types are
 exact: the prepare workflow reports a specific setup error before token
@@ -31,8 +33,10 @@ requires:
 - deletion and non-fast-forward protections.
 
 The weekly **Repository Policy** workflow audits the live rulesets against this
-checked-in policy. Run `python3 scripts/audit-repository-rules.py` for the same
-read-only audit.
+checked-in policy with a short-lived release-App token. For a local live audit,
+set `GH_TOKEN` to a token with repository Administration read permission, then
+run `python3 scripts/audit-repository-rules.py`. Offline fixture audits with
+`--rulesets FILE` do not require a token.
 
 ## Prepare a release
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -53,9 +53,10 @@ The workspace owns one version at `[workspace.package].version`; publishable
 members set `version.workspace = true`. Preparation discovers crates through
 `cargo metadata`, verifies internal publishable dependencies inherit through
 `workspace = true`, updates the shared version and exact workspace
-requirements, then updates locks, documentation references, provenance, and
-the changelog. It fails before writing if the workspace graph, inventory, or
-`[Unreleased]` section is invalid.
+requirements by manifest key (including renamed dependencies), then updates
+locks, documentation references, provenance, and the changelog. It fails
+before writing if the workspace graph, inventory, or `[Unreleased]` section is
+invalid.
 
 ```sh
 python3 scripts/release.py workspace-plan

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -51,7 +51,8 @@ run `python3 scripts/audit-repository-rules.py`. Offline fixture audits with
 
 The workspace owns one version at `[workspace.package].version`; publishable
 members set `version.workspace = true`. Preparation discovers crates through
-`cargo metadata`, updates that version and exact internal workspace
+`cargo metadata`, verifies internal publishable dependencies inherit through
+`workspace = true`, updates the shared version and exact workspace
 requirements, then updates locks, documentation references, provenance, and
 the changelog. It fails before writing if the workspace graph, inventory, or
 `[Unreleased]` section is invalid.

--- a/scripts/audit-repository-rules.py
+++ b/scripts/audit-repository-rules.py
@@ -62,7 +62,7 @@ def audit(policy: dict[str, Any], rulesets: list[dict[str, Any]]) -> list[str]:
     if any(
         not isinstance(check, dict)
         or not isinstance(check.get("job"), str)
-        or not check["job"]
+        or not check["job"].strip()
         for check in configured_checks
     ):
         raise ValueError("every required check must define a non-empty job name")

--- a/scripts/audit-repository-rules.py
+++ b/scripts/audit-repository-rules.py
@@ -49,47 +49,11 @@ def fetch_rulesets(repository: str, token: str) -> list[dict[str, Any]]:
     return [fetch_json(f"{base}/{summary['id']}", token) for summary in summaries]
 
 
-def audit(policy: dict[str, Any], rulesets: list[dict[str, Any]]) -> list[str]:
-    expected = policy.get("repository_rules")
-    if not isinstance(expected, dict):
-        raise ValueError("policy has no repository_rules object")
-    expected_refs = set(expected.get("include", []))
-    if not expected_refs:
-        raise ValueError("repository_rules.include must not be empty")
-    configured_checks = policy.get("required_checks")
-    if not isinstance(configured_checks, list) or not configured_checks:
-        raise ValueError("policy must define a non-empty required_checks list")
-    if any(
-        not isinstance(check, dict)
-        or not isinstance(check.get("job"), str)
-        or not check["job"].strip()
-        for check in configured_checks
-    ):
-        raise ValueError("every required check must define a non-empty job name")
-    required_checks = {check["job"] for check in configured_checks}
-    if len(required_checks) != len(configured_checks):
-        raise ValueError("required check job names must be unique")
-    applicable = [
-        ruleset
-        for ruleset in rulesets
-        if ruleset.get("enforcement") == expected.get("enforcement")
-        and expected_refs.issubset(
-            ruleset.get("conditions", {}).get("ref_name", {}).get("include", [])
-        )
-    ]
+def audit_ruleset(
+    expected: dict[str, Any], required_checks: set[str], ruleset: dict[str, Any]
+) -> list[str]:
     failures: list[str] = []
-    if not applicable:
-        return ["no active ruleset targets ~DEFAULT_BRANCH"]
-
-    if expected.get("forbid_bypass_actors"):
-        if any("bypass_actors" not in ruleset for ruleset in applicable):
-            failures.append(
-                "could not verify bypass actors because GitHub omitted that protected field"
-            )
-        elif any(ruleset.get("bypass_actors") for ruleset in applicable):
-            failures.append("default-branch rulesets must not define bypass actors")
-
-    rules = [rule for ruleset in applicable for rule in ruleset.get("rules", [])]
+    rules = ruleset.get("rules", [])
     rule_types = {rule.get("type") for rule in rules}
     for rule_type in ("deletion", "non_fast_forward"):
         if rule_type not in rule_types:
@@ -136,6 +100,62 @@ def audit(policy: dict[str, Any], rulesets: list[dict[str, Any]]) -> list[str]:
         if strict is not expected.get("strict_required_status_checks_policy"):
             failures.append("required status checks must require an up-to-date branch")
     return failures
+
+
+def audit(policy: dict[str, Any], rulesets: list[dict[str, Any]]) -> list[str]:
+    expected = policy.get("repository_rules")
+    if not isinstance(expected, dict):
+        raise ValueError("policy has no repository_rules object")
+    supported_keys = {
+        "enforcement",
+        "include",
+        "required_approving_review_count",
+        "dismiss_stale_reviews_on_push",
+        "required_review_thread_resolution",
+        "strict_required_status_checks_policy",
+    }
+    unsupported_keys = sorted(set(expected) - supported_keys)
+    if unsupported_keys:
+        raise ValueError(
+            "unsupported repository_rules keys: " + ", ".join(unsupported_keys)
+        )
+    expected_refs = set(expected.get("include", []))
+    if not expected_refs:
+        raise ValueError("repository_rules.include must not be empty")
+    configured_checks = policy.get("required_checks")
+    if not isinstance(configured_checks, list) or not configured_checks:
+        raise ValueError("policy must define a non-empty required_checks list")
+    if any(
+        not isinstance(check, dict)
+        or not isinstance(check.get("job"), str)
+        or not check["job"].strip()
+        for check in configured_checks
+    ):
+        raise ValueError("every required check must define a non-empty job name")
+    required_checks = {check["job"] for check in configured_checks}
+    if len(required_checks) != len(configured_checks):
+        raise ValueError("required check job names must be unique")
+    applicable = [
+        ruleset
+        for ruleset in rulesets
+        if ruleset.get("enforcement") == expected.get("enforcement")
+        and expected_refs.issubset(
+            ruleset.get("conditions", {}).get("ref_name", {}).get("include", [])
+        )
+    ]
+    if not applicable:
+        return ["no active ruleset targets ~DEFAULT_BRANCH"]
+
+    candidate_failures = [
+        audit_ruleset(expected, required_checks, ruleset) for ruleset in applicable
+    ]
+    if any(not failures for failures in candidate_failures):
+        return []
+    closest = min(candidate_failures, key=len)
+    return [
+        "no single default-branch ruleset satisfies the complete checked-in policy",
+        *closest,
+    ]
 
 
 def main() -> int:

--- a/scripts/audit-repository-rules.py
+++ b/scripts/audit-repository-rules.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 import urllib.request
 from pathlib import Path
@@ -18,25 +19,34 @@ def load_json(path: Path) -> Any:
         return json.load(stream)
 
 
-def fetch_json(url: str) -> Any:
-    request = urllib.request.Request(
+def api_request(url: str, token: str) -> urllib.request.Request:
+    if not token:
+        raise ValueError(
+            "an authenticated GitHub token is required for live ruleset audits"
+        )
+    return urllib.request.Request(
         url,
         headers={
             "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
             "User-Agent": "signal-fish-client-repository-policy-audit",
             "X-GitHub-Api-Version": API_VERSION,
         },
     )
+
+
+def fetch_json(url: str, token: str) -> Any:
+    request = api_request(url, token)
     with urllib.request.urlopen(request, timeout=30) as response:
         return json.load(response)
 
 
-def fetch_rulesets(repository: str) -> list[dict[str, Any]]:
+def fetch_rulesets(repository: str, token: str) -> list[dict[str, Any]]:
     base = f"https://api.github.com/repos/{repository}/rulesets"
-    summaries = fetch_json(base)
+    summaries = fetch_json(f"{base}?per_page=100", token)
     if not isinstance(summaries, list):
         raise ValueError("GitHub rulesets response was not a list")
-    return [fetch_json(f"{base}/{summary['id']}") for summary in summaries]
+    return [fetch_json(f"{base}/{summary['id']}", token) for summary in summaries]
 
 
 def audit(policy: dict[str, Any], rulesets: list[dict[str, Any]]) -> list[str]:
@@ -47,7 +57,9 @@ def audit(policy: dict[str, Any], rulesets: list[dict[str, Any]]) -> list[str]:
     if not expected_refs:
         raise ValueError("repository_rules.include must not be empty")
     required_checks = {
-        check["job"] for check in policy.get("required_checks", []) if isinstance(check, dict)
+        check["job"]
+        for check in policy.get("required_checks", [])
+        if isinstance(check, dict)
     }
     applicable = [
         ruleset
@@ -76,7 +88,10 @@ def audit(policy: dict[str, Any], rulesets: list[dict[str, Any]]) -> list[str]:
     if not pull_requests:
         failures.append("missing pull_request rule")
     else:
-        for key in ("dismiss_stale_reviews_on_push", "required_review_thread_resolution"):
+        for key in (
+            "dismiss_stale_reviews_on_push",
+            "required_review_thread_resolution",
+        ):
             actual = any(rule.get("parameters", {}).get(key) for rule in pull_requests)
             if actual is not expected.get(key):
                 failures.append(f"pull_request.{key} must be {expected.get(key)}")
@@ -89,7 +104,9 @@ def audit(policy: dict[str, Any], rulesets: list[dict[str, Any]]) -> list[str]:
                 "pull_request.required_approving_review_count is below the checked-in policy"
             )
 
-    status_rules = [rule for rule in rules if rule.get("type") == "required_status_checks"]
+    status_rules = [
+        rule for rule in rules if rule.get("type") == "required_status_checks"
+    ]
     if not status_rules:
         failures.append("missing required_status_checks rule")
     else:
@@ -112,13 +129,22 @@ def audit(policy: dict[str, Any], rulesets: list[dict[str, Any]]) -> list[str]:
 
 def main() -> int:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--policy", type=Path, default=Path(".github/required-checks.json"))
-    parser.add_argument("--repository", default="Ambiguous-Interactive/signal-fish-client-rust")
+    parser.add_argument(
+        "--policy", type=Path, default=Path(".github/required-checks.json")
+    )
+    parser.add_argument(
+        "--repository", default="Ambiguous-Interactive/signal-fish-client-rust"
+    )
     parser.add_argument("--rulesets", type=Path)
     args = parser.parse_args()
     try:
         policy = load_json(args.policy)
-        rulesets = load_json(args.rulesets) if args.rulesets else fetch_rulesets(args.repository)
+        token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN") or ""
+        rulesets = (
+            load_json(args.rulesets)
+            if args.rulesets
+            else fetch_rulesets(args.repository, token)
+        )
         if not isinstance(policy, dict) or not isinstance(rulesets, list):
             raise ValueError("policy must be an object and rulesets must be a list")
         failures = audit(policy, rulesets)

--- a/scripts/audit-repository-rules.py
+++ b/scripts/audit-repository-rules.py
@@ -81,10 +81,13 @@ def audit(policy: dict[str, Any], rulesets: list[dict[str, Any]]) -> list[str]:
     if not applicable:
         return ["no active ruleset targets ~DEFAULT_BRANCH"]
 
-    if expected.get("forbid_bypass_actors") and any(
-        ruleset.get("bypass_actors") for ruleset in applicable
-    ):
-        failures.append("default-branch rulesets must not define bypass actors")
+    if expected.get("forbid_bypass_actors"):
+        if any("bypass_actors" not in ruleset for ruleset in applicable):
+            failures.append(
+                "could not verify bypass actors because GitHub omitted that protected field"
+            )
+        elif any(ruleset.get("bypass_actors") for ruleset in applicable):
+            failures.append("default-branch rulesets must not define bypass actors")
 
     rules = [rule for ruleset in applicable for rule in ruleset.get("rules", [])]
     rule_types = {rule.get("type") for rule in rules}

--- a/scripts/audit-repository-rules.py
+++ b/scripts/audit-repository-rules.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Audit GitHub default-branch rulesets against the checked-in release policy."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+API_VERSION = "2022-11-28"
+
+
+def load_json(path: Path) -> Any:
+    with path.open(encoding="utf-8") as stream:
+        return json.load(stream)
+
+
+def fetch_json(url: str) -> Any:
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "signal-fish-client-repository-policy-audit",
+            "X-GitHub-Api-Version": API_VERSION,
+        },
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:
+        return json.load(response)
+
+
+def fetch_rulesets(repository: str) -> list[dict[str, Any]]:
+    base = f"https://api.github.com/repos/{repository}/rulesets"
+    summaries = fetch_json(base)
+    if not isinstance(summaries, list):
+        raise ValueError("GitHub rulesets response was not a list")
+    return [fetch_json(f"{base}/{summary['id']}") for summary in summaries]
+
+
+def audit(policy: dict[str, Any], rulesets: list[dict[str, Any]]) -> list[str]:
+    expected = policy.get("repository_rules")
+    if not isinstance(expected, dict):
+        raise ValueError("policy has no repository_rules object")
+    expected_refs = set(expected.get("include", []))
+    if not expected_refs:
+        raise ValueError("repository_rules.include must not be empty")
+    required_checks = {
+        check["job"] for check in policy.get("required_checks", []) if isinstance(check, dict)
+    }
+    applicable = [
+        ruleset
+        for ruleset in rulesets
+        if ruleset.get("enforcement") == expected.get("enforcement")
+        and expected_refs.issubset(
+            ruleset.get("conditions", {}).get("ref_name", {}).get("include", [])
+        )
+    ]
+    failures: list[str] = []
+    if not applicable:
+        return ["no active ruleset targets ~DEFAULT_BRANCH"]
+
+    if expected.get("forbid_bypass_actors") and any(
+        ruleset.get("bypass_actors") for ruleset in applicable
+    ):
+        failures.append("default-branch rulesets must not define bypass actors")
+
+    rules = [rule for ruleset in applicable for rule in ruleset.get("rules", [])]
+    rule_types = {rule.get("type") for rule in rules}
+    for rule_type in ("deletion", "non_fast_forward"):
+        if rule_type not in rule_types:
+            failures.append(f"missing {rule_type} rule")
+
+    pull_requests = [rule for rule in rules if rule.get("type") == "pull_request"]
+    if not pull_requests:
+        failures.append("missing pull_request rule")
+    else:
+        for key in ("dismiss_stale_reviews_on_push", "required_review_thread_resolution"):
+            actual = any(rule.get("parameters", {}).get(key) for rule in pull_requests)
+            if actual is not expected.get(key):
+                failures.append(f"pull_request.{key} must be {expected.get(key)}")
+        approvals = max(
+            rule.get("parameters", {}).get("required_approving_review_count", 0)
+            for rule in pull_requests
+        )
+        if approvals < expected.get("required_approving_review_count", 0):
+            failures.append(
+                "pull_request.required_approving_review_count is below the checked-in policy"
+            )
+
+    status_rules = [rule for rule in rules if rule.get("type") == "required_status_checks"]
+    if not status_rules:
+        failures.append("missing required_status_checks rule")
+    else:
+        actual_checks = {
+            check.get("context")
+            for rule in status_rules
+            for check in rule.get("parameters", {}).get("required_status_checks", [])
+        }
+        missing = sorted(required_checks - actual_checks)
+        if missing:
+            failures.append("missing required status checks: " + ", ".join(missing))
+        strict = any(
+            rule.get("parameters", {}).get("strict_required_status_checks_policy")
+            for rule in status_rules
+        )
+        if strict is not expected.get("strict_required_status_checks_policy"):
+            failures.append("required status checks must require an up-to-date branch")
+    return failures
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--policy", type=Path, default=Path(".github/required-checks.json"))
+    parser.add_argument("--repository", default="Ambiguous-Interactive/signal-fish-client-rust")
+    parser.add_argument("--rulesets", type=Path)
+    args = parser.parse_args()
+    try:
+        policy = load_json(args.policy)
+        rulesets = load_json(args.rulesets) if args.rulesets else fetch_rulesets(args.repository)
+        if not isinstance(policy, dict) or not isinstance(rulesets, list):
+            raise ValueError("policy must be an object and rulesets must be a list")
+        failures = audit(policy, rulesets)
+    except (OSError, ValueError, KeyError, json.JSONDecodeError) as error:
+        print(f"repository-policy error: {error}", file=sys.stderr)
+        return 1
+    if failures:
+        print("Repository rules do not match the checked-in policy:", file=sys.stderr)
+        for failure in failures:
+            print(f"- {failure}", file=sys.stderr)
+        return 1
+    print("Repository rules match the checked-in policy.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audit-repository-rules.py
+++ b/scripts/audit-repository-rules.py
@@ -56,11 +56,19 @@ def audit(policy: dict[str, Any], rulesets: list[dict[str, Any]]) -> list[str]:
     expected_refs = set(expected.get("include", []))
     if not expected_refs:
         raise ValueError("repository_rules.include must not be empty")
-    required_checks = {
-        check["job"]
-        for check in policy.get("required_checks", [])
-        if isinstance(check, dict)
-    }
+    configured_checks = policy.get("required_checks")
+    if not isinstance(configured_checks, list) or not configured_checks:
+        raise ValueError("policy must define a non-empty required_checks list")
+    if any(
+        not isinstance(check, dict)
+        or not isinstance(check.get("job"), str)
+        or not check["job"]
+        for check in configured_checks
+    ):
+        raise ValueError("every required check must define a non-empty job name")
+    required_checks = {check["job"] for check in configured_checks}
+    if len(required_checks) != len(configured_checks):
+        raise ValueError("required check job names must be unique")
     applicable = [
         ruleset
         for ruleset in rulesets

--- a/scripts/check-required-checks.py
+++ b/scripts/check-required-checks.py
@@ -29,10 +29,13 @@ def required_jobs(policy: dict[str, Any]) -> list[str]:
     return jobs
 
 
-def check_results(policy: dict[str, Any], payload: dict[str, Any]) -> list[str]:
-    runs = payload.get("check_runs")
-    if not isinstance(runs, list):
-        raise ValueError("check-runs payload must define check_runs")
+def check_results(policy: dict[str, Any], payload: Any) -> list[str]:
+    pages = payload if isinstance(payload, list) else [payload]
+    runs: list[Any] = []
+    for page in pages:
+        if not isinstance(page, dict) or not isinstance(page.get("check_runs"), list):
+            raise ValueError("check-runs payload must define check_runs on every page")
+        runs.extend(page["check_runs"])
     latest: dict[str, dict[str, Any]] = {}
     for run in runs:
         if not isinstance(run, dict) or not isinstance(run.get("name"), str):

--- a/scripts/check-required-checks.py
+++ b/scripts/check-required-checks.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Fail unless every configured aggregate check completed successfully."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def load_json(path: Path) -> Any:
+    with path.open(encoding="utf-8") as stream:
+        return json.load(stream)
+
+
+def required_jobs(policy: dict[str, Any]) -> list[str]:
+    checks = policy.get("required_checks")
+    if not isinstance(checks, list) or not checks:
+        raise ValueError("policy must define a non-empty required_checks list")
+    jobs: list[str] = []
+    for check in checks:
+        if not isinstance(check, dict) or not isinstance(check.get("job"), str):
+            raise ValueError("every required check must define a job name")
+        jobs.append(check["job"])
+    if len(jobs) != len(set(jobs)):
+        raise ValueError("required check job names must be unique")
+    return jobs
+
+
+def check_results(policy: dict[str, Any], payload: dict[str, Any]) -> list[str]:
+    runs = payload.get("check_runs")
+    if not isinstance(runs, list):
+        raise ValueError("check-runs payload must define check_runs")
+    latest: dict[str, dict[str, Any]] = {}
+    for run in runs:
+        if not isinstance(run, dict) or not isinstance(run.get("name"), str):
+            continue
+        current = latest.get(run["name"])
+        if current is None or int(run.get("id", 0)) > int(current.get("id", 0)):
+            latest[run["name"]] = run
+
+    failures = []
+    for job in required_jobs(policy):
+        run = latest.get(job)
+        if run is None:
+            failures.append(f"{job}: missing")
+        elif run.get("status") != "completed" or run.get("conclusion") != "success":
+            failures.append(
+                f"{job}: status={run.get('status', 'missing')}, "
+                f"conclusion={run.get('conclusion', 'missing')}"
+            )
+    return failures
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--check-runs", type=Path, required=True)
+    parser.add_argument("--policy", type=Path, required=True)
+    args = parser.parse_args()
+    try:
+        failures = check_results(load_json(args.policy), load_json(args.check_runs))
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        print(f"required-check error: {error}", file=sys.stderr)
+        return 1
+    if failures:
+        print("Required checks are not all successful:", file=sys.stderr)
+        for failure in failures:
+            print(f"- {failure}", file=sys.stderr)
+        return 1
+    print("All configured required checks completed successfully.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check-required-checks.py
+++ b/scripts/check-required-checks.py
@@ -21,8 +21,12 @@ def required_jobs(policy: dict[str, Any]) -> list[str]:
         raise ValueError("policy must define a non-empty required_checks list")
     jobs: list[str] = []
     for check in checks:
-        if not isinstance(check, dict) or not isinstance(check.get("job"), str):
-            raise ValueError("every required check must define a job name")
+        if (
+            not isinstance(check, dict)
+            or not isinstance(check.get("job"), str)
+            or not check["job"].strip()
+        ):
+            raise ValueError("every required check must define a non-empty job name")
         jobs.append(check["job"])
     if len(jobs) != len(set(jobs)):
         raise ValueError("required check job names must be unique")

--- a/scripts/pre-commit-llm.py
+++ b/scripts/pre-commit-llm.py
@@ -3,7 +3,7 @@
 Pre-commit hook for .llm/ folder enforcement.
 
 Checks include:
-- Sync selected crate-version references to Cargo.toml package version.
+- Sync selected crate-version references to Cargo.toml workspace package version.
 - Enforce .llm markdown line limits.
 - Validate folder-based Agent Skills metadata and naming.
 - Auto-generate .llm/skills/index.md from SKILL.md metadata and headings.
@@ -150,7 +150,7 @@ def validate_github_tool_order(repo_root: Path = REPO_ROOT) -> List[str]:
 
 
 def read_cargo_package_version() -> str:
-    """Read `[package].version` from Cargo.toml."""
+    """Read `[workspace.package].version` from Cargo.toml."""
     cargo_toml = REPO_ROOT / "Cargo.toml"
     try:
         content = cargo_toml.read_text(encoding="utf-8")
@@ -162,7 +162,7 @@ def read_cargo_package_version() -> str:
         stripped = line.strip()
 
         if stripped.startswith("[") and stripped.endswith("]"):
-            in_package_section = stripped == "[package]"
+            in_package_section = stripped == "[workspace.package]"
             continue
 
         if not in_package_section:
@@ -172,7 +172,7 @@ def read_cargo_package_version() -> str:
         if match:
             return match.group(1)
 
-    raise RuntimeError("Cargo.toml [package].version is missing or invalid.")
+    raise RuntimeError("Cargo.toml [workspace.package].version is missing or invalid.")
 
 
 def sync_crate_version_references(crate_version: str) -> Tuple[List[str], List[Path]]:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -10,13 +10,14 @@ import json
 import re
 import subprocess
 import sys
+import tomllib
 import urllib.error
 import urllib.request
 from pathlib import Path
+from typing import Any, Callable
 
 SEMVER_RE = re.compile(r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$")
 CORE_MANIFEST = "Cargo.toml"
-ADAPTER_MANIFEST = "crates/signal-fish-client-godot/Cargo.toml"
 LOCKSTEP_LOCKFILES = (
     "tests/godot-compat-min/Cargo.lock",
     "tests/godot-web-smoke/Cargo.lock",
@@ -75,35 +76,42 @@ def release_type(base: str, target: str) -> str:
     return "patch"
 
 
-def manifest_package_version(path: Path) -> str:
-    cargo = path.read_text(encoding="utf-8")
-    package = re.search(
-        r"^\[package\][ \t]*$\n(.*?)(?=^\[|\Z)",
-        cargo,
-        re.MULTILINE | re.DOTALL,
-    )
-    if package is None:
-        raise ReleaseError(f"{path} has no [package] section")
-    match = re.search(r'^version = "([^"]+)"$', package.group(1), re.MULTILINE)
-    if match is None:
-        raise ReleaseError(f"{path} has no package version")
-    parse_version(match.group(1))
-    return match.group(1)
+def read_toml(path: Path) -> dict[str, Any]:
+    with path.open("rb") as stream:
+        return tomllib.load(stream)
+
+
+def workspace_version(root: Path) -> str:
+    value = read_toml(root / CORE_MANIFEST).get("workspace", {}).get("package", {}).get("version")
+    if not isinstance(value, str):
+        raise ReleaseError("Cargo.toml has no [workspace.package] version")
+    parse_version(value)
+    return value
+
+
+def manifest_package_version(path: Path, inherited_version: str | None = None) -> str:
+    value = read_toml(path).get("package", {}).get("version")
+    if isinstance(value, str):
+        parse_version(value)
+        return value
+    if value == {"workspace": True} and inherited_version is not None:
+        return inherited_version
+    raise ReleaseError(f"{path} must inherit its package version from the workspace")
 
 
 def package_version(root: Path) -> str:
-    return manifest_package_version(root / CORE_MANIFEST)
+    return workspace_version(root)
 
 
-def replace_package_version(path: Path, old: str, new: str) -> None:
+def replace_workspace_version(path: Path, old: str, new: str) -> None:
     cargo = path.read_text(encoding="utf-8")
     package = re.search(
-        r"^\[package\][ \t]*$\n(.*?)(?=^\[|\Z)",
+        r"^\[workspace\.package\][ \t]*$\n(.*?)(?=^\[|\Z)",
         cargo,
         re.MULTILINE | re.DOTALL,
     )
     if package is None:
-        raise ReleaseError("Cargo.toml has no [package] section")
+        raise ReleaseError("Cargo.toml has no [workspace.package] section")
     updated, count = re.subn(
         rf'^version = "{re.escape(old)}"$',
         f'version = "{new}"',
@@ -112,26 +120,42 @@ def replace_package_version(path: Path, old: str, new: str) -> None:
         flags=re.MULTILINE,
     )
     if count != 1:
-        raise ReleaseError(f"Cargo.toml [package] does not contain version {old!r}")
+        raise ReleaseError(f"Cargo.toml [workspace.package] does not contain version {old!r}")
     path.write_text(cargo[: package.start(1)] + updated + cargo[package.end(1) :], encoding="utf-8")
 
 
-def replace_adapter_core_requirement(path: Path, old: str, new: str) -> None:
+def replace_workspace_requirements(path: Path, package_names: list[str], old: str, new: str) -> None:
     cargo = path.read_text(encoding="utf-8")
-    pattern = re.compile(
-        rf'^(signal-fish-client\s*=\s*\{{[^\n]*version\s*=\s*")='
-        rf'{re.escape(old)}("[^\n]*\}})$',
-        re.MULTILINE,
+    workspace_dependencies = re.search(
+        r"^\[workspace\.dependencies\][ \t]*$\n(.*?)(?=^\[|\Z)",
+        cargo,
+        re.MULTILINE | re.DOTALL,
     )
-    updated, count = pattern.subn(rf"\g<1>={new}\2", cargo, count=1)
-    if count != 1:
-        raise ReleaseError(f"{path} has no exact core requirement ={old}")
-    path.write_text(updated, encoding="utf-8")
+    if workspace_dependencies is None:
+        raise ReleaseError("Cargo.toml has no [workspace.dependencies] section")
+    updated = workspace_dependencies.group(1)
+    for name in package_names:
+        pattern = re.compile(
+            rf'^({re.escape(name)}\s*=\s*\{{[^\n]*version\s*=\s*")='
+            rf'{re.escape(old)}("[^\n]*\}})$',
+            re.MULTILINE,
+        )
+        updated, count = pattern.subn(rf"\g<1>={new}\2", updated, count=1)
+        if count != 1:
+            raise ReleaseError(f"Cargo.toml has no exact workspace requirement for {name} ={old}")
+    path.write_text(
+        cargo[: workspace_dependencies.start(1)]
+        + updated
+        + cargo[workspace_dependencies.end(1) :],
+        encoding="utf-8",
+    )
 
 
-def replace_lockstep_package_versions(path: Path, old: str, new: str) -> None:
+def replace_lockstep_package_versions(
+    path: Path, package_names: list[str], old: str, new: str
+) -> None:
     lock = path.read_text(encoding="utf-8")
-    for package in ("signal-fish-client", "signal-fish-client-godot"):
+    for package in package_names:
         pattern = re.compile(
             rf'(^\[\[package\]\]\nname = "{re.escape(package)}"\nversion = ")'
             rf'{re.escape(old)}("$)',
@@ -224,6 +248,166 @@ def require_clean(root: Path) -> None:
         raise ReleaseError("worktree must be clean before release preparation")
 
 
+def cargo_metadata(root: Path) -> dict[str, Any]:
+    result = subprocess.run(
+        ["cargo", "metadata", "--no-deps", "--format-version", "1"],
+        cwd=root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    value = json.loads(result.stdout)
+    if not isinstance(value, dict):
+        raise ReleaseError("cargo metadata did not return an object")
+    return value
+
+
+def workspace_plan(root: Path, metadata: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Discover publishable crates and order them dependency-first."""
+    root = root.resolve()
+    metadata = cargo_metadata(root) if metadata is None else metadata
+    members = set(metadata.get("workspace_members", []))
+    raw_packages = metadata.get("packages")
+    if not isinstance(raw_packages, list):
+        raise ReleaseError("cargo metadata has no package list")
+
+    workspace_packages: dict[str, dict[str, Any]] = {}
+    publishable: dict[str, dict[str, Any]] = {}
+    expected_version = workspace_version(root)
+    for package in raw_packages:
+        if not isinstance(package, dict) or package.get("id") not in members:
+            continue
+        name = package.get("name")
+        manifest_value = package.get("manifest_path")
+        if not isinstance(name, str) or not isinstance(manifest_value, str):
+            raise ReleaseError("cargo metadata returned an invalid workspace package")
+        if name in workspace_packages:
+            raise ReleaseError(f"duplicate workspace package name {name}")
+        workspace_packages[name] = package
+        publish = package.get("publish")
+        if publish is not None and (
+            not isinstance(publish, list) or "crates-io" not in publish
+        ):
+            continue
+        if package.get("version") != expected_version:
+            raise ReleaseError(
+                f"publishable package {name} must use workspace version {expected_version}"
+            )
+        manifest = Path(manifest_value).resolve()
+        try:
+            manifest.relative_to(root)
+        except ValueError as error:
+            raise ReleaseError(f"workspace package {name} is outside the workspace") from error
+        if read_toml(manifest).get("package", {}).get("version") != {"workspace": True}:
+            raise ReleaseError(f"publishable package {name} must set version.workspace = true")
+        publishable[name] = package
+
+    if not publishable:
+        raise ReleaseError("workspace has no crates publishable to crates.io")
+
+    dependencies: dict[str, set[str]] = {name: set() for name in publishable}
+    for name, package in publishable.items():
+        raw_dependencies = package.get("dependencies", [])
+        if not isinstance(raw_dependencies, list):
+            raise ReleaseError(f"cargo metadata returned invalid dependencies for {name}")
+        for dependency in raw_dependencies:
+            if not isinstance(dependency, dict) or dependency.get("kind") == "dev":
+                continue
+            dependency_name = dependency.get("name")
+            if dependency.get("source") is not None or dependency_name not in workspace_packages:
+                continue
+            if dependency_name not in publishable:
+                raise ReleaseError(
+                    f"publishable package {name} depends on non-publishable workspace package "
+                    f"{dependency_name}"
+                )
+            expected_requirement = f"={expected_version}"
+            if dependency.get("req") != expected_requirement:
+                raise ReleaseError(
+                    f"{name} must require workspace package {dependency_name} exactly at "
+                    f"{expected_requirement}"
+                )
+            dependencies[name].add(dependency_name)
+
+    ordered_names: list[str] = []
+    remaining = {name: set(values) for name, values in dependencies.items()}
+    while remaining:
+        ready = sorted(name for name, values in remaining.items() if not values)
+        if not ready:
+            cycle = ", ".join(sorted(remaining))
+            raise ReleaseError(f"publishable workspace dependency cycle: {cycle}")
+        for name in ready:
+            ordered_names.append(name)
+            del remaining[name]
+        for values in remaining.values():
+            values.difference_update(ready)
+
+    packages: list[dict[str, Any]] = []
+    for name in ordered_names:
+        manifest = Path(publishable[name]["manifest_path"]).resolve()
+        packages.append(
+            {
+                "name": name,
+                "version": expected_version,
+                "manifest_path": manifest.relative_to(root).as_posix(),
+                "artifact": f"{name}-{expected_version}.crate",
+                "dependencies": sorted(dependencies[name]),
+            }
+        )
+    return {"version": expected_version, "packages": packages}
+
+
+def registry_plan(
+    plan: dict[str, Any],
+    artifacts_dir: Path,
+    checksum_fetcher: Callable[[str, str], str | None] | None = None,
+) -> dict[str, Any]:
+    """Classify an interrupted release without ever overwriting registry state."""
+    if checksum_fetcher is None:
+        checksum_fetcher = registry_checksum
+    states: dict[str, str] = {}
+    packages: list[dict[str, Any]] = []
+    for package in plan["packages"]:
+        name = package["name"]
+        version = package["version"]
+        artifact = artifacts_dir / package["artifact"]
+        local_checksum = verify_artifact(artifact, None)
+        remote_checksum = checksum_fetcher(name, version)
+        if remote_checksum is None:
+            state = "unpublished"
+        elif remote_checksum.lower() == local_checksum:
+            state = "published-matching"
+        else:
+            raise ReleaseError(
+                f"published {name} {version} checksum does not match the local artifact"
+            )
+        if state == "published-matching":
+            incomplete = [
+                dependency
+                for dependency in package["dependencies"]
+                if states.get(dependency) != "published-matching"
+            ]
+            if incomplete:
+                raise ReleaseError(
+                    f"published {name} {version} has unpublished workspace dependencies: "
+                    + ", ".join(incomplete)
+                )
+        states[name] = state
+        packages.append(
+            {
+                **package,
+                "checksum": local_checksum,
+                "registry_checksum": remote_checksum,
+                "state": state,
+            }
+        )
+    return {
+        "version": plan["version"],
+        "packages": packages,
+        "pending": [package["name"] for package in packages if package["state"] == "unpublished"],
+    }
+
+
 def prepare(
     root: Path,
     level: str,
@@ -236,13 +420,16 @@ def prepare(
     dt.date.fromisoformat(date)
     if not allow_dirty:
         require_clean(root)
-    old = package_version(root)
-    adapter = root / ADAPTER_MANIFEST
-    if manifest_package_version(adapter) != old:
-        raise ReleaseError("core and adapter package versions must match before preparation")
-    adapter_text = adapter.read_text(encoding="utf-8")
-    if len(re.findall(rf'version\s*=\s*"={re.escape(old)}"', adapter_text)) != 1:
-        raise ReleaseError(f"adapter must require core exactly at ={old}")
+    plan = workspace_plan(root)
+    old = plan["version"]
+    package_names = [package["name"] for package in plan["packages"]]
+    required_packages = sorted(
+        {
+            dependency
+            for package in plan["packages"]
+            for dependency in package["dependencies"]
+        }
+    )
     new = bump_version(old, level)
     if breaking:
         policy = release_type(old, new)
@@ -257,7 +444,7 @@ def prepare(
             raise ReleaseError(f"{relative} does not contain required value {old!r}")
     for relative in LOCKSTEP_LOCKFILES:
         lock = (root / relative).read_text(encoding="utf-8")
-        for package in ("signal-fish-client", "signal-fish-client-godot"):
+        for package in package_names:
             marker = f'name = "{package}"\nversion = "{old}"'
             if lock.count(marker) != 1:
                 raise ReleaseError(f"{relative} has no unique locked {package} {old}")
@@ -278,11 +465,10 @@ def prepare(
     if release_heading(new).search(changelog_text) is not None:
         raise ReleaseError(f"CHANGELOG.md already contains release {new}")
 
-    replace_package_version(root / CORE_MANIFEST, old, new)
-    replace_package_version(adapter, old, new)
-    replace_adapter_core_requirement(adapter, old, new)
+    replace_workspace_version(root / CORE_MANIFEST, old, new)
+    replace_workspace_requirements(root / CORE_MANIFEST, required_packages, old, new)
     for relative in LOCKSTEP_LOCKFILES:
-        replace_lockstep_package_versions(root / relative, old, new)
+        replace_lockstep_package_versions(root / relative, package_names, old, new)
     for relative in VERSION_FILES:
         replace_required(root / relative, old, new)
     compatibility = root / "tests/compatibility.toml"
@@ -388,6 +574,13 @@ def main(argv: list[str] | None = None) -> int:
     package.add_argument("--root", type=Path, default=Path.cwd())
     package.add_argument("--manifest", type=Path, default=Path(CORE_MANIFEST))
 
+    workspace = subparsers.add_parser("workspace-plan")
+    workspace.add_argument("--root", type=Path, default=Path.cwd())
+
+    registry_state = subparsers.add_parser("registry-plan")
+    registry_state.add_argument("--root", type=Path, default=Path.cwd())
+    registry_state.add_argument("--artifacts-dir", type=Path, required=True)
+
     registry = subparsers.add_parser("registry-checksum")
     registry.add_argument("crate_name")
     registry.add_argument("version")
@@ -411,7 +604,18 @@ def main(argv: list[str] | None = None) -> int:
         elif args.command == "checksum":
             print(verify_artifact(args.crate, args.expected))
         elif args.command == "package-version":
-            print(manifest_package_version(args.root.resolve() / args.manifest))
+            root = args.root.resolve()
+            print(manifest_package_version(root / args.manifest, workspace_version(root)))
+        elif args.command == "workspace-plan":
+            print(json.dumps(workspace_plan(args.root.resolve()), indent=2))
+        elif args.command == "registry-plan":
+            root = args.root.resolve()
+            print(
+                json.dumps(
+                    registry_plan(workspace_plan(root), args.artifacts_dir.resolve()),
+                    indent=2,
+                )
+            )
         elif args.command == "registry-checksum":
             value = registry_checksum(args.crate_name, args.version)
             print(value or "UNPUBLISHED")

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -82,7 +82,12 @@ def read_toml(path: Path) -> dict[str, Any]:
 
 
 def workspace_version(root: Path) -> str:
-    value = read_toml(root / CORE_MANIFEST).get("workspace", {}).get("package", {}).get("version")
+    value = (
+        read_toml(root / CORE_MANIFEST)
+        .get("workspace", {})
+        .get("package", {})
+        .get("version")
+    )
     if not isinstance(value, str):
         raise ReleaseError("Cargo.toml has no [workspace.package] version")
     parse_version(value)
@@ -120,11 +125,17 @@ def replace_workspace_version(path: Path, old: str, new: str) -> None:
         flags=re.MULTILINE,
     )
     if count != 1:
-        raise ReleaseError(f"Cargo.toml [workspace.package] does not contain version {old!r}")
-    path.write_text(cargo[: package.start(1)] + updated + cargo[package.end(1) :], encoding="utf-8")
+        raise ReleaseError(
+            f"Cargo.toml [workspace.package] does not contain version {old!r}"
+        )
+    path.write_text(
+        cargo[: package.start(1)] + updated + cargo[package.end(1) :], encoding="utf-8"
+    )
 
 
-def replace_workspace_requirements(path: Path, package_names: list[str], old: str, new: str) -> None:
+def replace_workspace_requirements(
+    path: Path, package_names: list[str], old: str, new: str
+) -> None:
     cargo = path.read_text(encoding="utf-8")
     workspace_dependencies = re.search(
         r"^\[workspace\.dependencies\][ \t]*$\n(.*?)(?=^\[|\Z)",
@@ -142,7 +153,9 @@ def replace_workspace_requirements(path: Path, package_names: list[str], old: st
         )
         updated, count = pattern.subn(rf"\g<1>={new}\2", updated, count=1)
         if count != 1:
-            raise ReleaseError(f"Cargo.toml has no exact workspace requirement for {name} ={old}")
+            raise ReleaseError(
+                f"Cargo.toml has no exact workspace requirement for {name} ={old}"
+            )
     path.write_text(
         cargo[: workspace_dependencies.start(1)]
         + updated
@@ -198,7 +211,9 @@ def replace_required(path: Path, old: str, new: str) -> None:
     path.write_text(text.replace(old, new), encoding="utf-8")
 
 
-def cut_changelog(path: Path, old: str, new: str, date: str, breaking: bool = False) -> None:
+def cut_changelog(
+    path: Path, old: str, new: str, date: str, breaking: bool = False
+) -> None:
     text = path.read_text(encoding="utf-8")
     heading = "## [Unreleased]"
     start = text.find(heading)
@@ -262,7 +277,29 @@ def cargo_metadata(root: Path) -> dict[str, Any]:
     return value
 
 
-def workspace_plan(root: Path, metadata: dict[str, Any] | None = None) -> dict[str, Any]:
+def manifest_dependency_spec(
+    manifest: dict[str, Any], dependency: dict[str, Any]
+) -> Any:
+    kind = dependency.get("kind")
+    section = "build-dependencies" if kind == "build" else "dependencies"
+    table: Any = manifest
+    target = dependency.get("target")
+    if target is not None:
+        if not isinstance(target, str):
+            return None
+        table = manifest.get("target", {}).get(target, {})
+    if not isinstance(table, dict):
+        return None
+    dependencies = table.get(section)
+    if not isinstance(dependencies, dict):
+        return None
+    key = dependency.get("rename") or dependency.get("name")
+    return dependencies.get(key) if isinstance(key, str) else None
+
+
+def workspace_plan(
+    root: Path, metadata: dict[str, Any] | None = None
+) -> dict[str, Any]:
     """Discover publishable crates and order them dependency-first."""
     root = root.resolve()
     metadata = cargo_metadata(root) if metadata is None else metadata
@@ -272,6 +309,7 @@ def workspace_plan(root: Path, metadata: dict[str, Any] | None = None) -> dict[s
         raise ReleaseError("cargo metadata has no package list")
 
     workspace_packages: dict[str, dict[str, Any]] = {}
+    package_manifests: dict[str, dict[str, Any]] = {}
     publishable: dict[str, dict[str, Any]] = {}
     expected_version = workspace_version(root)
     for package in raw_packages:
@@ -297,9 +335,15 @@ def workspace_plan(root: Path, metadata: dict[str, Any] | None = None) -> dict[s
         try:
             manifest.relative_to(root)
         except ValueError as error:
-            raise ReleaseError(f"workspace package {name} is outside the workspace") from error
-        if read_toml(manifest).get("package", {}).get("version") != {"workspace": True}:
-            raise ReleaseError(f"publishable package {name} must set version.workspace = true")
+            raise ReleaseError(
+                f"workspace package {name} is outside the workspace"
+            ) from error
+        manifest_data = read_toml(manifest)
+        package_manifests[name] = manifest_data
+        if manifest_data.get("package", {}).get("version") != {"workspace": True}:
+            raise ReleaseError(
+                f"publishable package {name} must set version.workspace = true"
+            )
         publishable[name] = package
 
     if not publishable:
@@ -309,12 +353,17 @@ def workspace_plan(root: Path, metadata: dict[str, Any] | None = None) -> dict[s
     for name, package in publishable.items():
         raw_dependencies = package.get("dependencies", [])
         if not isinstance(raw_dependencies, list):
-            raise ReleaseError(f"cargo metadata returned invalid dependencies for {name}")
+            raise ReleaseError(
+                f"cargo metadata returned invalid dependencies for {name}"
+            )
         for dependency in raw_dependencies:
             if not isinstance(dependency, dict) or dependency.get("kind") == "dev":
                 continue
             dependency_name = dependency.get("name")
-            if dependency.get("source") is not None or dependency_name not in workspace_packages:
+            if (
+                dependency.get("source") is not None
+                or dependency_name not in workspace_packages
+            ):
                 continue
             if dependency_name not in publishable:
                 raise ReleaseError(
@@ -326,6 +375,17 @@ def workspace_plan(root: Path, metadata: dict[str, Any] | None = None) -> dict[s
                 raise ReleaseError(
                     f"{name} must require workspace package {dependency_name} exactly at "
                     f"{expected_requirement}"
+                )
+            specification = manifest_dependency_spec(
+                package_manifests[name], dependency
+            )
+            if (
+                not isinstance(specification, dict)
+                or specification.get("workspace") is not True
+            ):
+                raise ReleaseError(
+                    f"{name} must inherit workspace package {dependency_name} with "
+                    "workspace = true"
                 )
             dependencies[name].add(dependency_name)
 
@@ -404,7 +464,9 @@ def registry_plan(
     return {
         "version": plan["version"],
         "packages": packages,
-        "pending": [package["name"] for package in packages if package["state"] == "unpublished"],
+        "pending": [
+            package["name"] for package in packages if package["state"] == "unpublished"
+        ],
     }
 
 
@@ -435,7 +497,9 @@ def prepare(
         policy = release_type(old, new)
         old_major = parse_version(old)[0]
         if policy != "major" and not (old_major == 0 and policy == "minor"):
-            raise ReleaseError("breaking releases require a major bump or a pre-1.0 minor bump")
+            raise ReleaseError(
+                "breaking releases require a major bump or a pre-1.0 minor bump"
+            )
 
     # Validate every required source before writing any file. A stale inventory
     # must not leave a plausible-looking partial release bump behind.
@@ -449,18 +513,32 @@ def prepare(
             if lock.count(marker) != 1:
                 raise ReleaseError(f"{relative} has no unique locked {package} {old}")
     compatibility_text = (root / "tests/compatibility.toml").read_text(encoding="utf-8")
-    if len(re.findall(r'^client_version = "[^"]+"$', compatibility_text, re.MULTILINE)) != 1:
+    if (
+        len(re.findall(r'^client_version = "[^"]+"$', compatibility_text, re.MULTILINE))
+        != 1
+    ):
         raise ReleaseError("tests/compatibility.toml has no unique client_version")
     for relative in PROVENANCE_FILES:
         provenance = (root / relative).read_text(encoding="utf-8")
-        if len(re.findall(r'^synced = "[0-9]{4}-[0-9]{2}-[0-9]{2}"$', provenance, re.MULTILINE)) != 1:
+        if (
+            len(
+                re.findall(
+                    r'^synced = "[0-9]{4}-[0-9]{2}-[0-9]{2}"$', provenance, re.MULTILINE
+                )
+            )
+            != 1
+        ):
             raise ReleaseError(f"{relative} has no unique synced date")
     changelog_text = (root / "CHANGELOG.md").read_text(encoding="utf-8")
     unreleased_start = changelog_text.find("## [Unreleased]")
-    next_release = changelog_text.find("\n## [", unreleased_start + len("## [Unreleased]"))
+    next_release = changelog_text.find(
+        "\n## [", unreleased_start + len("## [Unreleased]")
+    )
     if unreleased_start < 0 or next_release < 0:
         raise ReleaseError("CHANGELOG.md has no complete [Unreleased] section")
-    if not changelog_text[unreleased_start + len("## [Unreleased]") : next_release].strip():
+    if not changelog_text[
+        unreleased_start + len("## [Unreleased]") : next_release
+    ].strip():
         raise ReleaseError("CHANGELOG.md [Unreleased] section is empty")
     if release_heading(new).search(changelog_text) is not None:
         raise ReleaseError(f"CHANGELOG.md already contains release {new}")
@@ -504,11 +582,15 @@ def semver_policy(root: Path, version: str) -> str:
     changelog = (root / "CHANGELOG.md").read_text(encoding="utf-8")
     heading = release_heading(version).search(changelog)
     if heading is None:
-        raise ReleaseError(f"CHANGELOG.md has no complete release section for {version}")
+        raise ReleaseError(
+            f"CHANGELOG.md has no complete release section for {version}"
+        )
     start = heading.start()
     end = changelog.find("\n## [", heading.end())
     if end < 0:
-        raise ReleaseError(f"CHANGELOG.md has no complete release section for {version}")
+        raise ReleaseError(
+            f"CHANGELOG.md has no complete release section for {version}"
+        )
     breaking = "<!-- semver-checks: major -->" in changelog[start:end]
     if not breaking:
         return policy
@@ -600,12 +682,22 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
     try:
         if args.command == "prepare":
-            print(prepare(args.root.resolve(), args.bump, args.date, args.allow_dirty, args.breaking))
+            print(
+                prepare(
+                    args.root.resolve(),
+                    args.bump,
+                    args.date,
+                    args.allow_dirty,
+                    args.breaking,
+                )
+            )
         elif args.command == "checksum":
             print(verify_artifact(args.crate, args.expected))
         elif args.command == "package-version":
             root = args.root.resolve()
-            print(manifest_package_version(root / args.manifest, workspace_version(root)))
+            print(
+                manifest_package_version(root / args.manifest, workspace_version(root))
+            )
         elif args.command == "workspace-plan":
             print(json.dumps(workspace_plan(args.root.resolve()), indent=2))
         elif args.command == "registry-plan":

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -481,6 +481,14 @@ def registry_plan(
         "pending": [
             package["name"] for package in packages if package["state"] == "unpublished"
         ],
+        "resume_requires_no_verify": any(
+            package["state"] == "unpublished"
+            and any(
+                states.get(dependency) == "published-matching"
+                for dependency in package["dependencies"]
+            )
+            for package in packages
+        ),
     }
 
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -134,7 +134,7 @@ def replace_workspace_version(path: Path, old: str, new: str) -> None:
 
 
 def replace_workspace_requirements(
-    path: Path, package_names: list[str], old: str, new: str
+    path: Path, dependency_keys: list[str], old: str, new: str
 ) -> None:
     cargo = path.read_text(encoding="utf-8")
     workspace_dependencies = re.search(
@@ -145,16 +145,16 @@ def replace_workspace_requirements(
     if workspace_dependencies is None:
         raise ReleaseError("Cargo.toml has no [workspace.dependencies] section")
     updated = workspace_dependencies.group(1)
-    for name in package_names:
+    for key in dependency_keys:
         pattern = re.compile(
-            rf'^({re.escape(name)}\s*=\s*\{{[^\n]*version\s*=\s*")='
+            rf'^({re.escape(key)}\s*=\s*\{{[^\n]*version\s*=\s*")='
             rf'{re.escape(old)}("[^\n]*\}})$',
             re.MULTILINE,
         )
         updated, count = pattern.subn(rf"\g<1>={new}\2", updated, count=1)
         if count != 1:
             raise ReleaseError(
-                f"Cargo.toml has no exact workspace requirement for {name} ={old}"
+                f"Cargo.toml has no exact workspace requirement for {key} ={old}"
             )
     path.write_text(
         cargo[: workspace_dependencies.start(1)]
@@ -350,6 +350,7 @@ def workspace_plan(
         raise ReleaseError("workspace has no crates publishable to crates.io")
 
     dependencies: dict[str, set[str]] = {name: set() for name in publishable}
+    workspace_requirements: set[tuple[str, str]] = set()
     for name, package in publishable.items():
         raw_dependencies = package.get("dependencies", [])
         if not isinstance(raw_dependencies, list):
@@ -388,6 +389,12 @@ def workspace_plan(
                     "workspace = true"
                 )
             dependencies[name].add(dependency_name)
+            dependency_key = dependency.get("rename") or dependency_name
+            if not isinstance(dependency_key, str):
+                raise ReleaseError(
+                    f"cargo metadata returned an invalid dependency key for {name}"
+                )
+            workspace_requirements.add((dependency_key, dependency_name))
 
     ordered_names: list[str] = []
     remaining = {name: set(values) for name, values in dependencies.items()}
@@ -414,7 +421,14 @@ def workspace_plan(
                 "dependencies": sorted(dependencies[name]),
             }
         )
-    return {"version": expected_version, "packages": packages}
+    return {
+        "version": expected_version,
+        "packages": packages,
+        "workspace_requirements": [
+            {"key": key, "package": package}
+            for key, package in sorted(workspace_requirements)
+        ],
+    }
 
 
 def registry_plan(
@@ -485,13 +499,9 @@ def prepare(
     plan = workspace_plan(root)
     old = plan["version"]
     package_names = [package["name"] for package in plan["packages"]]
-    required_packages = sorted(
-        {
-            dependency
-            for package in plan["packages"]
-            for dependency in package["dependencies"]
-        }
-    )
+    required_workspace_keys = [
+        requirement["key"] for requirement in plan["workspace_requirements"]
+    ]
     new = bump_version(old, level)
     if breaking:
         policy = release_type(old, new)
@@ -544,7 +554,9 @@ def prepare(
         raise ReleaseError(f"CHANGELOG.md already contains release {new}")
 
     replace_workspace_version(root / CORE_MANIFEST, old, new)
-    replace_workspace_requirements(root / CORE_MANIFEST, required_packages, old, new)
+    replace_workspace_requirements(
+        root / CORE_MANIFEST, required_workspace_keys, old, new
+    )
     for relative in LOCKSTEP_LOCKFILES:
         replace_lockstep_package_versions(root / relative, package_names, old, new)
     for relative in VERSION_FILES:

--- a/scripts/test_audit_repository_rules.py
+++ b/scripts/test_audit_repository_rules.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Tests for audit-repository-rules.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+SPEC = importlib.util.spec_from_file_location(
+    "audit_repository_rules", Path(__file__).with_name("audit-repository-rules.py")
+)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError("could not load audit-repository-rules.py")
+audit = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(audit)
+
+
+class RepositoryRuleTests(unittest.TestCase):
+    policy = {
+        "required_checks": [{"workflow": "CI", "job": "CI Required"}],
+        "repository_rules": {
+            "enforcement": "active",
+            "include": ["~DEFAULT_BRANCH"],
+            "required_approving_review_count": 1,
+            "dismiss_stale_reviews_on_push": True,
+            "required_review_thread_resolution": True,
+            "strict_required_status_checks_policy": True,
+            "forbid_bypass_actors": True,
+        },
+    }
+
+    @staticmethod
+    def ruleset() -> dict[str, object]:
+        return {
+            "enforcement": "active",
+            "conditions": {"ref_name": {"include": ["~DEFAULT_BRANCH"], "exclude": []}},
+            "rules": [
+                {"type": "deletion"},
+                {"type": "non_fast_forward"},
+                {
+                    "type": "pull_request",
+                    "parameters": {
+                        "required_approving_review_count": 1,
+                        "dismiss_stale_reviews_on_push": True,
+                        "required_review_thread_resolution": True,
+                    },
+                },
+                {
+                    "type": "required_status_checks",
+                    "parameters": {
+                        "strict_required_status_checks_policy": True,
+                        "required_status_checks": [{"context": "CI Required"}],
+                    },
+                },
+            ],
+        }
+
+    def test_accepts_matching_default_branch_rules(self) -> None:
+        self.assertEqual(audit.audit(self.policy, [self.ruleset()]), [])
+
+    def test_reports_missing_safety_rules_and_checks(self) -> None:
+        ruleset = self.ruleset()
+        ruleset["rules"] = []
+        failures = audit.audit(self.policy, [ruleset])
+        self.assertIn("missing deletion rule", failures)
+        self.assertIn("missing pull_request rule", failures)
+        self.assertIn("missing required_status_checks rule", failures)
+
+    def test_rejects_bypass_and_non_strict_checks(self) -> None:
+        ruleset = self.ruleset()
+        ruleset["bypass_actors"] = [{"actor_type": "OrganizationAdmin"}]
+        status = next(rule for rule in ruleset["rules"] if rule["type"] == "required_status_checks")
+        status["parameters"]["strict_required_status_checks_policy"] = False
+        failures = audit.audit(self.policy, [ruleset])
+        self.assertIn("default-branch rulesets must not define bypass actors", failures)
+        self.assertIn("required status checks must require an up-to-date branch", failures)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_audit_repository_rules.py
+++ b/scripts/test_audit_repository_rules.py
@@ -34,6 +34,7 @@ class RepositoryRuleTests(unittest.TestCase):
     def ruleset() -> dict[str, object]:
         return {
             "enforcement": "active",
+            "bypass_actors": [],
             "conditions": {"ref_name": {"include": ["~DEFAULT_BRANCH"], "exclude": []}},
             "rules": [
                 {"type": "deletion"},
@@ -100,6 +101,14 @@ class RepositoryRuleTests(unittest.TestCase):
         self.assertIn("default-branch rulesets must not define bypass actors", failures)
         self.assertIn(
             "required status checks must require an up-to-date branch", failures
+        )
+
+    def test_fails_closed_when_github_hides_bypass_actors(self) -> None:
+        ruleset = self.ruleset()
+        del ruleset["bypass_actors"]
+        self.assertIn(
+            "could not verify bypass actors because GitHub omitted that protected field",
+            audit.audit(self.policy, [ruleset]),
         )
 
 

--- a/scripts/test_audit_repository_rules.py
+++ b/scripts/test_audit_repository_rules.py
@@ -26,7 +26,6 @@ class RepositoryRuleTests(unittest.TestCase):
             "dismiss_stale_reviews_on_push": True,
             "required_review_thread_resolution": True,
             "strict_required_status_checks_policy": True,
-            "forbid_bypass_actors": True,
         },
     }
 
@@ -34,7 +33,6 @@ class RepositoryRuleTests(unittest.TestCase):
     def ruleset() -> dict[str, object]:
         return {
             "enforcement": "active",
-            "bypass_actors": [],
             "conditions": {"ref_name": {"include": ["~DEFAULT_BRANCH"], "exclude": []}},
             "rules": [
                 {"type": "deletion"},
@@ -88,9 +86,19 @@ class RepositoryRuleTests(unittest.TestCase):
                 with self.assertRaisesRegex(ValueError, "required.check"):
                     audit.audit(policy, [self.ruleset()])
 
-    def test_rejects_bypass_and_non_strict_checks(self) -> None:
+    def test_rejects_repository_rule_fields_the_token_cannot_audit(self) -> None:
+        policy = {
+            **self.policy,
+            "repository_rules": {
+                **self.policy["repository_rules"],
+                "forbid_bypass_actors": True,
+            },
+        }
+        with self.assertRaisesRegex(ValueError, "unsupported repository_rules keys"):
+            audit.audit(policy, [self.ruleset()])
+
+    def test_rejects_non_strict_checks(self) -> None:
         ruleset = self.ruleset()
-        ruleset["bypass_actors"] = [{"actor_type": "OrganizationAdmin"}]
         status = next(
             rule
             for rule in ruleset["rules"]
@@ -98,17 +106,20 @@ class RepositoryRuleTests(unittest.TestCase):
         )
         status["parameters"]["strict_required_status_checks_policy"] = False
         failures = audit.audit(self.policy, [ruleset])
-        self.assertIn("default-branch rulesets must not define bypass actors", failures)
         self.assertIn(
             "required status checks must require an up-to-date branch", failures
         )
 
-    def test_fails_closed_when_github_hides_bypass_actors(self) -> None:
-        ruleset = self.ruleset()
-        del ruleset["bypass_actors"]
+    def test_rejects_policy_split_across_multiple_rulesets(self) -> None:
+        review_ruleset = self.ruleset()
+        review_ruleset["name"] = "reviews-only"
+        review_ruleset["rules"] = review_ruleset["rules"][:-1]
+        status_ruleset = self.ruleset()
+        status_ruleset["name"] = "checks-only"
+        status_ruleset["rules"] = status_ruleset["rules"][-1:]
         self.assertIn(
-            "could not verify bypass actors because GitHub omitted that protected field",
-            audit.audit(self.policy, [ruleset]),
+            "no single default-branch ruleset satisfies the complete checked-in policy",
+            audit.audit(self.policy, [review_ruleset, status_ruleset]),
         )
 
 

--- a/scripts/test_audit_repository_rules.py
+++ b/scripts/test_audit_repository_rules.py
@@ -59,6 +59,14 @@ class RepositoryRuleTests(unittest.TestCase):
     def test_accepts_matching_default_branch_rules(self) -> None:
         self.assertEqual(audit.audit(self.policy, [self.ruleset()]), [])
 
+    def test_live_api_request_requires_and_sends_authentication(self) -> None:
+        with self.assertRaisesRegex(ValueError, "authenticated GitHub token"):
+            audit.api_request("https://api.github.test/rulesets", "")
+
+        request = audit.api_request("https://api.github.test/rulesets", "test-token")
+        self.assertEqual(request.get_header("Authorization"), "Bearer test-token")
+        self.assertEqual(request.get_header("X-github-api-version"), audit.API_VERSION)
+
     def test_reports_missing_safety_rules_and_checks(self) -> None:
         ruleset = self.ruleset()
         ruleset["rules"] = []
@@ -70,11 +78,17 @@ class RepositoryRuleTests(unittest.TestCase):
     def test_rejects_bypass_and_non_strict_checks(self) -> None:
         ruleset = self.ruleset()
         ruleset["bypass_actors"] = [{"actor_type": "OrganizationAdmin"}]
-        status = next(rule for rule in ruleset["rules"] if rule["type"] == "required_status_checks")
+        status = next(
+            rule
+            for rule in ruleset["rules"]
+            if rule["type"] == "required_status_checks"
+        )
         status["parameters"]["strict_required_status_checks_policy"] = False
         failures = audit.audit(self.policy, [ruleset])
         self.assertIn("default-branch rulesets must not define bypass actors", failures)
-        self.assertIn("required status checks must require an up-to-date branch", failures)
+        self.assertIn(
+            "required status checks must require an up-to-date branch", failures
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/test_audit_repository_rules.py
+++ b/scripts/test_audit_repository_rules.py
@@ -76,7 +76,12 @@ class RepositoryRuleTests(unittest.TestCase):
         self.assertIn("missing required_status_checks rule", failures)
 
     def test_rejects_empty_or_malformed_required_check_policy(self) -> None:
-        for required_checks in ([], None, [{"workflow": "CI"}]):
+        for required_checks in (
+            [],
+            None,
+            [{"workflow": "CI"}],
+            [{"workflow": "CI", "job": "   "}],
+        ):
             with self.subTest(required_checks=required_checks):
                 policy = {**self.policy, "required_checks": required_checks}
                 with self.assertRaisesRegex(ValueError, "required.check"):

--- a/scripts/test_audit_repository_rules.py
+++ b/scripts/test_audit_repository_rules.py
@@ -75,6 +75,13 @@ class RepositoryRuleTests(unittest.TestCase):
         self.assertIn("missing pull_request rule", failures)
         self.assertIn("missing required_status_checks rule", failures)
 
+    def test_rejects_empty_or_malformed_required_check_policy(self) -> None:
+        for required_checks in ([], None, [{"workflow": "CI"}]):
+            with self.subTest(required_checks=required_checks):
+                policy = {**self.policy, "required_checks": required_checks}
+                with self.assertRaisesRegex(ValueError, "required.check"):
+                    audit.audit(policy, [self.ruleset()])
+
     def test_rejects_bypass_and_non_strict_checks(self) -> None:
         ruleset = self.ruleset()
         ruleset["bypass_actors"] = [{"actor_type": "OrganizationAdmin"}]

--- a/scripts/test_pre_commit_llm.py
+++ b/scripts/test_pre_commit_llm.py
@@ -377,16 +377,17 @@ class TestCrateVersionSync:
     """Tests for Cargo version parsing and version-reference synchronization."""
 
     def test_read_cargo_package_version(self, tmp_path, monkeypatch):
-        """The package version is read from Cargo.toml [package]."""
+        """The package version is read from Cargo.toml [workspace.package]."""
         fake_root = tmp_path / "repo"
         fake_root.mkdir()
         (fake_root / "Cargo.toml").write_text(
             "[package]\n"
             'name = "signal-fish-client"\n'
-            'version = "1.2.3"\n'
+            "version.workspace = true\n"
             "\n"
-            "[dependencies]\n"
-            'tokio = "1"\n',
+            "[workspace]\n\n"
+            "[workspace.package]\n"
+            'version = "1.2.3"\n',
             encoding="utf-8",
         )
         monkeypatch.setattr(_mod, "REPO_ROOT", fake_root)

--- a/scripts/test_release.py
+++ b/scripts/test_release.py
@@ -9,7 +9,9 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
-SPEC = importlib.util.spec_from_file_location("release", Path(__file__).with_name("release.py"))
+SPEC = importlib.util.spec_from_file_location(
+    "release", Path(__file__).with_name("release.py")
+)
 if SPEC is None or SPEC.loader is None:
     raise RuntimeError("could not load scripts/release.py for testing")
 release = importlib.util.module_from_spec(SPEC)
@@ -74,8 +76,18 @@ class WorkspacePlanTests(unittest.TestCase):
             name = str(package["name"])
             manifest = self.root / name / "Cargo.toml"
             manifest.parent.mkdir(exist_ok=True)
+            dependency_lines = [
+                f"{dependency.get('rename') or dependency['name']} = {{ workspace = true }}"
+                for dependency in package.get("dependencies", [])
+                if dependency.get("kind") != "dev"
+            ]
+            dependencies = (
+                "\n[dependencies]\n" + "\n".join(dependency_lines) + "\n"
+                if dependency_lines
+                else ""
+            )
             manifest.write_text(
-                f'[package]\nname = "{name}"\nversion.workspace = true\n',
+                f'[package]\nname = "{name}"\nversion.workspace = true\n{dependencies}',
                 encoding="utf-8",
             )
             values.append(
@@ -88,7 +100,10 @@ class WorkspacePlanTests(unittest.TestCase):
                     "dependencies": package.get("dependencies", []),
                 }
             )
-        return {"workspace_members": [value["id"] for value in values], "packages": values}
+        return {
+            "workspace_members": [value["id"] for value in values],
+            "packages": values,
+        }
 
     @staticmethod
     def dependency(name: str, requirement: str = "=1.2.3") -> dict[str, object]:
@@ -103,18 +118,55 @@ class WorkspacePlanTests(unittest.TestCase):
             ]
         )
         plan = release.workspace_plan(self.root, metadata)
-        self.assertEqual([package["name"] for package in plan["packages"]], ["core", "adapter"])
+        self.assertEqual(
+            [package["name"] for package in plan["packages"]], ["core", "adapter"]
+        )
         self.assertEqual(plan["packages"][1]["dependencies"], ["core"])
 
     def test_rejects_non_exact_internal_requirement(self) -> None:
         metadata = self.metadata(
             [
                 {"name": "core"},
-                {"name": "adapter", "dependencies": [self.dependency("core", "^1.2.3")]},
+                {
+                    "name": "adapter",
+                    "dependencies": [self.dependency("core", "^1.2.3")],
+                },
             ]
         )
         with self.assertRaisesRegex(release.ReleaseError, "exactly"):
             release.workspace_plan(self.root, metadata)
+
+    def test_rejects_inline_exact_internal_requirement(self) -> None:
+        metadata = self.metadata(
+            [
+                {"name": "core"},
+                {"name": "adapter", "dependencies": [self.dependency("core")]},
+            ]
+        )
+        (self.root / "adapter" / "Cargo.toml").write_text(
+            '[package]\nname = "adapter"\nversion.workspace = true\n\n'
+            '[dependencies]\ncore = { version = "=1.2.3", path = "../core" }\n',
+            encoding="utf-8",
+        )
+        with self.assertRaisesRegex(release.ReleaseError, "workspace = true"):
+            release.workspace_plan(self.root, metadata)
+
+    def test_accepts_renamed_target_workspace_dependency(self) -> None:
+        dependency = self.dependency("core")
+        dependency.update({"rename": "core_alias", "target": "cfg(unix)"})
+        metadata = self.metadata(
+            [
+                {"name": "core"},
+                {"name": "adapter", "dependencies": [dependency]},
+            ]
+        )
+        (self.root / "adapter" / "Cargo.toml").write_text(
+            '[package]\nname = "adapter"\nversion.workspace = true\n\n'
+            "[target.'cfg(unix)'.dependencies]\ncore_alias = { workspace = true }\n",
+            encoding="utf-8",
+        )
+        plan = release.workspace_plan(self.root, metadata)
+        self.assertEqual(plan["packages"][1]["dependencies"], ["core"])
 
     def test_rejects_dependency_on_non_publishable_member(self) -> None:
         metadata = self.metadata(
@@ -146,7 +198,7 @@ class PreparationTests(unittest.TestCase):
             'publish = ["crates-io"]\nedition = "2021"\n\n'
             '[workspace]\nmembers = ["crates/signal-fish-client-godot"]\nresolver = "2"\n\n'
             '[workspace.package]\nversion = "1.2.3"\n\n'
-            '[workspace.dependencies]\n'
+            "[workspace.dependencies]\n"
             'signal-fish-client = { version = "=1.2.3", path = "." }\n',
             encoding="utf-8",
         )
@@ -157,7 +209,7 @@ class PreparationTests(unittest.TestCase):
         adapter.write_text(
             '[package]\nname = "signal-fish-client-godot"\nversion.workspace = true\n'
             'publish = ["crates-io"]\nedition = "2021"\n\n'
-            '[dependencies]\nsignal-fish-client.workspace = true\n',
+            "[dependencies]\nsignal-fish-client.workspace = true\n",
             encoding="utf-8",
         )
         (adapter.parent / "src").mkdir()
@@ -169,7 +221,9 @@ class PreparationTests(unittest.TestCase):
         for relative in release.PROVENANCE_FILES:
             path = self.root / relative
             path.parent.mkdir(parents=True, exist_ok=True)
-            path.write_text('client_version = "1.2.3"\nsynced = "2020-01-01"\n', encoding="utf-8")
+            path.write_text(
+                'client_version = "1.2.3"\nsynced = "2020-01-01"\n', encoding="utf-8"
+            )
         for relative in release.LOCKSTEP_LOCKFILES:
             path = self.root / relative
             path.parent.mkdir(parents=True, exist_ok=True)
@@ -203,7 +257,9 @@ class PreparationTests(unittest.TestCase):
         self.assertIn("## [Unreleased]\n\n## [1.3.0] - 2026-07-13", changelog)
         self.assertIn("compare/v1.2.3...v1.3.0", changelog)
         self.assertIn("compare/v1.3.0...HEAD", changelog)
-        compatibility = (self.root / "tests/compatibility.toml").read_text(encoding="utf-8")
+        compatibility = (self.root / "tests/compatibility.toml").read_text(
+            encoding="utf-8"
+        )
         self.assertIn('client_version = "1.3.0"', compatibility)
         self.assertIn('synced = "2026-07-13"', compatibility)
         self.assertEqual(release.previous_version(self.root, "1.3.0"), "1.2.3")
@@ -282,7 +338,9 @@ class PreparationTests(unittest.TestCase):
 
     def test_release_heading_does_not_prefix_match(self) -> None:
         changelog = self.root / "CHANGELOG.md"
-        text = changelog.read_text(encoding="utf-8").replace("## [1.2.3]", "## [1.2.30]")
+        text = changelog.read_text(encoding="utf-8").replace(
+            "## [1.2.3]", "## [1.2.30]"
+        )
         changelog.write_text(text, encoding="utf-8")
         self.assertIsNone(release.release_heading("1.2.3").search(text))
 
@@ -306,7 +364,9 @@ class ArtifactTests(unittest.TestCase):
 
     @mock.patch.object(release.urllib.request, "urlopen")
     def test_registry_404_means_unpublished(self, urlopen: mock.Mock) -> None:
-        urlopen.side_effect = release.urllib.error.HTTPError("url", 404, "missing", {}, None)
+        urlopen.side_effect = release.urllib.error.HTTPError(
+            "url", 404, "missing", {}, None
+        )
         self.assertIsNone(release.registry_checksum("demo", "1.2.3"))
 
     def test_registry_plan_state_matrix_and_publish_order(self) -> None:
@@ -353,7 +413,9 @@ class ArtifactTests(unittest.TestCase):
                 release.registry_plan(
                     plan,
                     artifacts,
-                    lambda name, _version: checksums["adapter"] if name == "adapter" else None,
+                    lambda name, _version: (
+                        checksums["adapter"] if name == "adapter" else None
+                    ),
                 )
             with self.assertRaisesRegex(release.ReleaseError, "does not match"):
                 release.registry_plan(
@@ -380,12 +442,14 @@ class WorkflowPolicyTests(unittest.TestCase):
         self.assertIn("RELEASE_APP_CLIENT_ID is not configured", self.prepare)
         self.assertIn("RELEASE_APP_PRIVATE_KEY", self.prepare)
         self.assertIn("dry_run:", self.prepare)
-        self.assertIn('branch=release/%s', self.prepare)
+        self.assertIn("branch=release/%s", self.prepare)
         self.assertIn("gh pr create", self.prepare)
 
     def test_publish_is_input_free_manual_only_and_protected(self) -> None:
         self.assertIn("workflow_dispatch:", self.publish)
-        dispatch = self.publish.split("workflow_dispatch:", 1)[1].split("permissions:", 1)[0]
+        dispatch = self.publish.split("workflow_dispatch:", 1)[1].split(
+            "permissions:", 1
+        )[0]
         self.assertNotIn("inputs:", dispatch)
         self.assertNotIn("push:\n", self.publish)
         self.assertIn("environment: crates-io", self.publish)
@@ -415,14 +479,18 @@ class WorkflowPolicyTests(unittest.TestCase):
         self.assertEqual(self.publish.count("check-runs?filter=latest"), 1)
         self.assertIn("scripts/check-required-checks.py", self.publish)
         self.assertIn("Expected one CycloneDX file", self.publish)
-        self.assertIn('$RUNNER_TEMP/release-assets', self.publish)
+        self.assertIn("$RUNNER_TEMP/release-assets", self.publish)
         self.assertIn("Release tooling dirtied the checkout", self.publish)
         self.assertIn("Release publication", self.publish)
         self.assertIn("fetch-tags: true", self.publish)
         self.assertIn("scripts/release.py workspace-plan", self.publish)
 
     def test_workflows_enumerate_publishable_workspace_crates(self) -> None:
-        for marker in ("workspace-plan", "mapfile -t packages", 'package_args+=(-p "$package")'):
+        for marker in (
+            "workspace-plan",
+            "mapfile -t packages",
+            'package_args+=(-p "$package")',
+        ):
             with self.subTest(marker=marker):
                 self.assertIn(marker, self.publish)
                 self.assertIn(marker, self.prepare)

--- a/scripts/test_release.py
+++ b/scripts/test_release.py
@@ -488,9 +488,15 @@ class WorkflowPolicyTests(unittest.TestCase):
         self.assertIn("Approve workflows to run", self.releasing)
         self.assertNotIn("signal-fish-release[bot]", self.prepare)
         self.assertIn('git config user.name "github-actions[bot]"', self.prepare)
-        self.assertIn(
+        bot_email = (
+            'git config user.email '
+            '"41898282+github-actions[bot]@users.noreply.github.com"'
+        )
+        self.assertIn(bot_email, self.prepare)
+        self.assertIn(bot_email, self.publish)
+        self.assertNotIn(
             'git config user.email "github-actions[bot]@users.noreply.github.com"',
-            self.prepare,
+            self.prepare + self.publish,
         )
 
     def test_publish_is_input_free_manual_only_and_protected(self) -> None:

--- a/scripts/test_release.py
+++ b/scripts/test_release.py
@@ -486,6 +486,12 @@ class WorkflowPolicyTests(unittest.TestCase):
         self.assertIn("gh pr create", self.prepare)
         self.assertIn("Approve workflows to run", self.prepare)
         self.assertIn("Approve workflows to run", self.releasing)
+        self.assertNotIn("signal-fish-release[bot]", self.prepare)
+        self.assertIn('git config user.name "github-actions[bot]"', self.prepare)
+        self.assertIn(
+            'git config user.email "github-actions[bot]@users.noreply.github.com"',
+            self.prepare,
+        )
 
     def test_publish_is_input_free_manual_only_and_protected(self) -> None:
         self.assertIn("workflow_dispatch:", self.publish)

--- a/scripts/test_release.py
+++ b/scripts/test_release.py
@@ -167,6 +167,10 @@ class WorkspacePlanTests(unittest.TestCase):
         )
         plan = release.workspace_plan(self.root, metadata)
         self.assertEqual(plan["packages"][1]["dependencies"], ["core"])
+        self.assertEqual(
+            plan["workspace_requirements"],
+            [{"key": "core_alias", "package": "core"}],
+        )
 
     def test_rejects_dependency_on_non_publishable_member(self) -> None:
         metadata = self.metadata(
@@ -264,6 +268,35 @@ class PreparationTests(unittest.TestCase):
         self.assertIn('synced = "2026-07-13"', compatibility)
         self.assertEqual(release.previous_version(self.root, "1.3.0"), "1.2.3")
         self.assertEqual(release.semver_policy(self.root, "1.3.0"), "minor")
+
+    def test_prepare_updates_renamed_workspace_requirement(self) -> None:
+        root_manifest = self.root / "Cargo.toml"
+        root_manifest.write_text(
+            root_manifest.read_text(encoding="utf-8").replace(
+                'signal-fish-client = { version = "=1.2.3", path = "." }',
+                'core_alias = { package = "signal-fish-client", '
+                'version = "=1.2.3", path = "." }',
+            ),
+            encoding="utf-8",
+        )
+        adapter_manifest = self.root / "crates/signal-fish-client-godot/Cargo.toml"
+        adapter_manifest.write_text(
+            adapter_manifest.read_text(encoding="utf-8").replace(
+                "signal-fish-client.workspace = true",
+                "core_alias.workspace = true",
+            ),
+            encoding="utf-8",
+        )
+
+        version = release.prepare(self.root, "minor", "2026-07-13", allow_dirty=True)
+
+        self.assertEqual(version, "1.3.0")
+        cargo = root_manifest.read_text(encoding="utf-8")
+        self.assertIn(
+            'core_alias = { package = "signal-fish-client", '
+            'version = "=1.3.0", path = "." }',
+            cargo,
+        )
 
     def test_pre_one_minor_can_persist_intentional_breaking_policy(self) -> None:
         for path in self.root.rglob("*"):

--- a/scripts/test_release.py
+++ b/scripts/test_release.py
@@ -550,6 +550,14 @@ class WorkflowPolicyTests(unittest.TestCase):
                 self.assertIn("runs-on: ubuntu-24.04", workflow)
                 self.assertIn("toolchain: ${{ env.RELEASE_RUST }}", workflow)
 
+    def test_ci_publish_dry_run_uses_the_release_toolchain(self) -> None:
+        publish_job = self.ci.split("  publish-dry-run:", 1)[1].split(
+            "\n  required:", 1
+        )[0]
+        self.assertIn("toolchain: ${{ env.RELEASE_RUST }}", publish_job)
+        self.assertIn('cargo +"${RELEASE_RUST}" publish --dry-run', publish_job)
+        self.assertIn('RELEASE_RUST: "1.96.1"', self.ci)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test_release.py
+++ b/scripts/test_release.py
@@ -431,16 +431,19 @@ class ArtifactTests(unittest.TestCase):
                 "adapter": release.sha256(artifacts / "adapter-1.2.3.crate"),
             }
             cases = (
-                ({}, ["core", "adapter"]),
-                ({"core": checksums["core"]}, ["adapter"]),
-                (checksums, []),
+                ({}, ["core", "adapter"], False),
+                ({"core": checksums["core"]}, ["adapter"], True),
+                (checksums, [], False),
             )
-            for published, expected in cases:
+            for published, expected, requires_no_verify in cases:
                 with self.subTest(published=published):
                     state = release.registry_plan(
                         plan, artifacts, lambda name, _version: published.get(name)
                     )
                     self.assertEqual(state["pending"], expected)
+                    self.assertEqual(
+                        state["resume_requires_no_verify"], requires_no_verify
+                    )
 
             with self.assertRaisesRegex(release.ReleaseError, "unpublished workspace"):
                 release.registry_plan(
@@ -503,6 +506,11 @@ class WorkflowPolicyTests(unittest.TestCase):
         ):
             with self.subTest(marker=marker):
                 self.assertIn(marker, self.publish)
+        self.assertEqual(
+            self.publish.count("resume_args+=(--no-verify)"),
+            2,
+            "both resumed dry-run and publish must tolerate crates.io index lag",
+        )
 
     def test_semver_policy_is_derived_and_check_runs_are_latest_only(self) -> None:
         self.assertIn('semver-policy "$version"', self.publish)

--- a/scripts/test_release.py
+++ b/scripts/test_release.py
@@ -472,14 +472,20 @@ class WorkflowPolicyTests(unittest.TestCase):
             encoding="utf-8"
         )
         cls.ci = (root / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+        cls.releasing = (root / "docs/releasing.md").read_text(encoding="utf-8")
 
-    def test_prepare_uses_app_token_and_supports_dry_run(self) -> None:
-        self.assertIn("actions/create-github-app-token@v3.2.0", self.prepare)
-        self.assertIn("RELEASE_APP_CLIENT_ID is not configured", self.prepare)
-        self.assertIn("RELEASE_APP_PRIVATE_KEY", self.prepare)
+    def test_prepare_uses_builtin_token_and_supports_dry_run(self) -> None:
+        self.assertNotIn("actions/create-github-app-token", self.prepare)
+        self.assertNotIn("RELEASE_APP_", self.prepare)
+        self.assertIn("contents: write", self.prepare)
+        self.assertIn("pull-requests: write", self.prepare)
+        self.assertIn("persist-credentials: true", self.prepare)
+        self.assertIn("GH_TOKEN: ${{ github.token }}", self.prepare)
         self.assertIn("dry_run:", self.prepare)
         self.assertIn("branch=release/%s", self.prepare)
         self.assertIn("gh pr create", self.prepare)
+        self.assertIn("Approve workflows to run", self.prepare)
+        self.assertIn("Approve workflows to run", self.releasing)
 
     def test_publish_is_input_free_manual_only_and_protected(self) -> None:
         self.assertIn("workflow_dispatch:", self.publish)

--- a/scripts/test_release.py
+++ b/scripts/test_release.py
@@ -27,19 +27,19 @@ class VersionTests(unittest.TestCase):
             with self.subTest(value=value), self.assertRaises(release.ReleaseError):
                 release.parse_version(value)
 
-    def test_package_version_is_scoped_to_package_section(self) -> None:
+    def test_package_version_is_scoped_to_workspace_package_section(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             (root / "Cargo.toml").write_text(
-                '[workspace.package]\nversion = "9.9.9"\n\n'
-                '[package]\nname = "demo"\nversion = "1.2.3"\n\n'
-                '[dependencies]\ndemo = { version = "8.8.8" }\n',
+                '[package]\nname = "demo"\nversion.workspace = true\n\n'
+                '[dependencies]\ndemo = { version = "8.8.8" }\n'
+                '\n[workspace]\n\n[workspace.package]\nversion = "1.2.3"\n',
                 encoding="utf-8",
             )
             self.assertEqual(release.package_version(root), "1.2.3")
-            release.replace_package_version(root / "Cargo.toml", "1.2.3", "1.2.4")
+            release.replace_workspace_version(root / "Cargo.toml", "1.2.3", "1.2.4")
             cargo = (root / "Cargo.toml").read_text(encoding="utf-8")
-            self.assertIn('[workspace.package]\nversion = "9.9.9"', cargo)
+            self.assertIn("version.workspace = true", cargo)
             self.assertIn('demo = { version = "8.8.8" }', cargo)
             self.assertEqual(release.package_version(root), "1.2.4")
 
@@ -56,18 +56,112 @@ class VersionTests(unittest.TestCase):
                 release.release_type("1.2.3", target)
 
 
+class WorkspacePlanTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        (self.root / "Cargo.toml").write_text(
+            '[workspace]\n\n[workspace.package]\nversion = "1.2.3"\n',
+            encoding="utf-8",
+        )
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def metadata(self, packages: list[dict[str, object]]) -> dict[str, object]:
+        values = []
+        for package in packages:
+            name = str(package["name"])
+            manifest = self.root / name / "Cargo.toml"
+            manifest.parent.mkdir(exist_ok=True)
+            manifest.write_text(
+                f'[package]\nname = "{name}"\nversion.workspace = true\n',
+                encoding="utf-8",
+            )
+            values.append(
+                {
+                    "id": name,
+                    "name": name,
+                    "version": package.get("version", "1.2.3"),
+                    "manifest_path": str(manifest),
+                    "publish": package.get("publish", ["crates-io"]),
+                    "dependencies": package.get("dependencies", []),
+                }
+            )
+        return {"workspace_members": [value["id"] for value in values], "packages": values}
+
+    @staticmethod
+    def dependency(name: str, requirement: str = "=1.2.3") -> dict[str, object]:
+        return {"name": name, "req": requirement, "kind": None, "source": None}
+
+    def test_discovers_publishable_crates_in_dependency_order(self) -> None:
+        metadata = self.metadata(
+            [
+                {"name": "adapter", "dependencies": [self.dependency("core")]},
+                {"name": "tool", "publish": []},
+                {"name": "core"},
+            ]
+        )
+        plan = release.workspace_plan(self.root, metadata)
+        self.assertEqual([package["name"] for package in plan["packages"]], ["core", "adapter"])
+        self.assertEqual(plan["packages"][1]["dependencies"], ["core"])
+
+    def test_rejects_non_exact_internal_requirement(self) -> None:
+        metadata = self.metadata(
+            [
+                {"name": "core"},
+                {"name": "adapter", "dependencies": [self.dependency("core", "^1.2.3")]},
+            ]
+        )
+        with self.assertRaisesRegex(release.ReleaseError, "exactly"):
+            release.workspace_plan(self.root, metadata)
+
+    def test_rejects_dependency_on_non_publishable_member(self) -> None:
+        metadata = self.metadata(
+            [
+                {"name": "tool", "publish": []},
+                {"name": "adapter", "dependencies": [self.dependency("tool")]},
+            ]
+        )
+        with self.assertRaisesRegex(release.ReleaseError, "non-publishable"):
+            release.workspace_plan(self.root, metadata)
+
+    def test_rejects_publish_dependency_cycle(self) -> None:
+        metadata = self.metadata(
+            [
+                {"name": "a", "dependencies": [self.dependency("b")]},
+                {"name": "b", "dependencies": [self.dependency("a")]},
+            ]
+        )
+        with self.assertRaisesRegex(release.ReleaseError, "cycle"):
+            release.workspace_plan(self.root, metadata)
+
+
 class PreparationTests(unittest.TestCase):
     def setUp(self) -> None:
         self.temp = tempfile.TemporaryDirectory()
         self.root = Path(self.temp.name)
-        (self.root / "Cargo.toml").write_text('[package]\nversion = "1.2.3"\n', encoding="utf-8")
-        adapter = self.root / release.ADAPTER_MANIFEST
-        adapter.parent.mkdir(parents=True, exist_ok=True)
-        adapter.write_text(
-            '[package]\nname = "signal-fish-client-godot"\nversion = "1.2.3"\n\n'
-            '[dependencies]\nsignal-fish-client = { version = "=1.2.3", path = "../.." }\n',
+        (self.root / "Cargo.toml").write_text(
+            '[package]\nname = "signal-fish-client"\nversion.workspace = true\n'
+            'publish = ["crates-io"]\nedition = "2021"\n\n'
+            '[workspace]\nmembers = ["crates/signal-fish-client-godot"]\nresolver = "2"\n\n'
+            '[workspace.package]\nversion = "1.2.3"\n\n'
+            '[workspace.dependencies]\n'
+            'signal-fish-client = { version = "=1.2.3", path = "." }\n',
             encoding="utf-8",
         )
+        (self.root / "src").mkdir()
+        (self.root / "src/lib.rs").write_text("", encoding="utf-8")
+        adapter = self.root / "crates/signal-fish-client-godot/Cargo.toml"
+        adapter.parent.mkdir(parents=True, exist_ok=True)
+        adapter.write_text(
+            '[package]\nname = "signal-fish-client-godot"\nversion.workspace = true\n'
+            'publish = ["crates-io"]\nedition = "2021"\n\n'
+            '[dependencies]\nsignal-fish-client.workspace = true\n',
+            encoding="utf-8",
+        )
+        (adapter.parent / "src").mkdir()
+        (adapter.parent / "src/lib.rs").write_text("", encoding="utf-8")
         for relative in release.VERSION_FILES:
             path = self.root / relative
             path.parent.mkdir(parents=True, exist_ok=True)
@@ -99,9 +193,9 @@ class PreparationTests(unittest.TestCase):
         version = release.prepare(self.root, "minor", "2026-07-13", allow_dirty=True)
         self.assertEqual(version, "1.3.0")
         self.assertEqual(release.package_version(self.root), "1.3.0")
-        adapter = (self.root / release.ADAPTER_MANIFEST).read_text(encoding="utf-8")
-        self.assertIn('version = "1.3.0"', adapter)
-        self.assertIn('version = "=1.3.0"', adapter)
+        cargo = (self.root / "Cargo.toml").read_text(encoding="utf-8")
+        self.assertIn('version = "1.3.0"', cargo)
+        self.assertIn('version = "=1.3.0"', cargo)
         for relative in release.LOCKSTEP_LOCKFILES:
             lock = (self.root / relative).read_text(encoding="utf-8")
             self.assertEqual(lock.count('version = "1.3.0"'), 2)
@@ -160,13 +254,15 @@ class PreparationTests(unittest.TestCase):
             release.prepare(self.root, "patch", "2026-07-13", allow_dirty=True)
         self.assertEqual(release.package_version(self.root), "1.2.3")
 
-    def test_mismatched_adapter_version_fails_before_writes(self) -> None:
-        adapter = self.root / release.ADAPTER_MANIFEST
+    def test_explicit_member_version_fails_before_writes(self) -> None:
+        adapter = self.root / "crates/signal-fish-client-godot/Cargo.toml"
         adapter.write_text(
-            adapter.read_text(encoding="utf-8").replace('version = "1.2.3"', 'version = "1.2.4"', 1),
+            adapter.read_text(encoding="utf-8").replace(
+                "version.workspace = true", 'version = "1.2.3"', 1
+            ),
             encoding="utf-8",
         )
-        with self.assertRaisesRegex(release.ReleaseError, "versions must match"):
+        with self.assertRaisesRegex(release.ReleaseError, "version.workspace"):
             release.prepare(self.root, "minor", "2026-07-13", allow_dirty=True)
         self.assertEqual(release.package_version(self.root), "1.2.3")
 
@@ -213,6 +309,59 @@ class ArtifactTests(unittest.TestCase):
         urlopen.side_effect = release.urllib.error.HTTPError("url", 404, "missing", {}, None)
         self.assertIsNone(release.registry_checksum("demo", "1.2.3"))
 
+    def test_registry_plan_state_matrix_and_publish_order(self) -> None:
+        plan = {
+            "version": "1.2.3",
+            "packages": [
+                {
+                    "name": "core",
+                    "version": "1.2.3",
+                    "manifest_path": "Cargo.toml",
+                    "artifact": "core-1.2.3.crate",
+                    "dependencies": [],
+                },
+                {
+                    "name": "adapter",
+                    "version": "1.2.3",
+                    "manifest_path": "adapter/Cargo.toml",
+                    "artifact": "adapter-1.2.3.crate",
+                    "dependencies": ["core"],
+                },
+            ],
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            artifacts = Path(directory)
+            (artifacts / "core-1.2.3.crate").write_bytes(b"core")
+            (artifacts / "adapter-1.2.3.crate").write_bytes(b"adapter")
+            checksums = {
+                "core": release.sha256(artifacts / "core-1.2.3.crate"),
+                "adapter": release.sha256(artifacts / "adapter-1.2.3.crate"),
+            }
+            cases = (
+                ({}, ["core", "adapter"]),
+                ({"core": checksums["core"]}, ["adapter"]),
+                (checksums, []),
+            )
+            for published, expected in cases:
+                with self.subTest(published=published):
+                    state = release.registry_plan(
+                        plan, artifacts, lambda name, _version: published.get(name)
+                    )
+                    self.assertEqual(state["pending"], expected)
+
+            with self.assertRaisesRegex(release.ReleaseError, "unpublished workspace"):
+                release.registry_plan(
+                    plan,
+                    artifacts,
+                    lambda name, _version: checksums["adapter"] if name == "adapter" else None,
+                )
+            with self.assertRaisesRegex(release.ReleaseError, "does not match"):
+                release.registry_plan(
+                    plan,
+                    artifacts,
+                    lambda name, _version: "0" * 64 if name == "core" else None,
+                )
+
 
 class WorkflowPolicyTests(unittest.TestCase):
     @classmethod
@@ -228,27 +377,29 @@ class WorkflowPolicyTests(unittest.TestCase):
 
     def test_prepare_uses_app_token_and_supports_dry_run(self) -> None:
         self.assertIn("actions/create-github-app-token@v3.2.0", self.prepare)
+        self.assertIn("RELEASE_APP_CLIENT_ID is not configured", self.prepare)
         self.assertIn("RELEASE_APP_PRIVATE_KEY", self.prepare)
         self.assertIn("dry_run:", self.prepare)
         self.assertIn('branch=release/%s', self.prepare)
         self.assertIn("gh pr create", self.prepare)
 
-    def test_publish_is_manual_only_and_protected(self) -> None:
+    def test_publish_is_input_free_manual_only_and_protected(self) -> None:
         self.assertIn("workflow_dispatch:", self.publish)
+        dispatch = self.publish.split("workflow_dispatch:", 1)[1].split("permissions:", 1)[0]
+        self.assertNotIn("inputs:", dispatch)
         self.assertNotIn("push:\n", self.publish)
         self.assertIn("environment: crates-io", self.publish)
         self.assertIn("cancel-in-progress: false", self.publish)
-        self.assertIn("expected strict X.Y.Z", self.publish)
         self.assertIn("checks: read", self.publish)
+        self.assertIn("Require the default branch", self.publish)
 
     def test_publish_has_fail_closed_recovery_and_assets(self) -> None:
         for marker in (
             "Existing tag",
-            "Published core checksum",
-            "registry-checksum",
+            "registry-plan",
             "SHA256SUMS",
             "cargo cyclonedx",
-            "actions/attest@v4.1.1",
+            "actions/attest@v4.2.0",
             "cargo publish --dry-run",
             "cargo publish",
             "gh release create",
@@ -256,59 +407,33 @@ class WorkflowPolicyTests(unittest.TestCase):
             with self.subTest(marker=marker):
                 self.assertIn(marker, self.publish)
 
-    def test_unpublished_registry_sentinel_is_compared_as_a_literal(self) -> None:
-        self.assertIn(
-            'if [ "$adapter_baseline" = "UNPUBLISHED" ]; then', self.publish
-        )
-        self.assertIn(
-            'if [ "$core_registry" = "UNPUBLISHED" ] '
-            '&& [ "$adapter_registry" != "UNPUBLISHED" ]; then',
-            self.publish,
-        )
-
     def test_semver_policy_is_derived_and_check_runs_are_latest_only(self) -> None:
-        self.assertIn('semver-policy "$VERSION"', self.publish)
+        self.assertIn('semver-policy "$version"', self.publish)
         self.assertIn('--release-type "$RELEASE_TYPE"', self.publish)
         self.assertIn('if [ "$BREAKING" = true ]', self.prepare)
         self.assertIn("chore!: prepare release", self.prepare)
-        self.assertEqual(self.publish.count("check-runs?filter=latest"), 2)
-        self.assertIn("Expected two CycloneDX JSON files", self.publish)
+        self.assertEqual(self.publish.count("check-runs?filter=latest"), 1)
+        self.assertIn("scripts/check-required-checks.py", self.publish)
+        self.assertIn("Expected one CycloneDX file", self.publish)
         self.assertIn('$RUNNER_TEMP/release-assets', self.publish)
         self.assertIn("Release tooling dirtied the checkout", self.publish)
         self.assertIn("Release publication", self.publish)
         self.assertIn("fetch-tags: true", self.publish)
-        self.assertIn("github.run_id", self.publish)
-        self.assertIn("scripts/release.py package-version", self.publish)
+        self.assertIn("scripts/release.py workspace-plan", self.publish)
 
-    def test_publish_reproduces_and_publishes_both_lockstep_crates(self) -> None:
-        for marker in (
-            "signal-fish-client-godot-${VERSION}.crate",
-            "[patch.crates-io]",
-            "cargo publish -p signal-fish-client",
-            "cargo publish --dry-run --no-verify -p signal-fish-client-godot",
-            "cargo publish --no-verify -p signal-fish-client-godot",
-            "core_published",
-            "adapter_published",
-            "ADAPTER_CHECKSUM",
-        ):
+    def test_workflows_enumerate_publishable_workspace_crates(self) -> None:
+        for marker in ("workspace-plan", "mapfile -t packages", 'package_args+=(-p "$package")'):
             with self.subTest(marker=marker):
                 self.assertIn(marker, self.publish)
+                self.assertIn(marker, self.prepare)
+        self.assertIn("workspace-plan", self.ci)
 
-    def test_unpublished_adapter_packaging_patches_to_local_core(self) -> None:
-        marker = "patch.crates-io.signal-fish-client.path='$core_path'"
-        for workflow in (self.ci, self.prepare, self.publish):
+    def test_release_toolchain_and_runner_are_pinned(self) -> None:
+        for workflow in (self.prepare, self.publish):
             with self.subTest(workflow=workflow[:40]):
-                self.assertIn(marker, workflow)
-
-    def test_adapter_publish_reuses_the_reproduced_local_core_patch(self) -> None:
-        publish_adapter = self.publish.split(
-            "- name: Dry-run and publish adapter to crates.io", 1
-        )[1].split("- name: Wait for adapter visibility", 1)[0]
-        self.assertIn("cargo publish --dry-run --no-verify", publish_adapter)
-        self.assertIn("cargo publish --no-verify", publish_adapter)
-        self.assertIn(
-            "patch.crates-io.signal-fish-client.path='$core_path'", publish_adapter
-        )
+                self.assertIn('RELEASE_RUST: "1.96.1"', workflow)
+                self.assertIn("runs-on: ubuntu-24.04", workflow)
+                self.assertIn("toolchain: ${{ env.RELEASE_RUST }}", workflow)
 
 
 if __name__ == "__main__":

--- a/scripts/test_required_checks.py
+++ b/scripts/test_required_checks.py
@@ -25,19 +25,49 @@ class RequiredCheckTests(unittest.TestCase):
     }
 
     def test_accepts_latest_successful_checks(self) -> None:
-        payload = {
-            "check_runs": [
-                {"id": 1, "name": "CI Required", "status": "completed", "conclusion": "failure"},
-                {"id": 3, "name": "CI Required", "status": "completed", "conclusion": "success"},
-                {"id": 2, "name": "Docs Required", "status": "completed", "conclusion": "success"},
-            ]
-        }
+        payload = [
+            {
+                "check_runs": [
+                    {
+                        "id": 1,
+                        "name": "CI Required",
+                        "status": "completed",
+                        "conclusion": "failure",
+                    },
+                    {
+                        "id": 2,
+                        "name": "Docs Required",
+                        "status": "completed",
+                        "conclusion": "success",
+                    },
+                ]
+            },
+            {
+                "check_runs": [
+                    {
+                        "id": 3,
+                        "name": "CI Required",
+                        "status": "completed",
+                        "conclusion": "success",
+                    }
+                ]
+            },
+        ]
         self.assertEqual(checks.check_results(self.policy, payload), [])
+
+    def test_rejects_malformed_page_in_paginated_payload(self) -> None:
+        with self.assertRaisesRegex(ValueError, "every page"):
+            checks.check_results(self.policy, [{"check_runs": []}, {}])
 
     def test_reports_missing_pending_and_failed_checks(self) -> None:
         payload = {
             "check_runs": [
-                {"id": 1, "name": "CI Required", "status": "in_progress", "conclusion": None}
+                {
+                    "id": 1,
+                    "name": "CI Required",
+                    "status": "in_progress",
+                    "conclusion": None,
+                }
             ]
         }
         self.assertEqual(

--- a/scripts/test_required_checks.py
+++ b/scripts/test_required_checks.py
@@ -88,6 +88,13 @@ class RequiredCheckTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "unique"):
             checks.required_jobs(policy)
 
+    def test_rejects_empty_or_whitespace_job_names(self) -> None:
+        for job in ("", "   "):
+            with self.subTest(job=job), self.assertRaisesRegex(ValueError, "job name"):
+                checks.required_jobs(
+                    {"required_checks": [{"workflow": "CI", "job": job}]}
+                )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test_required_checks.py
+++ b/scripts/test_required_checks.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Tests for check-required-checks.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+SPEC = importlib.util.spec_from_file_location(
+    "check_required_checks", Path(__file__).with_name("check-required-checks.py")
+)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError("could not load check-required-checks.py")
+checks = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(checks)
+
+
+class RequiredCheckTests(unittest.TestCase):
+    policy = {
+        "required_checks": [
+            {"workflow": "CI", "job": "CI Required"},
+            {"workflow": "Docs", "job": "Docs Required"},
+        ]
+    }
+
+    def test_accepts_latest_successful_checks(self) -> None:
+        payload = {
+            "check_runs": [
+                {"id": 1, "name": "CI Required", "status": "completed", "conclusion": "failure"},
+                {"id": 3, "name": "CI Required", "status": "completed", "conclusion": "success"},
+                {"id": 2, "name": "Docs Required", "status": "completed", "conclusion": "success"},
+            ]
+        }
+        self.assertEqual(checks.check_results(self.policy, payload), [])
+
+    def test_reports_missing_pending_and_failed_checks(self) -> None:
+        payload = {
+            "check_runs": [
+                {"id": 1, "name": "CI Required", "status": "in_progress", "conclusion": None}
+            ]
+        }
+        self.assertEqual(
+            checks.check_results(self.policy, payload),
+            [
+                "CI Required: status=in_progress, conclusion=None",
+                "Docs Required: missing",
+            ],
+        )
+
+    def test_rejects_duplicate_job_names(self) -> None:
+        policy = {
+            "required_checks": [
+                {"workflow": "One", "job": "Required"},
+                {"workflow": "Two", "job": "Required"},
+            ]
+        }
+        with self.assertRaisesRegex(ValueError, "unique"):
+            checks.required_jobs(policy)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -233,17 +233,26 @@ fn read_project_file(relative_path: &str) -> String {
     })
 }
 
-/// Reads Cargo.toml and returns the shared workspace package version.
-fn cargo_package_version() -> String {
-    let cargo = read_project_file("Cargo.toml");
-    let parsed: toml::Value = toml::from_str(&cargo).expect("Cargo.toml must be valid TOML");
+/// Reads the version from a workspace source manifest or a standalone package manifest.
+fn manifest_package_version(cargo: &str) -> Option<String> {
+    let parsed: toml::Value = toml::from_str(cargo).expect("Cargo.toml must be valid TOML");
     parsed
         .get("workspace")
         .and_then(|v| v.get("package"))
         .and_then(|v| v.get("version"))
         .and_then(toml::Value::as_str)
+        .or_else(|| {
+            parsed
+                .get("package")
+                .and_then(|v| v.get("version"))
+                .and_then(toml::Value::as_str)
+        })
         .map(std::string::ToString::to_string)
-        .expect("Cargo.toml must define [workspace.package].version as a string")
+}
+
+fn cargo_package_version() -> String {
+    manifest_package_version(&read_project_file("Cargo.toml"))
+        .expect("Cargo.toml must define [workspace.package].version or package.version as a string")
 }
 
 fn is_canonical_git_main_dependency(line: &str) -> bool {
@@ -1385,20 +1394,28 @@ mod ci_workflow_policy {
     }
 
     #[test]
-    fn isolated_core_msrv_manifest_materializes_the_workspace_version() {
+    fn isolated_core_msrv_uses_the_publishable_package_artifact() {
         let ci = ci_contents();
         let msrv_job =
             extract_job_block(&ci, "msrv").expect("ci.yml must define the msrv job under jobs");
 
         assert!(
             msrv_job.contains("core_version=$(python3 scripts/release.py package-version)"),
-            "isolating the root package must read the canonical workspace version"
+            "isolating the root package must locate the versioned crate artifact"
         );
         assert!(
-            msrv_job.contains(r#"/^version\.workspace = true$/"#)
-                && msrv_job.contains(r#"printf "version = \"%s\"\n", version"#),
-            "the standalone manifest must replace inherited package.version before removing [workspace]"
+            msrv_job.contains(
+                "cargo +1.96.1 package --locked --package signal-fish-client --no-verify"
+            ) && msrv_job.contains("--strip-components=1"),
+            "MSRV must test Cargo's publishable package, not a hand-edited source manifest"
         );
+        assert!(
+            msrv_job.contains("--all-features --no-run")
+                && msrv_job.contains("--all-features --lib"),
+            "MSRV must compile every test target and execute package-independent library tests"
+        );
+        assert!(!msrv_job.contains("git archive HEAD"));
+        assert!(!msrv_job.contains("awk -v version"));
     }
 
     #[test]
@@ -1528,6 +1545,22 @@ mod ci_workflow_policy {
 
 mod crate_version_consistency {
     use super::*;
+
+    #[test]
+    fn version_reader_accepts_workspace_source_and_standalone_package_manifests() {
+        assert_eq!(
+            manifest_package_version(
+                "[package]\nname = \"demo\"\nversion.workspace = true\n\n[workspace.package]\nversion = \"1.2.3\"\n"
+            )
+            .as_deref(),
+            Some("1.2.3")
+        );
+        assert_eq!(
+            manifest_package_version("[package]\nname = \"demo\"\nversion = \"1.2.3\"\n")
+                .as_deref(),
+            Some("1.2.3")
+        );
+    }
 
     fn is_semver(value: &str) -> bool {
         let mut parts = value.split('.');

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -1380,6 +1380,19 @@ mod ci_workflow_policy {
     }
 
     #[test]
+    fn semver_registry_search_matches_only_the_requested_crate_name() {
+        let workflow = read_project_file(".github/workflows/semver-checks.yml");
+        assert!(
+            workflow.contains(r#"grep -q "^${package} =""#),
+            "crates.io search results must be anchored at the start of a result line"
+        );
+        assert!(
+            !workflow.contains(r#"grep -qF "${package} =""#),
+            "a suffix crate name must not be mistaken for the requested crate"
+        );
+    }
+
+    #[test]
     fn ci_has_concurrency_block() {
         let contents = ci_contents();
         assert!(

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -82,10 +82,17 @@ mod required_check_policy {
     fn repository_policy_uses_the_authenticated_builtin_token() {
         let workflow = read_project_file(".github/workflows/repository-policy.yml");
         let audit = read_project_file("scripts/audit-repository-rules.py");
+        let policy: serde_json::Value =
+            serde_json::from_str(&read_project_file(".github/required-checks.json"))
+                .expect("required-checks policy must be valid JSON");
         assert!(!workflow.contains("actions/create-github-app-token"));
         assert!(!workflow.contains("RELEASE_APP_"));
         assert!(!workflow.contains("permission-administration"));
         assert!(workflow.contains("GH_TOKEN: ${{ github.token }}"));
+        assert!(!audit.contains("forbid_bypass_actors"));
+        assert!(policy["repository_rules"]
+            .get("forbid_bypass_actors")
+            .is_none());
         assert!(audit.contains(r#""Authorization": f"Bearer {token}""#));
     }
 }

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -20,6 +20,51 @@ fn project_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
 }
 
+mod required_check_policy {
+    use std::collections::BTreeSet;
+
+    use super::*;
+
+    #[test]
+    fn every_blocking_pr_workflow_has_a_stable_aggregate_gate() {
+        let policy: serde_json::Value =
+            serde_json::from_str(&read_project_file(".github/required-checks.json"))
+                .expect("required-checks policy must be valid JSON");
+        let checks = policy["required_checks"]
+            .as_array()
+            .expect("required_checks must be an array");
+        assert_eq!(checks.len(), 11);
+
+        let mut jobs = BTreeSet::new();
+        for check in checks {
+            let file = check["file"].as_str().expect("required check file");
+            let job = check["job"].as_str().expect("required check job");
+            assert!(
+                jobs.insert(job),
+                "required gate names must be unique: {job}"
+            );
+            let workflow = read_project_file(&format!(".github/workflows/{file}"));
+            assert!(
+                workflow.contains(&format!("name: {job}")),
+                "{file} must define aggregate gate {job}"
+            );
+            assert!(
+                workflow.contains("if: ${{ always() }}"),
+                "{file} aggregate gate must run even after a dependency failure"
+            );
+            assert!(
+                workflow.contains("NEEDS_JSON: ${{ toJSON(needs) }}"),
+                "{file} aggregate gate must inspect every dependency result"
+            );
+            assert!(
+                !workflow.contains("pull_request:\n    paths:")
+                    && !workflow.contains("branches: [main]\n    paths:"),
+                "{file} cannot use path filters when its gate must report on PR and main SHAs"
+            );
+        }
+    }
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Module: Godot issue #61 system-regression policy
 // ─────────────────────────────────────────────────────────────────────────────
@@ -88,10 +133,10 @@ mod godot_issue_61_policy {
                 && workflow.contains("NETEM_SEED: \"6101\"")
                 && workflow.contains("IPROUTE2_VERSION: \"6.6.0\"")
                 && workflow.contains("sha256sum --check")
-                && workflow.contains("actions/download-artifact@v7.0.0")
+                && workflow.contains("actions/download-artifact@v8.0.1")
                 && workflow.contains("--locked")
         );
-        assert_eq!(workflow.matches("runs-on: ubuntu-24.04").count(), 2);
+        assert_eq!(workflow.matches("runs-on: ubuntu-24.04").count(), 3);
         assert_eq!(workflow.matches("name: godot-web-export").count(), 2);
         for required in [
             "needs: build-export",
@@ -135,7 +180,9 @@ mod godot_issue_61_policy {
     fn llms_txt_is_in_the_blocking_docs_validation_surface() {
         let workflow = read_project_file(".github/workflows/docs-validation.yml");
         let rendering = read_project_file("scripts/check-docs-rendering.sh");
-        assert!(workflow.matches("- \"llms.txt\"").count() >= 2);
+        assert_eq!(workflow.matches("- \"llms.txt\"").count(), 0);
+        assert!(workflow.contains("  pull_request:\n"));
+        assert!(workflow.contains("name: Docs Validation Required"));
         assert!(workflow.contains("            \"llms.txt\""));
         assert!(rendering.contains("cmp -s \"$REPO_ROOT/llms.txt\" \"$SITE_DIR/llms.txt\""));
     }
@@ -166,16 +213,17 @@ fn read_project_file(relative_path: &str) -> String {
     })
 }
 
-/// Reads Cargo.toml and returns package version.
+/// Reads Cargo.toml and returns the shared workspace package version.
 fn cargo_package_version() -> String {
     let cargo = read_project_file("Cargo.toml");
     let parsed: toml::Value = toml::from_str(&cargo).expect("Cargo.toml must be valid TOML");
     parsed
-        .get("package")
+        .get("workspace")
+        .and_then(|v| v.get("package"))
         .and_then(|v| v.get("version"))
         .and_then(toml::Value::as_str)
         .map(std::string::ToString::to_string)
-        .expect("Cargo.toml must define [package].version as a string")
+        .expect("Cargo.toml must define [workspace.package].version as a string")
 }
 
 fn is_canonical_git_main_dependency(line: &str) -> bool {
@@ -358,6 +406,7 @@ const REQUIRED_WORKFLOW_PATHS: &[&str] = &[
     ".github/workflows/docs-deploy.yml",
     ".github/workflows/docs-validation.yml",
     ".github/workflows/examples-validation.yml",
+    ".github/workflows/godot-web.yml",
     ".github/workflows/no-panics.yml",
     ".github/workflows/security-supply-chain.yml",
     ".github/workflows/semver-checks.yml",
@@ -365,6 +414,8 @@ const REQUIRED_WORKFLOW_PATHS: &[&str] = &[
     ".github/workflows/wasm.yml",
     ".github/workflows/workflow-lint.yml",
     ".github/workflows/publish.yml",
+    ".github/workflows/prepare-release.yml",
+    ".github/workflows/repository-policy.yml",
     ".github/workflows/dependabot-auto-merge.yml",
     ".github/workflows/protocol-sync.yml",
 ];
@@ -1262,8 +1313,8 @@ mod ci_workflow_policy {
         );
         assert!(
             contents.contains("--release-type major")
-                && contents.contains("steps.pr-release-type.outputs.release-type == 'major'")
-                && contents.contains("steps.pr-release-type.outputs.release-type == 'auto'"),
+                && contents.contains("RELEASE_TYPE: ${{ steps.pr-release-type.outputs.release-type }}")
+                && contents.contains("if [ \"$RELEASE_TYPE\" = major ]; then"),
             "Semver CI must use major policy only for explicitly marked breaking PRs and retain inferred checks otherwise"
         );
     }

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -40,6 +40,10 @@ mod required_check_policy {
             let file = check["file"].as_str().expect("required check file");
             let job = check["job"].as_str().expect("required check job");
             assert!(
+                !job.trim().is_empty(),
+                "required check job names must not be blank"
+            );
+            assert!(
                 jobs.insert(job),
                 "required gate names must be unique: {job}"
             );

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -79,12 +79,13 @@ mod required_check_policy {
     }
 
     #[test]
-    fn repository_policy_uses_an_authenticated_least_privilege_token() {
+    fn repository_policy_uses_the_authenticated_builtin_token() {
         let workflow = read_project_file(".github/workflows/repository-policy.yml");
         let audit = read_project_file("scripts/audit-repository-rules.py");
-        assert!(workflow.contains("uses: actions/create-github-app-token@v3.2.0"));
-        assert!(workflow.contains("permission-administration: read"));
-        assert!(workflow.contains("GH_TOKEN: ${{ steps.app-token.outputs.token }}"));
+        assert!(!workflow.contains("actions/create-github-app-token"));
+        assert!(!workflow.contains("RELEASE_APP_"));
+        assert!(!workflow.contains("permission-administration"));
+        assert!(workflow.contains("GH_TOKEN: ${{ github.token }}"));
         assert!(audit.contains(r#""Authorization": f"Bearer {token}""#));
     }
 }
@@ -3587,6 +3588,20 @@ mod ci_config_validation {
             }
         }
         results
+    }
+
+    #[test]
+    fn workflows_do_not_depend_on_release_apps() {
+        for (path, contents) in all_workflow_files() {
+            assert!(
+                !contents.contains("actions/create-github-app-token"),
+                "{path} must use the built-in GITHUB_TOKEN, not a GitHub App token"
+            );
+            assert!(
+                !contents.contains("RELEASE_APP_"),
+                "{path} must not require release-App variables or secrets"
+            );
+        }
     }
 
     /// Extract all `uses: owner/repo@version` references from workflow YAML,

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -687,6 +687,23 @@ esac
         blocks
     }
 
+    fn retry_wrapper_generates_lockfile(line: &str) -> bool {
+        let tokens: Vec<_> = line.split_whitespace().collect();
+        let Some(wrapper) = tokens
+            .iter()
+            .position(|token| *token == "scripts/cargo-retry.sh")
+        else {
+            return false;
+        };
+        let cargo_args = &tokens[wrapper + 1..];
+
+        cargo_args.first() == Some(&"generate-lockfile")
+            || cargo_args
+                .first()
+                .is_some_and(|token| token.starts_with('+'))
+                && cargo_args.get(1) == Some(&"generate-lockfile")
+    }
+
     #[test]
     fn cargo_network_retry_is_configured_for_ci_resilience() {
         let contents = read_project_file(".cargo/config.toml");
@@ -789,9 +806,7 @@ esac
         for workflow_path in REQUIRED_WORKFLOW_PATHS {
             let contents = read_project_file(workflow_path);
             for (line_num, line) in contents.lines().enumerate() {
-                if line.contains("generate-lockfile")
-                    && !line.contains("scripts/cargo-retry.sh generate-lockfile")
-                {
+                if line.contains("generate-lockfile") && !retry_wrapper_generates_lockfile(line) {
                     violations.push(format!("{workflow_path}:{}: {line}", line_num + 1));
                 }
             }
@@ -804,6 +819,22 @@ esac
              Violations:\n{}",
             violations.join("\n")
         );
+    }
+
+    #[test]
+    fn lockfile_retry_policy_accepts_optional_cargo_toolchain_selector() {
+        assert!(retry_wrapper_generates_lockfile(
+            "run: bash scripts/cargo-retry.sh generate-lockfile"
+        ));
+        assert!(retry_wrapper_generates_lockfile(
+            "run: bash scripts/cargo-retry.sh +1.96.1 generate-lockfile"
+        ));
+        assert!(!retry_wrapper_generates_lockfile(
+            "run: cargo +1.96.1 generate-lockfile"
+        ));
+        assert!(!retry_wrapper_generates_lockfile(
+            "run: bash scripts/cargo-retry.sh +1.96.1 metadata # generate-lockfile"
+        ));
     }
 
     #[test]
@@ -1408,6 +1439,16 @@ mod ci_workflow_policy {
                 "cargo +1.96.1 package --locked --package signal-fish-client --no-verify"
             ) && msrv_job.contains("--strip-components=1"),
             "MSRV must test Cargo's publishable package, not a hand-edited source manifest"
+        );
+        let lockfile = msrv_job
+            .find("bash scripts/cargo-retry.sh +1.96.1 generate-lockfile")
+            .expect("MSRV package isolation must generate the gitignored root lockfile");
+        let package = msrv_job
+            .find("cargo +1.96.1 package --locked")
+            .expect("MSRV package isolation must package with the lockfile");
+        assert!(
+            lockfile < package,
+            "lockfile generation must precede --locked packaging"
         );
         assert!(
             msrv_job.contains("--all-features --no-run")

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -63,6 +63,26 @@ mod required_check_policy {
             );
         }
     }
+
+    #[test]
+    fn release_preflight_reads_every_page_of_commit_checks() {
+        let workflow = read_project_file(".github/workflows/publish.yml");
+        assert!(
+            workflow.contains("gh api --paginate --slurp"),
+            "release preflight must paginate check runs before enforcing required checks"
+        );
+        assert!(workflow.contains("check-runs?filter=latest&per_page=100"));
+    }
+
+    #[test]
+    fn repository_policy_uses_an_authenticated_least_privilege_token() {
+        let workflow = read_project_file(".github/workflows/repository-policy.yml");
+        let audit = read_project_file("scripts/audit-repository-rules.py");
+        assert!(workflow.contains("uses: actions/create-github-app-token@v3.2.0"));
+        assert!(workflow.contains("permission-administration: read"));
+        assert!(workflow.contains("GH_TOKEN: ${{ steps.app-token.outputs.token }}"));
+        assert!(audit.contains(r#""Authorization": f"Bearer {token}""#));
+    }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1361,6 +1381,23 @@ mod ci_workflow_policy {
             validation
                 .err()
                 .unwrap_or_else(|| "unknown MSRV validation error".to_string())
+        );
+    }
+
+    #[test]
+    fn isolated_core_msrv_manifest_materializes_the_workspace_version() {
+        let ci = ci_contents();
+        let msrv_job =
+            extract_job_block(&ci, "msrv").expect("ci.yml must define the msrv job under jobs");
+
+        assert!(
+            msrv_job.contains("core_version=$(python3 scripts/release.py package-version)"),
+            "isolating the root package must read the canonical workspace version"
+        );
+        assert!(
+            msrv_job.contains(r#"/^version\.workspace = true$/"#)
+                && msrv_job.contains(r#"printf "version = \"%s\"\n", version"#),
+            "the standalone manifest must replace inherited package.version before removing [workspace]"
         );
     }
 

--- a/tests/godot_adapter_policy_tests.rs
+++ b/tests/godot_adapter_policy_tests.rs
@@ -56,6 +56,7 @@ fn core_manifest_is_godot_independent() {
     for repository_only_test in [
         "!/tests/ci_config_tests.rs",
         "!/tests/godot_adapter_policy_tests.rs",
+        "!/tests/shared_core_policy_tests.rs",
     ] {
         assert!(
             package_include

--- a/tests/godot_adapter_policy_tests.rs
+++ b/tests/godot_adapter_policy_tests.rs
@@ -31,10 +31,10 @@ fn dependency<'a>(manifest: &'a toml::Value, name: &str) -> &'a toml::Value {
         .unwrap_or_else(|| panic!("missing dependency {name}"))
 }
 
-fn package_version(manifest: &toml::Value) -> &str {
-    manifest["package"]["version"]
+fn workspace_version(manifest: &toml::Value) -> &str {
+    manifest["workspace"]["package"]["version"]
         .as_str()
-        .unwrap_or_else(|| panic!("package.version must be a string"))
+        .unwrap_or_else(|| panic!("workspace.package.version must be a string"))
 }
 
 #[test]
@@ -67,9 +67,21 @@ fn core_manifest_is_godot_independent() {
 fn adapter_declares_lockstep_core_and_supported_godot_range() {
     let core = parse_toml(root().join("Cargo.toml"));
     let adapter = parse_toml(root().join(ADAPTER_MANIFEST));
-    let core_version = package_version(&core);
+    let core_version = workspace_version(&core);
 
-    assert_eq!(package_version(&adapter), core_version);
+    assert_eq!(
+        core["package"]["version"]["workspace"].as_bool(),
+        Some(true)
+    );
+    assert_eq!(
+        adapter["package"]["version"]["workspace"].as_bool(),
+        Some(true)
+    );
+    assert_eq!(core["package"]["publish"].as_array().map(Vec::len), Some(1));
+    assert_eq!(
+        adapter["package"]["publish"].as_array().map(Vec::len),
+        Some(1)
+    );
     assert_eq!(adapter["package"]["rust-version"].as_str(), Some("1.94.0"));
 
     let godot = dependency(&adapter, "godot");
@@ -91,11 +103,15 @@ fn adapter_declares_lockstep_core_and_supported_godot_range() {
 
     let core_dependency = dependency(&adapter, "signal-fish-client");
     let expected_core = format!("={core_version}");
+    assert_eq!(core_dependency["workspace"].as_bool(), Some(true));
     assert_eq!(
-        core_dependency["version"].as_str(),
+        core["workspace"]["dependencies"]["signal-fish-client"]["version"].as_str(),
         Some(expected_core.as_str())
     );
-    assert_eq!(core_dependency["default-features"].as_bool(), Some(false));
+    assert_eq!(
+        core["workspace"]["dependencies"]["signal-fish-client"]["default-features"].as_bool(),
+        Some(false)
+    );
     assert_eq!(
         core_dependency["features"].as_array(),
         Some(&vec![toml::Value::String("polling-client".to_string())])
@@ -105,7 +121,7 @@ fn adapter_declares_lockstep_core_and_supported_godot_range() {
 #[test]
 fn minimum_and_latest_fixtures_pin_the_contract_endpoints() {
     let core = parse_toml(root().join("Cargo.toml"));
-    let expected_client = package_version(&core);
+    let expected_client = workspace_version(&core);
 
     for (fixture, expected_godot) in [(MIN_FIXTURE, "0.4.5"), (LATEST_FIXTURE, "0.5.4")] {
         let manifest = parse_toml(root().join(fixture).join("Cargo.toml"));

--- a/tests/godot_adapter_policy_tests.rs
+++ b/tests/godot_adapter_policy_tests.rs
@@ -50,14 +50,20 @@ fn core_manifest_is_godot_independent() {
     assert!(!dependencies.contains_key("godot"));
     assert!(!features.contains_key("transport-godot"));
     assert!(!root().join("src/transports/godot_websocket.rs").exists());
-    assert!(
-        manifest["package"]["include"]
-            .as_array()
-            .expect("core package.include must be an array")
-            .iter()
-            .any(|value| value.as_str() == Some("!/tests/godot_adapter_policy_tests.rs")),
-        "repository-only adapter policy tests must not be shipped without their workspace inputs"
-    );
+    let package_include = manifest["package"]["include"]
+        .as_array()
+        .expect("core package.include must be an array");
+    for repository_only_test in [
+        "!/tests/ci_config_tests.rs",
+        "!/tests/godot_adapter_policy_tests.rs",
+    ] {
+        assert!(
+            package_include
+                .iter()
+                .any(|value| value.as_str() == Some(repository_only_test)),
+            "{repository_only_test} must not ship without its repository inputs"
+        );
+    }
 
     let library = fs::read_to_string(root().join("src/lib.rs")).expect("read core crate root");
     assert!(!library.contains("GodotWebSocketTransport"));

--- a/tests/godot_adapter_policy_tests.rs
+++ b/tests/godot_adapter_policy_tests.rs
@@ -104,6 +104,7 @@ fn adapter_declares_lockstep_core_and_supported_godot_range() {
     let core_dependency = dependency(&adapter, "signal-fish-client");
     let expected_core = format!("={core_version}");
     assert_eq!(core_dependency["workspace"].as_bool(), Some(true));
+    assert_eq!(core_dependency["default-features"].as_bool(), Some(false));
     assert_eq!(
         core["workspace"]["dependencies"]["signal-fish-client"]["version"].as_str(),
         Some(expected_core.as_str())


### PR DESCRIPTION
## Summary

- derive one lockstep workspace version and discover crates.io-publishable crates through Cargo metadata
- make Release input-free, checksum-aware, resumable, and generic across interdependent workspace members
- diagnose missing release App configuration before token generation and pin the release runner/toolchain
- add unique aggregate CI gates, checked-in default-branch policy, live ruleset auditing, tests, runbooks, and LLM guidance

## Evidence

- reproduced the reported missing `RELEASE_APP_CLIENT_ID` failure mode and added a fail-fast setup diagnostic
- verified Cargo 1.96.1 can package and dry-run both crates together
- prepared a copied workspace from 0.8.0 to 0.9.0 and verified both unpublished interdependent packages
- confirmed the recovery planner rejects the current 0.8.0 source because its bytes do not match the historical crates.io package

## Validation

- `cargo fmt && cargo clippy --workspace --all-targets --all-features -- -D warnings && cargo test --workspace --all-features`
- 33 release and repository-policy Python tests
- 114 pre-commit LLM tests
- actionlint, strict yamllint, workflow hygiene, Ruff, diff checks, and strict MkDocs rendering
- all repository pre-commit and pre-push guards

## Repository setting follow-up

After the new aggregate check names have completed once, update the active default-branch ruleset to match `.github/required-checks.json`. The read-only `scripts/audit-repository-rules.py` currently reports the expected missing pull-request and required-status-check rules.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes release publication, branch-protection enforcement, and crates.io recovery paths—security- and supply-chain-critical—even though behavior is fail-closed and heavily tested.
> 
> **Overview**
> This PR **centralizes branch protection** in `.github/required-checks.json` and adds **stable aggregate `* Required` jobs** across blocking workflows so merge/release gates always report on every PR and `main` push (path filters removed where they hid checks). Release preflight uses `check-required-checks.py`; a weekly **Repository Policy** workflow audits live rulesets against that file.
> 
> **Release and versioning** move to a single `[workspace.package].version` with `workspace-plan` / `registry-plan` in `scripts/release.py` to discover, order, package, dry-run, and **resume** crates.io publication by checksum. **Prepare Release** drops the GitHub App and uses `GITHUB_TOKEN` (with maintainer workflow approval on the PR). **Release** is manual-only with **no version input**, pins Rust **1.96.1** and **ubuntu-24.04**, and publishes pending workspace members generically (including `--no-verify` resume when a dependency is already on crates.io).
> 
> **CI** MSRV isolation now tests the **published `.crate`** (package with 1.96.1, test with 1.87.0). Semver, publish dry-run, and prep workflows iterate all publishable crates. Core `Cargo.toml` excludes repo-only policy tests from the published package; LLM skills and `docs/releasing.md` document the new invariants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55446119b20d13ef3ee8c5859e738163ca2eb8b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->