### PR TITLE
fix(ci): recover from enterprise PR policy

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -128,7 +128,6 @@ jobs:
       - name: Open release pull request
         id: open-pr
         if: ${{ !inputs.dry_run }}
-        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
           BRANCH: ${{ steps.version.outputs.branch }}
@@ -146,15 +145,29 @@ jobs:
               'The built-in workflow token explicitly dispatches every required check for this commit.' \
               'Merge only after every required check and review is green.'
           } > "$RUNNER_TEMP/release-pr.md"
-          pr_url=$(gh pr create \
+          set +e
+          pr_output=$(gh pr create \
             --base "$DEFAULT_BRANCH" \
             --head "$BRANCH" \
             --title "$title" \
-            --body-file "$RUNNER_TEMP/release-pr.md")
-          printf 'Opened %s\n' "$pr_url"
+            --body-file "$RUNNER_TEMP/release-pr.md" 2>&1)
+          status=$?
+          set -e
+          if [ "$status" -eq 0 ]; then
+            printf 'enterprise_blocked=false\n' >> "$GITHUB_OUTPUT"
+            printf 'Opened %s\n' "$pr_output"
+          elif grep -qF \
+            'GitHub Actions is not permitted to create or approve pull requests' \
+            <<< "$pr_output"; then
+            printf 'enterprise_blocked=true\n' >> "$GITHUB_OUTPUT"
+            printf '%s\n' "$pr_output" >&2
+          else
+            printf '%s\n' "$pr_output" >&2
+            exit "$status"
+          fi
 
       - name: Explain enterprise pull-request fallback
-        if: ${{ !inputs.dry_run && steps.open-pr.outcome == 'failure' }}
+        if: ${{ !inputs.dry_run && steps.open-pr.outputs.enterprise_blocked == 'true' }}
         env:
           BRANCH: ${{ steps.version.outputs.branch }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
@@ -173,12 +186,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Dispatch required checks for the release pull request
-        if: >-
-          ${{
-            !inputs.dry_run
-            && always()
-            && (steps.open-pr.outcome == 'success' || steps.open-pr.outcome == 'failure')
-          }}
+        if: ${{ !inputs.dry_run }}
         env:
           GH_TOKEN: ${{ github.token }}
           BRANCH: ${{ steps.version.outputs.branch }}

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -126,7 +126,9 @@ jobs:
           git push --set-upstream origin "$BRANCH"
 
       - name: Open release pull request
+        id: open-pr
         if: ${{ !inputs.dry_run }}
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
           BRANCH: ${{ steps.version.outputs.branch }}
@@ -151,8 +153,32 @@ jobs:
             --body-file "$RUNNER_TEMP/release-pr.md")
           printf 'Opened %s\n' "$pr_url"
 
+      - name: Explain enterprise pull-request fallback
+        if: ${{ !inputs.dry_run && steps.open-pr.outcome == 'failure' }}
+        env:
+          BRANCH: ${{ steps.version.outputs.branch }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          compare_url="https://github.com/${REPOSITORY}/compare/${DEFAULT_BRANCH}...${BRANCH}?expand=1"
+          printf '::warning::GitHub policy blocked GITHUB_TOKEN from opening the pull request. Open %s\n' \
+            "$compare_url"
+          {
+            printf '### Open the prepared release pull request as a maintainer\n\n'
+            printf 'Enterprise policy blocked the built-in token from creating the PR. '
+            printf 'The verified branch is pushed and its required checks are still dispatched.\n\n'
+            printf -- '- Open: [%s](%s)\n' "$compare_url" "$compare_url"
+            printf -- '- Or run: %s\n' \
+              "gh pr create --base $DEFAULT_BRANCH --head $BRANCH"
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Dispatch required checks for the release pull request
-        if: ${{ !inputs.dry_run }}
+        if: >-
+          ${{
+            !inputs.dry_run
+            && always()
+            && (steps.open-pr.outcome == 'success' || steps.open-pr.outcome == 'failure')
+          }}
         env:
           GH_TOKEN: ${{ github.token }}
           BRANCH: ${{ steps.version.outputs.branch }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -124,7 +124,7 @@ jobs:
             package_args+=(-p "$package")
           done
           cargo package "${package_args[@]}"
-          cargo cyclonedx --format json --workspace
+          cargo cyclonedx --format json --all
 
           asset_dir="$RUNNER_TEMP/release-assets"
           mkdir -p "$asset_dir"

--- a/.llm/skills/release-recovery/SKILL.md
+++ b/.llm/skills/release-recovery/SKILL.md
@@ -89,9 +89,14 @@ error; stop and investigate.
 ## Repository configuration
 
 Enable **Allow GitHub Actions to create and approve pull requests** in the
-repository's Actions settings. Prepare Release requests Contents and Pull
-requests write plus Actions write access for its built-in `GITHUB_TOKEN`; no
-App, personal access token, repository variable, or release secret is required.
+repository's Actions settings when organization policy permits it. Prepare
+Release requests Contents and Pull requests write plus Actions write access for
+its built-in `GITHUB_TOKEN`; no App, personal access token, repository variable,
+or release secret is required. If enterprise policy forbids PR creation, the
+workflow must treat only that step as recoverable, continue dispatching every
+required check for the pushed release branch, and emit a maintainer compare
+link plus `gh pr create` command in the job summary. Never add an App or stored
+PAT to evade that policy.
 
 The protected `crates-io` environment holds `CRATES_IO_TOKEN`. Bootstrap new
 workspace crates with a token limited to `signal-fish-client*` and

--- a/.llm/skills/release-recovery/SKILL.md
+++ b/.llm/skills/release-recovery/SKILL.md
@@ -96,7 +96,8 @@ or release secret is required. If enterprise policy forbids PR creation, the
 workflow must treat only that step as recoverable, continue dispatching every
 required check for the pushed release branch, and emit a maintainer compare
 link plus `gh pr create` command in the job summary. Never add an App or stored
-PAT to evade that policy.
+PAT to evade that policy. Match GitHub's exact enterprise-policy denial and
+fail closed with the original error for every other PR-creation failure.
 
 The protected `crates-io` environment holds `CRATES_IO_TOKEN`. Bootstrap new
 workspace crates with a token limited to `signal-fish-client*` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed release preparation failing after successfully verifying and pushing a
+  release branch when enterprise policy forbids `GITHUB_TOKEN` from opening
+  pull requests; required checks now still dispatch and the successful run
+  emits an app-free maintainer PR link and command.
+
 ## [0.9.0] - 2026-07-18
 
 <!-- semver-checks: major -->
@@ -60,10 +67,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed release preparation failing after successfully verifying and pushing a
-  release branch when enterprise policy forbids `GITHUB_TOKEN` from opening
-  pull requests; required checks now still dispatch and the successful run
-  emits an app-free maintainer PR link and command.
 - Fixed the Emscripten WebSocket transport consuming a queued frame while the
   browser socket was still connecting; pre-open and failed-send frames now
   remain owned by the caller for ordered retry.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed release preparation failing after successfully verifying and pushing a
+  release branch when enterprise policy forbids `GITHUB_TOKEN` from opening
+  pull requests; required checks now still dispatch and the successful run
+  emits an app-free maintainer PR link and command.
 - Fixed the Emscripten WebSocket transport consuming a queued frame while the
   browser socket was still connecting; pre-open and failed-send frames now
   remain owned by the caller for ordered retry.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   release branch when enterprise policy forbids `GITHUB_TOKEN` from opening
   pull requests; required checks now still dispatch and the successful run
   emits an app-free maintainer PR link and command.
+- Fixed release asset generation using Cargo's unsupported `--workspace` flag
+  with pinned `cargo-cyclonedx` 0.5.7; the workflow now uses the tool's `--all`
+  workspace flag and policy-tests that exact invocation.
 
 ## [0.9.0] - 2026-07-18
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -6,11 +6,19 @@ manual, protected, and fail-closed.
 
 ## One-time repository setup
 
-In **Settings > Actions > General > Workflow permissions**, enable **Allow
-GitHub Actions to create and approve pull requests**. Prepare Release uses only
-the run's built-in `GITHUB_TOKEN`, explicitly scoped to **Actions: write**,
-**Contents: write**, and **Pull requests: write**. It requires no GitHub App,
-personal access token, repository variable, or release secret.
+If organization policy permits it, enable **Allow GitHub Actions to create and
+approve pull requests** in **Settings > Actions > General > Workflow
+permissions**. Prepare Release uses only the run's built-in `GITHUB_TOKEN`,
+explicitly scoped to **Actions: write**, **Contents: write**, and **Pull
+requests: write**. It requires no GitHub App, personal access token, repository
+variable, or release secret.
+
+Some enterprise policies forbid that setting. In that mode, Prepare Release
+still succeeds after pushing the fully verified release branch and dispatching
+all required checks. Its job summary provides a compare link and an exact
+`gh pr create` command; a maintainer opens the PR with their existing GitHub
+authentication. Do not add an App or stored PAT to bypass the enterprise
+policy.
 
 GitHub suppresses ordinary workflow events created by `GITHUB_TOKEN`. Prepare
 Release therefore has **Actions: write** permission and explicitly dispatches
@@ -51,9 +59,12 @@ with repository Metadata read access, then run
 2. Run **Prepare Release** from the default branch with `dry_run` enabled and
    inspect the inferred version, generated diff, and validation output.
 3. Run it again with `dry_run` disabled. The built-in token creates
-   `release/X.Y.Z` and opens the preparation pull request.
-4. The workflow explicitly dispatches every required check against the release
-   commit; no workflow approval or release App is needed.
+   `release/X.Y.Z` and attempts to open the preparation pull request. If
+   enterprise policy blocks PR creation, use the maintainer link or command in
+   the successful run's job summary.
+4. Whether PR creation is automatic or maintainer-authenticated, the workflow
+   explicitly dispatches every required check against the release commit; no
+   workflow approval or release App is needed.
 5. Merge only after every aggregate required check, review, and thread is
    green.
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -18,7 +18,8 @@ still succeeds after pushing the fully verified release branch and dispatching
 all required checks. Its job summary provides a compare link and an exact
 `gh pr create` command; a maintainer opens the PR with their existing GitHub
 authentication. Do not add an App or stored PAT to bypass the enterprise
-policy.
+policy. Only GitHub's exact enterprise-policy denial is recoverable; every
+other PR-creation error fails the workflow with its original diagnostic.
 
 GitHub suppresses ordinary workflow events created by `GITHUB_TOKEN`. Prepare
 Release therefore has **Actions: write** permission and explicitly dispatches

--- a/scripts/test_release.py
+++ b/scripts/test_release.py
@@ -670,6 +670,10 @@ class WorkflowPolicyTests(unittest.TestCase):
             "both resumed dry-run and publish must tolerate crates.io index lag",
         )
 
+    def test_pinned_cyclonedx_uses_its_workspace_flag(self) -> None:
+        self.assertIn("cargo cyclonedx --format json --all", self.publish)
+        self.assertNotIn("cargo cyclonedx --format json --workspace", self.publish)
+
     def test_semver_policy_is_derived_and_check_runs_are_latest_only(self) -> None:
         self.assertIn('semver-policy "$version"', self.publish)
         self.assertIn('--release-type "$RELEASE_TYPE"', self.publish)

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -262,11 +262,14 @@ mod godot_issue_61_policy {
     fn prepare_release_survives_enterprise_pr_creation_policy() {
         let workflow = read_project_file(".github/workflows/prepare-release.yml");
         assert!(workflow.contains("id: open-pr"));
-        assert!(workflow.contains("continue-on-error: true"));
-        assert!(workflow.contains("steps.open-pr.outcome == 'failure'"));
+        assert!(!workflow.contains("continue-on-error: true"));
+        assert!(workflow.contains("enterprise_blocked=true"));
+        assert!(
+            workflow.contains("GitHub Actions is not permitted to create or approve pull requests")
+        );
+        assert!(workflow.contains("exit \"$status\""));
+        assert!(workflow.contains("steps.open-pr.outputs.enterprise_blocked == 'true'"));
         assert!(workflow.contains("Open the prepared release pull request as a maintainer"));
-        assert!(workflow
-            .contains("steps.open-pr.outcome == 'success' || steps.open-pr.outcome == 'failure'"));
     }
 
     #[test]

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -259,6 +259,17 @@ mod godot_issue_61_policy {
     }
 
     #[test]
+    fn prepare_release_survives_enterprise_pr_creation_policy() {
+        let workflow = read_project_file(".github/workflows/prepare-release.yml");
+        assert!(workflow.contains("id: open-pr"));
+        assert!(workflow.contains("continue-on-error: true"));
+        assert!(workflow.contains("steps.open-pr.outcome == 'failure'"));
+        assert!(workflow.contains("Open the prepared release pull request as a maintainer"));
+        assert!(workflow
+            .contains("steps.open-pr.outcome == 'success' || steps.open-pr.outcome == 'failure'"));
+    }
+
+    #[test]
     fn coverage_is_a_blocking_gate_with_a_measured_floor() {
         let workflow = read_project_file(".github/workflows/coverage.yml");
         assert!(!workflow.contains("continue-on-error: true"));


### PR DESCRIPTION
## Summary

- treat enterprise-blocked `GITHUB_TOKEN` PR creation as a recoverable prepare outcome
- continue dispatching every required check for the verified release branch
- emit a maintainer compare link and exact `gh pr create` command, without an App or stored PAT
- document and policy-test the enterprise fallback

## Evidence

- red-green `prepare_release_survives_enterprise_pr_creation_policy` regression
- `actionlint .github/workflows/prepare-release.yml`
- mandatory fmt/clippy/workspace test gate
- all 14 pre-commit and all 6 pre-push checks

This records the exact enterprise restriction encountered while preparing 0.9.0 and prevents future prepare runs from ending red after successful branch creation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and release-docs changes only; enterprise handling is narrowly scoped to one error string and other PR failures still abort the workflow.
> 
> **Overview**
> **Prepare Release** no longer fails after a verified branch is pushed when enterprise policy blocks `GITHUB_TOKEN` from opening PRs. The open-PR step detects GitHub’s exact denial message, sets `enterprise_blocked`, and leaves the run green; any other `gh pr create` error still fails closed. A follow-up step writes a compare link and maintainer `gh pr create` command to the job summary, and **required-check dispatch is unchanged** so checks still run without an App or PAT.
> 
> **Release** asset generation switches CycloneDX from unsupported `--workspace` to `--all` for pinned `cargo-cyclonedx` 0.5.7, with a policy test locking that invocation.
> 
> Docs (`docs/releasing.md`, release-recovery skill) and **CHANGELOG** record both behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d73755061346bc57efcc7ef1b420b6250652821. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->