### PR TITLE
chore: prepare release 0.10.0

### DIFF
--- a/.llm/context.md
+++ b/.llm/context.md
@@ -5,7 +5,7 @@
 - **Company:** Ambiguous Interactive
 - **Product:** Signal Fish Client SDK
 - **Crates:** `signal-fish-client` (core) and `signal-fish-client-godot` (adapter)
-- **Version:** 0.9.0 lockstep across both crates
+- **Version:** 0.10.0 lockstep across both crates
 - **Edition:** 2021
 - **MSRV:** Rust 1.87.0 for core; Rust 1.94.0 for the Godot adapter
 - **License:** MIT

--- a/.llm/skills/crate-publishing/SKILL.md
+++ b/.llm/skills/crate-publishing/SKILL.md
@@ -42,10 +42,10 @@ The workspace owns the lockstep version and exact internal requirement:
 
 ```toml
 [workspace.package]
-version = "0.9.0"
+version = "0.10.0"
 
 [workspace.dependencies]
-signal-fish-client = { version = "=0.9.0", path = ".", default-features = false }
+signal-fish-client = { version = "=0.10.0", path = ".", default-features = false }
 ```
 
 The adapter inherits that version and dependency, uses Rust 1.94.0, and has its

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-07-24
+
 ### Added
 
 - Added an opt-in `tls` feature that enables `wss://` for the built-in
@@ -430,6 +432,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - After: `SignalFishError::ServerError { message, error_code }` where `error_code` is `Option<ErrorCode>`
   - Recommended handling: `match error_code { Some(code) => ..., None => ... }`
 
-[Unreleased]: https://github.com/Ambiguous-Interactive/signal-fish-client-rust/compare/v0.9.0...HEAD
+[Unreleased]: https://github.com/Ambiguous-Interactive/signal-fish-client-rust/compare/v0.10.0...HEAD
+[0.10.0]: https://github.com/Ambiguous-Interactive/signal-fish-client-rust/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/Ambiguous-Interactive/signal-fish-client-rust/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/Ambiguous-Interactive/signal-fish-client-rust/compare/v0.6.0...v0.8.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,7 +131,7 @@ members = ["crates/signal-fish-client-godot"]
 resolver = "2"
 
 [workspace.package]
-version = "0.9.0"
+version = "0.10.0"
 
 [workspace.dependencies]
-signal-fish-client = { version = "=0.9.0", path = ".", default-features = false }
+signal-fish-client = { version = "=0.10.0", path = ".", default-features = false }

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ rooms, and receive strongly typed events.
 
 ```toml
 [dependencies]
-signal-fish-client = "0.9.0"
+signal-fish-client = "0.10.0"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ```
 
@@ -71,10 +71,10 @@ Without the built-in WebSocket transport (bring your own):
 
 ```toml
 [dependencies]
-signal-fish-client = { version = "0.9.0", default-features = false }
+signal-fish-client = { version = "0.10.0", default-features = false }
 ```
 
-The published `0.9.0` crate is the stable release. This `main`-branch README
+The published `0.10.0` crate is the stable release. This `main`-branch README
 also documents fixes listed under [`Unreleased`](CHANGELOG.md), including the
 issue #61 browser polling guarantees. Until the next release, test those APIs
 and fixes with:

--- a/docs/client.md
+++ b/docs/client.md
@@ -9,10 +9,10 @@ For WebAssembly environments without an async runtime,
 game-loop-driven alternative.
 
 !!! note "Published crate versus this guide"
-    The stable crates.io release is **0.9.0**. This guide tracks the current
+    The stable crates.io release is **0.10.0**. This guide tracks the current
     `main` branch, including polling budgets, close policies, queue-age
-    diagnostics, and adaptive Godot admission added after 0.9.0. Use the
-    [0.9.0 API docs](https://docs.rs/signal-fish-client/0.9.0/) for the
+    diagnostics, and adaptive Godot admission added after 0.10.0. Use the
+    [0.10.0 API docs](https://docs.rs/signal-fish-client/0.10.0/) for the
     published surface, or a `git` dependency on `main` for the unreleased APIs.
 
 ---
@@ -80,7 +80,7 @@ use signal_fish_client::{SignalFishConfig, protocol::GameDataEncoding};
 
 let config = SignalFishConfig {
     app_id: "mb_app_abc123".into(),
-    sdk_version: Some("0.9.0".into()),
+    sdk_version: Some("0.10.0".into()),
     platform: Some("rust".into()),
     game_data_format: Some(GameDataEncoding::Json),
     ..SignalFishConfig::new("mb_app_abc123")

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -590,7 +590,7 @@ serde_json = "1.0"  # Required for send_game_data(serde_json::Value)
 ```
 
 The stable crates.io dependency is
-`signal-fish-client = { version = "0.9.0", ... }`, but 0.9.0 predates the
+`signal-fish-client = { version = "0.10.0", ... }`, but 0.10.0 predates the
 issue #61 polling-throughput fix documented in this current-`main` guide.
 
 ### Source

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -21,21 +21,21 @@ cargo add signal-fish-client
 cargo add tokio --features macros,rt-multi-thread,signal
 ```
 
-The first command installs the stable crates.io release, currently **0.9.0**.
+The first command installs the stable crates.io release, currently **0.10.0**.
 The second is a direct Tokio dependency for the async example below; Rust code
 cannot use the SDK's transitive Tokio dependency directly.
 
 !!! note "Current-main documentation"
     This guide tracks the repository's unreleased `main` branch. To use
-    post-0.9.0 APIs such as polling work budgets, queue-age diagnostics, and
+    post-0.10.0 APIs such as polling work budgets, queue-age diagnostics, and
     the issue #61 Godot admission fix, use:
 
     ```toml
     signal-fish-client = { git = "https://github.com/Ambiguous-Interactive/signal-fish-client-rust" }
     ```
 
-    For the published 0.9.0 surface, use the version dependency below and the
-    [0.9.0 docs.rs pages](https://docs.rs/signal-fish-client/0.9.0/).
+    For the published 0.10.0 surface, use the version dependency below and the
+    [0.10.0 docs.rs pages](https://docs.rs/signal-fish-client/0.10.0/).
 
 ### Feature Flags
 
@@ -51,7 +51,7 @@ cannot use the SDK's transitive Tokio dependency directly.
 
 ```toml
 [dependencies]
-signal-fish-client = "0.9.0"
+signal-fish-client = "0.10.0"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
 ```
 
@@ -59,7 +59,7 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
 
 ```toml
 [dependencies]
-signal-fish-client = { version = "0.9.0", default-features = false }
+signal-fish-client = { version = "0.10.0", default-features = false }
 ```
 
 !!! tip
@@ -153,7 +153,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 !!! note
     `WebSocketTransport` requires the `transport-websocket` feature, which is enabled by default. If you disabled default features you will need to re-enable it explicitly:
     ```toml
-    signal-fish-client = { version = "0.9.0", default-features = false, features = ["transport-websocket"] }
+    signal-fish-client = { version = "0.10.0", default-features = false, features = ["transport-websocket"] }
     ```
 
 ## What Happens Under the Hood

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,8 +10,8 @@ description: "Signal Fish Client SDK — A transport-agnostic Rust client SDK fo
 **A transport-agnostic Rust client SDK for the Signal Fish multiplayer signaling protocol.**
 
 !!! note "Release status"
-    **0.9.0** is the current crates.io release. This site follows unreleased
-    `main`; use the [0.9.0 API docs](https://docs.rs/signal-fish-client/0.9.0/)
+    **0.10.0** is the current crates.io release. This site follows unreleased
+    `main`; use the [0.10.0 API docs](https://docs.rs/signal-fish-client/0.10.0/)
     for the published surface.
 
 [![Crates.io](https://img.shields.io/crates/v/signal-fish-client?style=flat-square&logo=rust)](https://crates.io/crates/signal-fish-client)
@@ -93,7 +93,7 @@ async fn main() -> Result<(), signal_fish_client::SignalFishError> {
 !!! tip "Feature flag"
     `WebSocketTransport` requires the **`transport-websocket`** feature, which is enabled by default. If you disabled default features, re-enable it explicitly:
     ```toml
-    signal-fish-client = { version = "0.9.0", default-features = false, features = ["transport-websocket"] }
+    signal-fish-client = { version = "0.10.0", default-features = false, features = ["transport-websocket"] }
     ```
 
 ---

--- a/docs/mesh-guide.md
+++ b/docs/mesh-guide.md
@@ -11,7 +11,7 @@ drive the whole handshake for you.
     `tokio-runtime` feature.
 
     ```toml
-    signal-fish-client = { version = "0.9.0", features = ["mesh"] }
+    signal-fish-client = { version = "0.10.0", features = ["mesh"] }
     ```
 
 ---

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -652,7 +652,7 @@ Every message on the wire is a JSON object with two top-level keys:
         "type": "Authenticate",
         "data": {
             "app_id": "mb_app_abc123",
-            "sdk_version": "0.9.0"
+            "sdk_version": "0.10.0"
         }
     }
     ```

--- a/docs/wasm.md
+++ b/docs/wasm.md
@@ -133,7 +133,7 @@ signal-fish-client = { git = "https://github.com/Ambiguous-Interactive/signal-fi
 
 These snippets use `main` because the ownership, bounded-work, and admission
 guarantees documented below are listed under `Unreleased`. Use the published
-`0.9.0` dependency with its [versioned API docs](https://docs.rs/signal-fish-client/0.9.0/)
+`0.10.0` dependency with its [versioned API docs](https://docs.rs/signal-fish-client/0.10.0/)
 when you do not need those fixes yet.
 
 The adapter supports godot-rust 0.4.5 through 0.5.x and requires Rust 1.94 or

--- a/tests/compatibility.toml
+++ b/tests/compatibility.toml
@@ -1,9 +1,9 @@
 # Canonical client/server protocol compatibility binding.
-client_version = "0.9.0"
+client_version = "0.10.0"
 server_version = "0.4.0"
 server_tag = "v0.4.0"
 server_commit = "50b28a9a13dc2b99d301bfb2482c5fd6f768a2e8"
-synced = "2026-07-18"
+synced = "2026-07-24"
 
 [wire_samples]
 "v2-client-messages.jsonl" = "929f25d702d3e21f2cca640cd14f9ce044945a6ef9c2c258de56f3f112164227"

--- a/tests/godot-compat-min/Cargo.lock
+++ b/tests/godot-compat-min/Cargo.lock
@@ -497,7 +497,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-fish-client"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "rmp",
  "rmp-serde",
@@ -512,7 +512,7 @@ dependencies = [
 
 [[package]]
 name = "signal-fish-client-godot"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "godot",
  "signal-fish-client",

--- a/tests/godot-web-smoke/Cargo.lock
+++ b/tests/godot-web-smoke/Cargo.lock
@@ -539,7 +539,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-fish-client"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "rmp",
  "rmp-serde",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "signal-fish-client-godot"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "godot",
  "signal-fish-client",

--- a/tests/server-spec/PROVENANCE.toml
+++ b/tests/server-spec/PROVENANCE.toml
@@ -9,7 +9,7 @@ path = "spec"
 # Exact server commit the spec bytes were copied from.
 commit = "50b28a9a13dc2b99d301bfb2482c5fd6f768a2e8"
 # ISO 8601 date of the last refresh.
-synced = "2026-07-18"
+synced = "2026-07-24"
 
 # SHA-256 of each vendored file. A policy test recomputes these, so the spec
 # cannot be edited without also updating this marker (keeps provenance honest).

--- a/tests/wire-samples/PROVENANCE.toml
+++ b/tests/wire-samples/PROVENANCE.toml
@@ -12,7 +12,7 @@ commit = "50b28a9a13dc2b99d301bfb2482c5fd6f768a2e8"
 protocol_version_min = 2
 protocol_version_max = 3
 # ISO 8601 date of the last refresh.
-synced = "2026-07-18"
+synced = "2026-07-24"
 
 # SHA-256 of each vendored file. A policy test recomputes these, so a sample
 # cannot be edited without also updating this marker (keeps provenance honest).


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Version and documentation-only changes with no runtime or API code in the diff; low risk aside from ensuring the tagged release matches the already-implemented 0.10.0 behavior described in the changelog.
> 
> **Overview**
> **Release 0.10.0 (2026-07-24)** — bumps the lockstep workspace version from **0.9.0** to **0.10.0** for `signal-fish-client` and `signal-fish-client-godot`, and moves the shipped notes out of `[Unreleased]` into a new changelog section.
> 
> The **0.10.0** release notes document opt-in **`tls`** / **`wss://`**, **`WebSocketConnectOptions`** (including default **`TCP_NODELAY`**), and release-workflow fixes; this PR does not add those features here—it only publishes the version and syncs references.
> 
> **Docs and metadata** now point at **0.10.0** everywhere consumers look: `README.md`, MkDocs (`getting-started`, `index`, `client`, `examples`, `mesh-guide`, `protocol`, `wasm`), `.llm/context.md`, and the crate-publishing skill examples. **`tests/compatibility.toml`** updates `client_version` and `synced`; fixture **`Cargo.lock`** files and wire-sample/server-spec **`PROVENANCE.toml`** `synced` dates align with the release cut.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90429d41067119b139932d284226825493a411e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->