### PR TITLE
fix(accountability): accept coalesced unsupported gaps

### DIFF
--- a/.llm/context.md
+++ b/.llm/context.md
@@ -144,6 +144,15 @@ they fire inside the lag bound and the fixed cadence never acts on them), exact
 state checksum convergence, drained queue age/depth with a non-positive final
 eight-sample soak age slope, relay/server conservation, and v3 peer departure.
 
+Delivery accountability accepts coalesced, mixed-reason
+`unsupported_format` gap ranges emitted by newer servers. Their inclusive
+sequence counts must still exactly match cumulative counter deltas, ranges may
+not overlap, and an optional rate-limited supplemental advisory is accepted
+only after an actual unsupported-format range, without requiring adjacency.
+Authoritative room and spectator exits discard all room-scoped gap, sender,
+advisory-authorization, and quarantine state while retaining connection-wide
+counters.
+
 ### Client Usage Pattern
 
 Connect a transport, construct `SignalFishConfig`, and pass both to `SignalFishClient::start`, which returns the handle and event receiver and

--- a/.llm/skills/v3-delivery-accountability/SKILL.md
+++ b/.llm/skills/v3-delivery-accountability/SKILL.md
@@ -33,15 +33,19 @@ One report carries at most `DELIVERY_REPORT_MAX_GAPS` (256) ranges.
 ## State Machine
 
 `src/accountability.rs` is ported from the server v0.4.0 native reference client
-at commit `50b28a9a13dc2b99d301bfb2482c5fd6f768a2e8`. Preserve that provenance
-when changing it. The validator covers:
+at commit `50b28a9a13dc2b99d301bfb2482c5fd6f768a2e8`, with unsupported-format
+advisory semantics synced from
+`522c9c6ba10f171957f49abda434d3c37425748d` and coalesced ranges from
+`970be936c8438a892be987257604fe073ae73564`. Preserve that provenance when
+changing it. The validator covers:
 
 - exact v2/v3 snapshot metadata shapes and duplicate members;
 - announced lifecycle epochs and same-epoch idempotence;
 - exact prior gap coverage and monotonic per-class counters;
 - `PlayerLeft.final_seq` retirement and lifecycle-overtaken stale tails;
 - reconnect snapshot/watermark equality;
-- immediate unsupported-format error/report causality;
+- optional rate-limited unsupported-format advisories with a prior causal
+  exact report;
 - positive, stable, cumulative relay statistics.
 
 Validate decoded text and binary messages through the same path before state or
@@ -58,8 +62,9 @@ are `ProtocolViolation` and must never be conflated.
 - `Observe`: emit the violation and still deliver the offending decoded
   message, leaving recovery to the application.
 
-Quarantine resets only on a new physical client state or an authoritative
-`RoomJoined`, `SpectatorJoined`, or `Reconnected` baseline.
+Quarantine resets only on a new physical client state, an authoritative
+`RoomJoined`, `SpectatorJoined`, or `Reconnected` baseline, or an authoritative
+`RoomLeft`/`SpectatorLeft` exit from the affected room.
 
 ## Reconnect Tokens
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed protocol-v3 accountability rejecting coalesced or mixed-reason
+  `unsupported_format` gap reports emitted by newer Signal Fish servers;
+  optional rate-limited advisories now require a prior causal report without
+  requiring adjacency. Range validity, non-overlap, and exact counter-delta
+  validation remain enforced, and room/spectator exits discard old-room gap
+  and advisory authorization.
+
 ## [0.10.0] - 2026-07-24
 
 ### Added

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,128 @@
+# Signal Fish Client — Current Roadmap
+
+## Current State
+
+- Latest released client: 0.10.0.
+- Canonical protocol fixture: Signal Fish Server 0.4.0 at commit
+  `50b28a9a13dc2b99d301bfb2482c5fd6f768a2e8`.
+- The async and polling clients share protocol behavior through `ClientCore`.
+- The lockstep Godot adapter supports native and official Godot 4.5 web
+  exports, with blocking real-server gameplay coverage.
+- Release preparation and publication are workspace-aware, reproducible, and
+  protected by required aggregate checks.
+
+Completed milestone history and verification evidence live in `progress/`.
+
+## Priority Order
+
+Work open issues in gameplay-impact order:
+
+1. correctness and server interoperability;
+2. client usability and safety;
+3. runtime performance;
+4. documentation-site presentation.
+
+Finish one coherent PR and make it fully green before starting the next. Do
+not stack dependent PRs.
+
+## Next Major Milestone — Signal Fish Server 0.7 Compatibility
+
+Track [issue #86](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/issues/86).
+The client must interoperate cleanly with Signal Fish Server 0.7.0 and adopt
+reference-client behavior where it strengthens the Rust SDK without weakening
+the transport abstraction or the v2 relay floor.
+
+### Discovery and Contract
+
+- Pin the exact server 0.7.0 tag and commit before changing code.
+- Diff the 0.4.0 and 0.7.0 AsyncAPI, golden wire samples, protocol guide,
+  error-code registry, and both upstream reference clients.
+- Classify every delta as wire-required, negotiated/additive, server-internal,
+  test-only, or intentionally out of scope.
+- Record the resulting compatibility contract and migration impact before
+  choosing a client release version.
+
+### Implementation
+
+- Refresh vendored protocol artifacts and their provenance/checksums as one
+  atomic conformance change.
+- Implement every required protocol, accountability, lifecycle, transport,
+  and error-model delta in the shared core so async and polling drivers remain
+  behaviorally identical.
+- Preserve byte-identical default v2 authentication and relay behavior unless
+  the new server contract proves that impossible.
+- Keep public types exhaustive; treat any required new enum variant as a
+  deliberate semver-breaking change.
+- Sweep documentation, examples, `.llm/context.md`, focused skills, and the
+  changelog for every changed guarantee.
+
+### Verification
+
+- Add red-green golden, malformed-input, negotiation, accountability, and
+  async/polling parity tests for every observable delta.
+- Run pinned-server E2E for the v2 relay floor and every negotiated v3 path,
+  including JSON/binary exchange, classified delivery, reconnect, graceful
+  drain, close metadata, and Godot browser gameplay.
+- Make fixture provenance and compatibility markers agree through offline
+  policy tests.
+- Run packaging, docs, MSRV, coverage, fuzz/mutation, and mandatory Rust gates
+  before publication.
+
+## Following Milestones
+
+### Safety and Static Analysis
+
+Consolidate [issue #78](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/issues/78)
+and [issue #84](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/issues/84)
+into one evidence-backed hardening milestone.
+
+- Inventory existing lint, unsafe-code, dependency, fuzz, and mutation gates
+  before adding tools.
+- Add only analyzers that find an actionable defect class with acceptable
+  runtime and stable Rust/MSRV behavior.
+- Prefer crate-level unsafe policy and narrowly justified exceptions over
+  source-text heuristics.
+- Keep warnings denied in every supported feature/target combination.
+- Close or re-scope the duplicate issue once one canonical implementation plan
+  is accepted.
+
+### Allocation and Performance Evidence
+
+Track [issue #82](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/issues/82).
+
+- Define representative lobby, JSON relay, binary relay, classified-delivery,
+  reconnect, and polling workloads.
+- Establish deterministic throughput, latency, allocation, and queue-age
+  baselines before optimizing.
+- Optimize only measured bottlenecks and retain regression thresholds that are
+  stable enough for CI.
+- Preserve frame ownership, backpressure, exact accountability, and event
+  delivery invariants in every optimization.
+
+### Documentation Design System
+
+Track [issue #80](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/issues/80).
+
+- Inventory and validate the supplied design assets and their licensing.
+- Translate the design system into MkDocs theme overrides without weakening
+  strict builds, accessibility, responsive behavior, or code readability.
+- Update repository and published-site branding together, with rendered visual
+  review at desktop and mobile sizes.
+
+## Permanent Acceptance Gates
+
+Every PR must satisfy:
+
+```shell
+cargo fmt && cargo clippy --workspace --all-targets --all-features -- -D warnings && cargo test --workspace --all-features
+```
+
+In addition:
+
+- all relevant repository policy, docs, MSRV, packaging, coverage,
+  server-E2E, and Godot-E2E checks pass;
+- user-visible changes appear under `CHANGELOG.md` `[Unreleased]`;
+- `PLAN.md`, `.llm/context.md`, and `progress/` reflect the actual state;
+- all actionable reviewer feedback is resolved;
+- the PR has one uniquely named required aggregate result per blocking
+  workflow and reaches a fully green state.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -355,7 +355,7 @@ loop as server messages arrive:
 | `room_code` | `Option<String>` | `RoomJoined` / `RoomLeft` / `Reconnected` / spectator lifecycle |
 | `reconnection_token` | `Option<String>` | `RoomJoined` / `Reconnected` / room exit |
 | `negotiated_protocol_version` | `Option<u16>` | `ProtocolInfo` / disconnect |
-| `delivery_quarantined` | `bool` | Protocol-v3 accountability policy / authoritative reset |
+| `quarantined` | `bool` | Protocol-v3 accountability policy / authoritative room baseline or exit |
 
 State flows **one direction**: the background task writes, your code reads
 through the accessors. You never set state directly.

--- a/progress/session-021-coalesced-unsupported-gaps.md
+++ b/progress/session-021-coalesced-unsupported-gaps.md
@@ -1,0 +1,69 @@
+# Session 021 — Coalesced Unsupported-Format Gaps
+
+## Objective
+
+Resolve client issue #81 before the broader Signal Fish Server 0.7
+compatibility milestone: accept the coalesced and mixed-reason
+`unsupported_format` delivery reports emitted by newer servers without
+weakening protocol-v3 accountability.
+
+## Evidence
+
+- The hosted issue remained open with no in-progress client PR.
+- Current `main` is the merge of PR #85. All 11 blocking workflow runs on its
+  PR head succeeded; subsequent scheduled Security, Unused Deps, and Coverage
+  runs on the exact main SHA also succeeded. Deep Safety is explicitly
+  informational/non-blocking and its latest run was cancelled during Miri.
+- `DeliveryAccountability::record_report` still required exactly one
+  single-sequence unsupported-format gap and armed supplemental-error causality
+  from the report's first gap.
+- Signal Fish Server reference-client commit
+  `970be936c8438a892be987257604fe073ae73564` removes those shape assumptions
+  while retaining range validation, in-report overlap checks, and exact
+  counter-delta comparison.
+- The merged server contract rate-limits supplemental advisories and requires
+  only a prior unsupported-format report; the client still required immediate
+  adjacency and rejected report rollover before an advisory. The native
+  reference behavior is commit
+  `522c9c6ba10f171957f49abda434d3c37425748d` from server PR #167.
+- Red tests reproduced both failures against the current validator before the
+  production change.
+
+## Implemented
+
+- Accept any valid unsupported-format inclusive range and multiple such ranges
+  in one report.
+- Accept optional rate-limited supplemental advisories only after a causal
+  unsupported-format report, without requiring adjacency, and clear that
+  room-scoped authorization on room reset.
+- Preserve `ProtocolViolationKind::Causality` classification for an advisory
+  that lacks a prior causal report.
+- Reset room-scoped accountability from the shared `ClientCore::clear_room`
+  path used by both room and spectator exits.
+- Retain atomic validation, the 256-range bound, checked range lengths,
+  monotonic cumulative counters, non-overlap, and exact reason-counter deltas.
+- Add tests for an exact three-sequence range, understated and overstated
+  counters, split unsupported ranges, a mixed report with the unsupported gap
+  after another reason, non-adjacent advisories, report rollover, and room-reset
+  invalidation.
+- Update the consumer changelog, canonical context, and current roadmap.
+
+## Validation
+
+- Red: focused unsupported-format tests failed with the former
+  `unsupported-format report must name exactly one sequence` violation.
+- Green: all 17 accountability unit tests and all 18 async/polling parity tests
+  pass with all features enabled.
+- Mandatory `cargo fmt`, workspace/all-target/all-feature Clippy with warnings
+  denied, and workspace/all-feature tests pass. The full suite includes 267
+  core unit tests, 207 repository policy tests, 64 async integration tests, 121
+  protocol tests, 18 parity tests, and 34 Godot adapter tests; the three live
+  server tests remain intentionally ignored without a configured server binary.
+- Workflow policy, LLM pre-commit validation, test-quality, and FFI-safety
+  scripts pass. `actionlint` is not installed locally; hosted Workflow Lint is
+  the authoritative gate.
+- Two adversarial review rounds found and drove fixes for non-adjacent
+  rate-limited advisories, diagnostic classification, authoritative room-exit
+  reset, public driver parity, transactional rejection proof, and lifecycle
+  documentation.
+- Hosted PR checks and reviewer feedback remain to be recorded after publish.

--- a/progress/session-021-coalesced-unsupported-gaps.md
+++ b/progress/session-021-coalesced-unsupported-gaps.md
@@ -66,4 +66,7 @@ weakening protocol-v3 accountability.
   rate-limited advisories, diagnostic classification, authoritative room-exit
   reset, public driver parity, transactional rejection proof, and lifecycle
   documentation.
-- Hosted PR checks and reviewer feedback remain to be recorded after publish.
+- PR #87's initial revision passed all 11 hosted workflows: CI, Coverage, Docs
+  Validation, Examples Validation, Godot Web, No Panics, Security, Semver
+  Checks, Unused Deps, WASM, and Workflow Lint. No review comments or unresolved
+  threads were present when the revision was promoted from draft.

--- a/src/accountability.rs
+++ b/src/accountability.rs
@@ -1,4 +1,7 @@
-// Ported from Signal Fish Server v0.4.0 native reference client (50b28a9a13dc2b99d301bfb2482c5fd6f768a2e8).
+// Ported from Signal Fish Server v0.4.0 native reference client
+// (50b28a9a13dc2b99d301bfb2482c5fd6f768a2e8). Rate-limited unsupported-format
+// advisories synced from 522c9c6ba10f171957f49abda434d3c37425748d; coalesced
+// ranges from 970be936c8438a892be987257604fe073ae73564.
 //! Client-side protocol-v3 delivery accountability.
 
 use std::collections::{BTreeMap, BTreeSet};
@@ -47,7 +50,7 @@ pub struct DeliveryAccountability {
     stale_senders: BTreeSet<PlayerId>,
     departed_senders: BTreeMap<(PlayerId, u32), DepartedSender>,
     pending_gaps: BTreeMap<(PlayerId, u32), Vec<DeliveryGap>>,
-    pending_unsupported_error: Option<DeliveryGap>,
+    unadvised_unsupported_gap: Option<DeliveryGap>,
     counters: Option<DeliveryCountersByClass>,
     last_relay_stats: Option<RelayStatsSnapshot>,
 }
@@ -67,7 +70,7 @@ impl DeliveryAccountability {
             stale_senders: BTreeSet::new(),
             departed_senders: BTreeMap::new(),
             pending_gaps: BTreeMap::new(),
-            pending_unsupported_error: None,
+            unadvised_unsupported_gap: None,
             counters: None,
             last_relay_stats: None,
         }
@@ -81,13 +84,13 @@ impl DeliveryAccountability {
         self.stale_senders.clear();
         self.departed_senders.clear();
         self.pending_gaps.clear();
+        self.unadvised_unsupported_gap = None;
     }
 
     /// Start accountability for a new physical connection.
     #[cfg(test)]
     pub fn reset_connection(&mut self) {
         self.reset_room();
-        self.pending_unsupported_error = None;
         self.counters = None;
         self.last_relay_stats = None;
     }
@@ -314,8 +317,9 @@ impl DeliveryAccountability {
         self.try_retire_departed(player_id, epoch)
     }
 
-    /// Enforce the inline unsupported-format replacement pair on the next
-    /// server frame. The boolean identifies Error(UnsupportedGameDataFormat).
+    /// Accept an optional rate-limited unsupported-format advisory only after
+    /// a causal exact report. The boolean identifies
+    /// Error(UnsupportedGameDataFormat).
     pub fn observe_server_message(
         &mut self,
         is_unsupported_format_error: bool,
@@ -323,21 +327,16 @@ impl DeliveryAccountability {
         if !self.protocol_v3 {
             return Ok(());
         }
-        match (self.pending_unsupported_error.take(), is_unsupported_format_error) {
-            (Some(_gap), true) => Ok(()),
-            (Some(gap), false) => Err(format!(
-                "delivery accountability violation: unsupported-format report for {} epoch {}, seq {} was not immediately followed by Error(UnsupportedGameDataFormat)",
-                gap.from_player, gap.epoch, gap.from_seq
-            )),
-            (None, true) => Err("delivery accountability violation: Error(UnsupportedGameDataFormat) lacked an immediately preceding causal DeliveryReport".to_string()),
-            (None, false) => Ok(()),
+        if is_unsupported_format_error && self.unadvised_unsupported_gap.take().is_none() {
+            return Err("delivery accountability violation: Error(UnsupportedGameDataFormat) lacked a prior causal DeliveryReport".to_string());
         }
+        Ok(())
     }
 
     /// A terminal socket outcome ends the observable stream, so no
     /// supplemental error is required after the final report.
     pub fn observe_terminal(&mut self) {
-        self.pending_unsupported_error = None;
+        self.unadvised_unsupported_gap = None;
     }
 
     pub fn record_relay_stats(
@@ -450,9 +449,6 @@ impl DeliveryAccountability {
                     .to_string(),
             );
         }
-        if self.pending_unsupported_error.is_some() {
-            return Err("delivery accountability violation: unsupported-format DeliveryReport was not immediately followed by its supplemental Error".to_string());
-        }
         if report.gaps.len() > DELIVERY_REPORT_MAX_GAPS {
             return Err(format!(
                 "delivery accountability violation: DeliveryReport contains {} gap ranges, limit is {DELIVERY_REPORT_MAX_GAPS}",
@@ -466,7 +462,7 @@ impl DeliveryAccountability {
         // that overlap another range in this same report.
         let mut report_ranges: BTreeMap<(PlayerId, u32), Vec<(u64, u64)>> = BTreeMap::new();
         let mut causal_counts = [0u64; 4];
-        let mut unsupported_seen = false;
+        let mut unsupported_gap = None;
         for gap in &report.gaps {
             self.validate_gap(gap)?;
             let count = gap
@@ -480,11 +476,13 @@ impl DeliveryAccountability {
                 DeliveryGapReason::LatestSuperseded => 0,
                 DeliveryGapReason::LatestDroppedFull => 1,
                 DeliveryGapReason::VolatileDropped => 2,
+                // The server coalesces consecutive undeliverable omissions so
+                // one report may contain multiple unsupported-format ranges,
+                // and each range may span multiple sequences (server issue
+                // #212). `validate_gap`, the overlap check below, and the
+                // counter-delta comparison still enforce exactness.
                 DeliveryGapReason::UnsupportedFormat => {
-                    if unsupported_seen || gap.from_seq != gap.to_seq || report.gaps.len() != 1 {
-                        return Err("delivery accountability violation: unsupported-format report must name exactly one sequence".to_string());
-                    }
-                    unsupported_seen = true;
+                    unsupported_gap = Some(gap.clone());
                     3
                 }
             };
@@ -551,8 +549,10 @@ impl DeliveryAccountability {
             gaps.push(gap.clone());
             gaps.sort_unstable_by_key(|candidate| candidate.from_seq);
         }
-        if unsupported_seen {
-            self.pending_unsupported_error = report.gaps.first().cloned();
+        if unsupported_gap.is_some() {
+            // Arm causality from an unsupported-format range regardless of its
+            // position in a potentially mixed-reason report.
+            self.unadvised_unsupported_gap = unsupported_gap;
         }
         self.counters = Some(report.per_class);
         for gap in &report.gaps {
@@ -1167,11 +1167,15 @@ mod tests {
     }
 
     fn unsupported_gap(sender: PlayerId, seq: u64) -> DeliveryGap {
+        unsupported_gap_range(sender, seq, seq)
+    }
+
+    fn unsupported_gap_range(sender: PlayerId, from_seq: u64, to_seq: u64) -> DeliveryGap {
         DeliveryGap {
             from_player: sender,
             epoch: 1,
-            from_seq: seq,
-            to_seq: seq,
+            from_seq,
+            to_seq,
             reason: DeliveryGapReason::UnsupportedFormat,
         }
     }
@@ -1737,7 +1741,7 @@ mod tests {
     }
 
     #[test]
-    fn unsupported_report_requires_the_immediate_error_or_terminal() {
+    fn unsupported_advisory_requires_a_prior_report_but_not_adjacency() {
         let sender = id(9);
         let report = DeliveryReportPayload {
             per_class: counters_with_unsupported(1),
@@ -1747,35 +1751,99 @@ mod tests {
         let mut paired = DeliveryAccountability::default();
         paired.note_player_joined(&player(sender, 1)).unwrap();
         paired.record_report(&report).unwrap();
+        paired.observe_server_message(false).unwrap();
         paired.observe_server_message(true).unwrap();
         paired.observe_server_message(false).unwrap();
         assert!(paired.observe_server_message(true).is_err());
 
-        let mut missing = DeliveryAccountability::default();
-        missing.note_player_joined(&player(sender, 1)).unwrap();
-        missing.record_report(&report).unwrap();
-        assert!(missing.observe_server_message(false).is_err());
-        // The intervening frame consumed the pending adjacency obligation;
-        // a later supplemental Error is now independently invalid.
-        assert!(missing.observe_server_message(true).is_err());
+        let mut rollover = DeliveryAccountability::default();
+        rollover.note_player_joined(&player(sender, 1)).unwrap();
+        rollover.record_report(&report).unwrap();
+        rollover
+            .record_report(&DeliveryReportPayload {
+                per_class: counters_with_unsupported(2),
+                gaps: vec![unsupported_gap(sender, 2)],
+            })
+            .unwrap();
+        rollover.observe_server_message(true).unwrap();
+
+        let mut room_reset = DeliveryAccountability::default();
+        room_reset.note_player_joined(&player(sender, 1)).unwrap();
+        room_reset.record_report(&report).unwrap();
+        room_reset.reset_room();
+        assert!(room_reset.observe_server_message(true).is_err());
 
         let mut terminal = DeliveryAccountability::default();
         terminal.note_player_joined(&player(sender, 1)).unwrap();
         terminal.record_report(&report).unwrap();
         terminal.observe_terminal();
 
+        // The server can absorb an unsupported range into an already-queued
+        // mixed report, so the unsupported range need not be first.
+        let mixed_unsupported = unsupported_gap(sender, 7);
         let mut mixed = DeliveryAccountability::default();
         mixed.note_player_joined(&player(sender, 1)).unwrap();
-        assert!(mixed
+        mixed
             .record_report(&DeliveryReportPayload {
                 per_class: {
                     let mut value = counters_with_unsupported(1);
                     value.latest.superseded = 1;
                     value
                 },
-                gaps: vec![unsupported_gap(sender, 1), gap(sender, 2, 2)],
+                gaps: vec![gap(sender, 2, 2), mixed_unsupported.clone()],
             })
-            .is_err());
+            .unwrap();
+        assert_eq!(
+            mixed.unadvised_unsupported_gap.as_ref(),
+            Some(&mixed_unsupported)
+        );
+        mixed.observe_server_message(true).unwrap();
+    }
+
+    #[test]
+    fn coalesced_unsupported_ranges_are_accepted_only_when_counters_match() {
+        let sender = id(10);
+        let coalesced = |count: u64| DeliveryReportPayload {
+            per_class: counters_with_unsupported(count),
+            gaps: vec![unsupported_gap_range(sender, 4, 6)],
+        };
+
+        let mut exact = DeliveryAccountability::default();
+        exact.note_player_joined(&player(sender, 1)).unwrap();
+        exact.record_report(&coalesced(3)).unwrap();
+        exact.observe_server_message(true).unwrap();
+
+        for skewed_count in [2, 4] {
+            let mut skewed = DeliveryAccountability::default();
+            skewed.note_player_joined(&player(sender, 1)).unwrap();
+            assert!(
+                skewed.record_report(&coalesced(skewed_count)).is_err(),
+                "a {skewed_count}-count report for a 3-sequence range must be rejected"
+            );
+            assert!(
+                skewed.observe_server_message(true).is_err(),
+                "a rejected report must not authorize an unsupported-format advisory"
+            );
+            skewed
+                .record_report(&coalesced(3))
+                .expect("a rejected report must not commit counters or gap ranges");
+            skewed
+                .observe_server_message(true)
+                .expect("the accepted exact report must authorize its advisory");
+        }
+
+        let mut split = DeliveryAccountability::default();
+        split.note_player_joined(&player(sender, 1)).unwrap();
+        split
+            .record_report(&DeliveryReportPayload {
+                per_class: counters_with_unsupported(5),
+                gaps: vec![
+                    unsupported_gap_range(sender, 1, 2),
+                    unsupported_gap_range(sender, 7, 9),
+                ],
+            })
+            .unwrap();
+        split.observe_server_message(true).unwrap();
     }
 
     #[test]

--- a/src/client_core.rs
+++ b/src/client_core.rs
@@ -534,6 +534,7 @@ impl ClientCore {
     }
 
     fn clear_room(&mut self) {
+        self.accountability.reset_room();
         self.snapshot.room_id = None;
         self.snapshot.room_code = None;
         self.snapshot.reconnection_token = None;

--- a/src/event.rs
+++ b/src/event.rs
@@ -556,7 +556,9 @@ pub enum ProtocolViolationKind {
 impl ProtocolViolationKind {
     #[cfg(any(test, feature = "tokio-runtime", feature = "polling-client"))]
     pub(crate) fn from_diagnostic(diagnostic: &str) -> Self {
-        if diagnostic.contains("immediately followed") || diagnostic.contains("preceding causal") {
+        if diagnostic.contains("immediately followed")
+            || diagnostic.contains("causal DeliveryReport")
+        {
             Self::Causality
         } else if diagnostic.contains("PlayerLeft")
             || diagnostic.contains("PlayerReconnected")
@@ -944,7 +946,7 @@ mod tests {
                 ProtocolViolationKind::Lifecycle,
             ),
             (
-                "DeliveryReport was not immediately followed by Error",
+                "Error(UnsupportedGameDataFormat) lacked a prior causal DeliveryReport",
                 ProtocolViolationKind::Causality,
             ),
             (

--- a/tests/polling_parity_tests.rs
+++ b/tests/polling_parity_tests.rs
@@ -23,12 +23,14 @@ use signal_fish_client::client::{SignalFishClient, SignalFishConfig};
 use signal_fish_client::error::SignalFishError;
 use signal_fish_client::polling_client::SignalFishPollingClient;
 use signal_fish_client::protocol::{
-    ConnectionInfo, GameDataEncoding, LobbyState, PlayerId, PlayerInfo, ProtocolInfoPayload,
-    ReconnectedPayload, RoomJoinedPayload, ServerMessage, TransportKind, V2BinaryGameDataFrame,
+    ConnectionInfo, DeliveryClass, DeliveryCountersByClass, DeliveryGap, DeliveryGapReason,
+    DeliveryReportPayload, GameDataEncoding, LatestDeliveryCounters, LobbyState, PlayerId,
+    PlayerInfo, ProtocolInfoPayload, ReconnectedPayload, ReliableDeliveryCounters,
+    RoomJoinedPayload, ServerMessage, SpectatorJoinedPayload, TransportKind, V2BinaryGameDataFrame,
     V3BinaryGameDataFrame,
 };
 use signal_fish_client::transport::TransportFrame;
-use signal_fish_client::ProtocolViolationPolicy;
+use signal_fish_client::{ErrorCode, ProtocolViolationPolicy};
 use signal_fish_client::{
     GameDataDelivery, JoinRoomParams, PeerSignal, SignalFishClientApi, SignalFishEvent, Transport,
 };
@@ -633,7 +635,10 @@ fn canonical_event(event: &SignalFishEvent) -> String {
     }
 }
 
-async fn assert_frame_trace_parity(frames: Vec<TransportFrame>, config: SignalFishConfig) {
+async fn assert_frame_trace_parity(
+    frames: Vec<TransportFrame>,
+    config: SignalFishConfig,
+) -> Vec<String> {
     let make_mock = || TraceMock::new(frames.clone());
 
     let async_mock = make_mock();
@@ -664,6 +669,7 @@ async fn assert_frame_trace_parity(frames: Vec<TransportFrame>, config: SignalFi
     assert_eq!(async_events, polling_events);
     assert_eq!(async_client.snapshot(), polling_client.snapshot());
     assert_eq!(async_client.stats(), polling_client.stats());
+    async_events
 }
 
 async fn assert_server_trace_parity(lines: &str, config: SignalFishConfig) {
@@ -672,7 +678,7 @@ async fn assert_server_trace_parity(lines: &str, config: SignalFishConfig) {
         .filter(|line| !line.trim().is_empty())
         .map(|line| TransportFrame::Text(line.to_owned()))
         .collect();
-    assert_frame_trace_parity(frames, config).await;
+    let _ = assert_frame_trace_parity(frames, config).await;
 }
 
 // ── PARITY 1: relay-floor Authenticate byte-identity ─────────────────
@@ -771,6 +777,82 @@ fn binary_accountability_prefix(player_id: PlayerId) -> Vec<TransportFrame> {
     ]
 }
 
+fn spectator_accountability_prefix(player_id: PlayerId) -> Vec<TransportFrame> {
+    let spectator_joined = ServerMessage::SpectatorJoined(Box::new(SpectatorJoinedPayload {
+        room_id: uuid::Uuid::from_u128(201),
+        room_code: "SPECTATOR".into(),
+        spectator_id: uuid::Uuid::from_u128(101),
+        game_name: "spectator-parity".into(),
+        current_players: vec![PlayerInfo {
+            id: player_id,
+            name: "sender".into(),
+            is_authority: false,
+            is_ready: false,
+            connected_at: "2026-01-01T00:00:00Z".into(),
+            connection_info: None,
+            epoch: Some(1),
+            seq: Some(0),
+        }],
+        current_spectators: vec![],
+        lobby_state: LobbyState::Lobby,
+        reason: None,
+    }));
+    vec![
+        TransportFrame::Text(PI_V3.into()),
+        TransportFrame::Text(
+            serde_json::to_string(&spectator_joined)
+                .expect("serialize spectator accountability prefix"),
+        ),
+    ]
+}
+
+fn text_server_frame(message: ServerMessage) -> TransportFrame {
+    TransportFrame::Text(
+        serde_json::to_string(&message).expect("serialize accountability parity fixture"),
+    )
+}
+
+fn mixed_coalesced_unsupported_report(sender: PlayerId) -> TransportFrame {
+    text_server_frame(ServerMessage::DeliveryReport(Box::new(
+        DeliveryReportPayload {
+            per_class: DeliveryCountersByClass {
+                reliable: ReliableDeliveryCounters {
+                    unsupported_format: 2,
+                    ..ReliableDeliveryCounters::default()
+                },
+                latest: LatestDeliveryCounters {
+                    superseded: 1,
+                    ..LatestDeliveryCounters::default()
+                },
+                ..DeliveryCountersByClass::default()
+            },
+            gaps: vec![
+                DeliveryGap {
+                    from_player: sender,
+                    epoch: 1,
+                    from_seq: 1,
+                    to_seq: 1,
+                    reason: DeliveryGapReason::LatestSuperseded,
+                },
+                DeliveryGap {
+                    from_player: sender,
+                    epoch: 1,
+                    from_seq: 2,
+                    to_seq: 3,
+                    reason: DeliveryGapReason::UnsupportedFormat,
+                },
+            ],
+        },
+    )))
+}
+
+fn unsupported_format_advisory() -> TransportFrame {
+    text_server_frame(ServerMessage::Error {
+        message: "unsupported payload format".into(),
+        error_code: Some(ErrorCode::UnsupportedGameDataFormat),
+    })
+}
+
 #[tokio::test]
 async fn inbound_binary_events_decode_failures_and_accountability_have_complete_parity() {
     let v2 = V2BinaryGameDataFrame {
@@ -780,7 +862,7 @@ async fn inbound_binary_events_decode_failures_and_accountability_have_complete_
     };
     let mut v2_config = SignalFishConfig::new("app");
     v2_config.game_data_format = Some(GameDataEncoding::MessagePack);
-    assert_frame_trace_parity(
+    let _ = assert_frame_trace_parity(
         vec![
             TransportFrame::Text(PI_V2.into()),
             TransportFrame::Binary(rmp_serde::to_vec_named(&v2).unwrap()),
@@ -813,7 +895,136 @@ async fn inbound_binary_events_decode_failures_and_accountability_have_complete_
             .enable_v3()
             .with_protocol_violation_policy(policy);
         config.game_data_format = Some(GameDataEncoding::MessagePack);
-        assert_frame_trace_parity(frames, config).await;
+        let _ = assert_frame_trace_parity(frames, config).await;
+    }
+}
+
+#[tokio::test]
+async fn mixed_coalesced_unsupported_advisory_trace_has_complete_policy_parity() {
+    let sender = uuid::Uuid::from_u128(302);
+
+    let mut frames = binary_accountability_prefix(sender);
+    frames.extend([
+        mixed_coalesced_unsupported_report(sender),
+        text_server_frame(ServerMessage::GameData {
+            from_player: sender,
+            data: serde_json::json!({"seq": 4}),
+            seq: Some(4),
+            epoch: Some(1),
+            class: Some(DeliveryClass::Reliable),
+            key: None,
+        }),
+        unsupported_format_advisory(),
+    ]);
+
+    for policy in [
+        ProtocolViolationPolicy::Quarantine,
+        ProtocolViolationPolicy::Disconnect,
+        ProtocolViolationPolicy::Observe,
+    ] {
+        let events = assert_frame_trace_parity(
+            frames.clone(),
+            SignalFishConfig::new("app")
+                .enable_v3()
+                .with_protocol_violation_policy(policy),
+        )
+        .await;
+        let event_kinds = events
+            .iter()
+            .map(|event| {
+                event
+                    .split('|')
+                    .next()
+                    .expect("event projection has a kind")
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            event_kinds,
+            [
+                "ProtocolInfo",
+                "RoomJoined",
+                "DeliveryReport",
+                "GameData",
+                "Error",
+                "Disconnected",
+            ],
+            "{policy:?} must accept and deliver the complete delayed-advisory trace"
+        );
+    }
+}
+
+#[tokio::test]
+async fn room_exit_clears_unsupported_advisory_authorization_in_both_drivers() {
+    let sender = uuid::Uuid::from_u128(303);
+    let cases = [
+        (
+            "RoomJoined",
+            "RoomLeft",
+            binary_accountability_prefix(sender),
+            text_server_frame(ServerMessage::RoomLeft),
+        ),
+        (
+            "SpectatorJoined",
+            "SpectatorLeft",
+            spectator_accountability_prefix(sender),
+            text_server_frame(ServerMessage::SpectatorLeft {
+                room_id: None,
+                room_code: None,
+                reason: None,
+                current_spectators: vec![],
+            }),
+        ),
+    ];
+
+    for (joined_kind, left_kind, prefix, leave_frame) in cases {
+        let mut frames = prefix;
+        frames.extend([
+            mixed_coalesced_unsupported_report(sender),
+            leave_frame,
+            unsupported_format_advisory(),
+        ]);
+        for policy in [
+            ProtocolViolationPolicy::Quarantine,
+            ProtocolViolationPolicy::Disconnect,
+            ProtocolViolationPolicy::Observe,
+        ] {
+            let events = assert_frame_trace_parity(
+                frames.clone(),
+                SignalFishConfig::new("app")
+                    .enable_v3()
+                    .with_protocol_violation_policy(policy),
+            )
+            .await;
+            assert!(
+                events.iter().any(|event| {
+                    event.starts_with("ProtocolViolation|Causality|")
+                        && event.contains("lacked a prior causal DeliveryReport")
+                }),
+                "{left_kind} under {policy:?} must revoke old-room advisory authorization: {events:?}"
+            );
+
+            let mut expected_kinds = vec![
+                "ProtocolInfo",
+                joined_kind,
+                "DeliveryReport",
+                left_kind,
+                "ProtocolViolation",
+            ];
+            if policy == ProtocolViolationPolicy::Observe {
+                expected_kinds.push("Error");
+            }
+            expected_kinds.push("Disconnected");
+            let event_kinds = events
+                .iter()
+                .map(|event| {
+                    event
+                        .split('|')
+                        .next()
+                        .expect("event projection has a kind")
+                })
+                .collect::<Vec<_>>();
+            assert_eq!(event_kinds, expected_kinds, "{left_kind} under {policy:?}");
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- accept coalesced and split `UnsupportedFormat` delivery gaps while retaining range validity, non-overlap, and exact counter-delta checks
- align unsupported-format advisory causality with the server's optional, rate-limited behavior, including delayed advisories and room-exit resets
- cover the shared async/polling core across every protocol-violation policy
- refresh accountability documentation, changelog, roadmap, and session evidence

## Root cause

The client assumed each unsupported-format report described exactly one sequence and that the matching `UnsupportedGameDataFormat` error arrived immediately afterward. The server now coalesces and splits unsupported ranges and emits supplemental advisories on a rate-limited basis. Valid server traces could therefore be quarantined or disconnected.

## Validation

- `cargo fmt`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- repository workflow, documentation, FFI-safety, and test-quality policy scripts
- independent adversarial review with no remaining findings

The full local suite passed, including 267 core unit tests, 207 CI-policy tests, 64 client integration tests, 18 async/polling parity tests, 121 protocol tests, and 34 Godot adapter tests. Three real-server tests remain intentionally ignored because no server binary is configured.

Closes #81

This also incorporates the same-class advisory behavior from server PR #167 and advances, but does not close, #86.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes protocol-v3 accountability semantics in shared `ClientCore`; incorrect logic could wrongly quarantine or accept invalid server traces, though coverage is strong and v2 is untouched.
> 
> **Overview**
> Fixes **protocol-v3 delivery accountability** so valid traces from newer Signal Fish servers are no longer quarantined or disconnected.
> 
> **Unsupported-format gap reports** may now include **coalesced multi-sequence ranges**, **multiple ranges in one report**, and **mixed-reason reports** where the unsupported gap is not first. The validator still requires non-overlapping ranges and **exact counter deltas**; rejected reports do not commit state or arm advisories.
> 
> **`UnsupportedGameDataFormat` advisories** are optional and rate-limited: they need a **prior causal** unsupported-format report, not immediate adjacency, and another report may arrive before the advisory. **`ClientCore::clear_room`** calls **`accountability.reset_room()`** on room/spectator leave so old-room gap and advisory authorization cannot satisfy a later error.
> 
> Async/polling **parity tests** cover mixed coalesced reports and post-exit causality violations across all violation policies. Docs, changelog, and roadmap are updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1bf8ac2bf171ed9c63082f773fb920027539c2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->