### PR TITLE
ci: harden deep safety analysis

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,9 @@
 # Goal: prefer fewer, larger ecosystem-based PRs over many tiny per-package PRs.
 #
 # Strategy:
-#   - One broad Cargo PR that batches ALL version updates (major/minor/patch).
+#   - One broad Cargo PR that batches root-workspace and standalone Godot
+#     fixture updates together, so Dependabot resolves the fixture's path
+#     dependencies from the same repository file set.
 #   - One broad GitHub Actions PR that batches ALL version updates.
 #   - open-pull-requests-limit: 1 per ecosystem so Dependabot can only open
 #     one consolidated batch PR at a time; once that batch is merged a fresh
@@ -16,7 +18,9 @@ version: 2
 updates:
   # ── Cargo (Rust) dependencies ──────────────────────────────────
   - package-ecosystem: cargo
-    directory: /
+    directories:
+      - /
+      - /tests/godot-web-smoke
     schedule:
       interval: weekly
       day: monday
@@ -36,30 +40,6 @@ updates:
           - patch
     commit-message:
       prefix: "deps"
-      include: scope
-
-  # ── Exact latest Godot compatibility fixture ──────────────────
-  - package-ecosystem: cargo
-    directory: /tests/godot-web-smoke
-    schedule:
-      interval: weekly
-      day: monday
-      timezone: America/New_York
-    labels:
-      - dependencies
-      - security
-    # Limit to 1 so compatibility evidence changes remain reviewable as one PR.
-    open-pull-requests-limit: 1
-    groups:
-      godot-latest-all:
-        patterns:
-          - "*"
-        update-types:
-          - major
-          - minor
-          - patch
-    commit-message:
-      prefix: "deps(godot-latest)"
       include: scope
 
   # ── GitHub Actions ─────────────────────────────────────────────

--- a/.github/workflows/deep-safety.yml
+++ b/.github/workflows/deep-safety.yml
@@ -106,10 +106,7 @@ jobs:
             exit 1
           fi
           fuzz_corpus=$(mktemp -d)
-          cleanup() {
-            rm -rf "$fuzz_corpus"
-          }
-          trap cleanup EXIT
+          trap 'rm -rf "$fuzz_corpus"' EXIT
           status=0
           for target in fuzz_server_message fuzz_client_message fuzz_binary_game_data; do
             corpus="$fuzz_corpus/$target"

--- a/.github/workflows/deep-safety.yml
+++ b/.github/workflows/deep-safety.yml
@@ -1,19 +1,17 @@
 # Deep safety analysis for signal-fish-client
 #
-# Non-blocking scheduled lanes for thorough safety and quality analysis
-# that would be too slow or noisy for every PR.
+# Scheduled lanes for thorough safety and quality analysis that would be too
+# slow for every PR. Every lane fails closed when its analyzer finds a defect
+# or cannot execute, so a green run is usable evidence.
 #
 # Jobs:
-#   miri    — Miri undefined behavior detection (nightly, sync tests only)
+#   miri    — Miri undefined behavior detection (nightly, protocol tests)
 #   fuzz    — Fuzz smoke tests for protocol parsing (nightly)
 #   mutants — Mutation testing on pure-logic modules (stable)
 #
 # Schedule: Weekdays at 04:00 UTC — staggered from unused-deps (05:00)
 # and security (06:00).
 #
-# All jobs use continue-on-error: true because these are informational
-# lanes — failures here are signals, not blockers.
-
 name: Deep Safety
 
 on:
@@ -37,18 +35,14 @@ jobs:
   # ──────────────────────────────────────────────────────────────
   # Miri — detect undefined behavior via interpretation
   #
-  # Scoped to synchronous test targets only. Miri does not support
-  # tokio's async runtime, so client_tests (all #[tokio::test])
-  # are excluded. protocol_tests and ci_config_tests are pure
-  # synchronous logic and run cleanly under Miri.
-  #
-  # This is an informational lane; failures do not block merges.
+  # Scoped to the synchronous protocol conformance target. Miri does not
+  # support tokio's async runtime, and repository-policy tests exercise shell
+  # processes rather than production memory safety.
   # ──────────────────────────────────────────────────────────────
   miri:
     name: Miri
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    continue-on-error: true
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
@@ -69,12 +63,6 @@ jobs:
         env:
           MIRIFLAGS: "-Zmiri-disable-isolation"
 
-      - name: Run Miri on CI config tests
-        if: always()
-        run: cargo +nightly miri test --test ci_config_tests
-        env:
-          MIRIFLAGS: "-Zmiri-disable-isolation"
-
   # ──────────────────────────────────────────────────────────────
   # Fuzz — smoke test protocol parsers with random input
   #
@@ -82,15 +70,13 @@ jobs:
   # or crashes in the JSON deserialization paths. This is a smoke
   # test, not a deep fuzzing campaign.
   #
-  # Fuzz targets exercise both UTF-8 (from_str) and raw byte
-  # (from_slice) deserialization paths for ServerMessage and
-  # ClientMessage.
+  # JSON targets exercise both UTF-8 and raw-byte deserialization. The binary
+  # target exercises the strict physical MessagePack envelope decoder.
   # ──────────────────────────────────────────────────────────────
   fuzz:
     name: Fuzz smoke tests
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    continue-on-error: true
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
@@ -111,12 +97,44 @@ jobs:
       - name: Generate lockfile
         run: bash scripts/cargo-retry.sh generate-lockfile --manifest-path fuzz/Cargo.toml
 
-      - name: Fuzz ServerMessage parsing
-        run: cd fuzz && cargo +nightly fuzz run fuzz_server_message seeds/fuzz_server_message -- -max_total_time=30
+      - name: Run every protocol fuzz target
+        run: |
+          set -euo pipefail
+          fuzz_host=$(rustc +nightly -vV | sed -n 's/^host: //p')
+          if [ -z "$fuzz_host" ]; then
+            printf 'Unable to determine the nightly Rust host target.\n' >&2
+            exit 1
+          fi
+          fuzz_corpus=$(mktemp -d)
+          cleanup() {
+            rm -rf "$fuzz_corpus"
+          }
+          trap cleanup EXIT
+          status=0
+          for target in fuzz_server_message fuzz_client_message fuzz_binary_game_data; do
+            corpus="$fuzz_corpus/$target"
+            mkdir -p "$corpus"
+            seed_args=()
+            if [ -d "seeds/$target" ]; then
+              seed_args+=("seeds/$target")
+            fi
+            if ! cargo +nightly fuzz run "$target" \
+              --target "$fuzz_host" \
+              "$corpus" "${seed_args[@]}" -- -max_total_time=30; then
+              status=1
+            fi
+          done
+          exit "$status"
+        working-directory: fuzz
 
-      - name: Fuzz ClientMessage parsing
+      - name: Upload fuzz crash artifacts
         if: always()
-        run: cd fuzz && cargo +nightly fuzz run fuzz_client_message seeds/fuzz_client_message -- -max_total_time=30
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: fuzz-artifacts-${{ github.run_id }}-${{ github.run_attempt }}
+          path: fuzz/artifacts/
+          if-no-files-found: ignore
+          retention-days: 30
 
   # ──────────────────────────────────────────────────────────────
   # Mutation testing — verify test suite catches injected faults
@@ -129,7 +147,6 @@ jobs:
     name: Mutation testing
     runs-on: ubuntu-latest
     timeout-minutes: 45
-    continue-on-error: true
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
@@ -149,7 +166,7 @@ jobs:
           tool: cargo-mutants@26.2.0
 
       - name: Run mutation tests
-        run: cargo mutants --timeout 60 --no-shuffle -j 2 --file src/protocol.rs --file src/error_codes.rs --file src/error.rs
+        run: cargo mutants --gitignore true --timeout 60 --no-shuffle -j 2 --file src/protocol.rs --file src/error_codes.rs --file src/error.rs
 
       - name: Upload mutation results
         if: always()

--- a/.github/workflows/deep-safety.yml
+++ b/.github/workflows/deep-safety.yml
@@ -1,8 +1,9 @@
 # Deep safety analysis for signal-fish-client
 #
-# Scheduled lanes for thorough safety and quality analysis that would be too
-# slow for every PR. Every lane fails closed when its analyzer finds a defect
-# or cannot execute, so a green run is usable evidence.
+# Thorough safety and quality analysis that would be too slow for every PR.
+# Pull requests run it only when analyzer or covered-code inputs change; the
+# weekday schedule catches ecosystem drift. Every lane fails closed when its
+# analyzer finds a defect or cannot execute, so a green run is usable evidence.
 #
 # Jobs:
 #   miri    — Miri undefined behavior detection (nightly, protocol tests)
@@ -15,6 +16,23 @@
 name: Deep Safety
 
 on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .cargo/**
+      - .github/workflows/deep-safety.yml
+      - Cargo.lock
+      - Cargo.toml
+      - fuzz/**
+      - scripts/cargo-retry.sh
+      - src/error.rs
+      - src/error_codes.rs
+      - src/lib.rs
+      - src/protocol.rs
+      - src/protocol/**
+      - src/signal.rs
+      - tests/protocol_tests.rs
   schedule:
     # Weekdays at 04:00 UTC — staggered from unused-deps at 05:00 and security at 06:00
     - cron: "0 4 * * 1-5"

--- a/.github/workflows/protocol-sync.yml
+++ b/.github/workflows/protocol-sync.yml
@@ -1,9 +1,10 @@
 # Protocol wire-sample drift detector for signal-fish-client
 #
-# Weekly (and on demand) re-fetches the Signal Fish server's published protocol
-# samples and fails loudly if the vendored copies under tests/wire-samples/ have
-# drifted from upstream. Fail-closed: a human runs the refresh procedure in
-# .llm/skills/protocol-wire-conformance/SKILL.md and reconciles any client type changes.
+# Weekly, on demand, and when protocol evidence changes in a pull request,
+# re-fetches the Signal Fish server's published protocol samples and fails
+# loudly if vendored copies have drifted from upstream. Fail-closed: a human
+# runs the refresh procedure in .llm/skills/protocol-wire-conformance/SKILL.md
+# and reconciles any client type changes.
 #
 # The concurrency group includes the event name so scheduled and manual runs on
 # the same ref do not cancel each other.
@@ -11,6 +12,15 @@
 name: Protocol Sync
 
 on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/protocol-sync.yml
+      - tests/server-spec/PROVENANCE.toml
+      - tests/server-spec/signal-fish-protocol.asyncapi.yaml
+      - tests/wire-samples/PROVENANCE.toml
+      - tests/wire-samples/*.jsonl
   schedule:
     # Mondays at 05:00 UTC — staggered from the other scheduled workflows.
     - cron: "0 5 * * 1"

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -84,6 +84,10 @@ jobs:
           version: 3.1.74
       - name: Cache Cargo artifacts
         uses: Swatinem/rust-cache@v2.9.2
+      - name: Validate Emscripten FFI safety policy
+        run: |
+          bash scripts/test_check_ffi_safety.sh
+          bash scripts/check-ffi-safety.sh
       - name: Build (no default features)
         run: >-
           cargo +nightly build -Zbuild-std

--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ logs/
 # Fuzz artifacts
 fuzz/artifacts/
 fuzz/corpus/
+/fuzz/target/
 
 progress/
 PLAN.md

--- a/.llm/context.md
+++ b/.llm/context.md
@@ -77,14 +77,14 @@ the sole documented exception because it binds the platform C API. The
 required WASM workflow runs the Emscripten FFI policy checker and its negative
 self-test before compiling and linting the actual target.
 
-The scheduled/manual Deep Safety workflow provides fail-closed evidence from
-Miri protocol tests, all three protocol fuzz targets, and a narrow mutation
-scope. Fuzzing selects the nightly host explicitly and writes discoveries only
-to temporary corpora; committed seeds are read-only inputs. The binary target
-exercises raw, valid, and perturbed protocol-v2 and protocol-v3 MessagePack
-envelopes. Deep Safety is intentionally not a PR-required workflow because of
-nightly/runtime variability; required Clippy and WASM aggregates enforce the
-compiler safety and warning policies on every PR.
+The change-scoped PR, scheduled, and manual Deep Safety workflow provides
+fail-closed evidence from Miri protocol tests, all three protocol fuzz targets,
+and a narrow mutation scope. Fuzzing selects the nightly host explicitly and
+writes discoveries only to temporary corpora; committed seeds are read-only
+inputs. The binary target exercises raw, valid, and perturbed protocol-v2 and
+protocol-v3 MessagePack envelopes. Deep Safety is intentionally not a required
+PR workflow because of nightly/runtime variability; required Clippy and WASM
+aggregates enforce the compiler safety and warning policies on every PR.
 
 Native ASan is deferred because the only owned unsafe implementation is
 Emscripten-only, so a native sanitizer lane would not execute it. The fuzz

--- a/.llm/context.md
+++ b/.llm/context.md
@@ -69,6 +69,37 @@ Only add `CHANGELOG.md` entries for user-visible changes.
 - Include: public API, behavior, protocol, feature flags, error-model, MSRV/dependency changes that affect consumers, and contributor-facing environment fixes that unblock using the repository.
 - Exclude: internal-only updates such as CI/script/pre-commit automation, refactors, tests, and non-behavioral maintenance.
 
+## Safety Analysis Policy
+
+Production Rust is safe by default. The core manifest denies `unsafe_code`, the
+Godot adapter forbids it, and the target-gated Emscripten WebSocket module is
+the sole documented exception because it binds the platform C API. The
+required WASM workflow runs the Emscripten FFI policy checker and its negative
+self-test before compiling and linting the actual target.
+
+The scheduled/manual Deep Safety workflow provides fail-closed evidence from
+Miri protocol tests, all three protocol fuzz targets, and a narrow mutation
+scope. Fuzzing selects the nightly host explicitly and writes discoveries only
+to temporary corpora; committed seeds are read-only inputs. The binary target
+exercises raw, valid, and perturbed protocol-v2 and protocol-v3 MessagePack
+envelopes. Deep Safety is intentionally not a PR-required workflow because of
+nightly/runtime variability; required Clippy and WASM aggregates enforce the
+compiler safety and warning policies on every PR.
+
+Native ASan is deferred because the only owned unsafe implementation is
+Emscripten-only, so a native sanitizer lane would not execute it. The fuzz
+lane's sanitizer instrumentation instead covers the owned protocol parsers it
+actually drives. Blanket Clippy pedantic/nursery/cargo groups are also deferred:
+the inventory produced more than 170 mostly stylistic/documentation findings,
+and its only suspicious correctness warning was verified as a false positive.
+Add either class only when it demonstrates a stable, actionable defect.
+
+Dependabot monitors the root Cargo workspace and the standalone Godot web
+fixture in one updater entry. They stay in the same updater file set so it can
+include the fixture's `../..` path dependencies while updating exact
+compatibility versions; a successful default-branch updater run is required
+after any change to this arrangement.
+
 ## Architecture — Core Modules
 
 | File | Purpose |

--- a/.llm/skills/protocol-wire-conformance/SKILL.md
+++ b/.llm/skills/protocol-wire-conformance/SKILL.md
@@ -77,11 +77,13 @@ In `tests/ci_config_tests.rs` (`protocol_wire_conformance_policy`):
 
 ## Drift Detection
 
-`.github/workflows/protocol-sync.yml` runs weekly: it re-fetches the upstream
-samples **and the AsyncAPI spec** and **fails loudly** if the vendored copies have drifted from the recorded
-commit (fail-closed, no auto-PR). When it fails, follow the refresh procedure
-above. This catches the "upstream changed but nobody refreshed us" case that the
-offline checksum test cannot.
+`.github/workflows/protocol-sync.yml` runs weekly, on manual dispatch, and on
+pull requests that change the workflow or vendored protocol evidence. It
+re-fetches the upstream samples **and the AsyncAPI spec** and **fails loudly**
+if the vendored copies have drifted from the recorded commit (fail-closed, no
+auto-PR). When it fails, follow the refresh procedure above. This catches the
+"upstream changed but nobody refreshed us" case that the offline checksum test
+cannot, while the path-scoped PR trigger proves changes immediately.
 
 ## Why Fail-Closed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,9 @@ toml = "1.0"
 sha2 = "0.11"
 # Generates and shrinks polling-driver scheduler transition sequences.
 proptest = "1.7"
+# Parses production sources in the offline sole-unsafe-exception policy test.
+proc-macro2 = "1"
+syn = { version = "2", features = ["full", "visit"] }
 
 [[example]]
 name = "basic_lobby"
@@ -125,6 +128,11 @@ panic = "deny"
 todo = "deny"
 unimplemented = "deny"
 indexing_slicing = "deny"
+
+[lints.rust]
+# Production Rust is safe by default. The Emscripten transport has the only
+# narrowly scoped exception because it binds the platform C WebSocket API.
+unsafe_code = "deny"
 
 [workspace]
 members = ["crates/signal-fish-client-godot"]

--- a/PLAN.md
+++ b/PLAN.md
@@ -64,12 +64,15 @@ into one evidence-backed hardening milestone.
 - The incompatible standalone-fixture Dependabot updater is consolidated with
   the root workspace so its file set can include local path dependencies;
   default-branch updater confirmation remains pending.
-- Local evidence is green. PR #91 at `a61522c` has all eleven required
+- Local evidence is green. PR #91 has all eleven required project-owned
   aggregates green plus green change-scoped Deep Safety and Protocol Sync runs.
-  Independent and Bugbot reviews report no actionable findings; Copilot's only
-  response is the tracked quota-limit condition from issue #90. Issues #78 and
-  #84 close with the PR. Default-branch Dependabot confirmation remains after
-  merge.
+  Independent and Bugbot reviews report no actionable findings. Literal
+  all-checks-green acceptance remains externally blocked: Copilot's reviewer
+  check failed on quota, there is no approval, and the live ruleset still does
+  not enforce either condition. Issue #90 requires this next open PR to prove
+  that governance before merge. Issues #78 and #84 close with the PR once that
+  blocker is resolved or explicitly re-scoped by a maintainer. Default-branch
+  Dependabot confirmation remains after merge.
 
 ## Next Major Milestone — Negotiated Token Binding
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -11,8 +11,12 @@
   exports, with blocking real-server gameplay coverage.
 - Release preparation and publication are workspace-aware, reproducible, and
   protected by required aggregate checks.
+- Signal Fish Server 0.7 compatibility shipped on `main` in
+  [PR #89](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/pull/89),
+  closing issue #86.
 
-Completed milestone history and verification evidence live in `progress/`.
+Curated milestone history and verification evidence live in tracked files
+under `progress/`.
 
 ## Priority Order
 
@@ -26,44 +30,52 @@ Work open issues in gameplay-impact order:
 Finish one coherent PR and make it fully green before starting the next. Do
 not stack dependent PRs.
 
-## In-flight Delivery — Signal Fish Server 0.7 Compatibility
+## Hosted Governance Blocker
 
-Track [issue #86](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/issues/86).
-The breaking 0.11-compatible source and conformance work is complete locally:
-generation-fenced signaling, Direct endpoint exposure, 0.7 error coverage,
-exact fixture provenance, async/polling parity, a pinned live 0.7 host-replan
-smoke, and both 0.7 and legacy-0.4 Godot gates. Remaining delivery work is
-hosted in [PR #89](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/pull/89).
-All eleven project-owned aggregate workflows are green at completion-audit
-commit `44a7054`, including null-generation hardening, exact 0.4/0.7
-release-digest binding, and the pinned live 0.4 mesh seam. Independent protocol
-and adversarial reviews report zero remaining findings. The final audit found
-that the live default-branch
-ruleset no longer enforces the checked-in approval and required-check policy,
-the scheduled repository-policy audit is therefore red, and an external
-Copilot quota check is red while the PR has no human approval.
 [Issue #90](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/issues/90)
-tracks restoring the live ruleset, resolving the non-actionable Copilot gate,
-and obtaining the required approval before maintainer merge closes #86.
-[Token-binding-v2](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/issues/88)
-remains a separate negotiated correctness/security milestone because server
-0.7 leaves it disabled by default.
+tracks live drift from `.github/required-checks.json`. Ruleset #14801090 still
+lacks approval and required-status-check rules, the scheduled Repository Policy
+workflow is genuinely red, and PR #89 demonstrated the impact by merging
+without the intended enforcement. Restoring the ruleset, resolving the
+non-actionable Copilot quota gate, and dispatching a green policy audit require
+maintainer-level repository administration. The next open PR is the enforcement
+proof because #89 is already merged.
 
-## Next Major Milestone — Safety and Static Analysis
+## In-flight Milestone — Safety and Static Analysis
 
 Consolidate [issue #78](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/issues/78)
 and [issue #84](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/issues/84)
 into one evidence-backed hardening milestone.
 
-- Inventory existing lint, unsafe-code, dependency, fuzz, and mutation gates
-  before adding tools.
-- Add only analyzers that find an actionable defect class with acceptable
-  runtime and stable Rust/MSRV behavior.
-- Prefer crate-level unsafe policy and narrowly justified exceptions over
-  source-text heuristics.
-- Keep warnings denied in every supported feature/target combination.
-- Close or re-scope the duplicate issue once one canonical implementation plan
-  is accepted.
+- The analyzer inventory is complete: required Clippy, rustdoc, dependency,
+  panic, coverage, target-build, and FFI gates plus scheduled fail-closed Miri,
+  fuzz, and mutation lanes cover the useful defect classes. Broad
+  pedantic/nursery lint expansion was rejected after more than 170 mostly
+  stylistic findings and one verified false positive; native ASan cannot
+  exercise the Emscripten-only owned unsafe path.
+- Compiler policy now denies unsafe Rust in the core, forbids it in the Godot
+  adapter, and documents the sole Emscripten FFI exception. The required WASM
+  workflow hosts the FFI checker and its 25-case self-test.
+- Deep Safety is being repaired to fail closed: Miri runs the 125 production
+  protocol tests; fuzz uses the actual host, isolated writable corpora, and all
+  JSON/binary v2/v3 targets; mutation testing has zero surviving mutants.
+- The incompatible standalone-fixture Dependabot updater is consolidated with
+  the root workspace so its file set can include local path dependencies;
+  default-branch updater confirmation remains pending.
+- Local evidence is green. Hosted Deep Safety and PR aggregate evidence remain
+  before #78 can close; #84 then closes as the duplicate milestone.
+
+## Next Major Milestone — Negotiated Token Binding
+
+Track [issue #88](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/issues/88).
+
+- Preserve byte-for-byte default connections while adding explicit disabled,
+  optional, and required token-binding-v2 modes.
+- Bind the native proof algorithm and negative cases to one exact server
+  release/commit, including replay, tamper, downgrade, and malformed envelopes.
+- Make handshake-material capability differences explicit for native, browser,
+  Godot, polling, and custom transports, with typed required-mode failures.
+- Keep keys, proofs, and handshake secrets out of `Debug`, tracing, and errors.
 
 ## Following Milestone — Allocation and Performance Evidence
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -59,11 +59,14 @@ into one evidence-backed hardening milestone.
 - Deep Safety is being repaired to fail closed: Miri runs the 125 production
   protocol tests; fuzz uses the actual host, isolated writable corpora, and all
   JSON/binary v2/v3 targets; mutation testing has zero surviving mutants.
+  Path-scoped PR triggers provide immediate hosted proof when analyzer or
+  covered-code inputs change without making the variable-runtime lane required.
 - The incompatible standalone-fixture Dependabot updater is consolidated with
   the root workspace so its file set can include local path dependencies;
   default-branch updater confirmation remains pending.
-- Local evidence is green. Hosted Deep Safety and PR aggregate evidence remain
-  before #78 can close; #84 then closes as the duplicate milestone.
+- Local evidence is green. PR #91 aggregate and change-scoped Deep Safety
+  evidence remain before #78 can close; #84 then closes as the duplicate
+  milestone.
 
 ## Next Major Milestone — Negotiated Token Binding
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -64,9 +64,12 @@ into one evidence-backed hardening milestone.
 - The incompatible standalone-fixture Dependabot updater is consolidated with
   the root workspace so its file set can include local path dependencies;
   default-branch updater confirmation remains pending.
-- Local evidence is green. PR #91 aggregate and change-scoped Deep Safety
-  evidence remain before #78 can close; #84 then closes as the duplicate
-  milestone.
+- Local evidence is green. PR #91 at `a61522c` has all eleven required
+  aggregates green plus green change-scoped Deep Safety and Protocol Sync runs.
+  Independent and Bugbot reviews report no actionable findings; Copilot's only
+  response is the tracked quota-limit condition from issue #90. Issues #78 and
+  #84 close with the PR. Default-branch Dependabot confirmation remains after
+  merge.
 
 ## Next Major Milestone — Negotiated Token Binding
 

--- a/crates/signal-fish-client-godot/Cargo.toml
+++ b/crates/signal-fish-client-godot/Cargo.toml
@@ -31,3 +31,7 @@ panic = "deny"
 todo = "deny"
 unimplemented = "deny"
 indexing_slicing = "deny"
+
+[lints.rust]
+# This adapter uses godot-rust's safe API and has no FFI exception of its own.
+unsafe_code = "forbid"

--- a/fuzz/fuzz_targets/fuzz_binary_game_data.rs
+++ b/fuzz/fuzz_targets/fuzz_binary_game_data.rs
@@ -1,8 +1,32 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
-use signal_fish_client::protocol::decode_v3_binary_game_data;
+use signal_fish_client::protocol::{decode_v2_binary_game_data, decode_v3_binary_game_data};
+
+// Valid envelopes keep the fuzzer past the map-header frontier from its first
+// iteration. Input bytes then perturb those envelopes so it explores both the
+// successful decoders and their strict validation branches.
+const V2_ENVELOPE: &[u8] = b"\x83\xabfrom_player\xc4\x10\x00\x11\x22\x33\x44\x55\x66\x77\x88\x99\xaa\xbb\xcc\xdd\xee\xff\xa8encoding\xacmessage_pack\xa7payload\xc4\x04\x00\x01\x02\xff";
+const V3_ENVELOPE: &[u8] = b"\x85\xabfrom_player\xc4\x10\x00\x11\x22\x33\x44\x55\x66\x77\x88\x99\xaa\xbb\xcc\xdd\xee\xff\xa8encoding\xa4json\xa7payload\xc4\x04\x00\x01\x02\xff\xa3seq\x09\xa5epoch\x03";
+
+fn exercise(wire: &[u8]) {
+    let _ = decode_v2_binary_game_data(wire);
+    let _ = decode_v3_binary_game_data(wire);
+}
+
+fn perturb(canonical: &[u8], input: &[u8]) -> Vec<u8> {
+    let mut candidate = canonical.to_vec();
+    for (index, byte) in input.iter().enumerate() {
+        let slot = index % candidate.len();
+        candidate[slot] ^= byte;
+    }
+    candidate
+}
 
 fuzz_target!(|wire: &[u8]| {
-    let _ = decode_v3_binary_game_data(wire);
+    exercise(wire);
+    exercise(V2_ENVELOPE);
+    exercise(V3_ENVELOPE);
+    exercise(&perturb(V2_ENVELOPE, wire));
+    exercise(&perturb(V3_ENVELOPE, wire));
 });

--- a/progress/session-023-deep-safety-hardening.md
+++ b/progress/session-023-deep-safety-hardening.md
@@ -85,21 +85,26 @@ the now-merged Server 0.7 delivery.
    `cargo fmt`, workspace/all-target/all-feature Clippy with `-D warnings`, and
    workspace/all-feature tests (including 212 CI-policy and 125 protocol
    integration tests).
-7. PR #91 head `a61522c` passed all eleven required aggregate workflows. The
+7. PR #91 implementation head `b97fb6f` passed all eleven required aggregate
+   workflows. The
    first Workflow Lint run exposed actionlint SC2317 on an indirectly invoked
    trap handler; commit `85be886` replaced it with an equivalent inline EXIT
-   trap, and hosted Workflow Lint run 31954358998 passed.
-8. Change-scoped Protocol Sync run 31954359013 passed against the current
-   server samples and AsyncAPI spec. Deep Safety run 31954359008 passed all
+   trap, and the final-head Workflow Lint run passed.
+8. Change-scoped Protocol Sync run 31955120960 passed against the current
+   server samples and AsyncAPI spec. Deep Safety run 31955120978 passed all
    three fail-closed jobs: Miri, mutation testing, and all-target fuzz smoke.
 9. Cursor Bugbot and the final independent adversarial review reported no
-   actionable findings or open threads. Copilot could not review because the
-   requesting account reached its quota; this is the external condition
-   already tracked in issue #90, not code feedback.
+   actionable findings or open threads. Across 58 checks, 54 succeeded and
+   three conditional jobs were skipped; only Copilot's reviewer check failed
+   because the requesting account reached its quota. There is no approval.
+   These are the external enforcement conditions tracked in issue #90, not
+   code defects or actionable feedback.
 
 ## Hosted Follow-up
 
-- Merge fully green PR #91; issues #78 and #84 close with it.
+- Do not merge PR #91 until a maintainer restores the ruleset and obtains the
+  approval/quota evidence required by issue #90, or explicitly re-scopes that
+  acceptance criterion. Issues #78 and #84 close with the eventual merge.
 - Confirm the combined Cargo updater succeeds after the configuration reaches
   the default branch. Dependabot cannot execute PR-branch configuration.
 - Maintainer administration is still required for issue #90: restore the live

--- a/progress/session-023-deep-safety-hardening.md
+++ b/progress/session-023-deep-safety-hardening.md
@@ -1,0 +1,96 @@
+# Session 023 — Deep Safety Hardening
+
+Date: 2026-08-16
+
+## Objective
+
+Consolidate issues #78 and #84 into one evidence-backed safety milestone,
+repair red or non-actionable analyzer lanes, and advance the stale roadmap from
+the now-merged Server 0.7 delivery.
+
+## Baseline Audit
+
+- PR #89 was already merged to `main` as `18a49e6`, issue #86 was closed, and
+  no open or draft PR remained. `PLAN.md` and session 022 still described the
+  delivery as pending.
+- The live default-branch ruleset still lacked review and required-check rules;
+  four scheduled Repository Policy runs were red. Issue #90 still required an
+  approval on already-merged PR #89, an impossible acceptance criterion.
+- Deep Safety was configured as informational. Its latest run selected a musl
+  cargo-fuzz target incompatible with ASan/static libc, Miri completed the
+  protocol suite and then timed out in repository-policy tests, and mutation
+  testing reported a surviving `ErrorCode::description -> "xyzzy"` mutant.
+- The binary MessagePack fuzz target existed but neither hosted nor local
+  automation ran it; it decoded v3 only. Committed seed directories were also
+  passed as libFuzzer's writable corpus and could accumulate generated files.
+- Rust compiler lints did not prohibit new unsafe code. Owned production unsafe
+  was confined to the target-gated Emscripten C WebSocket binding; the Godot
+  adapter had none.
+- Blanket Clippy pedantic/nursery/cargo groups produced more than 170 mostly
+  stylistic or documentation findings. The only suspicious correctness warning
+  was verified as a false positive. Native ASan could not exercise the sole
+  owned unsafe implementation because that code is Emscripten-only.
+- The standalone Godot fixture Dependabot updater failed at least three weeks
+  because its directory-scoped file set could not resolve `../..` path
+  dependencies outside the fixture.
+
+## Implementation
+
+- Denied unsafe Rust in the core crate, forbade it in the Godot adapter, and
+  documented one module-level Emscripten exception. The required WASM workflow
+  now runs the FFI checker and its 25 negative/self-test cases before actual
+  Emscripten compilation and Clippy.
+- Added an offline source-policy sweep so a second owned `unsafe` site or lint
+  exception fails required CI even if a future module tries to override the
+  core's deny-level lint or is hidden behind a target cfg.
+- Made all Deep Safety analyzers fail closed. Miri now runs only the 125
+  production protocol tests; repository-policy subprocess tests remain in
+  their appropriate required workflow.
+- Selected cargo-fuzz's target from the nightly host triple, ran all three fuzz
+  targets, isolated writable corpora under `mktemp`, retained seed directories
+  as read-only inputs, uploaded crash artifacts, ignored nested fuzz build
+  output, and prevented mutation worktrees from copying ignored artifacts.
+- Expanded binary fuzzing to both supported v2/v3 decoders. Every iteration
+  exercises raw input plus valid and input-perturbed canonical envelopes.
+- Replaced the mutation smoke assertion with an exact actionable-description
+  contract, killing the known whole-function survivor.
+- Combined the root workspace and standalone Godot fixture in one Dependabot
+  Cargo updater file set so it can include the fixture's local path
+  dependencies; default-branch execution remains the required proof.
+- Updated `.llm/context.md` and `PLAN.md` with the analyzer policy, completed
+  Server 0.7 delivery, live governance blocker, current safety work, and next
+  token-binding correctness milestone. The published progress claim now says
+  tracked history is curated rather than falsely claiming every local ignored
+  session is present.
+- Re-scoped issue #90 so the next open PR, rather than merged PR #89, proves
+  review and required-check enforcement.
+
+## Red-Green Evidence
+
+1. The original binary target reached 74 of 12,870 counters after 1,000 runs
+   from a shallow invalid seed. The revised v2/v3 canonical harness reached 202
+   counters in 1,000 isolated runs and exited successfully on the ARM host.
+2. Running fuzz against `seeds/$target` reproduced repository pollution. The
+   temporary first-corpus design left every source seed directory unchanged.
+3. The exact mutation scope finished in 1m25s: nine mutants, eight caught, zero
+   surviving, zero timeout, and one compile-unviable generic mutation.
+4. Miri passed all 125 protocol tests in 17 seconds after compilation.
+5. The FFI policy checker and all 25 self-tests passed. Workflow lint, YAML
+   lint, shellcheck, action-reference policy, and shell portability passed;
+   actionlint was unavailable locally and remains covered by hosted CI.
+6. The mandatory pre-commit gate passed with zero warnings or failures:
+   `cargo fmt`, workspace/all-target/all-feature Clippy with `-D warnings`, and
+   workspace/all-feature tests (including 212 CI-policy and 125 protocol
+   integration tests).
+
+## Hosted Work Remaining
+
+- Open one PR, run all required aggregates, dispatch Deep Safety and Protocol
+  Sync, and resolve every actionable review finding.
+- Confirm the combined Cargo updater succeeds after the configuration reaches
+  the default branch.
+- Maintainer administration is still required for issue #90: restore the live
+  ruleset, resolve the Copilot quota gate, and dispatch a green Repository
+  Policy audit. The available connector can inspect but cannot mutate rulesets.
+- Close #78 only after hosted Deep Safety is green; close #84 as its duplicate
+  milestone at the same point.

--- a/progress/session-023-deep-safety-hardening.md
+++ b/progress/session-023-deep-safety-hardening.md
@@ -46,6 +46,9 @@ the now-merged Server 0.7 delivery.
 - Made all Deep Safety analyzers fail closed. Miri now runs only the 125
   production protocol tests; repository-policy subprocess tests remain in
   their appropriate required workflow.
+- Added path-scoped PR triggers for Deep Safety and Protocol Sync so changes to
+  analyzer or protocol-evidence inputs produce immediate hosted proof without
+  making either variable-runtime workflow a required check for unrelated PRs.
 - Selected cargo-fuzz's target from the nightly host triple, ran all three fuzz
   targets, isolated writable corpora under `mktemp`, retained seed directories
   as read-only inputs, uploaded crash artifacts, ignored nested fuzz build
@@ -85,8 +88,8 @@ the now-merged Server 0.7 delivery.
 
 ## Hosted Work Remaining
 
-- Open one PR, run all required aggregates, dispatch Deep Safety and Protocol
-  Sync, and resolve every actionable review finding.
+- Complete PR #91's required aggregates, change-scoped Deep Safety and Protocol
+  Sync runs, and resolve every actionable review finding.
 - Confirm the combined Cargo updater succeeds after the configuration reaches
   the default branch.
 - Maintainer administration is still required for issue #90: restore the live

--- a/progress/session-023-deep-safety-hardening.md
+++ b/progress/session-023-deep-safety-hardening.md
@@ -85,15 +85,23 @@ the now-merged Server 0.7 delivery.
    `cargo fmt`, workspace/all-target/all-feature Clippy with `-D warnings`, and
    workspace/all-feature tests (including 212 CI-policy and 125 protocol
    integration tests).
+7. PR #91 head `a61522c` passed all eleven required aggregate workflows. The
+   first Workflow Lint run exposed actionlint SC2317 on an indirectly invoked
+   trap handler; commit `85be886` replaced it with an equivalent inline EXIT
+   trap, and hosted Workflow Lint run 31954358998 passed.
+8. Change-scoped Protocol Sync run 31954359013 passed against the current
+   server samples and AsyncAPI spec. Deep Safety run 31954359008 passed all
+   three fail-closed jobs: Miri, mutation testing, and all-target fuzz smoke.
+9. Cursor Bugbot and the final independent adversarial review reported no
+   actionable findings or open threads. Copilot could not review because the
+   requesting account reached its quota; this is the external condition
+   already tracked in issue #90, not code feedback.
 
-## Hosted Work Remaining
+## Hosted Follow-up
 
-- Complete PR #91's required aggregates, change-scoped Deep Safety and Protocol
-  Sync runs, and resolve every actionable review finding.
+- Merge fully green PR #91; issues #78 and #84 close with it.
 - Confirm the combined Cargo updater succeeds after the configuration reaches
-  the default branch.
+  the default branch. Dependabot cannot execute PR-branch configuration.
 - Maintainer administration is still required for issue #90: restore the live
   ruleset, resolve the Copilot quota gate, and dispatch a green Repository
   Policy audit. The available connector can inspect but cannot mutate rulesets.
-- Close #78 only after hosted Deep Safety is green; close #84 as its duplicate
-  milestone at the same point.

--- a/scripts/check-all.sh
+++ b/scripts/check-all.sh
@@ -520,35 +520,21 @@ fi
 echo ""
 
 # ── Phase 15: Miri (UB detection) ─────────────────────────────────
-# Miri is scoped to synchronous test targets only (protocol_tests,
-# ci_config_tests). Async/tokio tests are excluded because Miri does
-# not support tokio's runtime internals.
+# Miri is scoped to the synchronous production protocol tests. Async/tokio
+# tests are excluded because Miri does not support tokio's runtime internals;
+# repository-policy tests exercise shell processes, not production memory.
 echo -e "${YELLOW}Phase 15/$TOTAL_PHASES: Miri undefined behavior detection (nightly)...${NC}"
 if ! rustup run nightly cargo miri --version &>/dev/null 2>&1; then
     echo -e "${YELLOW}SKIP: Miri is not available (requires nightly + rustup component add miri --toolchain nightly).${NC}"
     echo "  Install: rustup component add miri --toolchain nightly"
     PHASE_RESULTS[15]="SKIP"
 else
-    PHASE15_FAIL=false
     if MIRIFLAGS="-Zmiri-disable-isolation" cargo +nightly miri test --test protocol_tests --all-features 2>&1; then
         echo -e "${GREEN}  Miri (protocol_tests): PASS${NC}"
+        PHASE_RESULTS[15]="PASS"
     else
         echo -e "${RED}  Miri (protocol_tests): FAIL${NC}"
-        PHASE15_FAIL=true
-    fi
-    if MIRIFLAGS="-Zmiri-disable-isolation" cargo +nightly miri test --test ci_config_tests 2>&1; then
-        echo -e "${GREEN}  Miri (ci_config_tests): PASS${NC}"
-    else
-        echo -e "${RED}  Miri (ci_config_tests): FAIL${NC}"
-        PHASE15_FAIL=true
-    fi
-    if [ "$PHASE15_FAIL" = true ]; then
-        # Miri failures are informational — do not count as hard failures
-        echo -e "${YELLOW}Phase 15: WARN (Miri found issues — informational only)${NC}"
-        PHASE_RESULTS[15]="WARN"
-    else
-        echo -e "${GREEN}Phase 15: PASS${NC}"
-        PHASE_RESULTS[15]="PASS"
+        mark_phase_fail 15
     fi
 fi
 echo ""
@@ -569,26 +555,40 @@ else
     PHASE16_FAIL=false
     FUZZ_DIR="$REPO_ROOT/fuzz"
     if [ -d "$FUZZ_DIR" ]; then
-        if (cd "$FUZZ_DIR" && cargo +nightly fuzz run fuzz_server_message seeds/fuzz_server_message -- -max_total_time=10) 2>&1; then
-            echo -e "${GREEN}  fuzz_server_message: PASS${NC}"
-        else
-            echo -e "${RED}  fuzz_server_message: FAIL${NC}"
+        FUZZ_HOST=$(rustc +nightly -vV | sed -n 's/^host: //p')
+        if [ -z "$FUZZ_HOST" ]; then
+            echo -e "${RED}  Unable to determine the nightly Rust host target.${NC}"
             PHASE16_FAIL=true
-        fi
-        if (cd "$FUZZ_DIR" && cargo +nightly fuzz run fuzz_client_message seeds/fuzz_client_message -- -max_total_time=10) 2>&1; then
-            echo -e "${GREEN}  fuzz_client_message: PASS${NC}"
         else
-            echo -e "${RED}  fuzz_client_message: FAIL${NC}"
-            PHASE16_FAIL=true
+            FUZZ_CORPUS=$(mktemp -d)
+            # shellcheck disable=SC2317  # trap handler invoked indirectly
+            cleanup_fuzz_corpus() {
+                rm -rf "$FUZZ_CORPUS"
+            }
+            trap cleanup_fuzz_corpus EXIT
+            for target in fuzz_server_message fuzz_client_message fuzz_binary_game_data; do
+                corpus="$FUZZ_CORPUS/$target"
+                mkdir -p "$corpus"
+                seed_args=()
+                if [ -d "$FUZZ_DIR/seeds/$target" ]; then
+                    seed_args+=("seeds/$target")
+                fi
+                if (cd "$FUZZ_DIR" && cargo +nightly fuzz run "$target" --target "$FUZZ_HOST" "$corpus" "${seed_args[@]}" -- -max_total_time=10) 2>&1; then
+                    echo -e "${GREEN}  $target: PASS${NC}"
+                else
+                    echo -e "${RED}  $target: FAIL${NC}"
+                    PHASE16_FAIL=true
+                fi
+            done
+            cleanup_fuzz_corpus
+            trap - EXIT
         fi
     else
         echo -e "${YELLOW}SKIP: fuzz/ directory not found.${NC}"
         PHASE_RESULTS[16]="SKIP"
     fi
     if [ "$PHASE16_FAIL" = true ]; then
-        # Fuzz failures are informational — do not count as hard failures
-        echo -e "${YELLOW}Phase 16: WARN (fuzz found issues — informational only)${NC}"
-        PHASE_RESULTS[16]="WARN"
+        mark_phase_fail 16
     elif [ "${PHASE_RESULTS[16]}" != "SKIP" ]; then
         echo -e "${GREEN}Phase 16: PASS${NC}"
         PHASE_RESULTS[16]="PASS"
@@ -597,23 +597,20 @@ fi
 echo ""
 
 # ── Phase 17: Mutation testing ───────────────────────────────────
-# Runs cargo-mutants on pure-logic modules. This is slow (several
-# minutes) and informational only — mutations that survive indicate
-# potential gaps in test coverage.
+# Runs cargo-mutants on pure-logic modules. Mutations that survive are
+# actionable gaps in test coverage and fail the phase.
 echo -e "${YELLOW}Phase 17/$TOTAL_PHASES: Mutation testing (cargo-mutants)...${NC}"
 if ! command -v cargo-mutants &>/dev/null; then
     echo -e "${YELLOW}SKIP: cargo-mutants is not installed.${NC}"
     echo "  Install: cargo install cargo-mutants"
     PHASE_RESULTS[17]="SKIP"
 else
-    if cargo mutants --timeout 60 --no-shuffle -j 2 --file src/protocol.rs --file src/error_codes.rs --file src/error.rs 2>&1; then
+    if cargo mutants --gitignore true --timeout 60 --no-shuffle -j 2 --file src/protocol.rs --file src/error_codes.rs --file src/error.rs 2>&1; then
         echo -e "${GREEN}Phase 17: PASS${NC}"
         PHASE_RESULTS[17]="PASS"
     else
-        # Mutation testing failures are informational — surviving mutants
-        # indicate test coverage gaps, not code defects.
-        echo -e "${YELLOW}Phase 17: WARN (surviving mutants found — informational only)${NC}"
-        PHASE_RESULTS[17]="WARN"
+        echo -e "${RED}Phase 17: FAIL (surviving mutants found)${NC}"
+        mark_phase_fail 17
     fi
 fi
 echo ""

--- a/src/transports/emscripten_websocket.rs
+++ b/src/transports/emscripten_websocket.rs
@@ -67,6 +67,10 @@
 //! let events = client.poll();
 //! ```
 
+// This target-only module is the core crate's sole unsafe-code exception. Its
+// raw calls, pointer lifetimes, callbacks, and cleanup paths are audited by
+// scripts/check-ffi-safety.sh and the Emscripten target CI lane.
+#![allow(unsafe_code)]
 #![allow(deprecated)]
 
 // Compile-time guard: this module requires the wasm32-unknown-emscripten target.

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -2868,10 +2868,12 @@ mod workflow_security {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Module: panic_policy
+// Module: safety_analysis_policy
 // ─────────────────────────────────────────────────────────────────────────────
 
-mod panic_policy {
+mod safety_analysis_policy {
+    use syn::visit::Visit;
+
     use super::*;
 
     const REQUIRED_DENY_LINTS: &[&str] = &[
@@ -2883,30 +2885,272 @@ mod panic_policy {
         "indexing_slicing",
     ];
 
+    fn manifest(path: &str) -> toml::Value {
+        toml::from_str(&read_project_file(path))
+            .unwrap_or_else(|error| panic!("{path} must be valid TOML: {error}"))
+    }
+
+    fn collect_rust_sources(directory: &Path, sources: &mut Vec<PathBuf>) {
+        for entry in std::fs::read_dir(directory)
+            .unwrap_or_else(|error| panic!("failed to read {}: {error}", directory.display()))
+        {
+            let entry = entry.expect("source directory entry");
+            let file_type = entry
+                .file_type()
+                .unwrap_or_else(|error| panic!("failed to inspect {:?}: {error}", entry.path()));
+            let path = entry.path();
+            if file_type.is_dir() {
+                collect_rust_sources(&path, sources);
+            } else if file_type.is_file()
+                && path.extension().and_then(|extension| extension.to_str()) == Some("rs")
+            {
+                sources.push(path);
+            }
+        }
+    }
+
+    #[derive(Default)]
+    struct UnsafeSyntax {
+        findings: Vec<&'static str>,
+    }
+
+    fn token_stream_contains_unsafe_policy(tokens: proc_macro2::TokenStream) -> bool {
+        tokens.into_iter().any(|token| match token {
+            proc_macro2::TokenTree::Ident(identifier) => matches!(
+                identifier.to_string().as_str(),
+                "unsafe" | "unsafe_code" | "no_mangle" | "export_name" | "link_section"
+            ),
+            proc_macro2::TokenTree::Group(group) => {
+                token_stream_contains_unsafe_policy(group.stream())
+            }
+            proc_macro2::TokenTree::Punct(_) | proc_macro2::TokenTree::Literal(_) => false,
+        })
+    }
+
+    impl<'ast> Visit<'ast> for UnsafeSyntax {
+        fn visit_attribute(&mut self, attribute: &'ast syn::Attribute) {
+            let unsafe_path = ["unsafe", "no_mangle", "export_name", "link_section"]
+                .iter()
+                .any(|name| attribute.path().is_ident(name));
+            let unsafe_nested_meta = match &attribute.meta {
+                syn::Meta::List(list) => token_stream_contains_unsafe_policy(list.tokens.clone()),
+                syn::Meta::Path(_) | syn::Meta::NameValue(_) => false,
+            };
+            if unsafe_path || unsafe_nested_meta {
+                self.findings.push("unsafe attribute or lint exception");
+            }
+            syn::visit::visit_attribute(self, attribute);
+        }
+
+        fn visit_macro(&mut self, macro_item: &'ast syn::Macro) {
+            if token_stream_contains_unsafe_policy(macro_item.tokens.clone()) {
+                self.findings.push("unsafe token in macro");
+            }
+            syn::visit::visit_macro(self, macro_item);
+        }
+
+        fn visit_expr_unsafe(&mut self, expression: &'ast syn::ExprUnsafe) {
+            self.findings.push("unsafe block");
+            syn::visit::visit_expr_unsafe(self, expression);
+        }
+
+        fn visit_item_fn(&mut self, function: &'ast syn::ItemFn) {
+            if function.sig.unsafety.is_some() {
+                self.findings.push("unsafe function");
+            }
+            syn::visit::visit_item_fn(self, function);
+        }
+
+        fn visit_impl_item_fn(&mut self, function: &'ast syn::ImplItemFn) {
+            if function.sig.unsafety.is_some() {
+                self.findings.push("unsafe implementation method");
+            }
+            syn::visit::visit_impl_item_fn(self, function);
+        }
+
+        fn visit_trait_item_fn(&mut self, function: &'ast syn::TraitItemFn) {
+            if function.sig.unsafety.is_some() {
+                self.findings.push("unsafe trait method");
+            }
+            syn::visit::visit_trait_item_fn(self, function);
+        }
+
+        fn visit_foreign_item_fn(&mut self, function: &'ast syn::ForeignItemFn) {
+            if function.sig.unsafety.is_some() {
+                self.findings.push("unsafe foreign function");
+            }
+            syn::visit::visit_foreign_item_fn(self, function);
+        }
+
+        fn visit_item_impl(&mut self, implementation: &'ast syn::ItemImpl) {
+            if implementation.unsafety.is_some() {
+                self.findings.push("unsafe implementation");
+            }
+            syn::visit::visit_item_impl(self, implementation);
+        }
+
+        fn visit_item_trait(&mut self, trait_item: &'ast syn::ItemTrait) {
+            if trait_item.unsafety.is_some() {
+                self.findings.push("unsafe trait");
+            }
+            syn::visit::visit_item_trait(self, trait_item);
+        }
+
+        fn visit_item_foreign_mod(&mut self, foreign: &'ast syn::ItemForeignMod) {
+            if foreign.unsafety.is_some() {
+                self.findings.push("unsafe extern block");
+            }
+            syn::visit::visit_item_foreign_mod(self, foreign);
+        }
+
+        fn visit_type_bare_fn(&mut self, function: &'ast syn::TypeBareFn) {
+            if function.unsafety.is_some() {
+                self.findings.push("unsafe function pointer");
+            }
+            syn::visit::visit_type_bare_fn(self, function);
+        }
+    }
+
+    fn unsafe_syntax_findings(contents: &str) -> Vec<&'static str> {
+        let syntax = syn::parse_file(contents).expect("production Rust source must parse");
+        let mut visitor = UnsafeSyntax::default();
+        visitor.visit_file(&syntax);
+        visitor.findings
+    }
+
+    #[test]
+    fn production_crates_deny_unsafe_code_by_default() {
+        let core = manifest("Cargo.toml");
+        let adapter = manifest("crates/signal-fish-client-godot/Cargo.toml");
+
+        assert_eq!(core["lints"]["rust"]["unsafe_code"].as_str(), Some("deny"));
+        assert_eq!(
+            adapter["lints"]["rust"]["unsafe_code"].as_str(),
+            Some("forbid")
+        );
+
+        let emscripten = read_project_file("src/transports/emscripten_websocket.rs");
+        assert!(emscripten.contains("#![allow(unsafe_code)]"));
+        assert!(emscripten.contains("sole unsafe-code exception"));
+    }
+
+    #[test]
+    fn emscripten_transport_is_the_only_owned_unsafe_source_or_exception() {
+        let root = project_root();
+        let allowed = root.join("src/transports/emscripten_websocket.rs");
+        let mut sources = Vec::new();
+        collect_rust_sources(&root.join("src"), &mut sources);
+        collect_rust_sources(
+            &root.join("crates/signal-fish-client-godot/src"),
+            &mut sources,
+        );
+
+        for source in sources {
+            if source == allowed {
+                continue;
+            }
+            let contents = std::fs::read_to_string(&source)
+                .unwrap_or_else(|error| panic!("failed to read {}: {error}", source.display()));
+            let findings = unsafe_syntax_findings(&contents);
+            assert!(findings.is_empty(), "{} contains {findings:?}; the Emscripten transport is the only permitted owned unsafe source or lint exception", source.display());
+        }
+    }
+
+    #[test]
+    fn unsafe_policy_scan_ignores_prose_but_detects_rust_tokens() {
+        assert!(unsafe_syntax_findings(
+            r####"
+            /// Documents an unsafe upstream behavior.
+            const DIAGNOSTIC: &str = r##"
+                unsafe_code must remain isolated
+                /* nested prose about unsafe behavior */
+            "##;
+            "####
+        )
+        .is_empty());
+        assert_eq!(
+            unsafe_syntax_findings("fn call() { unsafe { external_call(); } }"),
+            vec!["unsafe block"]
+        );
+        assert_eq!(
+            unsafe_syntax_findings("#![allow(unsafe_code)]"),
+            vec!["unsafe attribute or lint exception"]
+        );
+        assert!(!unsafe_syntax_findings(
+            "macro_rules! local { () => { #[allow(unsafe_code)] unsafe { call(); } } }"
+        )
+        .is_empty());
+        assert_eq!(
+            unsafe_syntax_findings("#[cfg_attr(target_os = \"none\", no_mangle)] fn hidden() {}"),
+            vec!["unsafe attribute or lint exception"]
+        );
+    }
+
     #[test]
     fn cargo_toml_has_all_panic_free_lints() {
-        let cargo = read_project_file("Cargo.toml");
+        let cargo = manifest("Cargo.toml");
+        let clippy = cargo["lints"]["clippy"]
+            .as_table()
+            .expect("Cargo.toml must define [lints.clippy]");
 
         for lint in REQUIRED_DENY_LINTS {
-            let pattern = format!("{lint} = \"deny\"");
-            assert!(
-                cargo.contains(&pattern),
-                "Cargo.toml is missing `{pattern}` in [lints.clippy]. \
-                 All panic-prone lints must be set to deny level to enforce \
-                 the project's panic-free policy in library code."
+            assert_eq!(
+                clippy.get(*lint).and_then(toml::Value::as_str),
+                Some("deny"),
+                "Cargo.toml must deny clippy::{lint}"
             );
         }
     }
 
     #[test]
-    fn cargo_toml_has_lints_clippy_section() {
-        let cargo = read_project_file("Cargo.toml");
-        assert!(
-            cargo.contains("[lints.clippy]"),
-            "Cargo.toml is missing [lints.clippy] section. \
-             This section is required to declare deny-level lints for \
-             the panic-free policy."
-        );
+    fn deep_safety_runs_every_analyzer_fail_closed() {
+        let workflow = read_project_file(".github/workflows/deep-safety.yml");
+        let local = read_project_file("scripts/check-all.sh");
+
+        assert!(!workflow.contains("continue-on-error"));
+        assert!(!workflow.contains("miri test --test ci_config_tests"));
+        assert!(workflow.contains("miri test --test protocol_tests --all-features"));
+        assert!(workflow.contains("fuzz_host=$(rustc +nightly -vV"));
+        assert!(workflow.contains("--target \"$fuzz_host\""));
+        assert!(workflow.contains("fuzz_corpus=$(mktemp -d)"));
+        assert!(workflow.contains("\"$corpus\" \"${seed_args[@]}\""));
+        assert!(workflow.contains("if-no-files-found: ignore"));
+        assert!(workflow.contains("cargo mutants --gitignore true"));
+        assert!(local.contains("FUZZ_CORPUS=$(mktemp -d)"));
+        assert!(local.contains("\"$corpus\" \"${seed_args[@]}\""));
+        assert!(local.contains("cargo mutants --gitignore true"));
+
+        let binary_target = read_project_file("fuzz/fuzz_targets/fuzz_binary_game_data.rs");
+        assert!(binary_target.contains("decode_v2_binary_game_data"));
+        assert!(binary_target.contains("decode_v3_binary_game_data"));
+        assert!(binary_target.contains("V2_ENVELOPE"));
+        assert!(binary_target.contains("V3_ENVELOPE"));
+
+        for target in [
+            "fuzz_server_message",
+            "fuzz_client_message",
+            "fuzz_binary_game_data",
+        ] {
+            assert!(
+                workflow.contains(target),
+                "Deep Safety must execute {target}"
+            );
+            assert!(
+                local.contains(target),
+                "scripts/check-all.sh must execute {target}"
+            );
+        }
+
+        for phase in [15, 16, 17] {
+            assert!(
+                local.contains(&format!("mark_phase_fail {phase}")),
+                "installed deep analyzer phase {phase} must fail closed"
+            );
+        }
+
+        let wasm = read_project_file(".github/workflows/wasm.yml");
+        assert!(wasm.contains("bash scripts/test_check_ffi_safety.sh"));
+        assert!(wasm.contains("bash scripts/check-ffi-safety.sh"));
     }
 }
 
@@ -2945,6 +3189,27 @@ mod dependency_policy {
              Dependabot must monitor Cargo dependencies to receive automated \
              security and version update PRs for Rust crates."
         );
+    }
+
+    #[test]
+    fn dependabot_includes_standalone_fixture_with_the_root_workspace() {
+        let contents = read_project_file(".github/dependabot.yml");
+        let cargo_sections: Vec<_> = dependabot_ecosystem_sections(&contents)
+            .into_iter()
+            .filter(|(ecosystem, _)| ecosystem == "cargo")
+            .collect();
+
+        assert_eq!(
+            cargo_sections.len(),
+            1,
+            "Cargo manifests must share one Dependabot updater file set"
+        );
+        let section = &cargo_sections[0].1;
+        assert!(section.contains("directories:"));
+        assert!(section.lines().any(|line| line.trim() == "- /"));
+        assert!(section
+            .lines()
+            .any(|line| line.trim() == "- /tests/godot-web-smoke"));
     }
 
     #[test]

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -3108,6 +3108,27 @@ mod safety_analysis_policy {
         let local = read_project_file("scripts/check-all.sh");
 
         assert!(!workflow.contains("continue-on-error"));
+        assert!(workflow.contains("pull_request:"));
+        for path in [
+            ".cargo/**",
+            ".github/workflows/deep-safety.yml",
+            "Cargo.lock",
+            "Cargo.toml",
+            "fuzz/**",
+            "scripts/cargo-retry.sh",
+            "src/error.rs",
+            "src/error_codes.rs",
+            "src/lib.rs",
+            "src/protocol.rs",
+            "src/protocol/**",
+            "src/signal.rs",
+            "tests/protocol_tests.rs",
+        ] {
+            assert!(
+                workflow.contains(&format!("- {path}")),
+                "Deep Safety PR trigger must cover {path}"
+            );
+        }
         assert!(!workflow.contains("miri test --test ci_config_tests"));
         assert!(workflow.contains("miri test --test protocol_tests --all-features"));
         assert!(workflow.contains("fuzz_host=$(rustc +nightly -vV"));
@@ -3151,6 +3172,33 @@ mod safety_analysis_policy {
         let wasm = read_project_file(".github/workflows/wasm.yml");
         assert!(wasm.contains("bash scripts/test_check_ffi_safety.sh"));
         assert!(wasm.contains("bash scripts/check-ffi-safety.sh"));
+
+        let protocol_sync = read_project_file(".github/workflows/protocol-sync.yml");
+        assert!(protocol_sync.contains("pull_request:"));
+        for path in [
+            ".github/workflows/protocol-sync.yml",
+            "tests/server-spec/PROVENANCE.toml",
+            "tests/server-spec/signal-fish-protocol.asyncapi.yaml",
+            "tests/wire-samples/PROVENANCE.toml",
+            "tests/wire-samples/*.jsonl",
+        ] {
+            assert!(
+                protocol_sync.contains(&format!("- {path}")),
+                "Protocol Sync PR trigger must cover {path}"
+            );
+        }
+
+        let required: serde_json::Value =
+            serde_json::from_str(&read_project_file(".github/required-checks.json"))
+                .expect("required-checks.json must parse");
+        let required_files: Vec<_> = required["required_checks"]
+            .as_array()
+            .expect("required_checks must be an array")
+            .iter()
+            .filter_map(|check| check["file"].as_str())
+            .collect();
+        assert!(!required_files.contains(&"deep-safety.yml"));
+        assert!(!required_files.contains(&"protocol-sync.yml"));
     }
 }
 

--- a/tests/protocol_tests.rs
+++ b/tests/protocol_tests.rs
@@ -2530,14 +2530,17 @@ fn player_name_rules_payload_round_trip() {
 }
 
 // ════════════════════════════════════════════════════════════════════
-// ErrorCode::description smoke test
+// ErrorCode::description behavior
 // ════════════════════════════════════════════════════════════════════
 
 #[test]
-fn error_code_description_not_empty() {
+fn error_code_description_is_actionable() {
     let code = ErrorCode::Unauthorized;
     let desc = code.description();
-    assert!(!desc.is_empty());
+    assert_eq!(
+        desc,
+        "Access denied. Authentication credentials are missing or invalid."
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- enforce the sole owned-`unsafe` exception with compiler lints plus an offline AST policy sweep
- run the Emscripten FFI checker and its self-tests in required hosted CI
- make Miri, fuzzing, and mutation analysis fail closed
- exercise all three fuzz targets with writable temporary corpora and valid v2/v3 binary seeds
- add path-scoped PR proof for Deep Safety and Protocol Sync
- repair the standalone Godot fixture's Dependabot scope with a multi-directory Cargo updater
- reconcile the roadmap and retain red/green evidence in `progress/session-023-deep-safety-hardening.md`

## Root cause

The safety lanes existed but did not reliably prove safety: Deep Safety tolerated failures, Miri covered unrelated repository-policy subprocess tests, the fuzz command selected an incompatible musl/ASan combination and omitted the binary target, committed seed directories were writable corpora, and mutation testing had a surviving `ErrorCode::description` mutant. The fixture Dependabot updater also could not resolve its sibling path dependency from a directory-scoped checkout.

## Validation

- `cargo fmt && cargo clippy --workspace --all-targets --all-features -- -D warnings && cargo test --workspace --all-features`
- 212 CI-policy tests and 125 protocol tests pass
- Miri protocol suite: 125 passed
- mutation scope: 9 mutants, 8 caught, 0 missed, 0 timeout, 1 unviable
- all three fuzz targets smoke-tested with the explicit nightly host
- FFI checker and all 25 checker self-tests pass
- shell/workflow/documentation/portability checks and `cargo machete` pass
- repeated independent adversarial review reports zero remaining issues

## Hosted proof

- final head `1625fae` passed all eleven required project-owned aggregates
- [Deep Safety run 31956069524](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/actions/runs/31956069524) passed Miri, mutation, and all-target fuzz jobs fail closed
- [Protocol Sync run 31956069553](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/actions/runs/31956069553) passed against current upstream samples and AsyncAPI
- Workflow Lint caught the initial trap-handler diagnostic; the inline cleanup fix is green
- Bugbot and independent review report no actionable findings or open threads
- Copilot's reviewer check is the sole failed check because the requesting account exhausted its quota; there is no approval

## Hosted blocker

- #90 requires this next open PR to prove approval and required-check enforcement; the live ruleset still lacks both rules
- PR #91 is technically clean and all project-owned checks pass, but it is not literally all-checks-green; do not merge until a maintainer fixes the ruleset/quota condition or explicitly re-scopes #90

## Post-merge follow-up

- confirm the multi-directory Dependabot updater on the default branch

Closes #78
Closes #84
Related #90

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CI enforcement, compiler unsafe policy, and protocol fuzz/Miri scope—important for safety posture but limited to tooling and test contracts rather than runtime protocol behavior on the default path.
> 
> **Overview**
> **Hardens safety evidence** so analyzer lanes fail closed instead of reporting informational warnings, and **locks down `unsafe` Rust** to a single documented Emscripten WebSocket exception.
> 
> Compiler **`unsafe_code = deny`** (core) and **`forbid`** (Godot) plus an offline AST sweep in CI-policy tests block new owned `unsafe` outside `emscripten_websocket.rs`. The required **WASM** workflow now runs the Emscripten FFI checker and self-tests before builds.
> 
> **Deep Safety** drops `continue-on-error`, scopes Miri to `protocol_tests`, runs all three fuzz targets with explicit nightly host triples and temp writable corpora (seeds read-only), uploads fuzz artifacts, and tightens mutation scope (`--gitignore true`). **Protocol Sync** and Deep Safety gain path-filtered **PR triggers** without becoming required checks. Local **`check-all.sh`** mirrors the same fail-closed Miri/fuzz/mutation behavior.
> 
> Binary fuzzing covers **v2 and v3** MessagePack decoders with canonical and perturbed envelopes. **Dependabot** merges root and Godot fixture into one multi-directory Cargo updater. Docs/plan/progress and a stricter **`ErrorCode::description`** test close the mutation gap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1625fae43c3eacb32b7a6d91aa36de694f04ed3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->