### PR TITLE
ci: automate app-free release preparation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/docs-validation.yml
+++ b/.github/workflows/docs-validation.yml
@@ -15,6 +15,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/examples-validation.yml
+++ b/.github/workflows/examples-validation.yml
@@ -13,6 +13,7 @@ on:
   pull_request:
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/godot-web.yml
+++ b/.github/workflows/godot-web.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/no-panics.yml
+++ b/.github/workflows/no-panics.yml
@@ -13,6 +13,7 @@ on:
   pull_request:
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -3,26 +3,14 @@ name: Prepare Release
 on:
   workflow_dispatch:
     inputs:
-      bump:
-        description: Version component to increment
-        required: true
-        type: choice
-        options:
-          - major
-          - minor
-          - patch
       dry_run:
         description: Validate and show the release changes without pushing a branch
         required: true
         default: true
         type: boolean
-      breaking:
-        description: This pre-1.0 minor or major release contains intentional API breaks
-        required: true
-        default: false
-        type: boolean
 
 permissions:
+  actions: write
   contents: write
   pull-requests: write
 
@@ -69,11 +57,22 @@ jobs:
           python3 -m unittest scripts/test_release.py scripts/test_required_checks.py
           scripts/test_audit_repository_rules.py
 
+      - name: Derive release intent
+        id: intent
+        run: |
+          python3 scripts/release.py release-intent > "$RUNNER_TEMP/release-intent.json"
+          jq . "$RUNNER_TEMP/release-intent.json"
+          {
+            printf 'bump=%s\n' "$(jq -r '.bump' "$RUNNER_TEMP/release-intent.json")"
+            printf 'breaking=%s\n' "$(jq -r '.breaking' "$RUNNER_TEMP/release-intent.json")"
+            printf 'target=%s\n' "$(jq -r '.target' "$RUNNER_TEMP/release-intent.json")"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Prepare release files
         id: version
         env:
-          BUMP: ${{ inputs.bump }}
-          BREAKING: ${{ inputs.breaking }}
+          BUMP: ${{ steps.intent.outputs.bump }}
+          BREAKING: ${{ steps.intent.outputs.breaking }}
         run: |
           args=()
           if [ "$BREAKING" = true ]; then
@@ -108,7 +107,7 @@ jobs:
         env:
           BRANCH: ${{ steps.version.outputs.branch }}
           VERSION: ${{ steps.version.outputs.version }}
-          BREAKING: ${{ inputs.breaking }}
+          BREAKING: ${{ steps.intent.outputs.breaking }}
         run: |
           git switch -c "$BRANCH"
           git config user.name "github-actions[bot]"
@@ -133,7 +132,7 @@ jobs:
           BRANCH: ${{ steps.version.outputs.branch }}
           VERSION: ${{ steps.version.outputs.version }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-          BREAKING: ${{ inputs.breaking }}
+          BREAKING: ${{ steps.intent.outputs.breaking }}
         run: |
           title="chore: prepare release ${VERSION}"
           if [ "$BREAKING" = true ]; then
@@ -142,11 +141,34 @@ jobs:
           {
             printf 'Automated release preparation for %s.\n\n' "$VERSION"
             printf '%s\n' \
-              'GitHub holds workflows triggered by this app-free automation for maintainer approval.' \
-              'Select **Approve workflows to run**, then merge only after every required check and review is green.'
+              'The built-in workflow token explicitly dispatches every required check for this commit.' \
+              'Merge only after every required check and review is green.'
           } > "$RUNNER_TEMP/release-pr.md"
-          gh pr create \
+          pr_url=$(gh pr create \
             --base "$DEFAULT_BRANCH" \
             --head "$BRANCH" \
             --title "$title" \
-            --body-file "$RUNNER_TEMP/release-pr.md"
+            --body-file "$RUNNER_TEMP/release-pr.md")
+          printf 'Opened %s\n' "$pr_url"
+
+      - name: Dispatch required checks for the release pull request
+        if: ${{ !inputs.dry_run }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BRANCH: ${{ steps.version.outputs.branch }}
+          VERSION: ${{ steps.version.outputs.version }}
+          BREAKING: ${{ steps.intent.outputs.breaking }}
+        run: |
+          base_sha=$(git rev-parse HEAD^)
+          title="chore: prepare release ${VERSION}"
+          if [ "$BREAKING" = true ]; then
+            title="chore!: prepare release ${VERSION}"
+          fi
+          while IFS= read -r workflow; do
+            if [ "$workflow" = semver-checks.yml ]; then
+              gh workflow run "$workflow" --ref "$BRANCH" \
+                -f "base_sha=${base_sha}" -f "pr_title=${title}"
+            else
+              gh workflow run "$workflow" --ref "$BRANCH"
+            fi
+          done < <(jq -r '.required_checks[].file' .github/required-checks.json)

--- a/.github/workflows/security-supply-chain.yml
+++ b/.github/workflows/security-supply-chain.yml
@@ -18,6 +18,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
   schedule:
     # Weekdays at 06:00 UTC — avoids weekend noise
     - cron: "0 6 * * 1-5"

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -20,6 +20,16 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
+    inputs:
+      base_sha:
+        description: Base commit for an explicitly dispatched candidate
+        required: true
+        type: string
+      pr_title:
+        description: Candidate title used to authorize breaking changes
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -66,9 +76,9 @@ jobs:
 
       - name: Classify PR release type
         id: pr-release-type
-        if: github.event_name == 'pull_request'
+        if: github.event_name != 'push'
         env:
-          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_TITLE: ${{ github.event.pull_request.title || inputs.pr_title }}
         run: |
           if [[ "$PR_TITLE" == *"!:"* ]]; then
             echo "release-type=major" >> "$GITHUB_OUTPUT"
@@ -78,9 +88,9 @@ jobs:
           fi
 
       - name: Check every publishable crate against the PR base
-        if: github.event_name == 'pull_request'
+        if: github.event_name != 'push'
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || inputs.base_sha }}
           RELEASE_TYPE: ${{ steps.pr-release-type.outputs.release-type }}
         run: |
           python3 scripts/release.py workspace-plan > "$RUNNER_TEMP/workspace-plan.json"
@@ -101,6 +111,7 @@ jobs:
         if: github.event_name == 'push'
         run: |
           python3 scripts/release.py workspace-plan > "$RUNNER_TEMP/workspace-plan.json"
+          RELEASE_TYPE=$(python3 scripts/release.py current-semver-policy)
           while IFS= read -r package; do
             if ! search_output="$(
               CARGO_TERM_COLOR=never bash scripts/cargo-retry.sh search "$package" --limit 1 2>&1
@@ -109,7 +120,8 @@ jobs:
               exit 1
             fi
             if printf '%s\n' "$search_output" | grep -q "^${package} ="; then
-              cargo semver-checks check-release --package "$package"
+              cargo semver-checks check-release --package "$package" \
+                --release-type "$RELEASE_TYPE"
             else
               printf 'Skipping %s: no crates.io baseline exists.\n' "$package"
             fi

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -111,7 +111,6 @@ jobs:
         if: github.event_name == 'push'
         run: |
           python3 scripts/release.py workspace-plan > "$RUNNER_TEMP/workspace-plan.json"
-          RELEASE_TYPE=$(python3 scripts/release.py current-semver-policy)
           while IFS= read -r package; do
             if ! search_output="$(
               CARGO_TERM_COLOR=never bash scripts/cargo-retry.sh search "$package" --limit 1 2>&1
@@ -120,6 +119,13 @@ jobs:
               exit 1
             fi
             if printf '%s\n' "$search_output" | grep -q "^${package} ="; then
+              baseline=$(printf '%s\n' "$search_output" | sed -n \
+                "s/^${package} = \"\([0-9][0-9.]*\)\".*/\1/p")
+              if [ -z "$baseline" ]; then
+                printf '::error::Could not parse the latest %s version from crates.io.\n' "$package"
+                exit 1
+              fi
+              RELEASE_TYPE=$(python3 scripts/release.py current-semver-policy "$baseline")
               cargo semver-checks check-release --package "$package" \
                 --release-type "$RELEASE_TYPE"
             else

--- a/.github/workflows/unused-deps.yml
+++ b/.github/workflows/unused-deps.yml
@@ -16,6 +16,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
   schedule:
     # Weekdays at 05:00 UTC — staggered from security workflow at 06:00
     - cron: "0 5 * * 1-5"

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -34,6 +34,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -13,6 +13,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.llm/context.md
+++ b/.llm/context.md
@@ -33,6 +33,9 @@ reproduce, attest, and publish every crates.io-publishable workspace member at
 the single `[workspace.package].version`. `scripts/release.py workspace-plan`
 discovers members with Cargo metadata and orders internal dependencies; Release
 has no version input and resumes only checksum-identical partial publication.
+Prepare Release derives its bump and breaking policy from `[Unreleased]`, so it
+also accepts no version, bump, breaking, or crate-selection input beyond its
+reversible dry-run switch.
 Release jobs pin Rust 1.96.1 and Ubuntu 24.04. See
 `skills/release-recovery/SKILL.md` and `docs/releasing.md`.
 
@@ -42,7 +45,8 @@ uniquely named aggregate `Required` job. The names and desired rules live in
 GitHub for visible drift with its authenticated built-in `GITHUB_TOKEN`.
 GitHub hides ruleset bypass actors from workflow tokens, so maintainers verify
 an empty bypass list in the ruleset UI. Prepare Release also uses only
-`GITHUB_TOKEN`; maintainers approve the resulting PR workflows before they run.
+`GITHUB_TOKEN` and explicitly dispatches the required workflows on its generated
+branch because ordinary token-created pull-request events are suppressed.
 Path filters must not suppress a configured required gate.
 
 ## GitHub Tool Order

--- a/.llm/skills/crate-publishing/SKILL.md
+++ b/.llm/skills/crate-publishing/SKILL.md
@@ -199,9 +199,17 @@ publication path.
 
 ```shell
 # Preview and prepare a lockstep release.
-python3 scripts/release.py prepare minor
+python3 scripts/release.py release-intent
 # In normal operations, dispatch Prepare Release instead; it creates the PR.
 ```
+
+Prepare Release takes no version, bump, breaking, or crate-selection input.
+`release-intent` derives the lockstep target from `[Unreleased]`: an explicit
+`**Breaking:**` entry selects major (pre-1.0 minor), feature-facing Keep a
+Changelog categories select minor, and Fixed/Security-only content selects
+patch. The workflow discovers every publishable crate and explicitly dispatches
+the checked-in required-check workflow list with its built-in token; never add a
+release App or PAT to restore implicit pull-request events.
 
 ### Version bump checklist
 

--- a/.llm/skills/release-recovery/SKILL.md
+++ b/.llm/skills/release-recovery/SKILL.md
@@ -45,6 +45,13 @@ shared version and exact requirements, updates locks, documentation,
 compatibility and provenance markers, and cuts the release. Update
 `scripts/test_release.py` when a release invariant changes.
 
+Push-time semver policy is relative to the exact latest crates.io version. If a
+cut workspace version is not published yet, combine that cut's policy with new
+`[Unreleased]` notes; once crates.io catches up, apply only the new notes. Reject
+registry lag beyond the changelog's immediate predecessor instead of silently
+weakening the check. Every changelog category must contain at least one list
+entry so empty headings cannot select a bump.
+
 ## Publishing order
 
 The release workflow must retain this order:

--- a/.llm/skills/release-recovery/SKILL.md
+++ b/.llm/skills/release-recovery/SKILL.md
@@ -11,10 +11,12 @@ recovery.
 ## Workflow split
 
 `.github/workflows/prepare-release.yml` is reversible. Manual dispatch from the
-default branch accepts a version bump, deliberate breaking marker, and dry-run
-mode. Its built-in `GITHUB_TOKEN` creates `release/X.Y.Z` and its pull request.
-GitHub holds the resulting PR workflows for a maintainer to select **Approve
-workflows to run**; this approval is required before normal checks execute.
+default branch accepts only a dry-run switch. It derives version and breaking
+policy from `[Unreleased]`, and its built-in `GITHUB_TOKEN` creates
+`release/X.Y.Z` and its pull request. Because GitHub suppresses ordinary events
+caused by that token, the workflow explicitly dispatches every entry in
+`.github/required-checks.json` against the release branch with Actions write
+permission. Do not restore an App or PAT for implicit event triggering.
 
 `.github/workflows/publish.yml` is irreversible. It is manual-only, has no
 version input, derives the version from the merged workspace, and uses the
@@ -34,11 +36,14 @@ dependency-first plan. It also reads each member manifest to require
 `workspace = true`; metadata's resolved exact requirement alone cannot prove
 that preparation will update the member on the next version bump.
 
-`python3 scripts/release.py prepare <major|minor|patch>` validates the complete
-inventory before writing, changes the shared version and exact requirements,
-updates locks, documentation, compatibility and provenance markers, and cuts a
-non-empty changelog release. Update `scripts/test_release.py` when a release
-invariant changes.
+`python3 scripts/release.py release-intent` derives the next version from the
+non-empty Keep a Changelog categories. `**Breaking:**` selects major (or minor
+for pre-1.0); Added, Changed, Deprecated, or Removed select minor; a
+Fixed/Security-only train selects patch. The workflow feeds that result to
+`prepare`, which validates the complete inventory before writing, changes the
+shared version and exact requirements, updates locks, documentation,
+compatibility and provenance markers, and cuts the release. Update
+`scripts/test_release.py` when a release invariant changes.
 
 ## Publishing order
 
@@ -78,8 +83,8 @@ error; stop and investigate.
 
 Enable **Allow GitHub Actions to create and approve pull requests** in the
 repository's Actions settings. Prepare Release requests Contents and Pull
-requests write access for its built-in `GITHUB_TOKEN`; no App, personal access
-token, repository variable, or release secret is required.
+requests write plus Actions write access for its built-in `GITHUB_TOKEN`; no
+App, personal access token, repository variable, or release secret is required.
 
 The protected `crates-io` environment holds `CRATES_IO_TOKEN`. Bootstrap new
 workspace crates with a token limited to `signal-fish-client*` and

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -41,6 +41,11 @@ exclude = [
     # route locally before publication.
     "^https://ambiguous-interactive\\.github\\.io/signal-fish-client-rust/fortress/?$",
 
+    # Same-site routes are validated against the just-built MkDocs site by
+    # scripts/check-docs-rendering.sh. Probing the live deployment here races
+    # docs-deploy on pushes to main and can transiently return 503.
+    "^https://[Aa]mbiguous-[Ii]nteractive\\.github\\.io/signal-fish-client-rust/",
+
     # Badge image URLs — shields.io can be flaky and badges may not
     # exist for unpublished crates
     "^https://img\\.shields\\.io/",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Changed release preparation to infer the lockstep version and breaking policy
+  from `[Unreleased]`, discover every publishable workspace crate, and dispatch
+  required checks with the built-in `GITHUB_TOKEN`; no release App, PAT,
+  version input, or crate selector is required.
 - **Breaking:** Godot consumers now depend on the lockstep companion adapter and
   import the transport from that crate; the transport-agnostic core keeps its
   Rust 1.87 MSRV while the adapter requires Rust 1.94. The tested production

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -67,6 +67,9 @@ before writing if the workspace graph, inventory, or `[Unreleased]` section is
 invalid. Release intent is deterministic: a `**Breaking:**` entry selects a
 major bump (or a pre-1.0 minor bump); Added, Changed, Deprecated, or Removed
 select minor; Fixed/Security-only trains select patch.
+Every category must contain at least one list entry. Main-branch semver checks
+combine a not-yet-published cut with new notes relative to the exact crates.io
+baseline, then return to the new notes alone once the registry catches up.
 
 ```sh
 python3 scripts/release.py workspace-plan

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -8,15 +8,15 @@ manual, protected, and fail-closed.
 
 In **Settings > Actions > General > Workflow permissions**, enable **Allow
 GitHub Actions to create and approve pull requests**. Prepare Release uses only
-the run's built-in `GITHUB_TOKEN`, explicitly scoped to **Contents: write** and
-**Pull requests: write**. It requires no GitHub App, personal access token,
-repository variable, or release secret.
+the run's built-in `GITHUB_TOKEN`, explicitly scoped to **Actions: write**,
+**Contents: write**, and **Pull requests: write**. It requires no GitHub App,
+personal access token, repository variable, or release secret.
 
-GitHub places workflows triggered by a pull request created with
-`GITHUB_TOKEN` into an approval-required state. After Prepare Release opens the
-pull request, a maintainer with write access must select **Approve workflows to
-run**. This manual approval is the deliberate app-free replacement for an App
-token that could trigger checks automatically.
+GitHub suppresses ordinary workflow events created by `GITHUB_TOKEN`. Prepare
+Release therefore has **Actions: write** permission and explicitly dispatches
+every workflow listed in `.github/required-checks.json` against the release
+branch after opening the pull request. Explicit `workflow_dispatch` runs are
+the supported exception, so checks start automatically without an App or PAT.
 
 Configure the protected `crates-io` environment with required reviewers, a
 default-branch deployment restriction, and a `CRATES_IO_TOKEN` secret. For the
@@ -46,14 +46,15 @@ with repository Metadata read access, then run
 
 ## Prepare a release
 
-1. Run **Prepare Release** from the default branch with `dry_run` enabled.
-2. Select `major`, `minor`, or `patch`. Enable `breaking` only for an
-   intentional major release or pre-1.0 breaking minor release.
-3. Inspect the generated diff and validation output.
-4. Run it again with `dry_run` disabled. The built-in token creates
+1. Keep `[Unreleased]` organized under Keep a Changelog categories and mark
+   intentional API breaks with `**Breaking:**`.
+2. Run **Prepare Release** from the default branch with `dry_run` enabled and
+   inspect the inferred version, generated diff, and validation output.
+3. Run it again with `dry_run` disabled. The built-in token creates
    `release/X.Y.Z` and opens the preparation pull request.
-5. Open the pull request and select **Approve workflows to run**.
-6. Merge only after every aggregate required check, review, and thread is
+4. The workflow explicitly dispatches every required check against the release
+   commit; no workflow approval or release App is needed.
+5. Merge only after every aggregate required check, review, and thread is
    green.
 
 The workspace owns one version at `[workspace.package].version`; publishable
@@ -63,11 +64,13 @@ members set `version.workspace = true`. Preparation discovers crates through
 requirements by manifest key (including renamed dependencies), then updates
 locks, documentation references, provenance, and the changelog. It fails
 before writing if the workspace graph, inventory, or `[Unreleased]` section is
-invalid.
+invalid. Release intent is deterministic: a `**Breaking:**` entry selects a
+major bump (or a pre-1.0 minor bump); Added, Changed, Deprecated, or Removed
+select minor; Fixed/Security-only trains select patch.
 
 ```sh
 python3 scripts/release.py workspace-plan
-python3 scripts/release.py prepare minor
+python3 scripts/release.py release-intent
 ```
 
 ## Publish a release

--- a/scripts/check-docs-rendering.sh
+++ b/scripts/check-docs-rendering.sh
@@ -448,6 +448,31 @@ else
         else
             fail "site/llms.txt is missing or differs from the canonical root llms.txt"
         fi
+
+        # 4g. Validate same-site discovery URLs against this exact build. This
+        #     is stronger and less flaky than racing the concurrent Pages
+        #     deployment from the link-check job on pushes to main.
+        SAME_SITE_ROUTES_OK=true
+        while IFS= read -r url; do
+            route=$(printf '%s\n' "$url" | sed -E \
+                's#^https://[Aa]mbiguous-[Ii]nteractive\.github\.io/signal-fish-client-rust/##; s#[?#].*$##')
+            if [[ -z "$route" || "$route" == */ ]]; then
+                expected="$SITE_DIR/${route}index.html"
+            elif [[ -f "$SITE_DIR/$route" ]]; then
+                expected="$SITE_DIR/$route"
+            else
+                expected="$SITE_DIR/$route/index.html"
+            fi
+            if [[ ! -f "$expected" ]]; then
+                fail "Same-site llms.txt route has no local build output: $url"
+                SAME_SITE_ROUTES_OK=false
+            fi
+        done < <(grep -Eo \
+            'https://[Aa]mbiguous-[Ii]nteractive\.github\.io/signal-fish-client-rust/[^])[:space:]]*' \
+            "$REPO_ROOT/llms.txt" | sort -u)
+        if [[ "$SAME_SITE_ROUTES_OK" == true ]]; then
+            pass "Every same-site llms.txt route exists in the local build"
+        fi
     fi
 fi
 

--- a/scripts/check-docs-rendering.sh
+++ b/scripts/check-docs-rendering.sh
@@ -453,7 +453,18 @@ else
         #     is stronger and less flaky than racing the concurrent Pages
         #     deployment from the link-check job on pushes to main.
         SAME_SITE_ROUTES_OK=true
+        SAME_SITE_ROUTES=()
         while IFS= read -r url; do
+            SAME_SITE_ROUTES+=("$url")
+        done < <(grep -Eo \
+            'https://[Aa]mbiguous-[Ii]nteractive\.github\.io/signal-fish-client-rust/[^])[:space:]]*' \
+            "$REPO_ROOT/llms.txt" | sort -u)
+        SAME_SITE_ROUTE_COUNT=${#SAME_SITE_ROUTES[@]}
+        if (( SAME_SITE_ROUTE_COUNT == 0 )); then
+            fail "No same-site discovery routes found in llms.txt"
+            SAME_SITE_ROUTES_OK=false
+        fi
+        for url in "${SAME_SITE_ROUTES[@]}"; do
             route=$(printf '%s\n' "$url" | sed -E \
                 's#^https://[Aa]mbiguous-[Ii]nteractive\.github\.io/signal-fish-client-rust/##; s#[?#].*$##')
             if [[ -z "$route" || "$route" == */ ]]; then
@@ -467,9 +478,7 @@ else
                 fail "Same-site llms.txt route has no local build output: $url"
                 SAME_SITE_ROUTES_OK=false
             fi
-        done < <(grep -Eo \
-            'https://[Aa]mbiguous-[Ii]nteractive\.github\.io/signal-fish-client-rust/[^])[:space:]]*' \
-            "$REPO_ROOT/llms.txt" | sort -u)
+        done
         if [[ "$SAME_SITE_ROUTES_OK" == true ]]; then
             pass "Every same-site llms.txt route exists in the local build"
         fi

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -243,6 +243,20 @@ def release_intent(root: Path) -> dict[str, Any]:
         )
     if len(categories) != len(set(categories)):
         raise ReleaseError("CHANGELOG.md [Unreleased] has duplicate categories")
+    category_headings = list(
+        re.finditer(r"^### ([^\n]+)[ \t]*$", body, re.MULTILINE)
+    )
+    for index, heading in enumerate(category_headings):
+        end = (
+            category_headings[index + 1].start()
+            if index + 1 < len(category_headings)
+            else len(body)
+        )
+        category_body = body[heading.end() : end]
+        if re.search(r"^-\s+\S", category_body, re.MULTILINE) is None:
+            raise ReleaseError(
+                f"CHANGELOG.md [Unreleased] has empty category {heading.group(1)}"
+            )
 
     current = workspace_version(root)
     major, _minor, _patch = parse_version(current)
@@ -688,11 +702,32 @@ def semver_policy(root: Path, version: str) -> str:
     raise ReleaseError("major semver policy is invalid for this version bump")
 
 
-def current_semver_policy(root: Path) -> str:
-    """Select policy for a main-branch release train or its just-cut release."""
-    if unreleased_changelog(root):
-        return str(release_intent(root)["semver_policy"])
-    return semver_policy(root, workspace_version(root))
+def current_semver_policy(root: Path, baseline: str) -> str:
+    """Select policy spanning the registry baseline through pending changes."""
+    current = workspace_version(root)
+    baseline_parts = parse_version(baseline)
+    current_parts = parse_version(current)
+    if baseline_parts > current_parts:
+        raise ReleaseError(
+            f"registry baseline {baseline} is newer than workspace version {current}"
+        )
+    pending = (
+        str(release_intent(root)["semver_policy"])
+        if unreleased_changelog(root)
+        else "patch"
+    )
+    if baseline == current:
+        return pending
+
+    previous = previous_version(root, current)
+    if baseline != previous:
+        raise ReleaseError(
+            f"registry baseline {baseline} is not the immediate predecessor {previous} "
+            f"of workspace version {current}"
+        )
+    cut = semver_policy(root, current)
+    rank = {"patch": 0, "minor": 1, "major": 2}
+    return max((cut, pending), key=rank.__getitem__)
 
 
 def sha256(path: Path) -> str:
@@ -778,6 +813,7 @@ def main(argv: list[str] | None = None) -> int:
     intent.add_argument("--root", type=Path, default=Path.cwd())
 
     current_policy = subparsers.add_parser("current-semver-policy")
+    current_policy.add_argument("baseline")
     current_policy.add_argument("--root", type=Path, default=Path.cwd())
 
     args = parser.parse_args(argv)
@@ -821,7 +857,7 @@ def main(argv: list[str] | None = None) -> int:
         elif args.command == "release-intent":
             print(json.dumps(release_intent(args.root.resolve()), indent=2))
         else:
-            print(current_semver_policy(args.root.resolve()))
+            print(current_semver_policy(args.root.resolve(), args.baseline))
     except (OSError, ValueError, ReleaseError, subprocess.CalledProcessError) as error:
         print(f"release error: {error}", file=sys.stderr)
         return 1

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -39,6 +39,15 @@ PROVENANCE_FILES = (
     "tests/server-spec/PROVENANCE.toml",
     "tests/wire-samples/PROVENANCE.toml",
 )
+CHANGELOG_CATEGORIES = (
+    "Added",
+    "Changed",
+    "Deprecated",
+    "Removed",
+    "Fixed",
+    "Security",
+)
+MINOR_CATEGORIES = frozenset(("Added", "Changed", "Deprecated", "Removed"))
 
 
 class ReleaseError(RuntimeError):
@@ -202,6 +211,65 @@ def previous_version(root: Path, version: str) -> str:
     previous = match.group(1)
     parse_version(previous)
     return previous
+
+
+def unreleased_changelog(root: Path) -> str:
+    """Return the complete Unreleased body without matching prefix headings."""
+    changelog = (root / "CHANGELOG.md").read_text(encoding="utf-8")
+    heading = "## [Unreleased]"
+    start = changelog.find(heading)
+    if start < 0:
+        raise ReleaseError("CHANGELOG.md has no [Unreleased] section")
+    content_start = start + len(heading)
+    end = changelog.find("\n## [", content_start)
+    if end < 0:
+        raise ReleaseError("CHANGELOG.md has no released section after [Unreleased]")
+    return changelog[content_start:end].strip()
+
+
+def release_intent(root: Path) -> dict[str, Any]:
+    """Derive the next lockstep release solely from the canonical changelog."""
+    body = unreleased_changelog(root)
+    if not body:
+        raise ReleaseError("CHANGELOG.md [Unreleased] section is empty")
+    categories = re.findall(r"^### ([^\n]+)[ \t]*$", body, re.MULTILINE)
+    if not categories:
+        raise ReleaseError("CHANGELOG.md [Unreleased] has no Keep a Changelog category")
+    unsupported = [name for name in categories if name not in CHANGELOG_CATEGORIES]
+    if unsupported:
+        raise ReleaseError(
+            "CHANGELOG.md [Unreleased] has unsupported categories: "
+            + ", ".join(unsupported)
+        )
+    if len(categories) != len(set(categories)):
+        raise ReleaseError("CHANGELOG.md [Unreleased] has duplicate categories")
+
+    current = workspace_version(root)
+    major, _minor, _patch = parse_version(current)
+    breaking = bool(
+        re.search(
+            r"^-\s+\*\*Breaking:\*\*|^<!--\s*semver-checks:\s*major\s*-->$",
+            body,
+            re.MULTILINE,
+        )
+    )
+    if breaking:
+        bump = "major" if major > 0 else "minor"
+        policy = "major"
+    elif MINOR_CATEGORIES.intersection(categories):
+        bump = "minor"
+        policy = "minor"
+    else:
+        bump = "patch"
+        policy = "patch"
+    return {
+        "current": current,
+        "target": bump_version(current, bump),
+        "bump": bump,
+        "breaking": breaking,
+        "semver_policy": policy,
+        "categories": categories,
+    }
 
 
 def replace_required(path: Path, old: str, new: str) -> None:
@@ -620,6 +688,13 @@ def semver_policy(root: Path, version: str) -> str:
     raise ReleaseError("major semver policy is invalid for this version bump")
 
 
+def current_semver_policy(root: Path) -> str:
+    """Select policy for a main-branch release train or its just-cut release."""
+    if unreleased_changelog(root):
+        return str(release_intent(root)["semver_policy"])
+    return semver_policy(root, workspace_version(root))
+
+
 def sha256(path: Path) -> str:
     digest = hashlib.sha256()
     with path.open("rb") as stream:
@@ -699,6 +774,12 @@ def main(argv: list[str] | None = None) -> int:
     semver.add_argument("version")
     semver.add_argument("--root", type=Path, default=Path.cwd())
 
+    intent = subparsers.add_parser("release-intent")
+    intent.add_argument("--root", type=Path, default=Path.cwd())
+
+    current_policy = subparsers.add_parser("current-semver-policy")
+    current_policy.add_argument("--root", type=Path, default=Path.cwd())
+
     args = parser.parse_args(argv)
     try:
         if args.command == "prepare":
@@ -735,8 +816,12 @@ def main(argv: list[str] | None = None) -> int:
             print(previous_version(args.root.resolve(), args.version))
         elif args.command == "release-type":
             print(release_type(args.base, args.target))
-        else:
+        elif args.command == "semver-policy":
             print(semver_policy(args.root.resolve(), args.version))
+        elif args.command == "release-intent":
+            print(json.dumps(release_intent(args.root.resolve()), indent=2))
+        else:
+            print(current_semver_policy(args.root.resolve()))
     except (OSError, ValueError, ReleaseError, subprocess.CalledProcessError) as error:
         print(f"release error: {error}", file=sys.stderr)
         return 1

--- a/scripts/test_release.py
+++ b/scripts/test_release.py
@@ -329,6 +329,18 @@ class PreparationTests(unittest.TestCase):
         with self.assertRaisesRegex(release.ReleaseError, "unsupported.*Surprise"):
             release.release_intent(self.root)
 
+    def test_release_intent_rejects_empty_changelog_categories(self) -> None:
+        changelog = self.root / "CHANGELOG.md"
+        changelog.write_text(
+            changelog.read_text(encoding="utf-8").replace(
+                "## [1.2.3]", "### Fixed\n\n## [1.2.3]"
+            ),
+            encoding="utf-8",
+        )
+
+        with self.assertRaisesRegex(release.ReleaseError, "empty.*Fixed"):
+            release.release_intent(self.root)
+
     def test_current_semver_policy_prefers_unreleased_intent(self) -> None:
         changelog = self.root / "CHANGELOG.md"
         changelog.write_text(
@@ -338,7 +350,7 @@ class PreparationTests(unittest.TestCase):
             encoding="utf-8",
         )
 
-        self.assertEqual(release.current_semver_policy(self.root), "major")
+        self.assertEqual(release.current_semver_policy(self.root, "1.2.3"), "major")
 
     def test_current_semver_policy_falls_back_to_cut_release(self) -> None:
         version = release.prepare(
@@ -350,7 +362,41 @@ class PreparationTests(unittest.TestCase):
         )
 
         self.assertEqual(version, "2.0.0")
-        self.assertEqual(release.current_semver_policy(self.root), "major")
+        self.assertEqual(release.current_semver_policy(self.root, "1.2.3"), "major")
+
+    def test_current_semver_policy_combines_unpublished_cut_and_new_notes(self) -> None:
+        version = release.prepare(
+            self.root,
+            "major",
+            "2026-07-13",
+            allow_dirty=True,
+            breaking=True,
+        )
+        changelog = self.root / "CHANGELOG.md"
+        changelog.write_text(
+            changelog.read_text(encoding="utf-8").replace(
+                "## [Unreleased]\n\n",
+                "## [Unreleased]\n\n### Fixed\n\n- Follow-up fix.\n\n",
+                1,
+            ),
+            encoding="utf-8",
+        )
+
+        self.assertEqual(version, "2.0.0")
+        self.assertEqual(release.current_semver_policy(self.root, "1.2.3"), "major")
+        self.assertEqual(release.current_semver_policy(self.root, "2.0.0"), "patch")
+
+    def test_current_semver_policy_rejects_non_predecessor_registry_lag(self) -> None:
+        release.prepare(
+            self.root,
+            "major",
+            "2026-07-13",
+            allow_dirty=True,
+            breaking=True,
+        )
+
+        with self.assertRaisesRegex(release.ReleaseError, "immediate predecessor"):
+            release.current_semver_policy(self.root, "1.0.0")
 
     def test_prepare_updates_renamed_workspace_requirement(self) -> None:
         root_manifest = self.root / "Cargo.toml"

--- a/scripts/test_release.py
+++ b/scripts/test_release.py
@@ -269,6 +269,89 @@ class PreparationTests(unittest.TestCase):
         self.assertEqual(release.previous_version(self.root, "1.3.0"), "1.2.3")
         self.assertEqual(release.semver_policy(self.root, "1.3.0"), "minor")
 
+    def test_release_intent_derives_minor_from_added_entries(self) -> None:
+        intent = release.release_intent(self.root)
+
+        self.assertEqual(
+            intent,
+            {
+                "current": "1.2.3",
+                "target": "1.3.0",
+                "bump": "minor",
+                "breaking": False,
+                "semver_policy": "minor",
+                "categories": ["Added"],
+            },
+        )
+
+    def test_release_intent_derives_patch_from_fix_only_entries(self) -> None:
+        changelog = self.root / "CHANGELOG.md"
+        changelog.write_text(
+            changelog.read_text(encoding="utf-8").replace("### Added", "### Fixed"),
+            encoding="utf-8",
+        )
+
+        intent = release.release_intent(self.root)
+
+        self.assertEqual(intent["target"], "1.2.4")
+        self.assertEqual(intent["bump"], "patch")
+        self.assertEqual(intent["semver_policy"], "patch")
+
+    def test_release_intent_derives_pre_one_breaking_minor(self) -> None:
+        for path in self.root.rglob("*"):
+            if path.is_file():
+                path.write_text(
+                    path.read_text(encoding="utf-8").replace("1.2.3", "0.7.0"),
+                    encoding="utf-8",
+                )
+        changelog = self.root / "CHANGELOG.md"
+        changelog.write_text(
+            changelog.read_text(encoding="utf-8").replace(
+                "- Good thing.", "- **Breaking:** Good thing."
+            ),
+            encoding="utf-8",
+        )
+
+        intent = release.release_intent(self.root)
+
+        self.assertEqual(intent["target"], "0.8.0")
+        self.assertEqual(intent["bump"], "minor")
+        self.assertTrue(intent["breaking"])
+        self.assertEqual(intent["semver_policy"], "major")
+
+    def test_release_intent_rejects_unknown_changelog_categories(self) -> None:
+        changelog = self.root / "CHANGELOG.md"
+        changelog.write_text(
+            changelog.read_text(encoding="utf-8").replace("### Added", "### Surprise"),
+            encoding="utf-8",
+        )
+
+        with self.assertRaisesRegex(release.ReleaseError, "unsupported.*Surprise"):
+            release.release_intent(self.root)
+
+    def test_current_semver_policy_prefers_unreleased_intent(self) -> None:
+        changelog = self.root / "CHANGELOG.md"
+        changelog.write_text(
+            changelog.read_text(encoding="utf-8").replace(
+                "- Good thing.", "- **Breaking:** Good thing."
+            ),
+            encoding="utf-8",
+        )
+
+        self.assertEqual(release.current_semver_policy(self.root), "major")
+
+    def test_current_semver_policy_falls_back_to_cut_release(self) -> None:
+        version = release.prepare(
+            self.root,
+            "major",
+            "2026-07-13",
+            allow_dirty=True,
+            breaking=True,
+        )
+
+        self.assertEqual(version, "2.0.0")
+        self.assertEqual(release.current_semver_policy(self.root), "major")
+
     def test_prepare_updates_renamed_workspace_requirement(self) -> None:
         root_manifest = self.root / "Cargo.toml"
         root_manifest.write_text(
@@ -479,13 +562,24 @@ class WorkflowPolicyTests(unittest.TestCase):
         self.assertNotIn("RELEASE_APP_", self.prepare)
         self.assertIn("contents: write", self.prepare)
         self.assertIn("pull-requests: write", self.prepare)
+        self.assertIn("actions: write", self.prepare)
         self.assertIn("persist-credentials: true", self.prepare)
         self.assertIn("GH_TOKEN: ${{ github.token }}", self.prepare)
         self.assertIn("dry_run:", self.prepare)
+        dispatch = self.prepare.split("workflow_dispatch:", 1)[1].split(
+            "permissions:", 1
+        )[0]
+        self.assertNotIn("bump:", dispatch)
+        self.assertNotIn("breaking:", dispatch)
+        self.assertIn("release-intent", self.prepare)
+        self.assertIn("steps.intent.outputs.bump", self.prepare)
+        self.assertIn("steps.intent.outputs.breaking", self.prepare)
         self.assertIn("branch=release/%s", self.prepare)
         self.assertIn("gh pr create", self.prepare)
-        self.assertIn("Approve workflows to run", self.prepare)
-        self.assertIn("Approve workflows to run", self.releasing)
+        self.assertIn(".github/required-checks.json", self.prepare)
+        self.assertIn('gh workflow run "$workflow" --ref "$BRANCH"', self.prepare)
+        self.assertNotIn("Approve workflows to run", self.prepare)
+        self.assertNotIn("Approve workflows to run", self.releasing)
         self.assertNotIn("signal-fish-release[bot]", self.prepare)
         self.assertIn('git config user.name "github-actions[bot]"', self.prepare)
         bot_email = (

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -228,6 +228,7 @@ mod godot_issue_61_policy {
     fn push_semver_policy_tracks_the_unreleased_release_train() {
         let workflow = read_project_file(".github/workflows/semver-checks.yml");
         assert!(workflow.contains("current-semver-policy"));
+        assert!(workflow.contains("current-semver-policy \"$baseline\""));
         assert!(workflow.contains("--release-type \"$RELEASE_TYPE\""));
         assert!(workflow.contains("workflow_dispatch:"));
         assert!(workflow.contains("base_sha:"));

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -212,11 +212,44 @@ mod godot_issue_61_policy {
     fn llms_txt_is_in_the_blocking_docs_validation_surface() {
         let workflow = read_project_file(".github/workflows/docs-validation.yml");
         let rendering = read_project_file("scripts/check-docs-rendering.sh");
+        let lychee = read_project_file(".lychee.toml");
         assert_eq!(workflow.matches("- \"llms.txt\"").count(), 0);
         assert!(workflow.contains("  pull_request:\n"));
         assert!(workflow.contains("name: Docs Validation Required"));
         assert!(workflow.contains("            \"llms.txt\""));
         assert!(rendering.contains("cmp -s \"$REPO_ROOT/llms.txt\" \"$SITE_DIR/llms.txt\""));
+        assert!(rendering.contains("Every same-site llms.txt route exists in the local build"));
+        assert!(lychee.contains(
+            "^https://[Aa]mbiguous-[Ii]nteractive\\\\.github\\\\.io/signal-fish-client-rust/"
+        ));
+    }
+
+    #[test]
+    fn push_semver_policy_tracks_the_unreleased_release_train() {
+        let workflow = read_project_file(".github/workflows/semver-checks.yml");
+        assert!(workflow.contains("current-semver-policy"));
+        assert!(workflow.contains("--release-type \"$RELEASE_TYPE\""));
+        assert!(workflow.contains("workflow_dispatch:"));
+        assert!(workflow.contains("base_sha:"));
+        assert!(workflow.contains("pr_title:"));
+    }
+
+    #[test]
+    fn every_required_workflow_supports_app_free_dispatch() {
+        let policy = read_project_file(".github/required-checks.json");
+        let policy: serde_json::Value =
+            serde_json::from_str(&policy).expect("required checks policy must be JSON");
+        for check in policy["required_checks"]
+            .as_array()
+            .expect("required_checks must be an array")
+        {
+            let file = check["file"].as_str().expect("check file must be a string");
+            let workflow = read_project_file(&format!(".github/workflows/{file}"));
+            assert!(
+                workflow.contains("  workflow_dispatch:"),
+                "{file} must support app-free explicit dispatch"
+            );
+        }
     }
 
     #[test]
@@ -1379,7 +1412,9 @@ mod ci_workflow_policy {
     fn semver_workflow_requires_explicit_breaking_marker_for_major_policy() {
         let contents = read_project_file(".github/workflows/semver-checks.yml");
         assert!(
-            contents.contains("PR_TITLE: ${{ github.event.pull_request.title }}")
+            contents.contains(
+                "PR_TITLE: ${{ github.event.pull_request.title || inputs.pr_title }}"
+            )
                 && contents.contains(r#"[[ "$PR_TITLE" == *"!:"* ]]"#),
             "Semver CI must derive intentional breaking changes from the explicit conventional-commit `!:` marker"
         );

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -219,6 +219,11 @@ mod godot_issue_61_policy {
         assert!(workflow.contains("            \"llms.txt\""));
         assert!(rendering.contains("cmp -s \"$REPO_ROOT/llms.txt\" \"$SITE_DIR/llms.txt\""));
         assert!(rendering.contains("Every same-site llms.txt route exists in the local build"));
+        assert!(
+            rendering.contains("SAME_SITE_ROUTE_COUNT"),
+            "same-site route validation must fail closed when llms.txt contains no matching routes"
+        );
+        assert!(rendering.contains("No same-site discovery routes found in llms.txt"));
         assert!(lychee.contains(
             "^https://[Aa]mbiguous-[Ii]nteractive\\\\.github\\\\.io/signal-fish-client-rust/"
         ));


### PR DESCRIPTION
## Summary

- derive the next lockstep release and breaking policy from `CHANGELOG.md` instead of manual version/bump/crate inputs
- enumerate publishable workspace crates in dependency order and retain checksum-aware partial-release recovery
- explicitly dispatch all required checks with the built-in `GITHUB_TOKEN`, removing the release App/PAT dependency
- make push-time semver checks follow the unreleased train and validate same-site docs routes against the local MkDocs build

## Evidence

- red-green release-tool tests cover minor, patch, pre-1.0 breaking, invalid changelog, and post-cut policy cases
- all 11 required workflows are policy-tested for app-free `workflow_dispatch`
- `cargo semver-checks check-release --package signal-fish-client --release-type major` passes against crates.io
- isolated rehearsal derives `0.9.0` and orders `signal-fish-client` before `signal-fish-client-godot`
- `cargo fmt && cargo clippy --workspace --all-targets --all-features -- -D warnings && cargo test --workspace --all-features`
- workflow lint, yamllint, docs rendering, pre-commit, and pre-push suites pass

After this merges, I will use the app-free workflows to prepare, merge, publish, and verify 0.9.0.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes touch release automation, required CI dispatch, and semver policy on main—high operational impact but covered by expanded `test_release.py` and CI policy tests.
> 
> **Overview**
> **Prepare Release** no longer asks for bump/breaking inputs: `scripts/release.py release-intent` reads `[Unreleased]` in `CHANGELOG.md` (categories, `**Breaking:**`, non-empty sections) and drives `prepare` plus PR title/breaking flags. Maintainer docs and agent skills are updated to match.
> 
> Because `GITHUB_TOKEN`-created PRs do not get normal check events, the workflow gains **Actions: write**, adds **`workflow_dispatch`** to every required workflow, and after opening the release PR **explicitly runs** each entry in `.github/required-checks.json` on the release branch (with `base_sha` / `pr_title` for semver). Manual “approve workflows” is removed in favor of this dispatch path.
> 
> **Semver Checks** on main now parse the latest crates.io version and call **`current-semver-policy`** so push checks follow the unreleased train when the workspace version is cut but not yet published; dispatched runs reuse the same PR-style base/title inputs.
> 
> Docs link validation skips live GitHub Pages URLs in lychee and instead checks **`llms.txt` same-site routes** against the local MkDocs build in `check-docs-rendering.sh`, avoiding races with Pages deploy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3f87c92680e9a6e5c8b71058a82eed2e4367dbc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->