### PR TITLE
fix: harden client correctness boundaries

### DIFF
--- a/.llm/context.md
+++ b/.llm/context.md
@@ -116,7 +116,9 @@ The minimum and latest Godot fixtures therefore remain deliberately standalone
 and are updated only with their locked compatibility/browser E2E evidence;
 putting them in the root workspace would unify incompatible Godot types and
 expand ordinary `--workspace --all-features` builds into engine-dependent
-fixtures. A fresh default-branch root updater run remains required hosted proof.
+fixtures. Default-branch updater run 31969079956 subsequently completed
+successfully on the root workspace, discovered the adapter dependencies,
+reported no resolution errors, and opened no Cargo PR.
 
 ## Architecture — Core Modules
 
@@ -137,7 +139,7 @@ fixtures. A fresh default-branch root updater run remains required hosted proof.
 | `src/mesh.rs` | `MeshSession` v3 state tracker (feature: `mesh`) |
 | `src/webrtc.rs` | `WebRtcDriver` seam + `MeshController` (feature: `mesh`) |
 | `src/transports/websocket.rs` | WebSocket transport (feature: `transport-websocket`) |
-| `crates/signal-fish-client-godot/src/lib.rs` | Godot 4.5 native/web `WebSocketPeer` adapter and its 34 fake-backend tests |
+| `crates/signal-fish-client-godot/src/lib.rs` | Godot 4.5 native/web `WebSocketPeer` adapter and its 35 fake-backend tests |
 
 ### Transport Trait
 
@@ -164,6 +166,21 @@ admission purposes; it is not peer delivery and never requires the socket-wide
 buffered byte count to reach zero. `Pending` before acceptance leaves the
 caller's `Option` intact. Close polling is idempotent. See
 `skills/transport-abstraction/SKILL.md`.
+
+The async driver retains an in-flight send in its main select loop and polls
+send and receive with the same runtime waker, so outbound backpressure cannot
+hide inbound frames, peer close, or shutdown. Once a transport takes ownership
+of a frame, graceful termination finishes that send before close under the
+configured deadline; expiry invokes `Transport::abort`. Terminal core
+state/event delivery and close progress are concurrent, so a full event channel
+cannot strand the backend.
+
+Public `Debug` and built-in transport tracing form an ambient-log boundary:
+reconnect/relay/TURN credentials, WebRTC SDP/ICE, arbitrary application data,
+buffered protocol frames, peer close reasons, and URL userinfo/query values
+must never be formatted. Safe diagnostics expose only variants, state flags,
+identifiers where appropriate, and byte lengths. Wire serialization and
+explicit public-field access remain unchanged.
 
 The Emscripten transport reports `Pending` while its browser WebSocket is still
 connecting and must not call `emscripten_websocket_send_*` or consume the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   inbound frames, peer close, and shutdown. Send and receive now make
   bidirectional progress, backend-owned sends finish before close, terminal
   state and events do not wait for graceful close, and close/abort progress is
-  bounded even when the event channel is full.
+  bounded even when the event channel is full. A peer close discovered while
+  a send is flushing also retains its close metadata instead of being
+  misclassified as a generic send failure.
 - Fixed async `*_reliable` sends retaining validation decisions made before a
   full command queue drained. Waiting sends now preserve immediate validation
   errors but revalidate connection, negotiation, binary-format, and current

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed public `Debug` implementations and built-in transport tracing exposing
+  reconnect and relay credentials, TURN userinfo, WebRTC signaling material,
+  peer-controlled close reasons, buffered protocol frames, arbitrary game
+  payloads, and credential-bearing WebSocket URLs. Ambient diagnostics now
+  retain only safe variant, state, and payload-length metadata.
+- Fixed the async transport loop allowing an indefinitely pending send to hide
+  inbound frames, peer close, and shutdown. Send and receive now make
+  bidirectional progress, backend-owned sends finish before close, terminal
+  state and events do not wait for graceful close, and close/abort progress is
+  bounded even when the event channel is full.
+- Fixed async `*_reliable` sends retaining validation decisions made before a
+  full command queue drained. Waiting sends now preserve immediate validation
+  errors but revalidate connection, negotiation, binary-format, and current
+  session-plan state atomically when queue capacity is actually reserved.
+  Generation-bearing and legacy generation-less re-plans cannot relabel or
+  admit stale signaling, while an idempotent plan reassertion stays valid.
 - Fixed the deprecated Emscripten WebSocket transport reclaiming callback
   state after the browser failed to unregister it, which could let a late
   callback access freed memory. Native cleanup now closes after logical

--- a/PLAN.md
+++ b/PLAN.md
@@ -69,7 +69,7 @@ were delivered by PR #91 and closed when it merged as `963a9fc`.
   Sync, but merged without the approval and quota-green state it explicitly
   required. That governance failure remains tracked in issue #90.
 
-## Current Correctness Follow-up — FFI and Dependency Automation
+## Completed Correctness Follow-up — FFI and Dependency Automation
 
 - Emscripten callback state is reclaimed only when its owner consumes a typed
   authorization produced after native close was attempted or observed and browser callback
@@ -86,22 +86,42 @@ were delivered by PR #91 and closed when it merged as `963a9fc`.
   file set. The corrective updater now starts only at `/`, where Cargo
   discovers the adapter workspace member. The exact minimum/latest Godot
   fixtures stay standalone and are maintained through their dedicated locked
-  E2E compatibility evidence. Issue #95 tracks fresh default-branch proof.
+  E2E compatibility evidence. Post-merge root-workspace updater run
+  [31969079956](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/actions/runs/31969079956)
+  completed successfully on `main`, discovered both workspace crates, reported
+  no dependency-resolution errors, and opened no Cargo PR. This satisfies the
+  hosted proof tracked by issue #95.
 - The checked-in `GITHUB_TOKEN` Dependabot auto-merge path is removed. Until
   issue #90 is fixed, dependency PRs must not bypass review/check policy or
   suppress CI for their merge SHA.
 
-## Next Major Milestone — Correctness Code Study
+## Completed Correctness Study — First Hardening Slice
 
 Track [issue #97](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/issues/97).
 
-- Audit the implementation, public API, distributed-state behavior, network
-  resilience, server/reference-client parity, and unexpected-input handling.
-- Decompose the broad study into bounded subsystem matrices with an explicit
-  invariant, authoritative reference, executable evidence, and follow-up issue
-  for every unresolved finding.
-- Fix correctness defects before usability, performance, or presentation work;
-  do not treat an absence of current test failures as proof of completeness.
+- Audited protocol/state, public API, transport/network behavior, the pinned
+  Server 0.7 contract, and native/browser reference-client assumptions through
+  three independent subsystem matrices and adversarial review loops.
+- Fixed stale reliable signaling and game data across queue waits, including
+  legacy generation-less plans and room changes; async send/receive/close
+  liveness; and the ambient `Debug`/tracing credential and payload leak class.
+- Decomposed every unresolved finding into issues #99–#107 with explicit
+  invariants and executable acceptance evidence. Session 026 records the
+  finding matrix and proof.
+
+## Next Correctness Milestone — Protocol State Validation
+
+Start with [issue #99](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/issues/99),
+then #100 and #101.
+
+- Reject lifecycle-invalid v3/room messages before they mutate shared state.
+- Validate authoritative SessionPlan cross-field shapes and peer membership
+  against the pinned Server 0.7 contract.
+- Track negotiated effective game-data encoding separately from the requested
+  preference, then make reconnect restoration atomic across negotiation,
+  accountability, membership, and plan state.
+- Continue correctness work through #102–#107 before usability, performance,
+  token binding, or presentation milestones.
 
 ## Following Milestone — Negotiated Token Binding
 

--- a/crates/signal-fish-client-godot/src/lib.rs
+++ b/crates/signal-fish-client-godot/src/lib.rs
@@ -1452,6 +1452,23 @@ mod tests {
     }
 
     #[test]
+    fn debug_redacts_peer_close_reason_transitively() {
+        let secret = "godot-close-secret";
+        let mut transport =
+            GodotWebSocketTransport::from_backend(Box::new(FakeBackend::new(PeerState::Closed)));
+        transport.close_info = Some(TransportCloseInfo {
+            code: Some(4000),
+            reason: Some(secret.into()),
+            clean: Some(true),
+            initiated_by_peer: true,
+        });
+
+        let output = format!("{transport:?}");
+        assert!(!output.contains(secret), "debug output leaked: {output}");
+        assert!(output.contains("has_reason: true"));
+    }
+
+    #[test]
     fn closing_and_closed_states_drain_already_buffered_packets() {
         let mut backend = FakeBackend::new(PeerState::Open);
         backend

--- a/progress/session-025-dependabot-root-workspace.md
+++ b/progress/session-025-dependabot-root-workspace.md
@@ -61,13 +61,18 @@ update behind zero-file PR #96, and restore truthful roadmap evidence.
   quota; it produced no actionable feedback or unresolved threads and remains
   an issue #90 maintainer-administration blocker.
 
-## Hosted Follow-up
+## Hosted Proof
 
 - Zero-file PR #96 was closed without merging after PR #98 incorporated the
   real Syn 3 update and the updater correction.
-- After merge, dispatch or observe a default-branch Cargo updater run and link
-  a successful result in issue #95. It must contain no dependency resolution
-  errors and must not create another zero-file PR.
+- Default-branch Cargo updater run
+  [31969079956](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/actions/runs/31969079956)
+  completed successfully on merged `main` commit `3461789`. Its dependency
+  snapshot included both the root `signal-fish-client` package and the
+  workspace-member `godot` dependency, reported no
+  `dependency_file_not_resolvable` errors, and completed without creating a
+  Cargo dependency PR. This satisfies issue #95's hosted proof without another
+  empty update.
 - Issue #90 still requires maintainer administration and an eligible
   independent reviewer before repository review/check enforcement can pass.
 - Begin issue #97 as bounded subsystem audits after this single PR is green.

--- a/progress/session-026-correctness-code-study.md
+++ b/progress/session-026-correctness-code-study.md
@@ -1,0 +1,112 @@
+# Session 026 — Correctness Code Study and Hardening
+
+Date: 2026-08-16
+
+## Objective
+
+Execute issue #97 as a data-backed study of protocol/state correctness, public
+API safety, transport/network resilience, pinned-server parity, and unexpected
+input behavior; fix the highest-impact proven defects and decompose every
+unresolved finding into a bounded issue.
+
+## Audit Method
+
+Three independent read-only audits covered:
+
+- protocol negotiation, reconnect, delivery accountability, session plans,
+  signaling generations, and Server 0.7 AsyncAPI/source parity;
+- public types, snapshots, operation guards, statistics, mesh capability, and
+  credential-bearing diagnostic paths;
+- async/polling transport ownership, FIFO/backpressure, shutdown, WebSocket
+  control frames, close metadata, malformed frames, and missing UDP scope.
+
+Each audit recorded an invariant, authoritative evidence, current executable
+coverage, severity, and bounded recommendation. Implemented changes then went
+through repeated adversarial review and correction.
+
+## Implemented Hardening
+
+### Reliable operation admission
+
+- Reliable async operations validate before waiting and again while holding a
+  reserved command permit, without holding the shared mutex across an await.
+- A signal produced for the current plan binds to its original wire generation
+  before waiting, preventing stale SDP/ICE from being relabeled after a re-plan.
+- A private plan revision fences Server 0.4-compatible generation-less plans;
+  generation-bearing plans continue to use their authoritative UUID so an
+  idempotent same-generation plan reassertion remains valid.
+- A private membership revision prevents JSON or binary game data begun in one
+  room from crossing a leave/reconnect/join boundary into another room.
+- Saturated-queue regressions prove changed-UUID rejection, `None -> None`
+  replacement rejection, same-UUID acceptance, JSON/binary room fencing,
+  fail-fast pre-negotiation, and absence of stale frames on the wire.
+
+### Async transport liveness and termination
+
+- The async loop retains one in-flight frame and polls send and receive
+  together. A legal indefinitely pending send can no longer hide later inbound
+  readiness, peer EOF, receive errors, or shutdown.
+- Backend-owned sends finish before graceful close under one deadline; a
+  caller-owned frame may be abandoned when termination wins.
+- Core state is terminal before the Disconnected event. Event delivery and
+  close progress run concurrently, so a full event channel cannot delay close
+  or abort forever.
+- The task watchdog includes scheduling grace beyond the transport deadline,
+  letting the loop invoke `Transport::abort` before task abortion.
+- Retained-frame, stored-waker, full-event-channel, hanging-close, and abort
+  regressions pin ownership, wake-driven progress, terminal ordering, and
+  bounded resource release. Transport error reasons are no longer double
+  prefixed.
+
+### Ambient diagnostic redaction
+
+- Replaced credential/payload-bearing derived Debug implementations across
+  protocol messages, reconnect payloads, connection info, ICE servers,
+  signaling, binary envelopes, raw transport frames, close metadata,
+  WebSocket state, mesh sessions, and driver/mesh events.
+- Native WebSocket tracing no longer records full URLs or peer-controlled close
+  reasons; Godot transport Debug inherits the redacted close metadata.
+- Sentinel tests cover direct and transitive wrappers and reject both string
+  secrets and decimal `Vec<u8>` Debug output. Serde/wire shapes, public fields,
+  variants, and Debug trait availability are unchanged.
+
+## Unresolved Finding Decomposition
+
+| Issue | Invariant / scope |
+| --- | --- |
+| #99 | Lifecycle/version/message-scope validation, semantic SessionPlan shapes, and signal peer membership |
+| #100 | Requested versus negotiated effective game-data encoding |
+| #101 | Atomic reconnect negotiation, accountability, snapshot, and plan restoration |
+| #102 | Mesh capability, controller startup, selected plan, and per-transport liveness semantics |
+| #103 | Coherent membership identity and locally enforced operation/role guards |
+| #104 | Connection readiness phases and exact ClientStats counting points |
+| #105 | Bounded WebSocket control-frame work, terminal EOF, and missing state-machine evidence |
+| #106 | Enforceable custom Transport abort/resource-release contract |
+| #107 | Datagram/UDP framing, trust, ordering, and resilience ownership |
+
+The study also confirmed strong existing coverage for strict v2/v3 binary
+decoding, exact delivery-gap accountability, bounded polling work/FIFO queues,
+malformed JSON/binary diagnostics, WebSocket close metadata and idempotency,
+TCP_NODELAY, TLS behavior, and async/polling shared-core parity.
+
+## Verification
+
+- Focused reliable-generation/membership, redaction, mesh, WebSocket, Godot,
+  and async transport liveness regressions pass.
+- The panic-free source policy passes.
+- Polling-only Clippy passes with `-D warnings`, proving async-only binding
+  state does not leak dead code into runtime-less feature builds.
+- Workspace/all-target/all-feature Clippy passes with `-D warnings`.
+- The mandatory workflow passes: formatting, workspace/all-target/all-feature
+  Clippy with `-D warnings`, and workspace/all-feature tests. The latter runs
+  294 core unit tests, 35 Godot adapter tests, all integration/policy suites,
+  and doc tests; five live-server E2E cases remain intentionally ignored in
+  local runs and are delegated to hosted blocking workflows.
+
+## Hosted State
+
+- Root-workspace Dependabot run 31969079956 succeeded on main and satisfied
+  issue #95; no Cargo dependency PR was opened.
+- Main project workflows were green in the session baseline audit. Repository
+  policy enforcement remains the maintainer-administration blocker tracked by
+  issue #90 and is not fixable from repository code alone.

--- a/progress/session-026-correctness-code-study.md
+++ b/progress/session-026-correctness-code-study.md
@@ -51,6 +51,9 @@ through repeated adversarial review and correction.
 - Core state is terminal before the Disconnected event. Event delivery and
   close progress run concurrently, so a full event channel cannot delay close
   or abort forever.
+- A peer close discovered while a send is still flushing remains a peer-close
+  terminal path with structured close metadata; a consequential send refusal
+  cannot overwrite that attribution.
 - The task watchdog includes scheduling grace beyond the transport deadline,
   letting the loop invoke `Transport::abort` before task abortion.
 - Retained-frame, stored-waker, full-event-channel, hanging-close, and abort

--- a/progress/session-026-correctness-code-study.md
+++ b/progress/session-026-correctness-code-study.md
@@ -97,6 +97,10 @@ TCP_NODELAY, TLS behavior, and async/polling shared-core parity.
 - Polling-only Clippy passes with `-D warnings`, proving async-only binding
   state does not leak dead code into runtime-less feature builds.
 - Workspace/all-target/all-feature Clippy passes with `-D warnings`.
+- The hosted mutation scope is reproducible locally: all 14 viable mutants in
+  `protocol.rs`, `error_codes.rs`, and `error.rs` are caught; one is unviable.
+  Redaction regressions assert both secret absence and safe structural output,
+  so an empty custom formatter cannot satisfy the tests.
 - The mandatory workflow passes: formatting, workspace/all-target/all-feature
   Clippy with `-D warnings`, and workspace/all-feature tests. The latter runs
   294 core unit tests, 35 Godot adapter tests, all integration/policy suites,

--- a/src/client.rs
+++ b/src/client.rs
@@ -1493,8 +1493,19 @@ async fn poll_transport_io(
                     return std::task::Poll::Ready(TransportIo::Sent { is_game_data });
                 }
                 std::task::Poll::Ready(Err(error)) => {
+                    let peer_closed = transport
+                        .close_info()
+                        .is_some_and(|info| info.initiated_by_peer);
                     *pending_send = None;
-                    return std::task::Poll::Ready(TransportIo::SendFailed(error));
+                    return std::task::Poll::Ready(if peer_closed {
+                        // A duplex transport can discover a peer close while
+                        // an accepted send is still flushing. Prefer the
+                        // authoritative terminal receive state and its close
+                        // metadata over the consequential send refusal.
+                        TransportIo::Received(None)
+                    } else {
+                        TransportIo::SendFailed(error)
+                    });
                 }
                 std::task::Poll::Pending => {}
             }
@@ -2557,6 +2568,100 @@ mod tests {
             self.retained_frame = None;
             self.controls.abort_called.store(true, Ordering::Release);
         }
+    }
+
+    /// Models a WebSocket peer close discovered while an accepted send is
+    /// still flushing. The close response needs another poll, so receive first
+    /// returns `Pending`; meanwhile further sends are terminally refused.
+    struct PeerCloseDuringSendTransport {
+        send_accepted: bool,
+        peer_close_observed: bool,
+        close_called: Arc<AtomicBool>,
+    }
+
+    impl PeerCloseDuringSendTransport {
+        fn new() -> (Self, Arc<AtomicBool>) {
+            let close_called = Arc::new(AtomicBool::new(false));
+            (
+                Self {
+                    send_accepted: false,
+                    peer_close_observed: false,
+                    close_called: Arc::clone(&close_called),
+                },
+                close_called,
+            )
+        }
+    }
+
+    impl Transport for PeerCloseDuringSendTransport {
+        fn poll_send(
+            &mut self,
+            _cx: &mut Context<'_>,
+            frame: &mut Option<TransportFrame>,
+        ) -> Poll<std::result::Result<(), SignalFishError>> {
+            if self.peer_close_observed {
+                return Poll::Ready(Err(SignalFishError::TransportClosed));
+            }
+            if !self.send_accepted {
+                assert!(frame.take().is_some());
+                self.send_accepted = true;
+            }
+            Poll::Pending
+        }
+
+        fn poll_recv(
+            &mut self,
+            cx: &mut Context<'_>,
+        ) -> Poll<Option<std::result::Result<TransportFrame, SignalFishError>>> {
+            if self.send_accepted && !self.peer_close_observed {
+                self.peer_close_observed = true;
+                cx.waker().wake_by_ref();
+            }
+            Poll::Pending
+        }
+
+        fn poll_close(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<std::result::Result<(), SignalFishError>> {
+            self.close_called.store(true, Ordering::Release);
+            Poll::Ready(Ok(()))
+        }
+
+        fn close_info(&self) -> Option<crate::transport::TransportCloseInfo> {
+            self.peer_close_observed
+                .then(|| crate::transport::TransportCloseInfo {
+                    code: Some(1000),
+                    reason: Some("normal closure".into()),
+                    clean: Some(true),
+                    initiated_by_peer: true,
+                })
+        }
+    }
+
+    #[tokio::test]
+    async fn peer_close_during_pending_send_uses_close_metadata() {
+        let (transport, close_called) = PeerCloseDuringSendTransport::new();
+        let (mut client, mut events) =
+            SignalFishClient::start(transport, SignalFishConfig::new("app"));
+
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Connected)
+        ));
+        let terminal = tokio::time::timeout(Duration::from_secs(1), events.recv())
+            .await
+            .expect("peer close must surface")
+            .expect("terminal event channel must remain open");
+        assert!(matches!(
+            terminal,
+            SignalFishEvent::Disconnected { reason, .. }
+                if reason.as_deref()
+                    == Some("closed by server: code=Some(1000), reason=Some(\"normal closure\")")
+        ));
+        wait_until(|| close_called.load(Ordering::Acquire)).await;
+
+        client.shutdown().await;
     }
 
     #[tokio::test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -99,7 +99,7 @@ use crate::protocol::{
 #[cfg(feature = "tokio-runtime")]
 use crate::signal::PeerSignal;
 #[cfg(feature = "tokio-runtime")]
-use crate::transport::{close_transport, recv_frame, send_frame, Transport, TransportFrame};
+use crate::transport::{close_transport, Transport, TransportFrame};
 
 /// Default capacity of the bounded event channel.
 const DEFAULT_EVENT_CHANNEL_CAPACITY: usize = 256;
@@ -109,6 +109,11 @@ const DEFAULT_COMMAND_CHANNEL_CAPACITY: usize = 1024;
 
 /// Default timeout for the graceful shutdown.
 const DEFAULT_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(1);
+
+/// Scheduling grace for the task watchdog after the transport loop's own
+/// close deadline. This lets the loop invoke `Transport::abort` first.
+#[cfg(feature = "tokio-runtime")]
+const SHUTDOWN_TASK_GRACE: Duration = Duration::from_millis(100);
 
 #[cfg(any(feature = "tokio-runtime", feature = "polling-client"))]
 pub(crate) fn bounded_binary_preview(bytes: &[u8]) -> String {
@@ -651,6 +656,7 @@ impl SignalFishClient {
             event_tx,
             loop_state,
             shutdown_rx,
+            config.shutdown_timeout,
         ));
 
         let client = Self {
@@ -687,7 +693,8 @@ impl SignalFishClient {
         // Await the transport loop with a timeout. If it doesn't exit in time,
         // abort it so the task cannot detach and run indefinitely.
         if let Some(mut task) = self.task.take() {
-            match tokio::time::timeout(self.shutdown_timeout, &mut task).await {
+            let task_timeout = self.shutdown_timeout.saturating_add(SHUTDOWN_TASK_GRACE);
+            match tokio::time::timeout(task_timeout, &mut task).await {
                 Ok(Ok(())) => {}
                 Ok(Err(join_err)) => {
                     warn!("transport loop terminated with join error: {join_err}");
@@ -1191,19 +1198,28 @@ impl SignalFishClient {
         result
     }
 
-    async fn send_operation_reliable(&self, operation: ClientOperation) -> Result<()> {
-        let command = lock_core(&self.state).prepare(operation)?;
-        self.send_command_reliable(command).await
-    }
-
-    async fn send_command_reliable(&self, command: ClientCommand) -> Result<()> {
-        if !lock_core(&self.state).is_connected() {
-            return Err(SignalFishError::NotConnected);
-        }
-        self.cmd_tx
-            .send(command)
+    async fn send_operation_reliable(&self, mut operation: ClientOperation) -> Result<()> {
+        // Preserve immediate state/negotiation errors even when the queue is
+        // full, then revalidate after waiting because room, plan, and format
+        // state can change while capacity is unavailable.
+        let binding = {
+            let core = lock_core(&self.state);
+            core.validate(&operation)?;
+            // A signal value is produced for the plan current when this call
+            // begins. Freeze that generation before waiting so revalidation
+            // rejects a stale signal instead of relabeling it after a re-plan.
+            core.bind_reliable_operation(&mut operation)
+        };
+        let permit = self
+            .cmd_tx
+            .reserve()
             .await
-            .map_err(|_| SignalFishError::NotConnected)
+            .map_err(|_| SignalFishError::NotConnected)?;
+        let core = lock_core(&self.state);
+        let command = core.prepare_reliable(operation, binding)?;
+        permit.send(command);
+        drop(core);
+        Ok(())
     }
 }
 
@@ -1366,35 +1382,132 @@ fn lock_core(state: &Arc<Mutex<ClientCore>>) -> std::sync::MutexGuard<'_, Client
 #[cfg(feature = "tokio-runtime")]
 async fn finish_core_shutdown(
     transport: &mut impl Transport,
+    pending_send: &mut Option<PendingSend>,
     event_tx: &mpsc::Sender<SignalFishEvent>,
     state: &Arc<Mutex<ClientCore>>,
+    shutdown_timeout: Duration,
 ) {
-    let _ = close_transport(transport).await;
     let event = lock_core(state).disconnect(Some("client shut down".into()));
     let _ = event_tx.try_send(event);
+    finish_send_and_close_bounded(transport, pending_send, state, shutdown_timeout).await;
 }
 
 #[cfg(feature = "tokio-runtime")]
 async fn emit_core_disconnected_or_shutdown(
     transport: &mut impl Transport,
+    pending_send: &mut Option<PendingSend>,
     event_tx: &mpsc::Sender<SignalFishEvent>,
     shutdown_rx: &mut tokio::sync::oneshot::Receiver<()>,
     state: &Arc<Mutex<ClientCore>>,
     reason: Option<String>,
+    shutdown_timeout: Duration,
 ) {
-    let _ = close_transport(transport).await;
     let event = lock_core(state).disconnect(reason);
-    tokio::select! {
-        biased;
-        result = event_tx.send(event.clone()) => {
-            if result.is_err() {
-                debug!("event channel closed, receiver dropped");
+    let deliver_event = async {
+        tokio::select! {
+            biased;
+            result = event_tx.send(event.clone()) => {
+                if result.is_err() {
+                    debug!("event channel closed, receiver dropped");
+                }
+            }
+            _ = &mut *shutdown_rx => {
+                let _ = event_tx.try_send(event);
             }
         }
-        _ = &mut *shutdown_rx => {
-            let _ = event_tx.try_send(event);
+    };
+    let close = finish_send_and_close_bounded(transport, pending_send, state, shutdown_timeout);
+    let ((), ()) = tokio::join!(deliver_event, close);
+}
+
+#[cfg(feature = "tokio-runtime")]
+async fn finish_send_and_close_bounded(
+    transport: &mut impl Transport,
+    pending_send: &mut Option<PendingSend>,
+    state: &Arc<Mutex<ClientCore>>,
+    timeout: Duration,
+) {
+    let accepted_send = pending_send
+        .as_ref()
+        .is_some_and(|pending| pending.frame.is_none());
+    let result = tokio::time::timeout(timeout, async {
+        if accepted_send {
+            let send_result = std::future::poll_fn(|cx| {
+                pending_send
+                    .as_mut()
+                    .map_or(std::task::Poll::Ready(Ok(())), |pending| {
+                        transport.poll_send(cx, &mut pending.frame)
+                    })
+            })
+            .await;
+            match send_result {
+                Ok(()) => {
+                    if pending_send
+                        .as_ref()
+                        .is_some_and(|pending| pending.is_game_data)
+                    {
+                        lock_core(state).record_game_data_sent();
+                    }
+                }
+                Err(error) => warn!("accepted send failed while closing transport: {error}"),
+            }
         }
+        *pending_send = None;
+        let _ = close_transport(transport).await;
+    })
+    .await;
+
+    if result.is_err() {
+        warn!("transport close did not finish within timeout; aborting transport");
+        transport.abort();
     }
+    *pending_send = None;
+}
+
+#[cfg(feature = "tokio-runtime")]
+struct PendingSend {
+    frame: Option<TransportFrame>,
+    is_game_data: bool,
+}
+
+#[cfg(feature = "tokio-runtime")]
+enum TransportIo {
+    Sent { is_game_data: bool },
+    SendFailed(SignalFishError),
+    Received(Option<std::result::Result<TransportFrame, SignalFishError>>),
+}
+
+/// Poll an in-flight send and receive together so a backpressured outbound
+/// frame cannot hide peer close, inbound errors, or server messages.
+#[cfg(feature = "tokio-runtime")]
+async fn poll_transport_io(
+    transport: &mut impl Transport,
+    pending_send: &mut Option<PendingSend>,
+) -> TransportIo {
+    std::future::poll_fn(|cx| {
+        if let Some(pending) = pending_send.as_mut() {
+            match transport.poll_send(cx, &mut pending.frame) {
+                std::task::Poll::Ready(Ok(())) => {
+                    let is_game_data = pending.is_game_data;
+                    *pending_send = None;
+                    return std::task::Poll::Ready(TransportIo::Sent { is_game_data });
+                }
+                std::task::Poll::Ready(Err(error)) => {
+                    *pending_send = None;
+                    return std::task::Poll::Ready(TransportIo::SendFailed(error));
+                }
+                std::task::Poll::Pending => {}
+            }
+        }
+
+        match transport.poll_recv(cx) {
+            std::task::Poll::Ready(incoming) => {
+                std::task::Poll::Ready(TransportIo::Received(incoming))
+            }
+            std::task::Poll::Pending => std::task::Poll::Pending,
+        }
+    })
+    .await
 }
 
 /// Background transport loop that multiplexes send/receive via `tokio::select!`.
@@ -1410,28 +1523,40 @@ async fn transport_loop(
     event_tx: mpsc::Sender<SignalFishEvent>,
     state: Arc<Mutex<ClientCore>>,
     mut shutdown_rx: tokio::sync::oneshot::Receiver<()>,
+    shutdown_timeout: Duration,
 ) {
     debug!("transport loop started");
+
+    let mut pending_send = None;
 
     if matches!(
         emit_event_or_shutdown(&event_tx, &mut shutdown_rx, SignalFishEvent::Connected).await,
         EmitOutcome::ShutdownRequested
     ) {
-        finish_core_shutdown(&mut transport, &event_tx, &state).await;
+        finish_core_shutdown(
+            &mut transport,
+            &mut pending_send,
+            &event_tx,
+            &state,
+            shutdown_timeout,
+        )
+        .await;
         debug!("transport loop exited");
         return;
     }
 
     loop {
         tokio::select! {
-            command = cmd_rx.recv() => {
+            command = cmd_rx.recv(), if pending_send.is_none() => {
                 let Some(command) = command else {
                     emit_core_disconnected_or_shutdown(
                         &mut transport,
+                        &mut pending_send,
                         &event_tx,
                         &mut shutdown_rx,
                         &state,
                         Some("client shut down".into()),
+                        shutdown_timeout,
                     ).await;
                     break;
                 };
@@ -1451,28 +1576,42 @@ async fn transport_loop(
                     }
                 };
                 if let Some(frame) = frame {
-                    if let Err(error) = send_frame(&mut transport, frame).await {
-                        emit_core_disconnected_or_shutdown(
-                            &mut transport,
-                            &event_tx,
-                            &mut shutdown_rx,
-                            &state,
-                            Some(format!("transport send error: {error}")),
-                        ).await;
-                        break;
-                    }
-                    if is_game_data {
-                        lock_core(&state).record_game_data_sent();
-                    }
+                    pending_send = Some(PendingSend {
+                        frame: Some(frame),
+                        is_game_data,
+                    });
                 }
             }
             _ = &mut shutdown_rx => {
-                finish_core_shutdown(&mut transport, &event_tx, &state).await;
+                finish_core_shutdown(
+                    &mut transport,
+                    &mut pending_send,
+                    &event_tx,
+                    &state,
+                    shutdown_timeout,
+                ).await;
                 break;
             }
-            incoming = recv_frame(&mut transport) => {
-                match incoming {
-                    Some(Ok(frame)) => {
+            io = poll_transport_io(&mut transport, &mut pending_send) => {
+                match io {
+                    TransportIo::Sent { is_game_data } => {
+                        if is_game_data {
+                            lock_core(&state).record_game_data_sent();
+                        }
+                    }
+                    TransportIo::SendFailed(error) => {
+                        emit_core_disconnected_or_shutdown(
+                            &mut transport,
+                            &mut pending_send,
+                            &event_tx,
+                            &mut shutdown_rx,
+                            &state,
+                            Some(error.to_string()),
+                            shutdown_timeout,
+                        ).await;
+                        break;
+                    }
+                    TransportIo::Received(Some(Ok(frame))) => {
                         let outcome = lock_core(&state).process_frame(frame);
                         let disconnect = outcome.disconnect;
                         let mut shutdown_requested = false;
@@ -1486,31 +1625,41 @@ async fn transport_loop(
                             }
                         }
                         if shutdown_requested {
-                            finish_core_shutdown(&mut transport, &event_tx, &state).await;
+                            finish_core_shutdown(
+                                &mut transport,
+                                &mut pending_send,
+                                &event_tx,
+                                &state,
+                                shutdown_timeout,
+                            ).await;
                             break;
                         }
                         if disconnect {
                             emit_core_disconnected_or_shutdown(
                                 &mut transport,
+                                &mut pending_send,
                                 &event_tx,
                                 &mut shutdown_rx,
                                 &state,
                                 Some("protocol accountability violation".into()),
+                                shutdown_timeout,
                             ).await;
                             break;
                         }
                     }
-                    Some(Err(error)) => {
+                    TransportIo::Received(Some(Err(error))) => {
                         emit_core_disconnected_or_shutdown(
                             &mut transport,
+                            &mut pending_send,
                             &event_tx,
                             &mut shutdown_rx,
                             &state,
-                            Some(format!("transport receive error: {error}")),
+                            Some(error.to_string()),
+                            shutdown_timeout,
                         ).await;
                         break;
                     }
-                    None => {
+                    TransportIo::Received(None) => {
                         let reason = transport.close_info().map(|info| {
                             format!(
                                 "closed by server: code={:?}, reason={:?}",
@@ -1519,10 +1668,12 @@ async fn transport_loop(
                         });
                         emit_core_disconnected_or_shutdown(
                             &mut transport,
+                            &mut pending_send,
                             &event_tx,
                             &mut shutdown_rx,
                             &state,
                             reason,
+                            shutdown_timeout,
                         ).await;
                         break;
                     }
@@ -1589,7 +1740,7 @@ mod tests {
     use std::future::Future;
     use std::pin::Pin;
     use std::sync::Mutex as StdMutex;
-    use std::task::{Context, Poll};
+    use std::task::{Context, Poll, Waker};
 
     #[test]
     fn snapshot_debug_redacts_reconnection_token() {
@@ -2303,6 +2454,163 @@ mod tests {
         }
     }
 
+    #[derive(Clone)]
+    struct PendingSendControls {
+        entered_send: Arc<AtomicBool>,
+        complete_send: Arc<AtomicBool>,
+        peer_closed: Arc<AtomicBool>,
+        close_called: Arc<AtomicBool>,
+        abort_called: Arc<AtomicBool>,
+        send_waker: Arc<StdMutex<Option<Waker>>>,
+        recv_waker: Arc<StdMutex<Option<Waker>>>,
+    }
+
+    impl PendingSendControls {
+        fn complete_send(&self) {
+            self.complete_send.store(true, Ordering::Release);
+            if let Some(waker) = self.send_waker.lock().unwrap().take() {
+                waker.wake();
+            }
+        }
+
+        fn close_peer(&self) {
+            self.peer_closed.store(true, Ordering::Release);
+            if let Some(waker) = self.recv_waker.lock().unwrap().take() {
+                waker.wake();
+            }
+        }
+    }
+
+    /// A transport that retains an accepted frame until independently woken.
+    /// Receive readiness is controlled separately, proving bidirectional
+    /// progress while the backend owns an incomplete send.
+    struct PendingSendTransport {
+        retained_frame: Option<TransportFrame>,
+        controls: PendingSendControls,
+    }
+
+    impl PendingSendTransport {
+        fn new() -> (Self, PendingSendControls) {
+            let controls = PendingSendControls {
+                entered_send: Arc::new(AtomicBool::new(false)),
+                complete_send: Arc::new(AtomicBool::new(false)),
+                peer_closed: Arc::new(AtomicBool::new(false)),
+                close_called: Arc::new(AtomicBool::new(false)),
+                abort_called: Arc::new(AtomicBool::new(false)),
+                send_waker: Arc::new(StdMutex::new(None)),
+                recv_waker: Arc::new(StdMutex::new(None)),
+            };
+            (
+                Self {
+                    retained_frame: None,
+                    controls: controls.clone(),
+                },
+                controls,
+            )
+        }
+    }
+
+    impl Transport for PendingSendTransport {
+        fn poll_send(
+            &mut self,
+            cx: &mut Context<'_>,
+            frame: &mut Option<TransportFrame>,
+        ) -> Poll<std::result::Result<(), SignalFishError>> {
+            if self.retained_frame.is_none() {
+                self.retained_frame = frame.take();
+                self.controls.entered_send.store(true, Ordering::Release);
+            }
+            if self.controls.complete_send.load(Ordering::Acquire) {
+                self.retained_frame = None;
+                Poll::Ready(Ok(()))
+            } else {
+                *self.controls.send_waker.lock().unwrap() = Some(cx.waker().clone());
+                Poll::Pending
+            }
+        }
+
+        fn poll_recv(
+            &mut self,
+            cx: &mut Context<'_>,
+        ) -> Poll<Option<std::result::Result<TransportFrame, SignalFishError>>> {
+            if self.controls.peer_closed.load(Ordering::Acquire) {
+                Poll::Ready(None)
+            } else {
+                *self.controls.recv_waker.lock().unwrap() = Some(cx.waker().clone());
+                Poll::Pending
+            }
+        }
+
+        fn poll_close(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<std::result::Result<(), SignalFishError>> {
+            assert!(
+                self.retained_frame.is_none(),
+                "backend-owned send must complete before close"
+            );
+            self.controls.close_called.store(true, Ordering::Release);
+            Poll::Ready(Ok(()))
+        }
+
+        fn abort(&mut self) {
+            self.retained_frame = None;
+            self.controls.abort_called.store(true, Ordering::Release);
+        }
+    }
+
+    #[tokio::test]
+    async fn pending_send_does_not_hide_peer_close() {
+        let (transport, controls) = PendingSendTransport::new();
+        let (mut client, mut events) =
+            SignalFishClient::start(transport, SignalFishConfig::new("app"));
+
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Connected)
+        ));
+        wait_until(|| controls.entered_send.load(Ordering::Acquire)).await;
+        controls.close_peer();
+        let terminal = tokio::time::timeout(Duration::from_secs(1), events.recv())
+            .await
+            .expect("peer close must surface while send remains pending")
+            .expect("terminal event channel must remain open");
+        assert!(matches!(terminal, SignalFishEvent::Disconnected { .. }));
+        assert!(!client.is_connected());
+        assert!(!controls.close_called.load(Ordering::Acquire));
+
+        controls.complete_send();
+        wait_until(|| controls.close_called.load(Ordering::Acquire)).await;
+
+        client.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn shutdown_preempts_pending_send_and_attempts_close() {
+        let (transport, controls) = PendingSendTransport::new();
+        let config = SignalFishConfig::new("app").with_shutdown_timeout(Duration::from_secs(1));
+        let (mut client, mut events) = SignalFishClient::start(transport, config);
+
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Connected)
+        ));
+        wait_until(|| controls.entered_send.load(Ordering::Acquire)).await;
+        let completion = controls.clone();
+        let complete = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            completion.complete_send();
+        });
+        tokio::time::timeout(Duration::from_millis(250), client.shutdown())
+            .await
+            .expect("shutdown must preempt a pending send");
+        complete.await.unwrap();
+
+        assert!(controls.close_called.load(Ordering::Acquire));
+        assert!(!controls.abort_called.load(Ordering::Acquire));
+        assert!(!client.is_connected());
+    }
+
     async fn wait_until(condition: impl Fn() -> bool) {
         tokio::time::timeout(std::time::Duration::from_secs(5), async {
             while !condition() {
@@ -2402,6 +2710,138 @@ mod tests {
         wait_for_sent_len(&sent, 3).await;
 
         let mut client = Arc::into_inner(client).expect("all clones dropped");
+        client.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn reliable_json_game_data_does_not_cross_room_membership() {
+        assert_reliable_game_data_rejected_after_room_change(false, true).await;
+    }
+
+    #[tokio::test]
+    async fn reliable_binary_game_data_does_not_cross_room_membership() {
+        assert_reliable_game_data_rejected_after_room_change(true, true).await;
+    }
+
+    #[tokio::test]
+    async fn reliable_json_game_data_does_not_cross_initial_room_join() {
+        assert_reliable_game_data_rejected_after_room_change(false, false).await;
+    }
+
+    #[tokio::test]
+    async fn reliable_binary_game_data_does_not_cross_initial_room_join() {
+        assert_reliable_game_data_rejected_after_room_change(true, false).await;
+    }
+
+    async fn assert_reliable_game_data_rejected_after_room_change(
+        binary: bool,
+        initially_in_room: bool,
+    ) {
+        let (transport, entered_send, permits, sent) = GatedSendTransport::new(0);
+        let mut config = SignalFishConfig::new("mb_test")
+            .enable_v3()
+            .with_command_channel_capacity(1);
+        if binary {
+            config.game_data_format = Some(GameDataEncoding::MessagePack);
+        }
+        let (mut client, mut events) = SignalFishClient::start(transport, config);
+
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Connected)
+        ));
+        wait_until(|| entered_send.load(Ordering::Acquire)).await;
+
+        let joined = |room_id, player_id| {
+            ServerMessage::RoomJoined(Box::new(RoomJoinedPayload {
+                room_id,
+                room_code: "ROOM".into(),
+                player_id,
+                game_name: "game".into(),
+                max_players: 2,
+                supports_authority: false,
+                current_players: vec![],
+                is_authority: false,
+                lobby_state: LobbyState::Waiting,
+                ready_players: vec![],
+                relay_type: "relay".into(),
+                current_spectators: vec![],
+                ice_servers: vec![],
+                reconnection_token: None,
+            }))
+        };
+        {
+            let mut core = lock_core(&client.state);
+            let _ = core.process_frame(TransportFrame::Text(protocol_info_v3_json()));
+            if initially_in_room {
+                let room_a = serde_json::to_string(&joined(
+                    uuid::Uuid::from_u128(100),
+                    uuid::Uuid::from_u128(101),
+                ))
+                .unwrap();
+                let _ = core.process_frame(TransportFrame::Text(room_a));
+            }
+        }
+
+        client
+            .send_game_data(serde_json::json!({ "fills": "queue" }))
+            .expect("capacity-1 queue should accept one filler command");
+        let client = Arc::new(client);
+        let sender = Arc::clone(&client);
+        let mut reliable = tokio::spawn(async move {
+            if binary {
+                sender
+                    .send_binary_game_data_reliable(b"stale-room-binary".to_vec())
+                    .await
+            } else {
+                sender
+                    .send_game_data_reliable(serde_json::json!({
+                        "value": "stale-room-json"
+                    }))
+                    .await
+            }
+        });
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), &mut reliable)
+                .await
+                .is_err(),
+            "reliable game data should wait for queue capacity"
+        );
+
+        {
+            let mut core = lock_core(&client.state);
+            if initially_in_room {
+                let room_left = serde_json::to_string(&ServerMessage::RoomLeft).unwrap();
+                let _ = core.process_frame(TransportFrame::Text(room_left));
+            }
+            let room_b = serde_json::to_string(&joined(
+                uuid::Uuid::from_u128(200),
+                uuid::Uuid::from_u128(201),
+            ))
+            .unwrap();
+            let _ = core.process_frame(TransportFrame::Text(room_b));
+        }
+        permits.add_permits(16);
+        let result = tokio::time::timeout(Duration::from_secs(1), reliable)
+            .await
+            .expect("reliable game data should finish after capacity opens")
+            .expect("reliable game data task should not panic");
+        assert!(
+            matches!(result, Err(SignalFishError::NotInRoom)),
+            "room-A data must be rejected after joining room B: {result:?}"
+        );
+        wait_for_sent_len(&sent, 2).await;
+        {
+            let messages = sent.lock().unwrap();
+            assert!(
+                messages.iter().all(|message| {
+                    !message.contains("stale-room-json") && !message.contains("stale-room-binary")
+                }),
+                "stale room data must never reach the transport"
+            );
+        }
+
+        let mut client = Arc::into_inner(client).expect("all client clones should be dropped");
         client.shutdown().await;
     }
 
@@ -2563,6 +3003,142 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn reliable_signal_revalidates_generation_after_waiting_for_capacity() {
+        assert_waiting_signal_rejected_after_replan(
+            Some(uuid::Uuid::from_u128(12)),
+            Some(uuid::Uuid::from_u128(13)),
+            true,
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn reliable_signal_revalidates_generationless_plan_revision() {
+        assert_waiting_signal_rejected_after_replan(None, None, true).await;
+    }
+
+    #[tokio::test]
+    async fn reliable_signal_accepts_reasserted_generation() {
+        let generation = Some(uuid::Uuid::from_u128(12));
+        assert_waiting_signal_rejected_after_replan(generation, generation, false).await;
+    }
+
+    async fn assert_waiting_signal_rejected_after_replan(
+        original_generation: Option<SessionGeneration>,
+        replacement_generation: Option<SessionGeneration>,
+        should_reject: bool,
+    ) {
+        use crate::protocol::{SessionPeer, SessionPlanPayload, Topology, TransportKind};
+
+        let peer = uuid::Uuid::from_u128(5);
+        let (transport, entered_send, permits, sent) = GatedSendTransport::new(0);
+        let config = SignalFishConfig::new("mb_test")
+            .enable_mesh()
+            .with_command_channel_capacity(1);
+        let (mut client, mut events) = SignalFishClient::start(transport, config);
+
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Connected)
+        ));
+        wait_until(|| entered_send.load(Ordering::Acquire)).await;
+
+        let plan = |generation| {
+            ServerMessage::SessionPlan(Box::new(SessionPlanPayload {
+                generation,
+                topology: Topology::Mesh,
+                transport: TransportKind::WebRtc,
+                host: None,
+                direct_endpoint: None,
+                fallback: TransportKind::Relay,
+                peers: vec![SessionPeer {
+                    player_id: peer,
+                    player_name: "peer".into(),
+                    is_authority: false,
+                    initiate: true,
+                }],
+                ice_servers: vec![],
+            }))
+        };
+        {
+            let mut core = lock_core(&client.state);
+            let _ = core.process_frame(TransportFrame::Text(protocol_info_v3_json()));
+            let original = serde_json::to_string(&plan(original_generation))
+                .expect("original SessionPlan should serialize");
+            let _ = core.process_frame(TransportFrame::Text(original));
+        }
+
+        client
+            .send_game_data(serde_json::json!({ "fills": "queue" }))
+            .expect("capacity-1 queue should accept one filler command");
+        let client = Arc::new(client);
+        let sender = Arc::clone(&client);
+        let mut reliable = tokio::spawn(async move {
+            sender
+                .send_signal_reliable(peer, PeerSignal::Offer("fresh-sdp".into()))
+                .await
+        });
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), &mut reliable)
+                .await
+                .is_err(),
+            "reliable signal should still be waiting for queue capacity"
+        );
+
+        {
+            let mut core = lock_core(&client.state);
+            let replacement = serde_json::to_string(&plan(replacement_generation))
+                .expect("replacement SessionPlan should serialize");
+            let _ = core.process_frame(TransportFrame::Text(replacement));
+        }
+        permits.add_permits(16);
+        let result = tokio::time::timeout(Duration::from_secs(1), reliable)
+            .await
+            .expect("reliable signal should finish after capacity is available")
+            .expect("reliable signal task should not panic");
+        if should_reject {
+            assert!(
+                matches!(
+                    result,
+                    Err(SignalFishError::StaleSessionGeneration {
+                        attempted,
+                        current,
+                    }) if attempted == original_generation && current == replacement_generation
+                ),
+                "revalidation should report the captured and replacement generations: {result:?}"
+            );
+        } else {
+            assert!(
+                result.is_ok(),
+                "an idempotent plan reassertion is valid: {result:?}"
+            );
+        }
+        let expected_messages = if should_reject { 2 } else { 3 };
+        wait_for_sent_len(&sent, expected_messages).await;
+
+        let signal_count = {
+            let messages = sent.lock().unwrap();
+            messages
+                .iter()
+                .filter(|message| {
+                    matches!(
+                        serde_json::from_str::<ClientMessage>(message),
+                        Ok(ClientMessage::Signal { .. })
+                    )
+                })
+                .count()
+        };
+        assert_eq!(
+            signal_count,
+            usize::from(!should_reject),
+            "only a signal for the current logical plan may reach the wire"
+        );
+
+        let mut client = Arc::into_inner(client).expect("all client clones should be dropped");
+        client.shutdown().await;
+    }
+
+    #[tokio::test]
     async fn send_signal_reliable_reaches_wire_after_v3() {
         let (transport, sent, _closed) = MockTransport::new(vec![
             Some(Ok(authenticated_json())),
@@ -2616,26 +3192,30 @@ mod tests {
     struct HangingCloseTransport {
         incoming: VecDeque<Option<std::result::Result<String, SignalFishError>>>,
         close_called: Arc<AtomicBool>,
+        abort_called: Arc<AtomicBool>,
         dropped: Arc<AtomicBool>,
     }
 
     impl HangingCloseTransport {
-        fn new() -> (Self, Arc<AtomicBool>, Arc<AtomicBool>) {
+        fn new() -> (Self, Arc<AtomicBool>, Arc<AtomicBool>, Arc<AtomicBool>) {
             Self::with_incoming(Vec::new())
         }
 
         fn with_incoming(
             incoming: Vec<Option<std::result::Result<String, SignalFishError>>>,
-        ) -> (Self, Arc<AtomicBool>, Arc<AtomicBool>) {
+        ) -> (Self, Arc<AtomicBool>, Arc<AtomicBool>, Arc<AtomicBool>) {
             let close_called = Arc::new(AtomicBool::new(false));
+            let abort_called = Arc::new(AtomicBool::new(false));
             let dropped = Arc::new(AtomicBool::new(false));
             (
                 Self {
                     incoming: VecDeque::from(incoming),
                     close_called: Arc::clone(&close_called),
+                    abort_called: Arc::clone(&abort_called),
                     dropped: Arc::clone(&dropped),
                 },
                 close_called,
+                abort_called,
                 dropped,
             )
         }
@@ -2679,11 +3259,15 @@ mod tests {
             // shutdown timeout/abort path can be exercised.
             Poll::Pending
         }
+
+        fn abort(&mut self) {
+            self.abort_called.store(true, Ordering::Release);
+        }
     }
 
     #[tokio::test]
     async fn shutdown_timeout_aborts_stuck_transport_task() {
-        let (transport, close_called, dropped) = HangingCloseTransport::new();
+        let (transport, close_called, abort_called, dropped) = HangingCloseTransport::new();
         let config = SignalFishConfig::new("mb_test")
             .with_shutdown_timeout(std::time::Duration::from_millis(20));
         let (mut client, mut events) = SignalFishClient::start(transport, config);
@@ -2699,10 +3283,61 @@ mod tests {
             "transport.close() should have been attempted during graceful shutdown"
         );
         assert!(
+            abort_called.load(Ordering::Acquire),
+            "the transport loop should invoke abort after its close deadline"
+        );
+        assert!(
             dropped.load(Ordering::Acquire),
             "timed-out shutdown should abort and drop the transport loop task"
         );
         assert!(!client.is_connected());
+    }
+
+    #[tokio::test]
+    async fn terminal_event_precedes_a_hanging_transport_close() {
+        let (transport, close_called, abort_called, dropped) =
+            HangingCloseTransport::with_incoming(vec![None]);
+        let config = SignalFishConfig::new("mb_test")
+            .with_shutdown_timeout(std::time::Duration::from_millis(100));
+        let (mut client, mut events) = SignalFishClient::start(transport, config);
+
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Connected)
+        ));
+        let terminal = tokio::time::timeout(Duration::from_millis(50), events.recv())
+            .await
+            .expect("terminal event must not wait for graceful close")
+            .expect("terminal event channel must remain open");
+        assert!(matches!(terminal, SignalFishEvent::Disconnected { .. }));
+        assert!(!client.is_connected());
+        assert!(close_called.load(Ordering::Acquire));
+
+        client.shutdown().await;
+        assert!(abort_called.load(Ordering::Acquire));
+        assert!(dropped.load(Ordering::Acquire));
+    }
+
+    #[tokio::test]
+    async fn terminal_close_progresses_while_event_channel_is_full() {
+        let (transport, _sent, closed) = MockTransport::new(vec![None]);
+        let config = SignalFishConfig::new("mb_test").with_event_channel_capacity(1);
+        let (mut client, mut events) = SignalFishClient::start(transport, config);
+
+        // Connected occupies the only event slot. The terminal event cannot be
+        // admitted yet, but transport close must still progress independently.
+        wait_until(|| closed.load(Ordering::Acquire)).await;
+        assert!(!client.is_connected());
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Connected)
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Disconnected { .. })
+        ));
+
+        client.shutdown().await;
     }
 
     #[tokio::test]
@@ -3158,7 +3793,7 @@ mod tests {
     /// emit the event. Both outcomes (event received or not) are acceptable.
     #[tokio::test]
     async fn shutdown_abort_may_skip_disconnected_event() {
-        let (transport, _close_called, _dropped) = HangingCloseTransport::new();
+        let (transport, _close_called, _abort_called, _dropped) = HangingCloseTransport::new();
         let config = SignalFishConfig::new("mb_test")
             .with_shutdown_timeout(std::time::Duration::from_millis(1));
         let (mut client, mut events) = SignalFishClient::start(transport, config);
@@ -3195,10 +3830,11 @@ mod tests {
 
     #[tokio::test]
     async fn shutdown_abort_clears_auth_and_room_state() {
-        let (transport, _close_called, _dropped) = HangingCloseTransport::with_incoming(vec![
-            Some(Ok(authenticated_json())),
-            Some(Ok(room_joined_json())),
-        ]);
+        let (transport, _close_called, _abort_called, _dropped) =
+            HangingCloseTransport::with_incoming(vec![
+                Some(Ok(authenticated_json())),
+                Some(Ok(room_joined_json())),
+            ]);
         let config = SignalFishConfig::new("mb_test")
             .with_shutdown_timeout(std::time::Duration::from_millis(1));
         let (mut client, mut events) = SignalFishClient::start(transport, config);

--- a/src/client_core.rs
+++ b/src/client_core.rs
@@ -23,10 +23,18 @@ pub(crate) struct FrameOutcome {
     pub(crate) disconnect: bool,
 }
 
-#[derive(Debug)]
 pub(crate) enum CoreCommand {
     Message(ClientMessage),
     Binary(Vec<u8>),
+}
+
+impl std::fmt::Debug for CoreCommand {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::Message(_) => "Message",
+            Self::Binary(_) => "Binary",
+        })
+    }
 }
 
 pub(crate) enum ClientOperation {
@@ -51,6 +59,16 @@ pub(crate) enum ClientOperation {
 pub(crate) enum SignalGeneration {
     Current,
     Exact(Option<SessionGeneration>),
+    #[cfg(feature = "tokio-runtime")]
+    Bound {
+        generation: Option<SessionGeneration>,
+        plan_revision: u64,
+    },
+}
+
+#[cfg(feature = "tokio-runtime")]
+pub(crate) struct ReliableOperationBinding {
+    room_revision: Option<u64>,
 }
 
 impl FrameOutcome {
@@ -73,6 +91,10 @@ pub(crate) struct ClientCore {
     violation_policy: ProtocolViolationPolicy,
     accountability: DeliveryAccountability,
     session_plan_seen: bool,
+    #[cfg(feature = "tokio-runtime")]
+    session_plan_revision: u64,
+    #[cfg(feature = "tokio-runtime")]
+    room_revision: u64,
 }
 
 impl ClientCore {
@@ -106,6 +128,10 @@ impl ClientCore {
             violation_policy,
             accountability: DeliveryAccountability::new(false),
             session_plan_seen: false,
+            #[cfg(feature = "tokio-runtime")]
+            session_plan_revision: 0,
+            #[cfg(feature = "tokio-runtime")]
+            room_revision: 0,
         }
     }
 
@@ -151,11 +177,11 @@ impl ClientCore {
         self.snapshot.room_code.as_deref()
     }
 
-    pub(crate) fn prepare(&self, operation: ClientOperation) -> crate::error::Result<CoreCommand> {
+    pub(crate) fn validate(&self, operation: &ClientOperation) -> crate::error::Result<()> {
         if !self.is_connected() {
             return Err(crate::SignalFishError::NotConnected);
         }
-        match &operation {
+        match operation {
             ClientOperation::GameData(_, GameDataDelivery::Latest { .. })
             | ClientOperation::GameData(_, GameDataDelivery::Volatile)
             | ClientOperation::Binary(_)
@@ -169,6 +195,86 @@ impl ClientCore {
         {
             return Err(crate::SignalFishError::BinaryFormatNotNegotiated);
         }
+        match operation {
+            ClientOperation::Signal(_, requested_generation, _)
+            | ClientOperation::RawSignal(_, requested_generation, _) => {
+                if !self.session_plan_seen {
+                    return Err(crate::SignalFishError::SessionPlanUnavailable);
+                }
+                let (stale, attempted) = match requested_generation {
+                    SignalGeneration::Current => (false, None),
+                    SignalGeneration::Exact(generation) => {
+                        (*generation != self.snapshot.session_generation, *generation)
+                    }
+                    #[cfg(feature = "tokio-runtime")]
+                    SignalGeneration::Bound {
+                        generation,
+                        plan_revision,
+                    } => (
+                        *generation != self.snapshot.session_generation
+                            || (generation.is_none()
+                                && *plan_revision != self.session_plan_revision),
+                        *generation,
+                    ),
+                };
+                if stale {
+                    return Err(crate::SignalFishError::StaleSessionGeneration {
+                        attempted,
+                        current: self.snapshot.session_generation,
+                    });
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    #[cfg(feature = "tokio-runtime")]
+    pub(crate) fn bind_reliable_operation(
+        &self,
+        operation: &mut ClientOperation,
+    ) -> ReliableOperationBinding {
+        let room_scoped = matches!(
+            operation,
+            ClientOperation::GameData(..)
+                | ClientOperation::Binary(_)
+                | ClientOperation::Signal(..)
+                | ClientOperation::RawSignal(..)
+        );
+        match operation {
+            ClientOperation::Signal(_, generation, _)
+            | ClientOperation::RawSignal(_, generation, _) => {
+                if matches!(generation, SignalGeneration::Current) {
+                    *generation = SignalGeneration::Bound {
+                        generation: self.snapshot.session_generation,
+                        plan_revision: self.session_plan_revision,
+                    };
+                }
+            }
+            _ => {}
+        }
+        ReliableOperationBinding {
+            room_revision: room_scoped.then_some(self.room_revision),
+        }
+    }
+
+    #[cfg(feature = "tokio-runtime")]
+    pub(crate) fn prepare_reliable(
+        &self,
+        operation: ClientOperation,
+        binding: ReliableOperationBinding,
+    ) -> crate::error::Result<CoreCommand> {
+        if binding
+            .room_revision
+            .is_some_and(|revision| revision != self.room_revision)
+        {
+            return Err(crate::SignalFishError::NotInRoom);
+        }
+        self.prepare(operation)
+    }
+
+    pub(crate) fn prepare(&self, operation: ClientOperation) -> crate::error::Result<CoreCommand> {
+        self.validate(&operation)?;
         let message = match operation {
             ClientOperation::JoinRoom(params) => ClientMessage::JoinRoom {
                 game_name: params.game_name,
@@ -215,20 +321,11 @@ impl ClientCore {
             ClientOperation::LeaveSpectator => ClientMessage::LeaveSpectator,
             ClientOperation::Ping => ClientMessage::Ping,
             ClientOperation::Signal(to, requested_generation, signal) => {
-                if !self.session_plan_seen {
-                    return Err(crate::SignalFishError::SessionPlanUnavailable);
-                }
                 let generation = match requested_generation {
                     SignalGeneration::Current => self.snapshot.session_generation,
-                    SignalGeneration::Exact(generation) => {
-                        if generation != self.snapshot.session_generation {
-                            return Err(crate::SignalFishError::StaleSessionGeneration {
-                                attempted: generation,
-                                current: self.snapshot.session_generation,
-                            });
-                        }
-                        generation
-                    }
+                    SignalGeneration::Exact(generation) => generation,
+                    #[cfg(feature = "tokio-runtime")]
+                    SignalGeneration::Bound { generation, .. } => generation,
                 };
                 ClientMessage::Signal {
                     to,
@@ -237,20 +334,11 @@ impl ClientCore {
                 }
             }
             ClientOperation::RawSignal(to, requested_generation, signal) => {
-                if !self.session_plan_seen {
-                    return Err(crate::SignalFishError::SessionPlanUnavailable);
-                }
                 let generation = match requested_generation {
                     SignalGeneration::Current => self.snapshot.session_generation,
-                    SignalGeneration::Exact(generation) => {
-                        if generation != self.snapshot.session_generation {
-                            return Err(crate::SignalFishError::StaleSessionGeneration {
-                                attempted: generation,
-                                current: self.snapshot.session_generation,
-                            });
-                        }
-                        generation
-                    }
+                    SignalGeneration::Exact(generation) => generation,
+                    #[cfg(feature = "tokio-runtime")]
+                    SignalGeneration::Bound { generation, .. } => generation,
                 };
                 ClientMessage::Signal {
                     to,
@@ -568,8 +656,7 @@ impl ClientCore {
                         None
                     }
                 }) {
-                    self.snapshot.session_generation = generation;
-                    self.session_plan_seen = true;
+                    self.replace_session_plan(generation);
                 }
             }
             ServerMessage::SpectatorJoined(payload) => {
@@ -582,8 +669,7 @@ impl ClientCore {
             }
             ServerMessage::SpectatorLeft { .. } => self.clear_room(),
             ServerMessage::SessionPlan(payload) => {
-                self.snapshot.session_generation = payload.generation;
-                self.session_plan_seen = true;
+                self.replace_session_plan(payload.generation);
             }
             ServerMessage::GameData { .. } | ServerMessage::GameDataBinary { .. } => {
                 self.stats.game_data_received = self.stats.game_data_received.saturating_add(1);
@@ -606,6 +692,8 @@ impl ClientCore {
         self.snapshot.session_generation = None;
         self.snapshot.quarantined = false;
         self.session_plan_seen = false;
+        #[cfg(feature = "tokio-runtime")]
+        self.advance_room_revision();
     }
 
     fn clear_room(&mut self) {
@@ -616,5 +704,25 @@ impl ClientCore {
         self.snapshot.session_generation = None;
         self.snapshot.quarantined = false;
         self.session_plan_seen = false;
+        #[cfg(feature = "tokio-runtime")]
+        self.advance_room_revision();
+    }
+
+    fn replace_session_plan(&mut self, generation: Option<SessionGeneration>) {
+        self.snapshot.session_generation = generation;
+        self.session_plan_seen = true;
+        #[cfg(feature = "tokio-runtime")]
+        self.advance_session_plan_revision();
+    }
+
+    #[cfg(feature = "tokio-runtime")]
+    fn advance_session_plan_revision(&mut self) {
+        self.session_plan_revision = self.session_plan_revision.wrapping_add(1);
+    }
+
+    #[cfg(feature = "tokio-runtime")]
+    fn advance_room_revision(&mut self) {
+        self.room_revision = self.room_revision.wrapping_add(1);
+        self.advance_session_plan_revision();
     }
 }

--- a/src/mesh.rs
+++ b/src/mesh.rs
@@ -345,6 +345,29 @@ mod tests {
     }
 
     #[test]
+    fn debug_redacts_nested_ice_credentials() {
+        let secret = "mesh-turn-secret";
+        let mut s = MeshSession::new();
+        s.apply(&plan(
+            Topology::Mesh,
+            None,
+            vec![peer(1, true)],
+            vec![IceServer {
+                urls: vec![format!("turn://user:{secret}@relay.example")],
+                username: Some("mesh-user".into()),
+                credential: Some(secret.into()),
+            }],
+        ));
+
+        let output = format!("{s:?}");
+        assert!(!output.contains(secret), "debug output leaked: {output}");
+        assert!(
+            !output.contains("mesh-user"),
+            "debug output leaked: {output}"
+        );
+    }
+
+    #[test]
     fn exposes_generation_and_direct_endpoint() {
         let mut s = MeshSession::new();
         let generation = uuid(12);

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -215,7 +215,7 @@ pub enum MessageTransport {
 }
 
 /// Connection information for P2P establishment.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum ConnectionInfo {
     /// Direct IP:port connection (for Mirror, FishNet, Unity NetCode direct).
@@ -255,6 +255,21 @@ pub enum ConnectionInfo {
     /// Custom connection data (extensible for other types).
     #[serde(rename = "custom")]
     Custom { data: serde_json::Value },
+}
+
+impl std::fmt::Debug for ConnectionInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Relay credentials and WebRTC descriptions contain authentication
+        // material. Keep Debug useful for variant identification without
+        // exposing any variant payload.
+        f.write_str(match self {
+            Self::Direct { .. } => "ConnectionInfo::Direct",
+            Self::UnityRelay { .. } => "ConnectionInfo::UnityRelay",
+            Self::Relay { .. } => "ConnectionInfo::Relay",
+            Self::WebRTC { .. } => "ConnectionInfo::WebRTC",
+            Self::Custom { .. } => "ConnectionInfo::Custom",
+        })
+    }
 }
 
 /// Describes why a spectator state change occurred.
@@ -401,7 +416,7 @@ pub struct PlayerNameRulesPayload {
 ///
 /// `username`/`credential` are present only for TURN servers; bare STUN entries
 /// omit them, keeping the wire bytes minimal.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct IceServer {
     /// STUN/TURN URLs (e.g. `stun:stun.l.google.com:19302`).
     pub urls: Vec<String>,
@@ -411,6 +426,14 @@ pub struct IceServer {
     /// TURN credential (omitted for credential-less STUN servers).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub credential: Option<String>,
+}
+
+impl std::fmt::Debug for IceServer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // TURN URLs can embed userinfo, and both explicit fields are
+        // credentials. Callers can inspect them deliberately after matching.
+        f.write_str("IceServer { <credentials redacted> }")
+    }
 }
 
 /// A peer the recipient should connect to within a [`SessionPlanPayload`] (protocol v3).
@@ -445,7 +468,7 @@ pub struct DirectEndpoint {
 
 /// Payload for the `RoomJoined` server message.
 /// Boxed in `ServerMessage` to reduce enum size.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct RoomJoinedPayload {
     pub room_id: RoomId,
     pub room_code: String,
@@ -472,9 +495,15 @@ pub struct RoomJoinedPayload {
     pub reconnection_token: Option<String>,
 }
 
+impl std::fmt::Debug for RoomJoinedPayload {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("RoomJoinedPayload { <credentials redacted> }")
+    }
+}
+
 /// Payload for the `Reconnected` server message.
 /// Boxed in `ServerMessage` to reduce enum size.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct ReconnectedPayload {
     pub room_id: RoomId,
     pub room_code: String,
@@ -505,6 +534,12 @@ pub struct ReconnectedPayload {
     /// Fresh token replacing the consumed reconnect token (v3 only).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reconnection_token: Option<String>,
+}
+
+impl std::fmt::Debug for ReconnectedPayload {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("ReconnectedPayload { <credentials redacted> }")
+    }
 }
 
 /// Payload for the `SpectatorJoined` server message.
@@ -563,7 +598,7 @@ pub struct SessionPlanPayload {
 // ── Messages ────────────────────────────────────────────────────────
 
 /// Message types sent from client to server.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 #[serde(tag = "type", content = "data")]
 pub enum ClientMessage {
     /// Authenticate with App ID (MUST be first message).
@@ -688,8 +723,32 @@ pub enum ClientMessage {
     },
 }
 
+impl std::fmt::Debug for ClientMessage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Commands can carry reconnect/relay credentials, WebRTC handshake
+        // secrets, and arbitrary application data. Debug exposes only the
+        // exhaustive wire variant.
+        f.write_str(match self {
+            Self::Authenticate { .. } => "Authenticate",
+            Self::JoinRoom { .. } => "JoinRoom",
+            Self::LeaveRoom => "LeaveRoom",
+            Self::GameData { .. } => "GameData",
+            Self::AuthorityRequest { .. } => "AuthorityRequest",
+            Self::PlayerReady => "PlayerReady",
+            Self::ProvideConnectionInfo { .. } => "ProvideConnectionInfo",
+            Self::Ping => "Ping",
+            Self::Reconnect { .. } => "Reconnect",
+            Self::JoinAsSpectator { .. } => "JoinAsSpectator",
+            Self::LeaveSpectator => "LeaveSpectator",
+            Self::StartGame => "StartGame",
+            Self::Signal { .. } => "Signal",
+            Self::TransportStatus { .. } => "TransportStatus",
+        })
+    }
+}
+
 /// Message types sent from server to client.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 #[serde(tag = "type", content = "data")]
 pub enum ServerMessage {
     /// Authentication successful.
@@ -896,6 +955,46 @@ pub enum ServerMessage {
     },
     /// Exact delivery accountability (protocol v3 only).
     DeliveryReport(Box<DeliveryReportPayload>),
+}
+
+impl std::fmt::Debug for ServerMessage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Server frames can carry rotated reconnect tokens, TURN credentials,
+        // peer connection secrets, signaling values, and application data.
+        f.write_str(match self {
+            Self::Authenticated { .. } => "Authenticated",
+            Self::ProtocolInfo(_) => "ProtocolInfo",
+            Self::AuthenticationError { .. } => "AuthenticationError",
+            Self::RoomJoined(_) => "RoomJoined",
+            Self::RoomJoinFailed { .. } => "RoomJoinFailed",
+            Self::RoomLeft => "RoomLeft",
+            Self::PlayerJoined { .. } => "PlayerJoined",
+            Self::PlayerLeft { .. } => "PlayerLeft",
+            Self::GameData { .. } => "GameData",
+            Self::GameDataBinary { .. } => "GameDataBinary",
+            Self::AuthorityChanged { .. } => "AuthorityChanged",
+            Self::AuthorityResponse { .. } => "AuthorityResponse",
+            Self::LobbyStateChanged { .. } => "LobbyStateChanged",
+            Self::GameStarting { .. } => "GameStarting",
+            Self::Pong => "Pong",
+            Self::Reconnected(_) => "Reconnected",
+            Self::ReconnectionFailed { .. } => "ReconnectionFailed",
+            Self::PlayerReconnected { .. } => "PlayerReconnected",
+            Self::SpectatorJoined(_) => "SpectatorJoined",
+            Self::SpectatorJoinFailed { .. } => "SpectatorJoinFailed",
+            Self::SpectatorLeft { .. } => "SpectatorLeft",
+            Self::NewSpectatorJoined { .. } => "NewSpectatorJoined",
+            Self::SpectatorDisconnected { .. } => "SpectatorDisconnected",
+            Self::Error { .. } => "Error",
+            Self::Signal { .. } => "Signal",
+            Self::NewPeer { .. } => "NewPeer",
+            Self::SessionPlan(_) => "SessionPlan",
+            Self::PeerTransportStatus { .. } => "PeerTransportStatus",
+            Self::RelayStats { .. } => "RelayStats",
+            Self::GoingAway { .. } => "GoingAway",
+            Self::DeliveryReport(_) => "DeliveryReport",
+        })
+    }
 }
 
 /// Preserve omission as `None` while rejecting explicit `null`.

--- a/src/protocol/binary.rs
+++ b/src/protocol/binary.rs
@@ -7,7 +7,7 @@ use serde::Serialize;
 use super::{GameDataEncoding, PlayerId};
 
 /// The mandatory metadata carried by every protocol-v3 binary game-data frame.
-#[derive(Debug, Serialize, PartialEq, Eq)]
+#[derive(Serialize, PartialEq, Eq)]
 pub struct V3BinaryGameDataFrame {
     pub from_player: PlayerId,
     pub encoding: GameDataEncoding,
@@ -17,13 +17,35 @@ pub struct V3BinaryGameDataFrame {
     pub epoch: u32,
 }
 
+impl std::fmt::Debug for V3BinaryGameDataFrame {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("V3BinaryGameDataFrame")
+            .field("from_player", &self.from_player)
+            .field("encoding", &self.encoding)
+            .field("payload_bytes", &self.payload.len())
+            .field("seq", &self.seq)
+            .field("epoch", &self.epoch)
+            .finish()
+    }
+}
+
 /// The frozen protocol-v2 MessagePack game-data envelope.
-#[derive(Debug, Serialize, PartialEq, Eq)]
+#[derive(Serialize, PartialEq, Eq)]
 pub struct V2BinaryGameDataFrame {
     pub from_player: PlayerId,
     pub encoding: GameDataEncoding,
     #[serde(with = "serde_bytes")]
     pub payload: Vec<u8>,
+}
+
+impl std::fmt::Debug for V2BinaryGameDataFrame {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("V2BinaryGameDataFrame")
+            .field("from_player", &self.from_player)
+            .field("encoding", &self.encoding)
+            .field("payload_bytes", &self.payload.len())
+            .finish()
+    }
 }
 
 /// Strictly decode the frozen protocol-v2 MessagePack envelope.

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -40,7 +40,7 @@ use serde::{Deserialize, Serialize};
 /// assert_eq!(back, offer);
 /// # Ok::<(), serde_json::Error>(())
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum PeerSignal {
     /// An SDP offer.
     Offer(String),
@@ -48,6 +48,18 @@ pub enum PeerSignal {
     Answer(String),
     /// A single ICE candidate (trickle ICE).
     IceCandidate(String),
+}
+
+impl std::fmt::Debug for PeerSignal {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // SDP and ICE candidates contain handshake credentials and network
+        // metadata. Expose only the signal kind through ambient Debug logs.
+        f.write_str(match self {
+            Self::Offer(_) => "Offer",
+            Self::Answer(_) => "Answer",
+            Self::IceCandidate(_) => "IceCandidate",
+        })
+    }
 }
 
 impl From<PeerSignal> for serde_json::Value {

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -9,7 +9,7 @@ use std::task::{Context, Poll};
 use crate::error::SignalFishError;
 
 /// One complete signaling transport frame.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub enum TransportFrame {
     /// JSON protocol message.
     Text(String),
@@ -17,8 +17,22 @@ pub enum TransportFrame {
     Binary(Vec<u8>),
 }
 
+impl std::fmt::Debug for TransportFrame {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Frames can contain every credential and application payload in the
+        // protocol. Length is safe and still useful for transport diagnostics.
+        match self {
+            Self::Text(text) => f.debug_struct("Text").field("bytes", &text.len()).finish(),
+            Self::Binary(bytes) => f
+                .debug_struct("Binary")
+                .field("bytes", &bytes.len())
+                .finish(),
+        }
+    }
+}
+
 /// Structured metadata for a terminal transport close.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Clone, Default, PartialEq, Eq)]
 pub struct TransportCloseInfo {
     /// Protocol close code, when supplied by the peer.
     pub code: Option<u16>,
@@ -28,6 +42,18 @@ pub struct TransportCloseInfo {
     pub clean: Option<bool>,
     /// True when the peer initiated the close.
     pub initiated_by_peer: bool,
+}
+
+impl std::fmt::Debug for TransportCloseInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Close reasons are peer-controlled and can contain arbitrary text.
+        f.debug_struct("TransportCloseInfo")
+            .field("code", &self.code)
+            .field("has_reason", &self.reason.is_some())
+            .field("clean", &self.clean)
+            .field("initiated_by_peer", &self.initiated_by_peer)
+            .finish()
+    }
 }
 
 /// Scheduling and buffering diagnostics reported by a transport.
@@ -143,6 +169,7 @@ where
 
 /// Drive one transport send to completion from an async runtime.
 #[cfg(feature = "tokio-runtime")]
+#[cfg(test)]
 pub(crate) async fn send_frame<T: Transport + ?Sized>(
     transport: &mut T,
     frame: TransportFrame,
@@ -153,6 +180,7 @@ pub(crate) async fn send_frame<T: Transport + ?Sized>(
 
 /// Await one inbound transport frame.
 #[cfg(feature = "tokio-runtime")]
+#[cfg(test)]
 pub(crate) async fn recv_frame<T: Transport + ?Sized>(
     transport: &mut T,
 ) -> Option<Result<TransportFrame, SignalFishError>> {

--- a/src/transports/websocket.rs
+++ b/src/transports/websocket.rs
@@ -125,7 +125,6 @@ impl WebSocketConnectOptions {
 ///
 /// [`poll_recv`](Transport::poll_recv) preserves the WebSocket stream's partial
 /// receive state across `Poll::Pending` and registers the supplied waker.
-#[derive(Debug)]
 pub struct WebSocketTransport {
     stream: Option<WsStream>,
     closed: bool,
@@ -133,6 +132,21 @@ pub struct WebSocketTransport {
     send_started: bool,
     control_flush_pending: bool,
     peer_close_pending: bool,
+}
+
+impl std::fmt::Debug for WebSocketTransport {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // The stream codec can retain raw inbound/outbound protocol frames,
+        // and close reasons are peer-controlled. Expose state only.
+        f.debug_struct("WebSocketTransport")
+            .field("has_stream", &self.stream.is_some())
+            .field("closed", &self.closed)
+            .field("has_close_info", &self.close_info.is_some())
+            .field("send_started", &self.send_started)
+            .field("control_flush_pending", &self.control_flush_pending)
+            .field("peer_close_pending", &self.peer_close_pending)
+            .finish()
+    }
 }
 
 impl WebSocketTransport {
@@ -188,7 +202,7 @@ impl WebSocketTransport {
         }
 
         tracing::debug!(
-            url = %url,
+            secure = url.starts_with("wss://"),
             disable_nagle = options.disable_nagle,
             "connecting to WebSocket server"
         );
@@ -204,7 +218,10 @@ impl WebSocketTransport {
                     SignalFishError::Io(std::io::Error::new(kind, e))
                 })?;
 
-        tracing::info!(url = %url, "WebSocket connection established");
+        tracing::info!(
+            secure = url.starts_with("wss://"),
+            "WebSocket connection established"
+        );
 
         Ok(Self {
             stream: Some(stream),
@@ -361,7 +378,11 @@ impl Transport for WebSocketTransport {
                     return Poll::Ready(Some(Ok(TransportFrame::Binary(bytes.to_vec()))))
                 }
                 Message::Close(frame) => {
-                    tracing::debug!(?frame, "received WebSocket close frame");
+                    tracing::debug!(
+                        code = frame.as_ref().map(|frame| u16::from(frame.code)),
+                        has_reason = frame.as_ref().is_some_and(|frame| !frame.reason.is_empty()),
+                        "received WebSocket close frame"
+                    );
                     // Remember structured close metadata so the client can
                     // attribute the disconnect via `close_info()`.
                     if let Some(frame) = frame {
@@ -543,6 +564,30 @@ mod tests {
                 .expect("querying TCP_NODELAY on the loopback socket must succeed"),
             _ => panic!("a ws:// connection must use the plain (non-TLS) stream variant"),
         }
+    }
+
+    #[test]
+    fn debug_omits_stream_contents_and_peer_close_reason() {
+        let secret = "websocket-debug-secret";
+        let transport = WebSocketTransport {
+            stream: None,
+            closed: true,
+            close_info: Some(TransportCloseInfo {
+                reason: Some(secret.into()),
+                ..TransportCloseInfo::default()
+            }),
+            send_started: false,
+            control_flush_pending: false,
+            peer_close_pending: false,
+        };
+
+        let output = format!("{transport:?}");
+        assert!(!output.contains(secret), "debug output leaked: {output}");
+        assert_eq!(
+            output,
+            "WebSocketTransport { has_stream: false, closed: true, has_close_info: true, \
+             send_started: false, control_flush_pending: false, peer_close_pending: false }"
+        );
     }
 
     // ── Mock-stream tests ────────────────────────────────────────────────

--- a/src/webrtc.rs
+++ b/src/webrtc.rs
@@ -95,7 +95,7 @@ impl std::fmt::Debug for MeshWaker {
 }
 
 /// An output produced by a [`WebRtcDriver`], drained via [`WebRtcDriver::poll`].
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub enum DriverEvent {
     /// A locally-produced signal to relay to `peer` (offer, answer, or a
     /// trickled ICE candidate). The controller forwards it to the server.
@@ -132,8 +132,20 @@ pub enum DriverEvent {
     },
 }
 
+impl std::fmt::Debug for DriverEvent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Driver events can contain SDP/ICE credentials and application data.
+        f.write_str(match self {
+            Self::Signal { .. } => "Signal",
+            Self::Connected { .. } => "Connected",
+            Self::Disconnected { .. } => "Disconnected",
+            Self::Data { .. } => "Data",
+        })
+    }
+}
+
 /// A high-level event surfaced by the [`MeshController`].
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub enum MeshEvent {
     /// An underlying signaling event passed through verbatim (`RoomJoined`,
     /// `GameData`, `LobbyStateChanged`, etc.). Signaling events the controller
@@ -154,6 +166,17 @@ pub enum MeshEvent {
         /// The received bytes.
         data: Vec<u8>,
     },
+}
+
+impl std::fmt::Debug for MeshEvent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::Signaling(_) => "Signaling",
+            Self::PeerConnected(_) => "PeerConnected",
+            Self::PeerDisconnected(_) => "PeerDisconnected",
+            Self::Data { .. } => "Data",
+        })
+    }
 }
 
 #[cfg(feature = "tokio-runtime")]
@@ -789,6 +812,46 @@ mod tests {
         fn assert_send<T: Send>() {}
         assert_send::<MeshController<SharedDriver>>();
     };
+
+    #[test]
+    fn driver_and_mesh_event_debug_redact_signaling_and_data() {
+        let secret = "webrtc-event-secret";
+        let peer = uuid::Uuid::from_u128(1);
+        let outputs = [
+            format!(
+                "{:?}",
+                DriverEvent::Signal {
+                    peer,
+                    generation: None,
+                    signal: PeerSignal::Offer(secret.into()),
+                }
+            ),
+            format!(
+                "{:?}",
+                DriverEvent::Data {
+                    peer,
+                    generation: None,
+                    data: secret.as_bytes().to_vec(),
+                }
+            ),
+            format!(
+                "{:?}",
+                MeshEvent::Data {
+                    from: peer,
+                    data: secret.as_bytes().to_vec(),
+                }
+            ),
+        ];
+        let binary_secret = format!("{:?}", secret.as_bytes());
+
+        for output in outputs {
+            assert!(!output.contains(secret), "debug output leaked: {output}");
+            assert!(
+                !output.contains(&binary_secret),
+                "debug output leaked binary bytes: {output}"
+            );
+        }
+    }
 
     // ── A recording mock driver ─────────────────────────────────────
 

--- a/tests/protocol_tests.rs
+++ b/tests/protocol_tests.rs
@@ -18,9 +18,11 @@ use signal_fish_client::protocol::{
     PeerConnectionInfo, PlayerInfo, PlayerNameRulesPayload, ProtocolInfoPayload, RateLimitInfo,
     ReconnectedPayload, RelayTransport, RoomJoinedPayload, ServerMessage, SessionPeer,
     SessionPlanPayload, SpectatorInfo, SpectatorJoinedPayload, SpectatorStateChangeReason,
-    Topology, TransportKind,
+    Topology, TransportKind, V2BinaryGameDataFrame, V3BinaryGameDataFrame,
 };
 use signal_fish_client::PeerSignal;
+use signal_fish_client::TransportCloseInfo;
+use signal_fish_client::TransportFrame;
 
 // ════════════════════════════════════════════════════════════════════
 // Helper
@@ -2548,4 +2550,188 @@ fn error_code_display_returns_description() {
     let code = ErrorCode::RoomNotFound;
     let display = format!("{code}");
     assert_eq!(display, code.description());
+}
+
+#[test]
+fn debug_redacts_credentials_signaling_and_application_payloads_transitively() {
+    const SECRETS: &[&str] = &[
+        "reconnect-secret",
+        "relay-secret",
+        "unity-key-secret",
+        "turn-secret",
+        "sdp-ice-secret",
+        "application-secret",
+    ];
+    let assert_redacted = |debug: String| {
+        for secret in SECRETS {
+            assert!(
+                !debug.contains(secret),
+                "Debug output exposed secret {secret:?}: {debug}"
+            );
+        }
+        assert!(
+            !debug.contains(&format!("{:?}", b"application-secret")),
+            "Debug output exposed binary application bytes: {debug}"
+        );
+    };
+
+    let relay = ConnectionInfo::Relay {
+        host: "relay.example".into(),
+        port: 7777,
+        transport: RelayTransport::Udp,
+        allocation_id: "allocation".into(),
+        token: "relay-secret".into(),
+        client_id: Some(7),
+    };
+    let unity = ConnectionInfo::UnityRelay {
+        allocation_id: "allocation".into(),
+        connection_data: "connection-data".into(),
+        key: "unity-key-secret".into(),
+    };
+    let ice = IceServer {
+        urls: vec!["turn:turn-secret@example.test".into()],
+        username: Some("turn-user".into()),
+        credential: Some("turn-secret".into()),
+    };
+    let player = PlayerInfo {
+        id: test_uuid(1),
+        name: "player".into(),
+        is_authority: false,
+        is_ready: true,
+        connected_at: "now".into(),
+        connection_info: Some(relay.clone()),
+        epoch: None,
+        seq: None,
+    };
+    let peer = PeerConnectionInfo {
+        player_id: test_uuid(2),
+        player_name: "peer".into(),
+        is_authority: false,
+        relay_type: "relay".into(),
+        connection_info: Some(unity.clone()),
+    };
+    let plan = SessionPlanPayload {
+        generation: Some(test_uuid(3)),
+        topology: Topology::Mesh,
+        transport: TransportKind::WebRtc,
+        host: None,
+        direct_endpoint: None,
+        peers: vec![],
+        ice_servers: vec![ice.clone()],
+        fallback: TransportKind::Relay,
+    };
+    let joined = RoomJoinedPayload {
+        room_id: test_uuid(4),
+        room_code: "ROOM".into(),
+        player_id: test_uuid(5),
+        game_name: "game".into(),
+        max_players: 2,
+        supports_authority: false,
+        current_players: vec![player.clone()],
+        is_authority: false,
+        lobby_state: LobbyState::Waiting,
+        ready_players: vec![],
+        relay_type: "relay".into(),
+        current_spectators: vec![],
+        ice_servers: vec![ice.clone()],
+        reconnection_token: Some("reconnect-secret".into()),
+    };
+    let reconnected = ReconnectedPayload {
+        room_id: test_uuid(4),
+        room_code: "ROOM".into(),
+        player_id: test_uuid(5),
+        game_name: "game".into(),
+        max_players: 2,
+        supports_authority: false,
+        current_players: vec![player.clone()],
+        is_authority: false,
+        lobby_state: LobbyState::Waiting,
+        ready_players: vec![],
+        relay_type: "relay".into(),
+        current_spectators: vec![],
+        ice_servers: vec![ice.clone()],
+        missed_events: vec![],
+        replay: None,
+        sender_watermarks: vec![],
+        reconnection_token: Some("reconnect-secret".into()),
+    };
+
+    let outputs = [
+        format!("{relay:?}"),
+        format!("{unity:?}"),
+        format!("{ice:?}"),
+        format!("{player:?}"),
+        format!("{peer:?}"),
+        format!("{plan:?}"),
+        format!("{joined:?}"),
+        format!("{reconnected:?}"),
+        format!(
+            "{:?}",
+            ClientMessage::Reconnect {
+                player_id: test_uuid(5),
+                room_id: test_uuid(4),
+                auth_token: "reconnect-secret".into(),
+            }
+        ),
+        format!(
+            "{:?}",
+            ClientMessage::Signal {
+                to: test_uuid(2),
+                generation: Some(test_uuid(3)),
+                signal: serde_json::json!({ "Offer": "sdp-ice-secret" }),
+            }
+        ),
+        format!("{:?}", ServerMessage::RoomJoined(Box::new(joined))),
+        format!(
+            "{:?}",
+            ServerMessage::GameStarting {
+                peer_connections: vec![peer],
+            }
+        ),
+        format!(
+            "{:?}",
+            ServerMessage::GameData {
+                from_player: test_uuid(2),
+                data: serde_json::json!({ "value": "application-secret" }),
+                seq: None,
+                epoch: None,
+                class: None,
+                key: None,
+            }
+        ),
+        format!("{:?}", PeerSignal::Offer("sdp-ice-secret".into())),
+        format!("{:?}", TransportFrame::Text("application-secret".into())),
+        format!(
+            "{:?}",
+            TransportFrame::Binary(b"application-secret".to_vec())
+        ),
+        format!(
+            "{:?}",
+            V2BinaryGameDataFrame {
+                from_player: test_uuid(2),
+                encoding: GameDataEncoding::MessagePack,
+                payload: b"application-secret".to_vec(),
+            }
+        ),
+        format!(
+            "{:?}",
+            V3BinaryGameDataFrame {
+                from_player: test_uuid(2),
+                encoding: GameDataEncoding::MessagePack,
+                payload: b"application-secret".to_vec(),
+                seq: 1,
+                epoch: 1,
+            }
+        ),
+        format!(
+            "{:?}",
+            TransportCloseInfo {
+                reason: Some("application-secret".into()),
+                ..TransportCloseInfo::default()
+            }
+        ),
+    ];
+    for output in outputs {
+        assert_redacted(output);
+    }
 }

--- a/tests/protocol_tests.rs
+++ b/tests/protocol_tests.rs
@@ -2656,6 +2656,20 @@ fn debug_redacts_credentials_signaling_and_application_payloads_transitively() {
         reconnection_token: Some("reconnect-secret".into()),
     };
 
+    for (debug, safe_marker) in [
+        (format!("{relay:?}"), "ConnectionInfo::Relay"),
+        (format!("{ice:?}"), "IceServer"),
+        (format!("{joined:?}"), "RoomJoinedPayload"),
+        (format!("{reconnected:?}"), "ReconnectedPayload"),
+        (format!("{:?}", ClientMessage::Ping), "Ping"),
+        (format!("{:?}", ServerMessage::Pong), "Pong"),
+    ] {
+        assert!(
+            debug.contains(safe_marker),
+            "Debug output omitted safe structural marker {safe_marker:?}: {debug:?}"
+        );
+    }
+
     let outputs = [
         format!("{relay:?}"),
         format!("{unity:?}"),


### PR DESCRIPTION
## Summary

- complete the issue #97 correctness code study across protocol/state, public API, transport/network, pinned Server 0.7 parity, and unexpected-input behavior
- fence async reliable operations across command-queue waits so stale signaling is never relabeled and JSON/binary game data cannot cross membership transitions
- make the async transport loop bidirectionally live while sends are pending, complete backend-owned sends before bounded close, and progress close independently of terminal-event backpressure
- redact the full credential/application-payload class from public `Debug` and built-in WebSocket tracing without changing serde/wire shapes or public field access
- record the evidence matrix and decompose every unresolved finding into #99–#107
- record successful root Dependabot hosted proof and close completed #95

## Correctness defects fixed

### Reliable queue admission

Reliable sends now validate before waiting and again under a reserved queue permit. Current-plan signaling is frozen to its originating generation; a private plan revision handles Server 0.4-compatible generation-less plans. A private room revision fences every room-scoped reliable operation, including pre-room calls, across RoomJoined/Reconnected/leave/rejoin transitions.

Saturated-queue tests cover changed UUID rejection, generation-less re-plan rejection, idempotent same-UUID acceptance, pre-room→join and room-A→room-B JSON/binary rejection, and no stale frame reaching the transport.

### Async transport liveness

The driver retains one pending frame and polls send/receive with the same real waker. Peer EOF, receive errors, and shutdown remain visible while a backend owns an incomplete send. Graceful termination completes accepted sends before close under one deadline, invokes `Transport::abort` on expiry, and lets close progress concurrently with a full terminal event channel. Peer-initiated close metadata remains authoritative when the same close refuses an in-flight send, and error reasons are normalized once.

### Diagnostic safety

Custom Debug implementations now protect reconnect/relay/TURN credentials, SDP/ICE, opaque application data, binary envelopes, buffered WebSocket state, and peer close reasons across direct and transitive wrappers. Native WebSocket tracing no longer logs full credential-bearing URLs or close text. Trait availability and wire serialization are unchanged.

## Study follow-ups

- #99 lifecycle/version scope, semantic SessionPlan validation, signal membership
- #100 effective game-data encoding negotiation
- #101 atomic reconnect/accountability/snapshot restoration
- #102 mesh capability/controller/liveness semantics
- #103 membership identity and local operation guards
- #104 readiness phases and ClientStats counting points
- #105 bounded WebSocket control work and terminal EOF
- #106 enforceable custom Transport abort contract
- #107 datagram/UDP scope and resilience

## Validation

- `cargo fmt && cargo clippy --workspace --all-targets --all-features -- -D warnings && cargo test --workspace --all-features`
- polling-only Clippy with `-D warnings`
- panic-free source policy
- all 18 pre-commit checks
- three independent audits and repeated adversarial reviews with zero remaining findings in the implemented scope
- final PR head `ff7caf6`: all 12 project workflows green, including Deep Safety mutation/fuzz/Miri and the complete Godot Web clean/impaired/soak matrix
- 53 successful check runs, two intentional skips, and Cursor Bugbot green with its only actionable thread resolved

Five local live-server E2E cases remain intentionally ignored and are delegated to hosted blocking workflows.

## Governance

Issue #90 remains an external maintainer-administration blocker: the live ruleset does not enforce the checked-in approval/required-check policy, the repository has no eligible independent reviewer beyond the PR author, and Copilot fails before analysis because the requester quota is exhausted. That quota-only result is the sole red check; this PR remains intentionally unmerged until the live policy/reviewer prerequisites are repaired.

Fixes #97.
Refs #99, #100, #101, #102, #103, #104, #105, #106, #107.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core async I/O, session-generation signaling, and room-scoped game data—areas where subtle bugs could leak stale wire traffic or stall shutdown; changes are heavily regression-tested but affect security-sensitive diagnostics and connection lifecycle.
> 
> **Overview**
> Closes the issue #97 correctness study with three hardening slices and documentation that records Dependabot root-workspace proof and follow-ups **#99–#107**.
> 
> **Reliable async sends** now validate before queue wait and again after reserving capacity. Session-plan **generation** and **room membership** are frozen at call start so stale WebRTC signaling cannot be relabeled after a re-plan and JSON/binary game data cannot cross leave/join boundaries.
> 
> The **async transport loop** keeps one in-flight send and polls send/receive together so backpressure cannot hide inbound frames, peer close, or shutdown. Graceful shutdown finishes accepted sends under a deadline, calls `Transport::abort` on expiry, and lets disconnect events and close progress run concurrently (a full event channel no longer blocks close forever).
> 
> **Public `Debug` and WebSocket tracing** no longer emit credentials, SDP/ICE, payloads, or peer close text—only safe variant/state/length metadata; serde wire shapes are unchanged. Regressions cover saturated-queue admission, transport liveness, and transitive redaction (including Godot close metadata).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f41281feb31be9ba13152d7d6afe01b50d899932. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->