### PR TITLE
ci(deps): repair Cargo updater workspace resolution

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,10 +3,11 @@
 # Goal: prefer fewer, larger ecosystem-based PRs over many tiny per-package PRs.
 #
 # Strategy:
-#   - One broad Cargo PR that groups a dependency name across the root
-#     workspace, its Godot adapter, and the standalone Godot fixture. Listing
-#     the adapter explicitly keeps its manifest in Dependabot's temporary file
-#     set when resolving the fixture's local path dependency.
+#   - One broad Cargo PR for the root workspace, which includes the Godot
+#     adapter as a workspace member. The exact minimum/latest Godot fixtures
+#     stay standalone so Cargo cannot unify their deliberately incompatible
+#     binding versions; update their locked dependencies only with dedicated
+#     compatibility and browser E2E evidence.
 #   - One broad GitHub Actions PR that batches ALL version updates.
 #   - open-pull-requests-limit: 1 per ecosystem so Dependabot can only open
 #     one consolidated batch PR at a time; once that batch is merged a fresh
@@ -19,10 +20,7 @@ version: 2
 updates:
   # ── Cargo (Rust) dependencies ──────────────────────────────────
   - package-ecosystem: cargo
-    directories:
-      - /
-      - /crates/signal-fish-client-godot
-      - /tests/godot-web-smoke
+    directory: /
     schedule:
       interval: weekly
       day: monday
@@ -34,7 +32,6 @@ updates:
     open-pull-requests-limit: 1
     groups:
       cargo-all-dependencies:
-        group-by: dependency-name
         patterns:
           - "*"
         update-types:

--- a/.llm/context.md
+++ b/.llm/context.md
@@ -107,13 +107,16 @@ the inventory produced more than 170 mostly stylistic/documentation findings,
 and its only suspicious correctness warning was verified as a false positive.
 Add either class only when it demonstrates a stable, actionable defect.
 
-Dependabot monitors the root Cargo workspace, the Godot adapter manifest, and
-the standalone Godot web fixture in one updater entry. All three directories
-are explicit so its temporary file set can resolve the fixture's `../..` path
-dependencies while updating exact compatibility versions. A successful
-default-branch updater run is required after any change to this arrangement;
-the first two-directory attempt failed because Dependabot omitted the adapter
-manifest and then opened a zero-file PR.
+Dependabot monitors the root Cargo workspace from one root updater; Cargo
+discovers the Godot adapter as a real workspace member. Hosted run 31964370221
+proved that a multi-directory Cargo updater does not combine directory file
+sets: adapter processing lost the workspace root, fixture processing lost its
+sibling path dependency, and Dependabot opened the second zero-file PR #96.
+The minimum and latest Godot fixtures therefore remain deliberately standalone
+and are updated only with their locked compatibility/browser E2E evidence;
+putting them in the root workspace would unify incompatible Godot types and
+expand ordinary `--workspace --all-features` builds into engine-dependent
+fixtures. A fresh default-branch root updater run remains required hosted proof.
 
 ## Architecture — Core Modules
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ sha2 = "0.11"
 proptest = "1.7"
 # Parses production sources in the offline sole-unsafe-exception policy test.
 proc-macro2 = "1"
-syn = { version = "2", features = ["full", "visit"] }
+syn = { version = "3", features = ["full", "visit"] }
 
 [[example]]
 name = "basic_lobby"

--- a/PLAN.md
+++ b/PLAN.md
@@ -35,17 +35,19 @@ not stack dependent PRs.
 [Issue #90](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/issues/90)
 tracks live drift from `.github/required-checks.json`. Ruleset #14801090 still
 lacks approval and required-status-check rules, the scheduled Repository Policy
-workflow is genuinely red, and PRs #91 and #92 demonstrated the impact by
-merging without an approval or enforced required checks. PR #92 auto-merged
+workflow is genuinely red, and PRs #91, #92, and #94 demonstrated the impact
+by merging without an approval or enforced required checks. PR #92 auto-merged
 while a required aggregate was still running, then produced no push CI on its
 zero-file merge commit. The checked-in `GITHUB_TOKEN` Dependabot auto-merge path
 is now removed; repository policy rejects Dependabot-specific workflows,
 automated-merge primitives, and non-allowlisted workflow write permissions.
+PR #94 then merged despite its explicit do-not-merge gates and zero approvals.
 Ordinary reviewed merges remain policy but are not enforced until issue #90 is
-fixed. Restoring
-the live ruleset, disabling or funding the quota-broken Copilot review gate,
-and dispatching a green policy audit still require maintainer administration.
-The next open PR remains the end-to-end enforcement proof.
+fixed. Restoring the live ruleset, disabling or funding the quota-broken
+Copilot review gate, adding an eligible independent reviewer (the repository
+currently has only the PR author's collaborator account), and dispatching a
+green policy audit still require maintainer administration. The next valid
+non-bot PR remains the end-to-end enforcement proof.
 
 ## Completed Milestone — Safety and Static Analysis
 
@@ -78,14 +80,30 @@ were delivered by PR #91 and closed when it merged as `963a9fc`.
   with 43 checker self-tests.
 - Dependabot's first default-branch Cargo run after PR #91 failed because its
   temporary file set omitted `crates/signal-fish-client-godot/Cargo.toml`, then
-  opened the zero-file PR #92. The combined Cargo updater now lists the root,
-  adapter, and standalone fixture explicitly; a subsequent updater run must
-  prove all three resolve together.
+  opened zero-file PR #92. The three-directory attempt also failed in run
+  31964370221 with eleven resolution errors and opened zero-file PR #96:
+  Dependabot processes each Cargo directory independently rather than as one
+  file set. The corrective updater now starts only at `/`, where Cargo
+  discovers the adapter workspace member. The exact minimum/latest Godot
+  fixtures stay standalone and are maintained through their dedicated locked
+  E2E compatibility evidence. Issue #95 tracks fresh default-branch proof.
 - The checked-in `GITHUB_TOKEN` Dependabot auto-merge path is removed. Until
   issue #90 is fixed, dependency PRs must not bypass review/check policy or
   suppress CI for their merge SHA.
 
-## Next Major Milestone — Negotiated Token Binding
+## Next Major Milestone — Correctness Code Study
+
+Track [issue #97](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/issues/97).
+
+- Audit the implementation, public API, distributed-state behavior, network
+  resilience, server/reference-client parity, and unexpected-input handling.
+- Decompose the broad study into bounded subsystem matrices with an explicit
+  invariant, authoritative reference, executable evidence, and follow-up issue
+  for every unresolved finding.
+- Fix correctness defects before usability, performance, or presentation work;
+  do not treat an absence of current test failures as proof of completeness.
+
+## Following Milestone — Negotiated Token Binding
 
 Track [issue #88](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/issues/88).
 
@@ -97,7 +115,7 @@ Track [issue #88](https://github.com/Ambiguous-Interactive/signal-fish-client-ru
   Godot, polling, and custom transports, with typed required-mode failures.
 - Keep keys, proofs, and handshake secrets out of `Debug`, tracing, and errors.
 
-## Following Milestone — Allocation and Performance Evidence
+## Later Milestone — Allocation and Performance Evidence
 
 Track [issue #82](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/issues/82).
 

--- a/progress/session-024-ffi-lifetime-and-dependency-governance.md
+++ b/progress/session-024-ffi-lifetime-and-dependency-governance.md
@@ -75,9 +75,12 @@ continuing the negotiated token-binding milestone.
 
 ## Hosted Follow-up
 
-- A default-branch Dependabot run must prove that the explicit root, adapter,
-  and fixture directory set resolves successfully. Do not treat configuration
-  shape alone as proof.
+- Default-branch Dependabot run 31964370221 disproved the three-directory
+  design after this session merged. It failed with eleven resolution errors
+  because each directory received an isolated temporary file set, then opened
+  zero-file PR #96. Session 025 records the replacement root-workspace design;
+  do not treat either configuration shape as proof without a successful hosted
+  updater run.
 - Issue #90 remains a maintainer-admin blocker: restore the live ruleset,
   remove the quota-broken Copilot gate or fund it, and dispatch Repository
   Policy to green.

--- a/progress/session-025-dependabot-root-workspace.md
+++ b/progress/session-025-dependabot-root-workspace.md
@@ -55,11 +55,14 @@ update behind zero-file PR #96, and restore truthful roadmap evidence.
   Clippy with `-D warnings`, and workspace/all-feature tests.
 - `scripts/check-all.sh --quick` passed formatting, the FFI safety policy,
   three Clippy feature combinations, and three test feature combinations.
-- Hosted PR checks are pending branch publication.
+- PR #98 is ready for review with all twelve workflows and all eleven required
+  aggregates green. Its 54-check inventory contains no failures, and it has no
+  comments, reviews, or unresolved threads.
 
 ## Hosted Follow-up
 
-- Close zero-file PR #96 after this branch contains the real Syn 3 update.
+- Zero-file PR #96 was closed without merging after PR #98 incorporated the
+  real Syn 3 update and the updater correction.
 - After merge, dispatch or observe a default-branch Cargo updater run and link
   a successful result in issue #95. It must contain no dependency resolution
   errors and must not create another zero-file PR.

--- a/progress/session-025-dependabot-root-workspace.md
+++ b/progress/session-025-dependabot-root-workspace.md
@@ -55,9 +55,11 @@ update behind zero-file PR #96, and restore truthful roadmap evidence.
   Clippy with `-D warnings`, and workspace/all-feature tests.
 - `scripts/check-all.sh --quick` passed formatting, the FFI safety policy,
   three Clippy feature combinations, and three test feature combinations.
-- PR #98 is ready for review with all twelve workflows and all eleven required
-  aggregates green. Its 54-check inventory contains no failures, and it has no
-  comments, reviews, or unresolved threads.
+- PR #98 is ready for review with all twelve project workflows and all eleven
+  required aggregates green. The repository's non-required automated Copilot
+  review check failed twice because the configured account has exhausted its
+  quota; it produced no actionable feedback or unresolved threads and remains
+  an issue #90 maintainer-administration blocker.
 
 ## Hosted Follow-up
 

--- a/progress/session-025-dependabot-root-workspace.md
+++ b/progress/session-025-dependabot-root-workspace.md
@@ -1,0 +1,68 @@
+# Session 025 — Dependabot Root Workspace Recovery
+
+Date: 2026-08-16
+
+## Objective
+
+Re-audit the post-PR-94 hosted state, repair the still-failing Cargo dependency
+updater without weakening compatibility coverage, incorporate the real Syn 3
+update behind zero-file PR #96, and restore truthful roadmap evidence.
+
+## Baseline Audit
+
+- Default-branch Cargo updater run 31964370221 failed with eleven
+  `dependency_file_not_resolvable` errors after attempting all three configured
+  directories.
+- Dependabot processed directories independently: adapter processing lacked
+  the root workspace metadata, while the standalone web fixture lacked its
+  sibling adapter path dependency.
+- The failed run opened PR #96 for Syn 3.0.3, but its commit tree was identical
+  to `main` and the PR contained zero changed files. The root manifest still
+  required Syn 2.
+- Main had ten green required aggregates while Godot Web was still running;
+  Repository Policy remained red because the live ruleset lacked review and
+  required-status-check rules.
+- Open correctness issue #97 superseded token binding as the next
+  gameplay-impact priority but was absent from `PLAN.md`.
+
+## Implementation
+
+- Replaced the multi-directory Cargo updater with one `directory: /` updater.
+  Cargo discovers the adapter through actual workspace membership, avoiding
+  the isolated-subdirectory failure mode.
+- Kept the minimum and latest Godot fixtures standalone. This preserves their
+  exact incompatible Godot endpoints and avoids making ordinary mandatory
+  workspace gates require the engine-dependent browser fixture. Their locked
+  dependencies remain deliberate manual upgrades gated by compatibility and
+  browser E2E.
+- Replaced the false policy test that equated YAML directory listing with a
+  shared updater file set. The new test enforces one resolvable root updater,
+  real adapter workspace membership, and standalone compatibility fixtures.
+- Incorporated the actual Syn 3 dependency update. Migrated the safety AST
+  scanner to Syn 3's `Safety` and `TypeFnPtr` APIs and added adversarial
+  regression cases for safety-bearing nodes, parsed attribute expressions,
+  unparsed macro tokens, and unsafe assembly macros.
+- Updated canonical context, roadmap priority, session 024's hosted follow-up,
+  and this progress record. No changelog entry was added because all changes
+  are internal dependency/CI/test maintenance.
+- Rewrote issue #95 around a truthful root-only hosted proof while retaining
+  explicit manual compatibility maintenance for the standalone fixtures.
+
+## Verification
+
+- All 213 repository-policy tests pass with Syn 3.
+- The mandatory workflow passed: `cargo fmt`, workspace/all-target/all-feature
+  Clippy with `-D warnings`, and workspace/all-feature tests.
+- `scripts/check-all.sh --quick` passed formatting, the FFI safety policy,
+  three Clippy feature combinations, and three test feature combinations.
+- Hosted PR checks are pending branch publication.
+
+## Hosted Follow-up
+
+- Close zero-file PR #96 after this branch contains the real Syn 3 update.
+- After merge, dispatch or observe a default-branch Cargo updater run and link
+  a successful result in issue #95. It must contain no dependency resolution
+  errors and must not create another zero-file PR.
+- Issue #90 still requires maintainer administration and an eligible
+  independent reviewer before repository review/check enforcement can pass.
+- Begin issue #97 as bounded subsystem audits after this single PR is green.

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -2900,13 +2900,41 @@ mod safety_analysis_policy {
         tokens.into_iter().any(|token| match token {
             proc_macro2::TokenTree::Ident(identifier) => matches!(
                 identifier.to_string().as_str(),
-                "unsafe" | "unsafe_code" | "no_mangle" | "export_name" | "link_section"
+                "unsafe"
+                    | "unsafe_code"
+                    | "no_mangle"
+                    | "export_name"
+                    | "link_section"
+                    | "asm"
+                    | "global_asm"
+                    | "naked_asm"
             ),
             proc_macro2::TokenTree::Group(group) => {
                 token_stream_contains_unsafe_policy(group.stream())
             }
             proc_macro2::TokenTree::Punct(_) | proc_macro2::TokenTree::Literal(_) => false,
         })
+    }
+
+    fn use_tree_contains_unsafe_assembly(tree: &syn::UseTree) -> bool {
+        match tree {
+            syn::UseTree::Path(path) => {
+                matches!(
+                    path.ident.to_string().as_str(),
+                    "asm" | "global_asm" | "naked_asm"
+                ) || use_tree_contains_unsafe_assembly(&path.tree)
+            }
+            syn::UseTree::Name(name) => matches!(
+                name.ident.to_string().as_str(),
+                "asm" | "global_asm" | "naked_asm"
+            ),
+            syn::UseTree::Rename(rename) => matches!(
+                rename.ident.to_string().as_str(),
+                "asm" | "global_asm" | "naked_asm"
+            ),
+            syn::UseTree::Group(group) => group.items.iter().any(use_tree_contains_unsafe_assembly),
+            syn::UseTree::Glob(_) => false,
+        }
     }
 
     impl<'ast> Visit<'ast> for UnsafeSyntax {
@@ -2921,14 +2949,35 @@ mod safety_analysis_policy {
             if unsafe_path || unsafe_nested_meta {
                 self.findings.push("unsafe attribute or lint exception");
             }
-            syn::visit::visit_attribute(self, attribute);
+            if let syn::Meta::NameValue(name_value) = &attribute.meta {
+                self.visit_expr(&name_value.value);
+            }
         }
 
         fn visit_macro(&mut self, macro_item: &'ast syn::Macro) {
-            if token_stream_contains_unsafe_policy(macro_item.tokens.clone()) {
-                self.findings.push("unsafe token in macro");
+            let unsafe_macro = macro_item.path.segments.last().is_some_and(|segment| {
+                matches!(
+                    segment.ident.to_string().as_str(),
+                    "asm" | "global_asm" | "naked_asm"
+                )
+            });
+            if unsafe_macro {
+                self.findings.push("unsafe assembly macro");
             }
             syn::visit::visit_macro(self, macro_item);
+        }
+
+        fn visit_item_use(&mut self, item: &'ast syn::ItemUse) {
+            if use_tree_contains_unsafe_assembly(&item.tree) {
+                self.findings.push("unsafe assembly macro import");
+            }
+            syn::visit::visit_item_use(self, item);
+        }
+
+        fn visit_token_stream(&mut self, tokens: &'ast proc_macro2::TokenStream) {
+            if token_stream_contains_unsafe_policy(tokens.clone()) {
+                self.findings.push("unsafe token in unparsed syntax");
+            }
         }
 
         fn visit_expr_unsafe(&mut self, expression: &'ast syn::ExprUnsafe) {
@@ -2937,28 +2986,28 @@ mod safety_analysis_policy {
         }
 
         fn visit_item_fn(&mut self, function: &'ast syn::ItemFn) {
-            if function.sig.unsafety.is_some() {
+            if matches!(function.sig.safety, syn::Safety::Unsafe(_)) {
                 self.findings.push("unsafe function");
             }
             syn::visit::visit_item_fn(self, function);
         }
 
         fn visit_impl_item_fn(&mut self, function: &'ast syn::ImplItemFn) {
-            if function.sig.unsafety.is_some() {
+            if matches!(function.sig.safety, syn::Safety::Unsafe(_)) {
                 self.findings.push("unsafe implementation method");
             }
             syn::visit::visit_impl_item_fn(self, function);
         }
 
         fn visit_trait_item_fn(&mut self, function: &'ast syn::TraitItemFn) {
-            if function.sig.unsafety.is_some() {
+            if matches!(function.sig.safety, syn::Safety::Unsafe(_)) {
                 self.findings.push("unsafe trait method");
             }
             syn::visit::visit_trait_item_fn(self, function);
         }
 
         fn visit_foreign_item_fn(&mut self, function: &'ast syn::ForeignItemFn) {
-            if function.sig.unsafety.is_some() {
+            if matches!(function.sig.safety, syn::Safety::Unsafe(_)) {
                 self.findings.push("unsafe foreign function");
             }
             syn::visit::visit_foreign_item_fn(self, function);
@@ -2985,11 +3034,25 @@ mod safety_analysis_policy {
             syn::visit::visit_item_foreign_mod(self, foreign);
         }
 
-        fn visit_type_bare_fn(&mut self, function: &'ast syn::TypeBareFn) {
+        fn visit_item_mod(&mut self, module: &'ast syn::ItemMod) {
+            if module.unsafety.is_some() {
+                self.findings.push("unsafe module");
+            }
+            syn::visit::visit_item_mod(self, module);
+        }
+
+        fn visit_foreign_item_static(&mut self, item: &'ast syn::ForeignItemStatic) {
+            if matches!(item.safety, syn::Safety::Unsafe(_)) {
+                self.findings.push("unsafe foreign static");
+            }
+            syn::visit::visit_foreign_item_static(self, item);
+        }
+
+        fn visit_type_fn_ptr(&mut self, function: &'ast syn::TypeFnPtr) {
             if function.unsafety.is_some() {
                 self.findings.push("unsafe function pointer");
             }
-            syn::visit::visit_type_bare_fn(self, function);
+            syn::visit::visit_type_fn_ptr(self, function);
         }
     }
 
@@ -3066,6 +3129,61 @@ mod safety_analysis_policy {
             unsafe_syntax_findings("#[cfg_attr(target_os = \"none\", no_mangle)] fn hidden() {}"),
             vec!["unsafe attribute or lint exception"]
         );
+        assert_eq!(
+            unsafe_syntax_findings("#[doc = unsafe { \"hidden\" }] fn hidden() {}"),
+            vec!["unsafe block"]
+        );
+        assert!(!unsafe_syntax_findings(
+            "macro_rules! hidden { () => { core::arch::global_asm!(\"\"); } }"
+        )
+        .is_empty());
+        assert!(!unsafe_syntax_findings(
+            "use core::arch::global_asm as emit; #[cfg(any())] emit!(\"\");"
+        )
+        .is_empty());
+        let mut verbatim_visitor = UnsafeSyntax::default();
+        let verbatim_tokens = "unsafe<'a> fn()"
+            .parse::<proc_macro2::TokenStream>()
+            .expect("verbatim test tokens must lex");
+        verbatim_visitor.visit_token_stream(&verbatim_tokens);
+        assert_eq!(
+            verbatim_visitor.findings,
+            vec!["unsafe token in unparsed syntax"]
+        );
+
+        for (source, expected) in [
+            ("unsafe fn direct() {}", "unsafe function"),
+            (
+                "struct S; impl S { unsafe fn method() {} }",
+                "unsafe implementation method",
+            ),
+            ("trait T { unsafe fn method(); }", "unsafe trait method"),
+            (
+                "unsafe extern \"C\" { unsafe fn foreign(); }",
+                "unsafe extern block",
+            ),
+            (
+                "unsafe extern \"C\" { unsafe fn foreign(); }",
+                "unsafe foreign function",
+            ),
+            (
+                "unsafe extern \"C\" { unsafe static FOREIGN: u8; }",
+                "unsafe foreign static",
+            ),
+            (
+                "trait T {} struct S; unsafe impl T for S {}",
+                "unsafe implementation",
+            ),
+            ("unsafe trait T {}", "unsafe trait"),
+            ("unsafe mod ffi {}", "unsafe module"),
+            ("type Callback = unsafe fn();", "unsafe function pointer"),
+            ("core::arch::global_asm!(\"\");", "unsafe assembly macro"),
+        ] {
+            assert!(
+                unsafe_syntax_findings(source).contains(&expected),
+                "{source:?} must produce {expected:?}"
+            );
+        }
     }
 
     #[test]
@@ -3313,7 +3431,7 @@ mod dependency_policy {
     }
 
     #[test]
-    fn dependabot_includes_standalone_fixture_with_the_root_workspace() {
+    fn dependabot_uses_one_resolvable_root_workspace() {
         let contents = read_project_file(".github/dependabot.yml");
         let cargo_sections: Vec<_> = dependabot_ecosystem_sections(&contents)
             .into_iter()
@@ -3323,55 +3441,46 @@ mod dependency_policy {
         assert_eq!(
             cargo_sections.len(),
             1,
-            "Cargo manifests must share one Dependabot updater file set"
+            "Cargo dependencies must use one Dependabot updater"
         );
         let section = &cargo_sections[0].1;
-        let configured: std::collections::BTreeSet<_> =
-            dependabot_directory_values(section).into_iter().collect();
-        let expected = std::collections::BTreeSet::from([
-            "/".to_string(),
-            "/crates/signal-fish-client-godot".to_string(),
-            "/tests/godot-web-smoke".to_string(),
-        ]);
-        assert_eq!(configured, expected);
+        assert_eq!(
+            dependabot_directory_values(section),
+            vec!["/"],
+            "the Cargo updater must start at the root workspace; subdirectory updaters cannot \
+             resolve inherited workspace metadata or sibling path dependencies"
+        );
 
-        let fixture_dir = project_root().join("tests/godot-web-smoke");
-        let fixture: toml::Value =
-            toml::from_str(&read_project_file("tests/godot-web-smoke/Cargo.toml"))
-                .expect("standalone fixture manifest must parse");
-        let dependencies = fixture
-            .get("dependencies")
-            .and_then(toml::Value::as_table)
-            .expect("fixture dependencies must be a table");
-        for (name, dependency) in dependencies {
-            let Some(relative_path) = dependency.get("path").and_then(toml::Value::as_str) else {
-                continue;
-            };
-            let target = std::fs::canonicalize(fixture_dir.join(relative_path))
-                .expect("fixture path dependency target must exist");
-            let relative = target
-                .strip_prefix(project_root())
-                .expect("fixture path dependency must remain inside the repository");
-            let updater_directory = if relative.as_os_str().is_empty() {
-                "/".to_string()
-            } else {
-                format!("/{}", relative.to_string_lossy().replace('\\', "/"))
-            };
+        let root = cargo_toml();
+        let members: std::collections::BTreeSet<_> = root["workspace"]["members"]
+            .as_array()
+            .expect("root workspace members must be an array")
+            .iter()
+            .map(|member| {
+                member
+                    .as_str()
+                    .expect("workspace member paths must be strings")
+            })
+            .collect();
+        assert!(
+            members.contains("crates/signal-fish-client-godot"),
+            "the root updater must cover the adapter through real Cargo workspace membership; \
+             exact-version compatibility fixtures must remain standalone"
+        );
+        for fixture in ["tests/godot-compat-min", "tests/godot-web-smoke"] {
             assert!(
-                configured.contains(&updater_directory),
-                "fixture dependency {name} resolves to {updater_directory}, which must be an \
-                 explicit Dependabot directory so its manifest enters the updater file set"
+                !members.contains(fixture),
+                "{fixture} must not be a root workspace member"
+            );
+            let fixture_manifest: toml::Value =
+                toml::from_str(&read_project_file(&format!("{fixture}/Cargo.toml")))
+                    .unwrap_or_else(|error| panic!("{fixture} manifest must parse: {error}"));
+            assert!(
+                fixture_manifest["workspace"].is_table(),
+                "{fixture} must remain a standalone workspace so Cargo cannot unify its exact \
+                 Godot version with the adapter or the other compatibility endpoint"
             );
         }
-
-        assert_eq!(
-            dependabot_group_by_values(section),
-            vec![(
-                "cargo-all-dependencies".to_string(),
-                "dependency-name".to_string()
-            )],
-            "the Cargo group must structurally group matching dependency names across directories"
-        );
     }
 
     #[test]
@@ -3414,14 +3523,20 @@ mod dependency_policy {
         sections
     }
 
-    /// Reads only list values structurally nested under the updater's
-    /// top-level `directories:` key (four-space key, six-space list items).
+    /// Reads updater roots from either a top-level `directory:` scalar or the
+    /// list values structurally nested under a top-level `directories:` key.
     fn dependabot_directory_values(section: &str) -> Vec<String> {
         let mut in_directories = false;
         let mut directories = Vec::new();
         for line in section.lines() {
             let trimmed = line.trim();
             let indent = line.len() - line.trim_start().len();
+            if indent == 4 {
+                if let Some(value) = trimmed.strip_prefix("directory:") {
+                    directories.push(value.trim().trim_matches(['\'', '"']).to_string());
+                    continue;
+                }
+            }
             if indent == 4 && trimmed == "directories:" {
                 in_directories = true;
                 continue;
@@ -3439,40 +3554,6 @@ mod dependency_policy {
             }
         }
         directories
-    }
-
-    /// Reads `group-by` only when it is structurally nested beneath a named
-    /// entry of the updater's top-level `groups` mapping.
-    fn dependabot_group_by_values(section: &str) -> Vec<(String, String)> {
-        let mut in_groups = false;
-        let mut current_group: Option<String> = None;
-        let mut values = Vec::new();
-        for line in section.lines() {
-            let trimmed = line.trim();
-            let indent = line.len() - line.trim_start().len();
-            if indent == 4 && trimmed == "groups:" {
-                in_groups = true;
-                continue;
-            }
-            if !in_groups || trimmed.is_empty() || trimmed.starts_with('#') {
-                continue;
-            }
-            if indent <= 4 {
-                break;
-            }
-            if indent == 6 && trimmed.ends_with(':') {
-                current_group = Some(trimmed.trim_end_matches(':').to_string());
-                continue;
-            }
-            if indent == 8 {
-                if let (Some(group), Some(value)) =
-                    (&current_group, trimmed.strip_prefix("group-by:"))
-                {
-                    values.push((group.clone(), value.trim().to_string()));
-                }
-            }
-        }
-        values
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- replace the failing three-directory Cargo Dependabot configuration with one root-workspace updater
- keep the exact Godot 0.4.5 and 0.5.4 fixtures standalone and document their manual compatibility/E2E upgrade policy
- incorporate the real Syn 3 update hidden behind zero-file PR #96
- migrate and harden the owned-unsafe AST scanner for Syn 3 safety nodes, parsed attributes, verbatim tokens, and direct/wrapped/aliased assembly macros
- reconcile PLAN, canonical context, and progress evidence with the hosted updater and repository-governance failures

## Root cause

Cargo updater run [31964370221](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/actions/runs/31964370221) processed each configured directory in an isolated temporary file set. Adapter processing could not inherit root workspace metadata, while fixture processing could not resolve its sibling adapter path dependency. The failed run reported eleven `dependency_file_not_resolvable` errors and still opened #96 with an empty commit and zero changed files.

The root updater lets Cargo discover the adapter through real workspace membership. The Godot fixtures remain separate because joining them to the root workspace would unify deliberately incompatible binding endpoints and make mandatory `--workspace --all-features` gates engine-dependent.

## Impact

This restores a resolvable Cargo dependency graph for hosted Dependabot without weakening the locked Godot compatibility fixtures. It also applies Syn 3 as a real source change and keeps the repository-policy scanner fail-closed across the Syn 3 AST.

No crate API or runtime behavior changes, so no changelog entry is needed.

## Validation

- `cargo fmt && cargo clippy --workspace --all-targets --all-features -- -D warnings && cargo test --workspace --all-features`
- `bash scripts/check-all.sh --quick`
- all 18 pre-commit checks
- two adversarial review loops with zero remaining findings

## Hosted follow-up

After merge, issue #95 requires a successful default-branch Cargo updater run with no dependency resolution errors and either a clean no-update result or a PR with a real diff. Repository ruleset enforcement remains tracked separately in #90.

Refs #95. Supersedes #96.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Dependabot config, dev-only `syn`, CI policy tests, and documentation; no production runtime or public API surface.
> 
> **Overview**
> Repairs hosted **Cargo Dependabot** after multi-directory updates produced isolated temp file sets, resolution failures, and zero-file PRs. Cargo monitoring is now a **single root** updater (`directory: /`) so the Godot adapter is picked up via workspace membership; minimum/latest Godot fixtures stay **standalone** so incompatible binding versions are not unified and mandatory workspace builds do not depend on engine fixtures.
> 
> Applies the real **`syn` 3** dev-dependency bump (replacing the empty Syn PR) and updates the repository-policy **unsafe-syntax AST scanner** for Syn 3 (`Safety`, `TypeFnPtr`, attribute values, verbatim tokens, assembly macros/imports). The Dependabot policy test now asserts one root updater plus adapter membership and standalone fixtures instead of listing three directories.
> 
> **PLAN**, canonical context, and progress notes document the hosted failure, governance blockers, and correctness study #97 as the next milestone. No runtime or public API changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0b7b858c26e531e9e3e03cd428a3487fbcea82b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->