### PR TITLE
fix!: make negotiation and reconnect state transactional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,12 @@ jobs:
           - server_version: "0.7.0"
             server_sha256: "70c6d12ac77843038c96d374a91225825c685cbf65fd7bedfd26b08d4003af7e"
             test_name: e2e_server_070_generation_signal_and_host_replan
+          - server_version: "0.7.0"
+            server_sha256: "70c6d12ac77843038c96d374a91225825c685cbf65fd7bedfd26b08d4003af7e"
+            test_name: e2e_server_070_rkyv_request_resolves_to_json
+          - server_version: "0.7.0"
+            server_sha256: "70c6d12ac77843038c96d374a91225825c685cbf65fd7bedfd26b08d4003af7e"
+            test_name: e2e_reconnect_after_disconnect_uses_server_token
           - server_version: "0.4.0"
             server_sha256: "971410b9503dd2f0c9f69c8a0a97e043e3979c79bf3d305e2ad03e21da8584e9"
             test_name: e2e_server_040_generationless_mesh_signal

--- a/.llm/context.md
+++ b/.llm/context.md
@@ -409,6 +409,11 @@ lifecycle/plan/signal offenders are always suppressed; delivery-accountability
 new authoritative room/reconnect snapshot. `Pong` remains connection-scoped
 while authentication and protocol negotiation are still in flight.
 
+Requested game-data format preserves omission; effective format resolves from
+the first canonical Server 0.7 `ProtocolInfo`, with unsupported requests using
+JSON. V3 reconnects require replay, complete watermarks, and a rotated token;
+v2 exposes none. `Reconnected` fences peers until a fresh live `SessionPlan`.
+
 ### No Heavy Dependencies
 
 No `chrono` (timestamps remain `String` from the server), no `bytes` (binary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `SignalFishPollingClient`, and `SignalFishClientApi`, so custom drivers can
   atomically refuse stale output when a replacement session plan races their
   event loop.
+- Added `ClientSnapshot::{requested_game_data_format,
+  effective_game_data_format}` and matching async, polling, and
+  `SignalFishClientApi` accessors. Configuration omission now remains visible
+  separately from the format selected by the server.
 
 ### Changed
 
@@ -43,8 +47,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   plan, and never routes `Direct` or `Relay` plans through a WebRTC driver.
   Protocol-v3 signal sends before the first `SessionPlan` now fail locally.
   Generation-less server 0.4 plans and signals remain supported adaptively.
+- **Breaking:** the exhaustive `ClientSnapshot` struct has two new game-data
+  negotiation fields. `SignalFishClientApi` provides corresponding default
+  requested/effective format accessors through `snapshot()`.
+- Reconnect is now a hard WebRTC plan boundary: `MeshSession` and
+  `MeshController` clear the previous plan and driver peers at `Reconnected`,
+  then wait for Server 0.7's fresh live `SessionPlan` before authorizing new
+  signaling.
 
 ### Fixed
+
+- Fixed game-data encoding being treated as one mutable requested/effective
+  value. The shared core now resolves the first canonical Server 0.7
+  `ProtocolInfo.game_data_formats` atomically, preserves the configured request,
+  ignores the earlier unsupported-format advisory for state selection, validates
+  binary envelopes and outbound admission against the effective format, and
+  refuses fallback binary sends before transport admission. JSON-origin text
+  relays remain valid for MessagePack recipients, matching the server
+  materializer. Async, polling, and pinned Server 0.7 tests cover supported
+  MessagePack and unsupported Rkyv fallback.
+- Fixed malformed `Reconnected` baselines being applied under `Observe` and v3
+  payloads accepting missing replay/token metadata. Reconnect validation is now
+  version-strict and transactional: v3 requires replay status, a nonempty token
+  rotated from the submitted credential, exact player stamps, and complete
+  matching watermarks; v2 rejects those v3-only fields. Non-replayable nested
+  protocol/session messages remain rejected, and stale driver output is fenced
+  until the fresh post-reconnect plan.
 
 - Fixed decoded server messages being accepted outside their negotiated
   lifecycle/version phase, malformed authoritative session plans replacing

--- a/PLAN.md
+++ b/PLAN.md
@@ -118,16 +118,26 @@ Lifecycle/plan/signaling-invalid frames are observable but transactional under
 every policy; async and polling drivers retain identical behavior. Session 027
 records the rule-to-test/source matrix and verification evidence.
 
-## Next Correctness Milestone — Negotiation and Reconnect State
+## Current Correctness Milestone — Negotiation and Reconnect State
 
-Continue with #100 and #101.
+Issues #100 and #101 are implemented together for review because both depend on
+the first authoritative `ProtocolInfo` and reconnect state transaction.
 
-- Track negotiated effective game-data encoding separately from the requested
-  preference.
-- Make reconnect restoration atomic across negotiation, accountability,
-  membership, and plan state.
-- Continue correctness work through #102–#107 before usability, performance,
-  token binding, or presentation milestones.
+- Requested and effective game-data formats are distinct public state. The
+  shared core resolves Server 0.7's canonical format advertisement atomically,
+  and async/polling plus pinned-server evidence covers supported and fallback
+  paths before transport admission.
+- Reconnect restoration is version-strict and transactional across replay,
+  token rotation, accountability, membership, and plan state under every
+  violation policy. The old WebRTC plan is fenced until Server 0.7's fresh live
+  post-reconnect plan arrives.
+- Session 028 records the rule-to-source-to-test matrix and local pinned-server
+  evidence. Hosted review and aggregate checks remain the completion gate.
+
+## Next Correctness Milestone — Delivery Semantics and Liveness
+
+Continue with #102, then #105, #103, #104, #106, and #107 before usability,
+performance, token binding, or presentation milestones.
 
 ## Following Milestone — Negotiated Token Binding
 

--- a/docs/client.md
+++ b/docs/client.md
@@ -36,7 +36,7 @@ let config = SignalFishConfig::new("mb_app_abc123");
 | `app_id` | `String` | *(required)* | Public App ID that identifies the game application. |
 | `sdk_version` | `Option<String>` | Crate version at compile time | SDK version string sent during authentication. |
 | `platform` | `Option<String>` | `None` | Platform identifier (e.g. `"unity"`, `"godot"`, `"rust"`). |
-| `game_data_format` | `Option<GameDataEncoding>` | `None` | Preferred game data encoding format (`Json`, `MessagePack`, or `Rkyv`). |
+| `game_data_format` | `Option<GameDataEncoding>` | `None` | Requested game-data encoding (`Json`, `MessagePack`, or reserved `Rkyv`). The effective wire format is resolved from the first authoritative `ProtocolInfo`; omission and unsupported requests resolve to JSON on Server 0.7. |
 | `protocol_version` | `Option<u16>` | `None` | Highest signaling protocol version advertised. `None` preserves the v2 relay floor. Prefer `enable_v3()` or `enable_mesh()` over setting this alone. |
 | `supported_transports` | `Option<Vec<TransportKind>>` | `None` | Protocol-v3 data-path transports the application can actually fulfill. |
 | `supported_topologies` | `Option<Vec<Topology>>` | `None` | Protocol-v3 session topologies the application can participate in. |
@@ -398,10 +398,13 @@ the selected server delivery class.
 `send_binary_game_data(payload)` queues a physical WebSocket binary
 frame; `send_binary_game_data_reliable` waits for local queue capacity. Binary
 frames use the protocol-reliable delivery path and require v3 negotiation.
-They also require a binary `game_data_format`; the default/JSON format returns
-`BinaryFormatNotNegotiated` before anything is queued. If the server reports an
-unsupported requested format and falls back to JSON, subsequent binary sends
-fail the same way.
+They also require an effectively negotiated binary format; the default/JSON
+format returns `BinaryFormatNotNegotiated` before anything is queued. The
+client resolves this from `ProtocolInfo.game_data_formats`, not from the
+earlier advisory `UnsupportedGameDataFormat` error. An unsupported request
+(including Server 0.7's reserved `Rkyv`) resolves to JSON, so binary sends fail
+locally even when that advisory arrives before `Authenticated` and
+`ProtocolInfo`.
 Inbound envelopes are decoded strictly; malformed maps, duplicate or missing
 fields, invalid UUID representation, zero stamps, and trailing bytes surface as
 bounded `DecodeFailed` events.
@@ -521,7 +524,17 @@ Use the `player_id` and `room_id` from the original `RoomJoined` event and the
 server-issued token from `client.snapshot().reconnection_token`. A successful
 `Reconnected` response rotates the token; read and persist the replacement
 snapshot before another unexpected disconnect. Tokens are connection secrets:
-do not log them.
+do not log them. Terminal reconnect responses must match the player, room, and
+credential of an admitted `Reconnect` command. Under v3, the client accepts a
+reconnect baseline only when it contains replay status, a nonempty rotated
+token, exact player stamps, and sender watermarks covering the complete
+current-player snapshot. Malformed
+baselines are never applied, including under `ProtocolViolationPolicy::Observe`.
+
+Reconnect is also a hard session-plan boundary. The old generation and peer
+set are fenced immediately, and Server 0.7 follows `Reconnected` with a fresh
+live `SessionPlan` for a finalized room. `ProtocolInfo`, `SessionPlan`, signals,
+and game data are not legal `missed_events` replay entries.
 
 ---
 
@@ -545,17 +558,20 @@ Useful for keeping the connection alive through proxies or load balancers.
 
 `snapshot()` synchronously returns one coherent `ClientSnapshot`, including
 connection/authentication state, room/player IDs, room code, the latest
-reconnection token, negotiated protocol version, current session generation,
-and whether delivery is quarantined. Prefer it whenever multiple fields must
-describe the same instant.
+reconnection token, requested and effective game-data formats, negotiated
+protocol version, current session generation, and whether delivery is
+quarantined. Prefer it whenever multiple fields must describe the same instant.
 
-Synchronous accessors use atomics; async accessors acquire an internal mutex.
+Synchronous snapshot and negotiation accessors briefly lock the shared core;
+the async room-ID accessors acquire the same internal mutex.
 
 | Method | Signature | Description |
 |---|---|---|
 | `is_connected()` | `fn is_connected(&self) -> bool` | Returns `true` if the transport is believed to be connected. |
 | `is_authenticated()` | `fn is_authenticated(&self) -> bool` | Returns `true` if the server has confirmed authentication. |
 | `snapshot()` | `fn snapshot(&self) -> ClientSnapshot` | Returns coherent session, reconnect-token, negotiation, and quarantine state. |
+| `requested_game_data_format()` | `fn requested_game_data_format(&self) -> Option<GameDataEncoding>` | Exact preference supplied in `SignalFishConfig`, preserving omission. |
+| `effective_game_data_format()` | `fn effective_game_data_format(&self) -> Option<GameDataEncoding>` | Server-selected format; `None` before valid `ProtocolInfo` or after disconnect. |
 | `current_room_id()` | `async fn current_room_id(&self) -> Option<RoomId>` | Returns the current room ID, if in a room. |
 | `current_player_id()` | `async fn current_player_id(&self) -> Option<PlayerId>` | Returns the current player ID, if assigned by the server. |
 | `current_room_code()` | `async fn current_room_code(&self) -> Option<String>` | Returns the current room code, if in a room. |
@@ -756,6 +772,8 @@ All accessors are **synchronous** (no async, no mutex):
 | `is_authenticated()` | `bool` | Whether the server confirmed authentication. |
 | `is_closing()` | `bool` | Whether `poll()` must continue driving a close lifecycle. |
 | `negotiated_protocol_version()` | `Option<u16>` | Negotiated v3-or-newer version; `None` before `ProtocolInfo` or on the v2 floor. |
+| `requested_game_data_format()` | `Option<GameDataEncoding>` | Exact configured preference, preserving omission. |
+| `effective_game_data_format()` | `Option<GameDataEncoding>` | Server-selected format; `None` before valid `ProtocolInfo` or after disconnect. |
 | `supports_mesh()` | `bool` | Whether WebRTC was advertised and protocol v3 was negotiated. |
 | `current_player_id()` | `Option<PlayerId>` | Current player ID, if assigned. |
 | `current_room_id()` | `Option<RoomId>` | Current room ID, if in a room. |

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -35,7 +35,7 @@ variants**:
 | `ProtocolUnsupported` | `mode: &'static str` | A protocol-v3-only operation (classified latest/volatile JSON, binary game data, signaling, or transport-status reporting) was attempted before v3 was negotiated. `mode` is `"pre-negotiation"` (no `ProtocolInfo` yet — negotiation still in flight) or `"relay-only"` (a `ProtocolInfo` arrived but negotiated v2, the terminal relay floor). See [Protocol Versioning](protocol-versioning.md#the-fail-fast-guard). |
 | `SessionPlanUnavailable` | — | No authoritative WebRTC plan currently authorizes the signal: no plan has arrived, or the target is self, unknown, departed, or absent from the replace-on-plan peer set/current room roster. The set may be extended by a valid compatibility `NewPeer`; the frame is refused locally. |
 | `StaleSessionGeneration` | `attempted: Option<SessionGeneration>`, `current: Option<SessionGeneration>` | A generation-bound driver signal was produced after its session plan had been replaced. The client refuses it rather than relabeling stale signaling. |
-| `BinaryFormatNotNegotiated` | — | A binary send was attempted on a connection using the default JSON game-data format. Request `MessagePack` (or a future server-supported binary encoding) in `SignalFishConfig::game_data_format`. |
+| `BinaryFormatNotNegotiated` | — | A binary send was attempted after negotiation resolved to JSON. Request `MessagePack` and confirm `effective_game_data_format() == Some(MessagePack)`; unsupported requests resolve to JSON and are refused before transport admission. Before `ProtocolInfo`, v3-only sends return `ProtocolUnsupported` instead. |
 | `Timeout` | — | An operation timed out. |
 | `Io` | `std::io::Error` | An I/O error occurred. Implements `From<std::io::Error>`. |
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -82,7 +82,13 @@ pub enum GameDataEncoding {
 |---------|-----------|-------------|
 | `Json` | `"json"` | JSON payloads delivered over text frames (default). |
 | `MessagePack` | `"message_pack"` | MessagePack binary payloads delivered over binary frames. |
-| `Rkyv` | `"rkyv"` | Rkyv zero-copy binary format. **Reserved:** the current server never negotiates rkyv — requesting it silently downgrades to JSON. |
+| `Rkyv` | `"rkyv"` | Rkyv zero-copy binary format. **Reserved:** Server 0.7 never advertises it; requesting it produces an `UnsupportedGameDataFormat` advisory and resolves to JSON. |
+
+Server 0.7 advertises exactly `[Json]` or `[Json, MessagePack]`. The first valid
+`ProtocolInfo` atomically resolves the client's effective format: a requested
+advertised format wins, while omission or an unsupported request resolves to
+JSON. The earlier unsupported-format error is advisory and does not mutate the
+negotiated state.
 
 ---
 
@@ -377,7 +383,7 @@ pub struct ProtocolInfoPayload {
 | `recommended_version` | `Option<String>` | Recommended SDK version. |
 | `capabilities` | `Vec<String>` | List of server-supported capability flags. |
 | `notes` | `Option<String>` | Freeform notes from the server (e.g. deprecation warnings). |
-| `game_data_formats` | `Vec<GameDataEncoding>` | Game-data encodings the server supports. |
+| `game_data_formats` | `Vec<GameDataEncoding>` | Ordered server-supported encodings. Server 0.7 emits exactly `[Json]` or `[Json, MessagePack]`; malformed, empty, duplicate, or reordered lists are rejected transactionally. |
 | `player_name_rules` | `Option<PlayerNameRulesPayload>` | Validation rules for player names (if enforced). |
 | `protocol_version` | `Option<u16>` | **Protocol v3+.** The negotiated protocol version. `None` for a v2 negotiation, keeping v2 bytes identical. |
 | `min_protocol_version` | `Option<u16>` | **Protocol v3+.** Lowest version this deployment accepts. |
@@ -462,8 +468,10 @@ pub struct SessionPeer {
 The per-recipient authoritative plan the server sends when a room finalizes
 (delivered as a [`SessionPlan`](events.md#mesh-events-protocol-v3) event).
 Relay plans can explicitly reset a prior peer-to-peer plan. A plan is also sent
-again on late join, host re-election, or reconnect replay; each one **fully
-replaces** the previous plan.
+again on late join, host re-election, or as a fresh live message after a
+successful reconnect; each one **fully replaces** the previous plan. A
+`Reconnected` baseline fences the prior plan immediately, and `SessionPlan` is
+not a legal `missed_events` replay entry.
 
 ```rust,ignore
 pub struct SessionPlanPayload {
@@ -611,7 +619,7 @@ pub enum ServerMessage { /* ... */ }
 | `LobbyStateChanged` | Lobby state changed (player readiness, room full, etc.). |
 | `GameStarting` | Game is starting — includes peer connection info for all players. |
 | `Pong` | Connection-scoped response to a `Ping`, including before authentication/negotiation completes. |
-| `Reconnected` | Reconnection successful. Contains full room state and missed events. |
+| `Reconnected` | Reconnection successful. Contains full room state and the canonical replayable control-event subset. Under v3, replay status, a rotated nonempty token, exact snapshot stamps, and complete matching sender watermarks are required. |
 | `ReconnectionFailed` | Reconnection failed. |
 | `PlayerReconnected` | Another player reconnected. |
 | `SpectatorJoined` | Successfully joined as a spectator. |
@@ -647,6 +655,7 @@ safely ignores any of these it doesn't recognize.
 | `ClientMessage::Authenticate` | `protocol_version`, `supported_transports`, `supported_topologies` | Advertise the highest version, data-path transports, and topologies the client can fulfill. Set by `SignalFishConfig::enable_mesh()`. |
 | `ServerMessage::ProtocolInfo` | `protocol_version`, `min_protocol_version`, `max_protocol_version` | The negotiated version (plus the deployment's accepted range). |
 | `RoomJoinedPayload` / `ReconnectedPayload` | `ice_servers: Vec<IceServer>` | ICE pre-gather: STUN/TURN servers delivered during the lobby wait so WebRTC candidate gathering can start early. Empty (and absent from the wire) for v2. |
+| `ReconnectedPayload` | `replay`, `sender_watermarks`, `reconnection_token` | Required v3 authoritative replay/accountability baseline and rotated reconnect credential. All are absent/empty under v2. |
 
 ---
 

--- a/progress/session-028-negotiation-reconnect-state.md
+++ b/progress/session-028-negotiation-reconnect-state.md
@@ -39,7 +39,10 @@ bound to Signal Fish Server 0.7.0 commit
 - Three adversarial reviews found and drove fixes for JSON-origin relay
   representation, reconnect-response causality, stale WebRTC output, malformed
   negotiation tuples, fixture validity, and secret-safe assertions; the final
-  review reported no remaining findings.
+  local review reported no remaining findings. Hosted review then identified a
+  coalesced plan-barrier race; the controller now advances one revision per
+  consumed room/plan/spectator barrier instead of copying the core's latest
+  revision, with an exact queued-replan regression.
 - `cargo fmt`, all-target/all-feature clippy with warnings denied, the complete
   all-feature workspace suite, feature-isolation checks, rustdoc, and local docs
   validation pass. Hosted CI evidence is recorded on the pull request.

--- a/progress/session-028-negotiation-reconnect-state.md
+++ b/progress/session-028-negotiation-reconnect-state.md
@@ -42,7 +42,9 @@ bound to Signal Fish Server 0.7.0 commit
   local review reported no remaining findings. Hosted review then identified a
   coalesced plan-barrier race; the controller now advances one revision per
   consumed room/plan/spectator barrier instead of copying the core's latest
-  revision, with an exact queued-replan regression.
+  revision, with an exact queued-replan regression. A follow-up review kept
+  disconnect fencing on the plan revision so reliable room sends retain their
+  authoritative `NotConnected` result after waiting for queue capacity.
 - `cargo fmt`, all-target/all-feature clippy with warnings denied, the complete
   all-feature workspace suite, feature-isolation checks, rustdoc, and local docs
   validation pass. Hosted CI evidence is recorded on the pull request.

--- a/progress/session-028-negotiation-reconnect-state.md
+++ b/progress/session-028-negotiation-reconnect-state.md
@@ -1,0 +1,45 @@
+# Session 028 — Negotiation and Reconnect State
+
+## Scope
+
+Issues #100 and #101 harden the shared async/polling state transaction around
+the first authoritative `ProtocolInfo` and a successful reconnect. The work is
+bound to Signal Fish Server 0.7.0 commit
+`3f7f43d4cd4b3cc7f8fb893220dc35c9b1fad333`.
+
+## Rule → Source → Evidence
+
+| Rule | Pinned Server 0.7 source | Executable evidence |
+| --- | --- | --- |
+| Preserve the exact requested game-data format, including omission, while leaving the effective format unresolved until the first valid `ProtocolInfo`. | `src/websocket/connection.rs:2016-2062`; `src/config/protocol.rs:73-82`. | `polling_parity_tests::requested_and_effective_game_data_formats_have_complete_parity`; `polling_parity_tests::malformed_duplicate_and_around_negotiation_frames_have_complete_parity`. |
+| Accept only Server 0.7's canonical `[Json]` or `[Json, MessagePack]` advertisement. Resolve an advertised request to itself and omission/unsupported requests to JSON. The earlier `UnsupportedGameDataFormat` frame is advisory and arrives before `Authenticated`/`ProtocolInfo`. | `src/websocket/connection.rs:2016-2062`; `src/config/protocol.rs:73-82`. | `polling_parity_tests::json_fallback_is_enforced_before_outbound_transport_admission_in_both_drivers`; `polling_parity_tests::fallback_json_is_delivered_and_binary_is_rejected_with_driver_parity`; `real_server_e2e::e2e_server_070_rkyv_request_resolves_to_json`. |
+| Use the effective format for physical binary representation and outbound binary admission; JSON-origin relays remain text for every recipient format. Clear only effective state on disconnect. | `src/websocket/sending.rs:259-345` plus AsyncAPI game-data frames. | `polling_parity_tests::message_pack_receiver_accepts_json_origin_text_relay_with_driver_parity`; shared-core negotiation tests; supported-MessagePack binary parity coverage. |
+| Reconnect replay admits only the canonical seven membership/lobby/authority controls; `ProtocolInfo`, `SessionPlan`, signaling, and game data are not replay entries. | `src/server/reconnection_service.rs:954-1111`; AsyncAPI v3 `Reconnected`. | `client_core::tests::reconnect_replay_rejects_non_replayable_session_messages_atomically`; negotiation robustness and polling parity nested-`ProtocolInfo` tests. |
+| A reconnect terminal response must match an admitted player/room/token request. V3 also requires replay status, exact current-player stamps, complete matching sender watermarks, and a nonempty rotated token; v2 exposes none of those fields. Invalid authoritative baselines never apply under any policy. | `src/server/reconnection_service.rs:954-1111`; server spec tests `V3Reconnected` requirements. | `client_core::tests::reconnect_responses_require_the_matching_admitted_request`; `client_core::tests::reconnected_payload_version_matrix_is_transactional`; `client_core::tests::invalid_reconnect_accountability_never_resets_the_existing_frontier`; reconnect-aware polling parity. |
+| `Reconnected` is an immediate plan fence. A finalized room receives a separate fresh live `SessionPlan` with a new generation and refreshed ICE/TURN state. | `src/server/reconnection_service.rs:1183-1381`. | `mesh::tests::reconnect_fences_the_old_plan_until_a_fresh_live_plan_arrives`; `webrtc::tests::reconnect_fences_stale_driver_output_until_the_replacement_plan`; `client_tests::reconnect_receives_fresh_authoritative_session_plan`; strengthened real-server reconnect E2E. |
+
+## Public API and Compatibility
+
+- `ClientSnapshot` now exposes `requested_game_data_format` and
+  `effective_game_data_format`; async, polling, and object-safe shared APIs have
+  matching accessors.
+- These additions are breaking for exhaustive `ClientSnapshot` literals, so
+  they are recorded for 0.11. `SignalFishClientApi` supplies default accessors.
+- Server 0.4 v2 reconnect shapes remain accepted: no v3 stamps, replay status,
+  watermarks, or reconnect-token field is required or permitted.
+
+## Review and Verification
+
+- Three independent pre-implementation audits compared open issues, local
+  code, pinned Server 0.7 behavior, public API, test parity, and WebRTC state.
+- Targeted shared-core, async/polling, mesh-controller, and ignored real-server
+  tests passed locally. The real-server runs used an ARM64 binary built directly
+  from the pinned commit; both unsupported-Rkyv fallback and finalized reconnect
+  with replay/watermark/token/fresh-plan assertions passed.
+- Three adversarial reviews found and drove fixes for JSON-origin relay
+  representation, reconnect-response causality, stale WebRTC output, malformed
+  negotiation tuples, fixture validity, and secret-safe assertions; the final
+  review reported no remaining findings.
+- `cargo fmt`, all-target/all-feature clippy with warnings denied, the complete
+  all-feature workspace suite, feature-isolation checks, rustdoc, and local docs
+  validation pass. Hosted CI evidence is recorded on the pull request.

--- a/src/accountability.rs
+++ b/src/accountability.rs
@@ -1054,7 +1054,10 @@ pub(crate) fn validate_server_frame(
     physical_binary_frame: bool,
 ) -> Result<GameDataDisposition, String> {
     let mismatch = match message {
-        ServerMessage::GameData { .. } => negotiated_encoding != GameDataEncoding::Json,
+        // JSON-origin relays remain text GameData for every recipient format.
+        // The negotiated encoding controls physical binary acceptance and the
+        // binary envelope's embedded encoding, not ordinary JSON sends.
+        ServerMessage::GameData { .. } => physical_binary_frame,
         ServerMessage::GameDataBinary { encoding, .. } => {
             !physical_binary_frame
                 || negotiated_encoding == GameDataEncoding::Json

--- a/src/client.rs
+++ b/src/client.rs
@@ -2942,6 +2942,50 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn reliable_game_data_reports_disconnect_after_waiting_for_capacity() {
+        let (transport, entered_send, permits, _) = GatedSendTransport::new(0);
+        let config = SignalFishConfig::new("mb_test").with_command_channel_capacity(1);
+        let (mut client, mut events) = SignalFishClient::start(transport, config);
+
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Connected)
+        ));
+        wait_until(|| entered_send.load(Ordering::Acquire)).await;
+
+        client
+            .send_game_data(serde_json::json!({ "fills": "queue" }))
+            .expect("capacity-1 queue should accept one filler command");
+        let client = Arc::new(client);
+        let sender = Arc::clone(&client);
+        let mut reliable = tokio::spawn(async move {
+            sender
+                .send_game_data_reliable(serde_json::json!({ "waited": true }))
+                .await
+        });
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), &mut reliable)
+                .await
+                .is_err(),
+            "reliable game data should wait for queue capacity"
+        );
+
+        lock_core(&client.state).disconnect(None);
+        permits.add_permits(16);
+        let result = tokio::time::timeout(Duration::from_secs(1), reliable)
+            .await
+            .expect("reliable game data should finish after capacity opens")
+            .expect("reliable game data task should not panic");
+        assert!(
+            matches!(result, Err(SignalFishError::NotConnected)),
+            "disconnect should remain authoritative over room binding: {result:?}"
+        );
+
+        let mut client = Arc::into_inner(client).expect("all client clones should be dropped");
+        client.shutdown().await;
+    }
+
+    #[tokio::test]
     async fn reliable_json_game_data_does_not_cross_room_membership() {
         assert_reliable_game_data_rejected_after_room_change(false, true).await;
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -527,6 +527,20 @@ pub struct ClientSnapshot {
     pub connected: bool,
     pub authenticated: bool,
     pub negotiated_protocol_version: Option<u16>,
+    /// Exact game-data preference supplied in [`SignalFishConfig`].
+    ///
+    /// `None` means the caller accepted the default JSON format. This value is
+    /// retained for the lifetime of the client, including reconnects and after
+    /// disconnect, so diagnostics never confuse the request with the format
+    /// selected by the server.
+    pub requested_game_data_format: Option<GameDataEncoding>,
+    /// Game-data format selected for this connection from the first valid
+    /// [`ProtocolInfo`](SignalFishEvent::ProtocolInfo).
+    ///
+    /// `None` until negotiation completes and after the connection ends. An
+    /// unsupported preference resolves to `Some(GameDataEncoding::Json)` in
+    /// accordance with the Signal Fish Server 0.7 fallback contract.
+    pub effective_game_data_format: Option<GameDataEncoding>,
     pub player_id: Option<PlayerId>,
     pub room_id: Option<RoomId>,
     pub room_code: Option<String>,
@@ -548,6 +562,14 @@ impl std::fmt::Debug for ClientSnapshot {
             .field(
                 "negotiated_protocol_version",
                 &self.negotiated_protocol_version,
+            )
+            .field(
+                "requested_game_data_format",
+                &self.requested_game_data_format,
+            )
+            .field(
+                "effective_game_data_format",
+                &self.effective_game_data_format,
             )
             .field("player_id", &self.player_id)
             .field("room_id", &self.room_id)
@@ -634,13 +656,12 @@ impl SignalFishClient {
         let (event_tx, event_rx) = mpsc::channel::<SignalFishEvent>(capacity);
         let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
 
-        let requested_game_data_encoding = config.game_data_format.unwrap_or_default();
         let mesh_enabled = config
             .supported_transports
             .as_ref()
             .is_some_and(|transports| transports.contains(&TransportKind::WebRtc));
         let state = Arc::new(Mutex::new(ClientCore::new(
-            requested_game_data_encoding,
+            config.game_data_format,
             config.protocol_violation_policy,
             mesh_enabled,
         )));
@@ -1123,6 +1144,22 @@ impl SignalFishClient {
         lock_core(&self.state).negotiated_protocol_version()
     }
 
+    /// Exact game-data preference supplied in [`SignalFishConfig`].
+    pub fn requested_game_data_format(&self) -> Option<GameDataEncoding> {
+        lock_core(&self.state).requested_game_data_format()
+    }
+
+    /// Server-selected game-data format, or `None` while negotiation is
+    /// incomplete or after disconnect.
+    pub fn effective_game_data_format(&self) -> Option<GameDataEncoding> {
+        lock_core(&self.state).effective_game_data_format()
+    }
+
+    #[cfg(feature = "mesh")]
+    pub(crate) fn session_plan_revision(&self) -> u64 {
+        lock_core(&self.state).session_plan_revision()
+    }
+
     /// Returns `true` once the connection has negotiated protocol v3 and this
     /// client advertised WebRTC support through [`SignalFishConfig::enable_mesh`].
     ///
@@ -1189,10 +1226,21 @@ impl SignalFishClient {
         // Keep the state lock through nonblocking queue admission. In
         // particular, an exact-generation signal must not pass validation and
         // then race with a replacement SessionPlan before it is queued.
-        let core = lock_core(&self.state);
+        let reconnect_request = match &operation {
+            ClientOperation::Reconnect(player_id, room_id, token) => {
+                Some((*player_id, *room_id, token.clone()))
+            }
+            _ => None,
+        };
+        let mut core = lock_core(&self.state);
         let command = core.prepare(operation)?;
         let result = match self.cmd_tx.try_send(command) {
-            Ok(()) => Ok(()),
+            Ok(()) => {
+                if let Some((player_id, room_id, token)) = reconnect_request {
+                    core.record_reconnect_admitted(player_id, room_id, token);
+                }
+                Ok(())
+            }
             Err(mpsc::error::TrySendError::Full(_)) => Err(SignalFishError::SendBufferFull {
                 capacity: self.cmd_tx.max_capacity(),
             }),
@@ -1817,6 +1865,27 @@ mod tests {
             &mut self,
             _cx: &mut Context<'_>,
         ) -> Poll<Option<std::result::Result<TransportFrame, SignalFishError>>> {
+            let reconnect_response_is_gated = self.incoming.front().is_some_and(|item| {
+                let Some(Ok(json)) = item else {
+                    return false;
+                };
+                matches!(
+                    serde_json::from_str::<serde_json::Value>(json)
+                        .ok()
+                        .and_then(|value| value.get("type")?.as_str().map(str::to_owned))
+                        .as_deref(),
+                    Some("Reconnected" | "ReconnectionFailed")
+                )
+            });
+            let reconnect_was_sent = self.sent.lock().unwrap().iter().any(|json| {
+                matches!(
+                    serde_json::from_str::<ClientMessage>(json),
+                    Ok(ClientMessage::Reconnect { .. })
+                )
+            });
+            if reconnect_response_is_gated && !reconnect_was_sent {
+                return Poll::Pending;
+            }
             if let Some(item) = self.incoming.pop_front() {
                 // An explicit `None` entry signals a clean transport close;
                 // `Some(result)` delivers the scripted message or error.
@@ -1880,7 +1949,7 @@ mod tests {
                 recommended_version: None,
                 capabilities: vec![],
                 notes: None,
-                game_data_formats: vec![],
+                game_data_formats: vec![GameDataEncoding::Json, GameDataEncoding::MessagePack],
                 player_name_rules: None,
                 protocol_version: None,
                 min_protocol_version: None,
@@ -3023,12 +3092,12 @@ mod tests {
             recommended_version: None,
             capabilities: vec![],
             notes: None,
-            game_data_formats: vec![],
+            game_data_formats: vec![GameDataEncoding::Json, GameDataEncoding::MessagePack],
             player_name_rules: None,
             protocol_version: Some(3),
             min_protocol_version: Some(2),
             max_protocol_version: Some(3),
-            transports: None,
+            transports: Some(vec![crate::protocol::MessageTransport::Websocket]),
         }))
         .unwrap()
     }
@@ -3981,6 +4050,13 @@ mod tests {
         let _ = events.recv().await; // Connected
         let _ = events.recv().await; // Authenticated
         let _ = events.recv().await; // ProtocolInfo
+        client
+            .reconnect(
+                uuid::Uuid::from_u128(200),
+                uuid::Uuid::from_u128(100),
+                "submitted-token".into(),
+            )
+            .unwrap();
         let ev = events.recv().await.unwrap(); // Reconnected
         assert!(matches!(ev, SignalFishEvent::Reconnected { .. }));
 

--- a/src/client_api.rs
+++ b/src/client_api.rs
@@ -2,7 +2,9 @@
 
 use crate::client::{ClientSnapshot, ClientStats, GameDataDelivery, JoinRoomParams};
 use crate::error::Result;
-use crate::protocol::{ConnectionInfo, PlayerId, RoomId, SessionGeneration, TransportKind};
+use crate::protocol::{
+    ConnectionInfo, GameDataEncoding, PlayerId, RoomId, SessionGeneration, TransportKind,
+};
 use crate::signal::PeerSignal;
 
 /// Object-safe synchronous command and state surface shared by both clients.
@@ -91,6 +93,17 @@ pub trait SignalFishClientApi {
     /// Negotiated v3-or-newer protocol version.
     fn negotiated_protocol_version(&self) -> Option<u16> {
         self.snapshot().negotiated_protocol_version
+    }
+
+    /// Exact game-data preference supplied in [`SignalFishConfig`](crate::SignalFishConfig).
+    fn requested_game_data_format(&self) -> Option<GameDataEncoding> {
+        self.snapshot().requested_game_data_format
+    }
+
+    /// Server-selected game-data format, or `None` outside a negotiated
+    /// connection.
+    fn effective_game_data_format(&self) -> Option<GameDataEncoding> {
+        self.snapshot().effective_game_data_format
     }
 
     /// Whether WebRTC mesh was advertised and protocol v3 was negotiated.

--- a/src/client_core.rs
+++ b/src/client_core.rs
@@ -473,6 +473,8 @@ impl ClientCore {
         self.session_transport = None;
         self.retired_generationless_signal_peers.clear();
         self.pending_reconnects.clear();
+        #[cfg(feature = "tokio-runtime")]
+        self.advance_room_revision();
     }
 
     pub(crate) fn disconnect(&mut self, reason: Option<String>) -> SignalFishEvent {

--- a/src/client_core.rs
+++ b/src/client_core.rs
@@ -474,7 +474,7 @@ impl ClientCore {
         self.retired_generationless_signal_peers.clear();
         self.pending_reconnects.clear();
         #[cfg(feature = "tokio-runtime")]
-        self.advance_room_revision();
+        self.advance_session_plan_revision();
     }
 
     pub(crate) fn disconnect(&mut self, reason: Option<String>) -> SignalFishEvent {

--- a/src/client_core.rs
+++ b/src/client_core.rs
@@ -4,7 +4,7 @@
 //! separate. Everything that interprets protocol frames or mutates observable
 //! client state lives here so both drivers cannot drift semantically.
 
-use std::collections::HashSet;
+use std::collections::{HashSet, VecDeque};
 
 use crate::accountability::{self, DeliveryAccountability, GameDataDisposition};
 use crate::client::{
@@ -87,7 +87,6 @@ pub(crate) struct ClientCore {
     snapshot: ClientSnapshot,
     protocol_info_seen: bool,
     mesh_enabled: bool,
-    game_data_encoding: GameDataEncoding,
     stats: ClientStats,
     last_server_error: Option<ServerErrorInfo>,
     violation_policy: ProtocolViolationPolicy,
@@ -99,6 +98,7 @@ pub(crate) struct ClientCore {
     session_peers: HashSet<PlayerId>,
     session_transport: Option<TransportKind>,
     retired_generationless_signal_peers: HashSet<PlayerId>,
+    pending_reconnects: VecDeque<PendingReconnect>,
     #[cfg(feature = "tokio-runtime")]
     session_plan_revision: u64,
     #[cfg(feature = "tokio-runtime")]
@@ -123,6 +123,12 @@ struct RoomBaseline {
     players: HashSet<PlayerId>,
 }
 
+struct PendingReconnect {
+    player_id: PlayerId,
+    room_id: RoomId,
+    token: String,
+}
+
 impl ClientCore {
     pub(crate) fn authenticate(config: &SignalFishConfig) -> CoreCommand {
         CoreCommand::Message(ClientMessage::Authenticate {
@@ -137,18 +143,18 @@ impl ClientCore {
     }
 
     pub(crate) fn new(
-        game_data_encoding: GameDataEncoding,
+        requested_game_data_format: Option<GameDataEncoding>,
         violation_policy: ProtocolViolationPolicy,
         mesh_enabled: bool,
     ) -> Self {
         Self {
             snapshot: ClientSnapshot {
                 connected: true,
+                requested_game_data_format,
                 ..ClientSnapshot::default()
             },
             protocol_info_seen: false,
             mesh_enabled,
-            game_data_encoding,
             stats: ClientStats::default(),
             last_server_error: None,
             violation_policy,
@@ -160,6 +166,7 @@ impl ClientCore {
             session_peers: HashSet::new(),
             session_transport: None,
             retired_generationless_signal_peers: HashSet::new(),
+            pending_reconnects: VecDeque::new(),
             #[cfg(feature = "tokio-runtime")]
             session_plan_revision: 0,
             #[cfg(feature = "tokio-runtime")]
@@ -185,6 +192,19 @@ impl ClientCore {
 
     pub(crate) fn negotiated_protocol_version(&self) -> Option<u16> {
         self.snapshot.negotiated_protocol_version
+    }
+
+    pub(crate) fn requested_game_data_format(&self) -> Option<GameDataEncoding> {
+        self.snapshot.requested_game_data_format
+    }
+
+    pub(crate) fn effective_game_data_format(&self) -> Option<GameDataEncoding> {
+        self.snapshot.effective_game_data_format
+    }
+
+    #[cfg(all(feature = "mesh", feature = "tokio-runtime"))]
+    pub(crate) fn session_plan_revision(&self) -> u64 {
+        self.session_plan_revision
     }
 
     pub(crate) fn supports_mesh(&self) -> bool {
@@ -223,7 +243,7 @@ impl ClientCore {
             _ => {}
         }
         if matches!(&operation, ClientOperation::Binary(_))
-            && self.game_data_encoding == GameDataEncoding::Json
+            && self.effective_game_data_format() == Some(GameDataEncoding::Json)
         {
             return Err(crate::SignalFishError::BinaryFormatNotNegotiated);
         }
@@ -421,9 +441,23 @@ impl ClientCore {
         self.stats.game_data_sent = self.stats.game_data_sent.saturating_add(1);
     }
 
+    pub(crate) fn record_reconnect_admitted(
+        &mut self,
+        player_id: PlayerId,
+        room_id: RoomId,
+        token: String,
+    ) {
+        self.pending_reconnects.push_back(PendingReconnect {
+            player_id,
+            room_id,
+            token,
+        });
+    }
+
     pub(crate) fn clear_session(&mut self) {
         self.snapshot.authenticated = false;
         self.snapshot.negotiated_protocol_version = None;
+        self.snapshot.effective_game_data_format = None;
         self.snapshot.player_id = None;
         self.snapshot.room_id = None;
         self.snapshot.room_code = None;
@@ -438,6 +472,7 @@ impl ClientCore {
         self.session_peers.clear();
         self.session_transport = None;
         self.retired_generationless_signal_peers.clear();
+        self.pending_reconnects.clear();
     }
 
     pub(crate) fn disconnect(&mut self, reason: Option<String>) -> SignalFishEvent {
@@ -497,6 +532,7 @@ impl ClientCore {
                 | ServerMessage::SpectatorJoined(_)
                 | ServerMessage::Reconnected(_)
         );
+        let effective_game_data_format = self.effective_game_data_format().unwrap_or_default();
         let validation = if duplicate_protocol_info {
             self.accountability
                 .observe_server_message(false)
@@ -505,7 +541,7 @@ impl ClientCore {
             accountability::validate_server_frame(
                 &mut self.accountability,
                 &server_msg,
-                self.game_data_encoding,
+                effective_game_data_format,
                 false,
             )
         };
@@ -523,7 +559,20 @@ impl ClientCore {
                     outcome.disconnect = true;
                     return outcome;
                 }
-                let disposition = if self.violation_policy == ProtocolViolationPolicy::Observe {
+                let disposition = if self.violation_policy == ProtocolViolationPolicy::Observe
+                    && matches!(server_msg, ServerMessage::GameDataBinary { .. })
+                {
+                    match accountability::validate_server_message(
+                        &mut self.accountability,
+                        &server_msg,
+                    ) {
+                        Ok(disposition) => disposition,
+                        Err(diagnostic) => {
+                            self.push_violation(&mut outcome.events, diagnostic);
+                            GameDataDisposition::Apply
+                        }
+                    }
+                } else if self.violation_policy == ProtocolViolationPolicy::Observe {
                     GameDataDisposition::Apply
                 } else {
                     GameDataDisposition::Stale
@@ -532,7 +581,10 @@ impl ClientCore {
             }
         };
 
-        if validation_failed && self.violation_policy == ProtocolViolationPolicy::Quarantine {
+        if validation_failed
+            && (authoritative_baseline
+                || self.violation_policy == ProtocolViolationPolicy::Quarantine)
+        {
             return outcome;
         }
         if duplicate_protocol_info {
@@ -580,10 +632,18 @@ impl ClientCore {
             );
             return outcome;
         }
+        let Some(effective_game_data_format) = self.effective_game_data_format() else {
+            self.reject_inbound(
+                &mut outcome,
+                "lifecycle violation: binary game data arrived before game-data format negotiation completed"
+                    .into(),
+            );
+            return outcome;
+        };
         let mut observe_representation_violation = false;
         if let Err(diagnostic) = accountability::validate_physical_binary_allowed(
             &mut self.accountability,
-            self.game_data_encoding,
+            effective_game_data_format,
         ) {
             self.push_violation(&mut outcome.events, diagnostic);
             match self.violation_policy {
@@ -625,7 +685,7 @@ impl ClientCore {
             accountability::validate_server_frame(
                 &mut self.accountability,
                 &server_msg,
-                self.game_data_encoding,
+                effective_game_data_format,
                 true,
             )
         };
@@ -767,6 +827,7 @@ impl ClientCore {
         }
 
         match message {
+            ServerMessage::ProtocolInfo(payload) => validate_protocol_info_formats(payload),
             ServerMessage::RoomJoined(payload) => {
                 validate_local_player_snapshot(payload.player_id, &payload.current_players)
             }
@@ -833,8 +894,12 @@ impl ClientCore {
             }
             ServerMessage::Reconnected(payload) => {
                 validate_local_player_snapshot(payload.player_id, &payload.current_players)?;
-                self.validate_reconnect_replay(payload)
+                self.validate_reconnected_payload(payload)
             }
+            ServerMessage::ReconnectionFailed { .. } if self.pending_reconnects.is_empty() => Err(
+                "lifecycle violation: ReconnectionFailed arrived without an admitted Reconnect"
+                    .into(),
+            ),
             _ => Ok(()),
         }
     }
@@ -1000,6 +1065,59 @@ impl ClientCore {
         Ok(())
     }
 
+    fn validate_reconnected_payload(
+        &self,
+        payload: &crate::protocol::ReconnectedPayload,
+    ) -> Result<(), String> {
+        let Some(pending) = self.pending_reconnects.front() else {
+            return Err(
+                "lifecycle violation: Reconnected arrived without an admitted Reconnect".into(),
+            );
+        };
+        if payload.player_id != pending.player_id || payload.room_id != pending.room_id {
+            return Err(
+                "lifecycle violation: Reconnected identity did not match the admitted Reconnect"
+                    .into(),
+            );
+        }
+        let protocol_v3 = self
+            .snapshot
+            .negotiated_protocol_version
+            .is_some_and(|version| version >= 3);
+        if protocol_v3 {
+            if payload.replay.is_none() {
+                return Err(
+                    "lifecycle violation: v3 Reconnected omitted replay completeness".into(),
+                );
+            }
+            let Some(token) = payload
+                .reconnection_token
+                .as_deref()
+                .filter(|token| !token.is_empty())
+            else {
+                return Err(
+                    "lifecycle violation: v3 Reconnected omitted a nonempty rotated reconnection token"
+                        .into(),
+                );
+            };
+            if pending.token == token {
+                return Err(
+                    "lifecycle violation: v3 Reconnected did not rotate the submitted reconnection token"
+                        .into(),
+                );
+            }
+        } else if payload.replay.is_some()
+            || !payload.sender_watermarks.is_empty()
+            || payload.reconnection_token.is_some()
+        {
+            return Err(
+                "lifecycle violation: v2 Reconnected exposed v3 replay, watermark, or token metadata"
+                    .into(),
+            );
+        }
+        self.validate_reconnect_replay(payload)
+    }
+
     fn update_state(&mut self, message: &ServerMessage) {
         match message {
             ServerMessage::Authenticated { .. } => self.snapshot.authenticated = true,
@@ -1007,9 +1125,6 @@ impl ClientCore {
                 message,
                 error_code,
             } => {
-                if error_code.as_ref() == Some(&crate::ErrorCode::UnsupportedGameDataFormat) {
-                    self.game_data_encoding = GameDataEncoding::Json;
-                }
                 self.last_server_error = Some(ServerErrorInfo {
                     message: message.clone(),
                     error_code: error_code.clone(),
@@ -1024,6 +1139,11 @@ impl ClientCore {
             ServerMessage::ProtocolInfo(payload) => {
                 self.snapshot.negotiated_protocol_version =
                     payload.protocol_version.filter(|version| *version >= 3);
+                self.snapshot.effective_game_data_format =
+                    Some(resolve_effective_game_data_format(
+                        self.requested_game_data_format(),
+                        &payload.game_data_formats,
+                    ));
                 self.protocol_info_seen = true;
             }
             ServerMessage::RoomJoined(payload) => {
@@ -1043,6 +1163,7 @@ impl ClientCore {
             }
             ServerMessage::RoomLeft => self.clear_room(),
             ServerMessage::Reconnected(payload) => {
+                self.pending_reconnects.pop_front();
                 self.set_room(RoomBaseline {
                     player_id: payload.player_id,
                     room_id: payload.room_id,
@@ -1073,6 +1194,9 @@ impl ClientCore {
                 });
             }
             ServerMessage::SpectatorLeft { .. } => self.clear_room(),
+            ServerMessage::ReconnectionFailed { .. } => {
+                self.pending_reconnects.pop_front();
+            }
             ServerMessage::SessionPlan(payload) => {
                 self.replace_session_plan(
                     payload.generation,
@@ -1188,6 +1312,46 @@ impl ClientCore {
     }
 }
 
+fn validate_protocol_info_formats(
+    payload: &crate::protocol::ProtocolInfoPayload,
+) -> Result<(), String> {
+    match payload.game_data_formats.as_slice() {
+        [GameDataEncoding::Json]
+        | [GameDataEncoding::Json, GameDataEncoding::MessagePack] => Ok(()),
+        formats => Err(format!(
+            "lifecycle violation: ProtocolInfo game_data_formats {formats:?} does not match the canonical Server 0.7 negotiation order [Json, MessagePack?]"
+        )),
+    }?;
+    match (
+        payload.protocol_version,
+        payload.min_protocol_version,
+        payload.max_protocol_version,
+    ) {
+        (None, None, None) if payload.transports.is_none() => Ok(()),
+        (Some(version), Some(min), Some(max))
+            if version >= 3
+                && min >= 2
+                && min <= version
+                && version <= max
+                && payload.transports.as_deref() == Some(&[crate::protocol::MessageTransport::Websocket]) =>
+        {
+            Ok(())
+        }
+        version_tuple => Err(format!(
+            "lifecycle violation: ProtocolInfo version range {version_tuple:?} and transports presence do not form a coherent v2/v3 negotiation"
+        )),
+    }
+}
+
+fn resolve_effective_game_data_format(
+    requested: Option<GameDataEncoding>,
+    advertised: &[GameDataEncoding],
+) -> GameDataEncoding {
+    requested
+        .filter(|format| advertised.contains(format))
+        .unwrap_or(GameDataEncoding::Json)
+}
+
 fn validate_local_player_snapshot(
     local_player_id: PlayerId,
     players: &[crate::protocol::PlayerInfo],
@@ -1281,8 +1445,9 @@ fn direct_host_is_usable(host: &str) -> bool {
 mod tests {
     use super::*;
     use crate::protocol::{
-        DirectEndpoint, IceServer, LobbyState, PlayerInfo, ProtocolInfoPayload, RateLimitInfo,
-        ReconnectedPayload, RoomJoinedPayload, SenderWatermark, SessionPeer,
+        DirectEndpoint, IceServer, LobbyState, MessageTransport, PlayerInfo, ProtocolInfoPayload,
+        RateLimitInfo, ReconnectedPayload, ReplayStatus, RoomJoinedPayload, SenderWatermark,
+        SessionPeer,
     };
 
     const LOCAL: u128 = 1;
@@ -1320,7 +1485,7 @@ mod tests {
             protocol_version: version,
             min_protocol_version: version.map(|_| 2),
             max_protocol_version: version,
-            transports: None,
+            transports: version.map(|_| vec![MessageTransport::Websocket]),
         })
     }
 
@@ -1383,7 +1548,7 @@ mod tests {
             current_spectators: vec![],
             ice_servers: vec![],
             missed_events,
-            replay: None,
+            replay: Some(ReplayStatus::Complete),
             sender_watermarks: [LOCAL, PEER, 4]
                 .into_iter()
                 .map(|id| SenderWatermark {
@@ -1392,12 +1557,26 @@ mod tests {
                     seq: 0,
                 })
                 .collect(),
-            reconnection_token: Some("token".into()),
+            reconnection_token: Some("rotated-token".into()),
         }))
     }
 
+    fn reconnected_v2() -> ServerMessage {
+        let ServerMessage::Reconnected(mut payload) = reconnected(vec![]) else {
+            unreachable!("reconnected helper always returns Reconnected")
+        };
+        for player in &mut payload.current_players {
+            player.epoch = None;
+            player.seq = None;
+        }
+        payload.replay = None;
+        payload.sender_watermarks.clear();
+        payload.reconnection_token = None;
+        ServerMessage::Reconnected(payload)
+    }
+
     fn v3_room(policy: ProtocolViolationPolicy) -> ClientCore {
-        let mut core = ClientCore::new(GameDataEncoding::Json, policy, true);
+        let mut core = ClientCore::new(Some(GameDataEncoding::Json), policy, true);
         assert_eq!(process(&mut core, authenticated()).events.len(), 1);
         assert_eq!(process(&mut core, protocol_info(Some(3))).events.len(), 1);
         assert_eq!(process(&mut core, room_joined()).events.len(), 1);
@@ -1487,7 +1666,7 @@ mod tests {
 
         for (name, prefix, invalid) in cases {
             let mut core = ClientCore::new(
-                GameDataEncoding::Json,
+                Some(GameDataEncoding::Json),
                 ProtocolViolationPolicy::Observe,
                 true,
             );
@@ -1660,9 +1839,14 @@ mod tests {
             ProtocolViolationPolicy::Observe,
         ] {
             for local_count in [0, 2] {
-                let mut core = ClientCore::new(GameDataEncoding::Json, policy, true);
+                let mut core = ClientCore::new(Some(GameDataEncoding::Json), policy, true);
                 let _ = process(&mut core, authenticated());
                 let _ = process(&mut core, protocol_info(Some(3)));
+                core.record_reconnect_admitted(
+                    PlayerId::from_u128(LOCAL),
+                    RoomId::from_u128(10),
+                    "submitted-token".into(),
+                );
                 let before = core.snapshot();
                 let stats_before = core.stats();
                 let ServerMessage::RoomJoined(mut payload) = room_joined() else {
@@ -1828,7 +2012,7 @@ mod tests {
             ProtocolViolationPolicy::Observe,
         ] {
             for nested in &invalid {
-                let mut core = ClientCore::new(GameDataEncoding::Json, policy, true);
+                let mut core = ClientCore::new(Some(GameDataEncoding::Json), policy, true);
                 let _ = process(&mut core, authenticated());
                 let _ = process(&mut core, protocol_info(Some(3)));
                 let before = core.snapshot();
@@ -1841,6 +2025,376 @@ mod tests {
                 );
                 assert_eq!(core.stats(), ClientStats::default());
             }
+        }
+    }
+
+    #[test]
+    fn reconnected_payload_version_matrix_is_transactional() {
+        let mut v3_invalid = Vec::new();
+
+        let ServerMessage::Reconnected(mut missing_replay) = reconnected(vec![]) else {
+            unreachable!()
+        };
+        missing_replay.replay = None;
+        v3_invalid.push(("missing replay", ServerMessage::Reconnected(missing_replay)));
+
+        let ServerMessage::Reconnected(mut missing_token) = reconnected(vec![]) else {
+            unreachable!()
+        };
+        missing_token.reconnection_token = None;
+        v3_invalid.push(("missing token", ServerMessage::Reconnected(missing_token)));
+
+        let ServerMessage::Reconnected(mut empty_token) = reconnected(vec![]) else {
+            unreachable!()
+        };
+        empty_token.reconnection_token = Some(String::new());
+        v3_invalid.push(("empty token", ServerMessage::Reconnected(empty_token)));
+
+        let ServerMessage::Reconnected(mut missing_watermark) = reconnected(vec![]) else {
+            unreachable!()
+        };
+        missing_watermark.sender_watermarks.pop();
+        v3_invalid.push((
+            "missing watermark",
+            ServerMessage::Reconnected(missing_watermark),
+        ));
+
+        let ServerMessage::Reconnected(mut duplicate_watermark) = reconnected(vec![]) else {
+            unreachable!()
+        };
+        duplicate_watermark
+            .sender_watermarks
+            .push(duplicate_watermark.sender_watermarks[0]);
+        v3_invalid.push((
+            "duplicate watermark",
+            ServerMessage::Reconnected(duplicate_watermark),
+        ));
+
+        let ServerMessage::Reconnected(mut mismatched_watermark) = reconnected(vec![]) else {
+            unreachable!()
+        };
+        mismatched_watermark.sender_watermarks[0].seq = 1;
+        v3_invalid.push((
+            "mismatched watermark",
+            ServerMessage::Reconnected(mismatched_watermark),
+        ));
+
+        let ServerMessage::Reconnected(mut missing_self) = reconnected(vec![]) else {
+            unreachable!()
+        };
+        missing_self
+            .current_players
+            .retain(|player| player.id != missing_self.player_id);
+        missing_self
+            .sender_watermarks
+            .retain(|watermark| watermark.player_id != missing_self.player_id);
+        v3_invalid.push(("missing self", ServerMessage::Reconnected(missing_self)));
+
+        let ServerMessage::Reconnected(mut duplicate_self) = reconnected(vec![]) else {
+            unreachable!()
+        };
+        duplicate_self
+            .current_players
+            .push(duplicate_self.current_players[0].clone());
+        v3_invalid.push(("duplicate self", ServerMessage::Reconnected(duplicate_self)));
+
+        let ServerMessage::Reconnected(mut unrotated_token) = reconnected(vec![]) else {
+            unreachable!()
+        };
+        unrotated_token.reconnection_token = Some("submitted-token".into());
+        v3_invalid.push((
+            "unrotated token",
+            ServerMessage::Reconnected(unrotated_token),
+        ));
+
+        for policy in [
+            ProtocolViolationPolicy::Quarantine,
+            ProtocolViolationPolicy::Disconnect,
+            ProtocolViolationPolicy::Observe,
+        ] {
+            for (name, invalid) in &v3_invalid {
+                let mut core = ClientCore::new(Some(GameDataEncoding::Json), policy, true);
+                let _ = process(&mut core, authenticated());
+                let _ = process(&mut core, protocol_info(Some(3)));
+                core.record_reconnect_admitted(
+                    PlayerId::from_u128(LOCAL),
+                    RoomId::from_u128(10),
+                    "submitted-token".into(),
+                );
+                let before = core.snapshot();
+                let outcome = process(&mut core, invalid.clone());
+                assert!(
+                    matches!(
+                        outcome.events.as_slice(),
+                        [SignalFishEvent::ProtocolViolation { .. }]
+                    ),
+                    "{name}: {:#?}",
+                    outcome.events
+                );
+                assert_eq!(
+                    outcome.disconnect,
+                    policy == ProtocolViolationPolicy::Disconnect,
+                    "{name}"
+                );
+                let mut expected = before;
+                expected.quarantined = policy == ProtocolViolationPolicy::Quarantine;
+                assert_eq!(core.snapshot(), expected, "{name}");
+                assert_eq!(core.membership, Membership::None, "{name}");
+                assert!(!core.session_plan_seen, "{name}");
+                assert!(core.session_peers.is_empty(), "{name}");
+            }
+        }
+
+        let mut v2_invalid = Vec::new();
+        let ServerMessage::Reconnected(mut replay) = reconnected_v2() else {
+            unreachable!()
+        };
+        replay.replay = Some(ReplayStatus::Complete);
+        v2_invalid.push(ServerMessage::Reconnected(replay));
+        let ServerMessage::Reconnected(mut token) = reconnected_v2() else {
+            unreachable!()
+        };
+        token.reconnection_token = Some("v3-only".into());
+        v2_invalid.push(ServerMessage::Reconnected(token));
+        let ServerMessage::Reconnected(mut watermark) = reconnected_v2() else {
+            unreachable!()
+        };
+        watermark.sender_watermarks.push(SenderWatermark {
+            player_id: PlayerId::from_u128(LOCAL),
+            epoch: 1,
+            seq: 0,
+        });
+        v2_invalid.push(ServerMessage::Reconnected(watermark));
+
+        for invalid in v2_invalid {
+            let mut core = ClientCore::new(
+                Some(GameDataEncoding::Json),
+                ProtocolViolationPolicy::Observe,
+                true,
+            );
+            let _ = process(&mut core, authenticated());
+            let _ = process(&mut core, protocol_info(None));
+            core.record_reconnect_admitted(
+                PlayerId::from_u128(LOCAL),
+                RoomId::from_u128(10),
+                "submitted-token".into(),
+            );
+            let before = core.snapshot();
+            let outcome = process(&mut core, invalid);
+            assert!(matches!(
+                outcome.events.as_slice(),
+                [SignalFishEvent::ProtocolViolation { .. }]
+            ));
+            assert_eq!(core.snapshot(), before);
+        }
+
+        for (version, valid) in [(None, reconnected_v2()), (Some(3), reconnected(vec![]))] {
+            let mut core = ClientCore::new(
+                Some(GameDataEncoding::Json),
+                ProtocolViolationPolicy::Observe,
+                true,
+            );
+            let _ = process(&mut core, authenticated());
+            let _ = process(&mut core, protocol_info(version));
+            core.record_reconnect_admitted(
+                PlayerId::from_u128(LOCAL),
+                RoomId::from_u128(10),
+                "submitted-token".into(),
+            );
+            let outcome = process(&mut core, valid);
+            assert!(matches!(
+                outcome.events.as_slice(),
+                [SignalFishEvent::Reconnected { .. }]
+            ));
+            assert_eq!(core.membership, Membership::Player);
+        }
+    }
+
+    #[test]
+    fn reconnect_responses_require_the_matching_admitted_request() {
+        let new_core = || {
+            let mut core = ClientCore::new(
+                Some(GameDataEncoding::Json),
+                ProtocolViolationPolicy::Observe,
+                true,
+            );
+            let _ = process(&mut core, authenticated());
+            let _ = process(&mut core, protocol_info(Some(3)));
+            core
+        };
+
+        let mut unsolicited = new_core();
+        let before = unsolicited.snapshot();
+        assert_lifecycle_violation(&process(&mut unsolicited, reconnected(vec![])));
+        assert_eq!(unsolicited.snapshot(), before);
+
+        let mut wrong_identity = new_core();
+        wrong_identity.record_reconnect_admitted(
+            PlayerId::from_u128(99),
+            RoomId::from_u128(10),
+            "submitted-token".into(),
+        );
+        let before = wrong_identity.snapshot();
+        assert_lifecycle_violation(&process(&mut wrong_identity, reconnected(vec![])));
+        assert_eq!(wrong_identity.snapshot(), before);
+
+        let mut failed = new_core();
+        failed.record_reconnect_admitted(
+            PlayerId::from_u128(LOCAL),
+            RoomId::from_u128(10),
+            "submitted-token".into(),
+        );
+        let failure = process(
+            &mut failed,
+            ServerMessage::ReconnectionFailed {
+                reason: "expired".into(),
+                error_code: crate::ErrorCode::ReconnectionExpired,
+            },
+        );
+        assert!(matches!(
+            failure.events.as_slice(),
+            [SignalFishEvent::ReconnectionFailed { .. }]
+        ));
+        let ServerMessage::Reconnected(mut unrotated) = reconnected(vec![]) else {
+            unreachable!()
+        };
+        unrotated.reconnection_token = Some("submitted-token".into());
+        assert_lifecycle_violation(&process(&mut failed, ServerMessage::Reconnected(unrotated)));
+    }
+
+    #[test]
+    fn protocol_info_version_tuple_is_coherent_and_transactional() {
+        let mut invalid = Vec::new();
+
+        let ServerMessage::ProtocolInfo(mut missing_min) = protocol_info(Some(3)) else {
+            unreachable!()
+        };
+        missing_min.min_protocol_version = None;
+        invalid.push(missing_min);
+
+        let ServerMessage::ProtocolInfo(mut missing_transports) = protocol_info(Some(3)) else {
+            unreachable!()
+        };
+        missing_transports.transports = None;
+        invalid.push(missing_transports);
+
+        let ServerMessage::ProtocolInfo(mut empty_transports) = protocol_info(Some(3)) else {
+            unreachable!()
+        };
+        empty_transports.transports = Some(vec![]);
+        invalid.push(empty_transports);
+
+        let ServerMessage::ProtocolInfo(mut duplicate_transports) = protocol_info(Some(3)) else {
+            unreachable!()
+        };
+        duplicate_transports.transports = Some(vec![
+            MessageTransport::Websocket,
+            MessageTransport::Websocket,
+        ]);
+        invalid.push(duplicate_transports);
+
+        let ServerMessage::ProtocolInfo(mut inverted) = protocol_info(Some(3)) else {
+            unreachable!()
+        };
+        inverted.min_protocol_version = Some(4);
+        invalid.push(inverted);
+
+        let ServerMessage::ProtocolInfo(mut outside) = protocol_info(Some(3)) else {
+            unreachable!()
+        };
+        outside.max_protocol_version = Some(2);
+        invalid.push(outside);
+
+        let ServerMessage::ProtocolInfo(mut v2_with_range) = protocol_info(None) else {
+            unreachable!()
+        };
+        v2_with_range.min_protocol_version = Some(2);
+        invalid.push(v2_with_range);
+
+        let ServerMessage::ProtocolInfo(mut v2_with_transports) = protocol_info(None) else {
+            unreachable!()
+        };
+        v2_with_transports.transports = Some(vec![MessageTransport::Websocket]);
+        invalid.push(v2_with_transports);
+
+        for payload in invalid {
+            let mut core = ClientCore::new(
+                Some(GameDataEncoding::MessagePack),
+                ProtocolViolationPolicy::Observe,
+                true,
+            );
+            let _ = process(&mut core, authenticated());
+            let before = core.snapshot();
+            assert_lifecycle_violation(&process(&mut core, ServerMessage::ProtocolInfo(payload)));
+            assert_eq!(core.snapshot(), before);
+            assert!(!core.protocol_info_seen);
+        }
+    }
+
+    #[test]
+    fn invalid_reconnect_accountability_never_resets_the_existing_frontier() {
+        for policy in [
+            ProtocolViolationPolicy::Quarantine,
+            ProtocolViolationPolicy::Disconnect,
+            ProtocolViolationPolicy::Observe,
+        ] {
+            let mut core = v3_room(policy);
+            let first = process(
+                &mut core,
+                ServerMessage::GameData {
+                    from_player: PlayerId::from_u128(PEER),
+                    data: serde_json::json!({"seq": 1}),
+                    seq: Some(1),
+                    epoch: Some(1),
+                    class: Some(DeliveryClass::Reliable),
+                    key: None,
+                },
+            );
+            assert!(matches!(
+                first.events.as_slice(),
+                [SignalFishEvent::GameData { .. }]
+            ));
+            let before = core.snapshot();
+            let peers_before = core.session_peers.clone();
+            core.membership = Membership::None;
+            core.record_reconnect_admitted(
+                PlayerId::from_u128(LOCAL),
+                RoomId::from_u128(10),
+                "submitted-token".into(),
+            );
+
+            let ServerMessage::Reconnected(mut invalid) = reconnected(vec![]) else {
+                unreachable!()
+            };
+            invalid.sender_watermarks.pop();
+            let outcome = process(&mut core, ServerMessage::Reconnected(invalid));
+            assert!(matches!(
+                outcome.events.as_slice(),
+                [SignalFishEvent::ProtocolViolation { .. }]
+            ));
+            let mut expected = before;
+            expected.quarantined = policy == ProtocolViolationPolicy::Quarantine;
+            assert_eq!(core.snapshot(), expected);
+            assert_eq!(core.session_peers, peers_before);
+
+            core.membership = Membership::Player;
+            core.snapshot.quarantined = false;
+            let next = process(
+                &mut core,
+                ServerMessage::GameData {
+                    from_player: PlayerId::from_u128(PEER),
+                    data: serde_json::json!({"seq": 2}),
+                    seq: Some(2),
+                    epoch: Some(1),
+                    class: Some(DeliveryClass::Reliable),
+                    key: None,
+                },
+            );
+            assert!(
+                matches!(next.events.as_slice(), [SignalFishEvent::GameData { .. }]),
+                "{policy:?}: {:#?}",
+                next.events
+            );
         }
     }
 
@@ -2081,7 +2635,7 @@ mod tests {
                     ServerMessage::RoomLeft,
                 ],
             ] {
-                let mut core = ClientCore::new(GameDataEncoding::Json, policy, true);
+                let mut core = ClientCore::new(Some(GameDataEncoding::Json), policy, true);
                 for message in prefix {
                     let _ = process(&mut core, message);
                 }
@@ -2131,7 +2685,7 @@ mod tests {
     #[test]
     fn authority_denial_is_connection_scoped_after_negotiation() {
         let mut core = ClientCore::new(
-            GameDataEncoding::Json,
+            Some(GameDataEncoding::Json),
             ProtocolViolationPolicy::Observe,
             true,
         );

--- a/src/error.rs
+++ b/src/error.rs
@@ -104,7 +104,7 @@ pub enum SignalFishError {
 
     /// Binary game data was requested without negotiating a binary encoding.
     #[error(
-        "binary game data requires game_data_format=message_pack or rkyv; this connection uses JSON"
+        "binary game data requires an effectively negotiated MessagePack format; this connection uses JSON"
     )]
     BinaryFormatNotNegotiated,
 

--- a/src/mesh.rs
+++ b/src/mesh.rs
@@ -148,31 +148,23 @@ impl MeshSession {
             // ICE pre-gather: seed the ICE servers during the lobby wait. Do not
             // create peers here — a relay-floor room may never produce a plan.
             SignalFishEvent::RoomJoined { ice_servers, .. } => self.apply_pre_gather(ice_servers),
-            // Reconnect: seed pre-gather ICE, then defensively replay any mesh
-            // events the server batched into `missed_events`. Today's server
-            // rebuilds the session by re-sending a *live* `SessionPlan` after the
-            // `Reconnected` (so `missed_events` is empty), but folding here keeps
-            // the view correct against servers that carry mesh state in
-            // `missed_events`. The fold is idempotent and a later live plan
-            // replaces the peer set wholesale.
-            SignalFishEvent::Reconnected {
-                ice_servers,
-                missed_events,
-                ..
-            } => {
-                let mut changed = self.apply_pre_gather(ice_servers);
-                for missed in missed_events {
-                    match missed {
-                        // Terminal / meta events never belong in a reconnect
-                        // replay — by definition we are back in the room.
-                        SignalFishEvent::RoomLeft
-                        | SignalFishEvent::Disconnected { .. }
-                        | SignalFishEvent::Reconnected { .. }
-                        | SignalFishEvent::RoomJoined { .. } => {}
-                        other => changed |= self.apply(other),
-                    }
-                }
-                changed
+            // Reconnect is a hard plan boundary. Server 0.7 publishes a fresh
+            // live SessionPlan after this baseline; SessionPlan and other mesh
+            // controls are not valid replay entries. Clear the prior plan and
+            // peer set immediately so stale topology cannot remain actionable
+            // during the gap, then seed the refreshed pre-gather ICE servers.
+            SignalFishEvent::Reconnected { ice_servers, .. } => {
+                let had_authoritative_state = self.generation.is_some()
+                    || self.topology.is_some()
+                    || self.transport.is_some()
+                    || self.fallback.is_some()
+                    || self.host.is_some()
+                    || self.direct_endpoint.is_some()
+                    || !self.peers.is_empty();
+                let ice_changed = self.ice_servers != *ice_servers;
+                *self = Self::default();
+                let _ = self.apply_pre_gather(ice_servers);
+                had_authoritative_state || ice_changed
             }
             // The session is over.
             SignalFishEvent::RoomLeft | SignalFishEvent::Disconnected { .. } => {
@@ -735,56 +727,33 @@ mod tests {
     }
 
     #[test]
-    fn reconnect_replays_missed_mesh_events_to_rebuild_view() {
-        // A server that batches mesh state into `Reconnected.missed_events`
-        // (instead of re-sending a live SessionPlan) must still rebuild the view.
+    fn reconnect_fences_the_old_plan_until_a_fresh_live_plan_arrives() {
         let mut s = MeshSession::new();
-        let changed = s.apply(&reconnected(
-            vec![ice("stun:pre")],
-            vec![
-                plan(
-                    Topology::Mesh,
-                    None,
-                    vec![peer(1, true)],
-                    vec![ice("stun:plan")],
-                ),
-                SignalFishEvent::NewPeer {
-                    peer_id: uuid(2),
-                    you_initiate: false,
-                },
-            ],
-        ));
-        assert!(changed, "replaying missed mesh events changes the view");
+        assert!(s.apply(&plan(
+            Topology::Mesh,
+            None,
+            vec![peer(1, true)],
+            vec![ice("stun:old")],
+        )));
         assert_eq!(s.topology(), Some(Topology::Mesh));
-        assert!(s.peer(uuid(1)).is_some(), "plan peer restored");
-        assert!(s.peer(uuid(2)).is_some(), "missed NewPeer restored");
-        // The plan's ICE supersedes the pre-gather set.
-        assert_eq!(s.ice_servers(), &[ice("stun:plan")]);
-    }
 
-    #[test]
-    fn reconnect_ignores_terminal_events_in_missed_events() {
-        // Build an active mesh, then a reconnect whose missed_events contains a
-        // stray terminal event must NOT reset the freshly rebuilt session.
-        let mut s = MeshSession::new();
         let changed = s.apply(&reconnected(
-            vec![],
-            vec![
-                plan(Topology::Mesh, None, vec![peer(1, true)], vec![]),
-                SignalFishEvent::RoomLeft,
-                SignalFishEvent::Disconnected {
-                    reason: None,
-                    last_server_error: None,
-                },
-            ],
+            vec![ice("stun:refreshed")],
+            // Mesh controls are not canonical replay entries. Even if a caller
+            // constructs such an event directly, they cannot revive the old
+            // plan across the reconnect boundary.
+            vec![plan(
+                Topology::Mesh,
+                None,
+                vec![peer(2, false)],
+                vec![ice("stun:replayed")],
+            )],
         ));
         assert!(changed);
-        assert_eq!(
-            s.topology(),
-            Some(Topology::Mesh),
-            "terminal events were ignored"
-        );
-        assert!(s.peer(uuid(1)).is_some());
+        assert!(s.topology().is_none());
+        assert!(s.generation().is_none());
+        assert!(s.peers().is_empty());
+        assert_eq!(s.ice_servers(), &[ice("stun:refreshed")]);
     }
 
     #[test]

--- a/src/mesh.rs
+++ b/src/mesh.rs
@@ -167,7 +167,10 @@ impl MeshSession {
                 had_authoritative_state || ice_changed
             }
             // The session is over.
-            SignalFishEvent::RoomLeft | SignalFishEvent::Disconnected { .. } => {
+            SignalFishEvent::RoomLeft
+            | SignalFishEvent::SpectatorJoined { .. }
+            | SignalFishEvent::SpectatorLeft { .. }
+            | SignalFishEvent::Disconnected { .. } => {
                 let had_state = self.topology.is_some()
                     || !self.peers.is_empty()
                     || !self.ice_servers.is_empty();
@@ -535,13 +538,29 @@ mod tests {
     }
 
     #[test]
-    fn reset_on_disconnect_and_room_left() {
+    fn room_and_spectator_transitions_reset_authoritative_mesh_state() {
         for terminal in [
             SignalFishEvent::Disconnected {
                 reason: None,
                 last_server_error: None,
             },
             SignalFishEvent::RoomLeft,
+            SignalFishEvent::SpectatorJoined {
+                room_id: uuid(10),
+                room_code: "WATCH".into(),
+                spectator_id: uuid(11),
+                game_name: "g".into(),
+                current_players: vec![],
+                current_spectators: vec![],
+                lobby_state: crate::protocol::LobbyState::Waiting,
+                reason: None,
+            },
+            SignalFishEvent::SpectatorLeft {
+                room_id: Some(uuid(10)),
+                room_code: Some("WATCH".into()),
+                reason: None,
+                current_spectators: vec![],
+            },
         ] {
             let mut s = MeshSession::new();
             s.apply(&plan(

--- a/src/polling_client.rs
+++ b/src/polling_client.rs
@@ -29,10 +29,9 @@ use crate::client_core::{
 };
 use crate::error::{Result, SignalFishError};
 use crate::event::SignalFishEvent;
-#[cfg(test)]
-use crate::protocol::GameDataEncoding;
 use crate::protocol::{
-    ClientMessage, ConnectionInfo, PlayerId, RoomId, SessionGeneration, TransportKind,
+    ClientMessage, ConnectionInfo, GameDataEncoding, PlayerId, RoomId, SessionGeneration,
+    TransportKind,
 };
 use crate::signal::PeerSignal;
 use crate::transport::{Transport, TransportDiagnostics, TransportFrame};
@@ -232,7 +231,6 @@ impl<T: Transport> SignalFishPollingClient<T> {
         mut options: PollingClientOptions,
     ) -> Self {
         options.work_budget = options.work_budget.clamped();
-        let requested_game_data_encoding = config.game_data_format.unwrap_or_default();
         let mesh_enabled = config
             .supported_transports
             .as_ref()
@@ -252,7 +250,7 @@ impl<T: Transport> SignalFishPollingClient<T> {
             cmd_queue,
             command_capacity: config.command_channel_capacity.max(1),
             core: ClientCore::new(
-                requested_game_data_encoding,
+                config.game_data_format,
                 config.protocol_violation_policy,
                 mesh_enabled,
             ),
@@ -707,6 +705,17 @@ impl<T: Transport> SignalFishPollingClient<T> {
         self.core.negotiated_protocol_version()
     }
 
+    /// Exact game-data preference supplied in [`SignalFishConfig`].
+    pub fn requested_game_data_format(&self) -> Option<GameDataEncoding> {
+        self.core.requested_game_data_format()
+    }
+
+    /// Server-selected game-data format, or `None` while negotiation is
+    /// incomplete or after disconnect.
+    pub fn effective_game_data_format(&self) -> Option<GameDataEncoding> {
+        self.core.effective_game_data_format()
+    }
+
     /// Returns `true` once the connection has negotiated protocol v3 and this
     /// client advertised WebRTC support through [`SignalFishConfig::enable_mesh`].
     /// This is the "am I in mesh mode?" check.
@@ -850,8 +859,19 @@ impl<T: Transport> SignalFishPollingClient<T> {
     // ── Private helpers ─────────────────────────────────────────────
 
     fn queue_operation(&mut self, operation: ClientOperation) -> Result<()> {
+        let reconnect_request = match &operation {
+            ClientOperation::Reconnect(player_id, room_id, token) => {
+                Some((*player_id, *room_id, token.clone()))
+            }
+            _ => None,
+        };
         let command = self.core.prepare(operation)?;
-        self.queue_command_at(command, Instant::now())
+        self.queue_command_at(command, Instant::now())?;
+        if let Some((player_id, room_id, token)) = reconnect_request {
+            self.core
+                .record_reconnect_admitted(player_id, room_id, token);
+        }
+        Ok(())
     }
 
     fn queue_command_at(&mut self, command: PollingCommand, now: Instant) -> Result<()> {
@@ -1374,6 +1394,27 @@ mod tests {
             &mut self,
             _cx: &mut std::task::Context<'_>,
         ) -> std::task::Poll<Option<std::result::Result<TransportFrame, SignalFishError>>> {
+            let reconnect_response_is_gated = self.incoming.front().is_some_and(|item| {
+                let Some(Ok(TransportFrame::Text(json))) = item else {
+                    return false;
+                };
+                matches!(
+                    serde_json::from_str::<serde_json::Value>(json)
+                        .ok()
+                        .and_then(|value| value.get("type")?.as_str().map(str::to_owned))
+                        .as_deref(),
+                    Some("Reconnected" | "ReconnectionFailed")
+                )
+            });
+            let reconnect_was_sent = self.sent.iter().any(|json| {
+                matches!(
+                    serde_json::from_str::<ClientMessage>(json),
+                    Ok(ClientMessage::Reconnect { .. })
+                )
+            });
+            if reconnect_response_is_gated && !reconnect_was_sent {
+                return std::task::Poll::Pending;
+            }
             if let Some(item) = self.incoming.pop_front() {
                 std::task::Poll::Ready(item)
             } else {
@@ -2073,11 +2114,10 @@ mod tests {
 
     // ── Protocol v2/v3: start_game, signaling, negotiation guard ────
 
-    const PROTOCOL_INFO_V3: &str = r#"{"type":"ProtocolInfo","data":{"capabilities":[],"game_data_formats":[],"protocol_version":3,"min_protocol_version":2,"max_protocol_version":3}}"#;
+    const PROTOCOL_INFO_V3: &str = r#"{"type":"ProtocolInfo","data":{"capabilities":[],"game_data_formats":["json","message_pack"],"protocol_version":3,"min_protocol_version":2,"max_protocol_version":3,"transports":["websocket"]}}"#;
     // A v2 negotiation omits the version fields entirely (so the bytes stay
     // identical to a v2 server), which deserializes to `protocol_version: None`.
-    const PROTOCOL_INFO_V2: &str =
-        r#"{"type":"ProtocolInfo","data":{"capabilities":[],"game_data_formats":[]}}"#;
+    const PROTOCOL_INFO_V2: &str = r#"{"type":"ProtocolInfo","data":{"capabilities":[],"game_data_formats":["json","message_pack"]}}"#;
     const PEER_UUID: &str = "00000000-0000-0000-0000-000000000007";
 
     /// Parse every queued outgoing frame into a `ClientMessage`.
@@ -2313,9 +2353,16 @@ mod tests {
             current_spectators: vec![],
             ice_servers: vec![],
             missed_events: vec![],
-            replay: None,
-            sender_watermarks: vec![],
-            reconnection_token: None,
+            replay: Some(crate::protocol::ReplayStatus::Complete),
+            sender_watermarks: [local, peer]
+                .into_iter()
+                .map(|player_id| crate::protocol::SenderWatermark {
+                    player_id,
+                    epoch: 1,
+                    seq: 0,
+                })
+                .collect(),
+            reconnection_token: Some("rotated-token".into()),
         };
         let reconnected =
             serde_json::to_string(&ServerMessage::Reconnected(Box::new(payload))).unwrap();
@@ -2325,6 +2372,10 @@ mod tests {
             Some(Ok(reconnected)),
         ]);
         let mut client = SignalFishPollingClient::new(transport, default_config().enable_mesh());
+        client.poll();
+        client
+            .reconnect(local, uuid::Uuid::from_u128(100), "submitted-token".into())
+            .expect("reconnect must queue");
         client.poll();
         assert_eq!(client.negotiated_protocol_version(), Some(3));
         assert!(client.supports_mesh());
@@ -2337,7 +2388,7 @@ mod tests {
     #[test]
     fn v4_negotiation_still_enables_mesh() {
         // `>= 3` (not `== 3`): a future v4 negotiation must still enable mesh.
-        let pi_v4 = r#"{"type":"ProtocolInfo","data":{"capabilities":[],"game_data_formats":[],"protocol_version":4,"min_protocol_version":2,"max_protocol_version":4}}"#;
+        let pi_v4 = r#"{"type":"ProtocolInfo","data":{"capabilities":[],"game_data_formats":["json","message_pack"],"protocol_version":4,"min_protocol_version":2,"max_protocol_version":4,"transports":["websocket"]}}"#;
         let peer: PlayerId = PEER_UUID.parse().unwrap();
         let mut incoming = finalized_v3_room_incoming(
             peer,
@@ -2384,12 +2435,12 @@ mod tests {
             recommended_version: None,
             capabilities: vec![],
             notes: None,
-            game_data_formats: vec![],
+            game_data_formats: vec![GameDataEncoding::Json, GameDataEncoding::MessagePack],
             player_name_rules: None,
             protocol_version: Some(3),
             min_protocol_version: Some(2),
             max_protocol_version: Some(3),
-            transports: None,
+            transports: Some(vec![crate::protocol::MessageTransport::Websocket]),
         }
     }
 
@@ -2853,6 +2904,18 @@ mod tests {
         ]);
         let mut client = SignalFishPollingClient::new(transport, default_config());
 
+        client.poll();
+        client
+            .reconnect(
+                "00000000-0000-0000-0000-000000000003"
+                    .parse()
+                    .expect("test player_id UUID must parse"),
+                "00000000-0000-0000-0000-000000000001"
+                    .parse()
+                    .expect("test room_id UUID must parse"),
+                "submitted-token".into(),
+            )
+            .expect("reconnect must queue");
         let events = client.poll();
 
         // Verify the Reconnected event is emitted.
@@ -3921,6 +3984,14 @@ mod tests {
 
         let transport = MockTransport::new().with_incoming(authenticated_incoming(json));
         let mut client = SignalFishPollingClient::new(transport, default_config());
+        client.poll();
+        client
+            .reconnect(
+                uuid::Uuid::from_u128(20),
+                uuid::Uuid::from_u128(10),
+                "submitted-token".into(),
+            )
+            .expect("reconnect must queue");
         let events = client.poll();
 
         assert!(events

--- a/src/webrtc.rs
+++ b/src/webrtc.rs
@@ -264,6 +264,10 @@ mod controller {
         /// target peer (see `disconnect_peer`) — an abandoned handshake's
         /// signal must not be relayed stale.
         pending_signal: Option<(PlayerId, Option<SessionGeneration>, PeerSignal)>,
+        /// Last core plan barrier folded into `session`. The core can process a
+        /// reconnect/replan before this controller consumes its queued event;
+        /// a revision mismatch therefore fences driver output first.
+        observed_session_plan_revision: u64,
     }
 
     impl<D: WebRtcDriver> MeshController<D> {
@@ -300,6 +304,7 @@ mod controller {
                 pump_interval: DEFAULT_PUMP_INTERVAL,
                 ready,
                 pending_signal: None,
+                observed_session_plan_revision: 0,
             }
         }
 
@@ -335,6 +340,15 @@ mod controller {
         /// loses a signal.
         pub async fn recv(&mut self) -> Option<MeshEvent> {
             loop {
+                if self.observed_session_plan_revision != self.client.session_plan_revision() {
+                    match self.events.recv().await {
+                        Some(event) => {
+                            self.handle_event(&event);
+                            return Some(MeshEvent::Signaling(Box::new(event)));
+                        }
+                        None => return None,
+                    }
+                }
                 // Surface any pending driver output first (relaying signals /
                 // reporting status as side effects). This is deliberately
                 // synchronous: it must not await while the controller — the
@@ -371,9 +385,19 @@ mod controller {
 
         /// Fold the mesh session view, then perform the driver choreography for
         /// `event`.
-        fn handle_event(&mut self, event: &SignalFishEvent) {
+        pub(super) fn handle_event(&mut self, event: &SignalFishEvent) {
             self.session.apply(event);
             self.choreograph(event);
+            if matches!(
+                event,
+                SignalFishEvent::RoomJoined { .. }
+                    | SignalFishEvent::Reconnected { .. }
+                    | SignalFishEvent::SessionPlan { .. }
+                    | SignalFishEvent::RoomLeft
+                    | SignalFishEvent::Disconnected { .. }
+            ) {
+                self.observed_session_plan_revision = self.client.session_plan_revision();
+            }
         }
 
         /// Drive the driver in response to a single signaling event. The mesh
@@ -478,32 +502,14 @@ mod controller {
                 SignalFishEvent::RoomJoined { ice_servers, .. } if !ice_servers.is_empty() => {
                     self.driver.set_ice_servers(ice_servers);
                 }
-                // Reconnect: apply ICE pre-gather, then defensively replay any
-                // mesh events the server batched into `missed_events`. Today's
-                // server rebuilds the session by re-sending a *live* `SessionPlan`
-                // after `Reconnected` (so `missed_events` is empty), but replaying
-                // here keeps the client correct against servers that instead carry
-                // mesh state in `missed_events`. The fold is idempotent and a later
-                // live plan replaces the peer set wholesale.
-                SignalFishEvent::Reconnected {
-                    ice_servers,
-                    missed_events,
-                    ..
-                } => {
-                    if !ice_servers.is_empty() {
-                        self.driver.set_ice_servers(ice_servers);
+                // Reconnect fences the old WebRTC plan immediately. The server
+                // follows with a fresh live SessionPlan and a new generation;
+                // until then no peer or buffered signal remains authoritative.
+                SignalFishEvent::Reconnected { ice_servers, .. } => {
+                    for peer in std::mem::take(&mut self.known_peers) {
+                        self.disconnect_peer(peer.id);
                     }
-                    for missed in missed_events {
-                        match missed {
-                            // Terminal / meta events never belong in a reconnect
-                            // replay — by definition we are back in the room.
-                            SignalFishEvent::RoomLeft
-                            | SignalFishEvent::Disconnected { .. }
-                            | SignalFishEvent::Reconnected { .. }
-                            | SignalFishEvent::RoomJoined { .. } => {}
-                            other => self.choreograph(other),
-                        }
-                    }
+                    self.driver.set_ice_servers(ice_servers);
                 }
                 _ => {}
             }
@@ -1112,6 +1118,24 @@ mod tests {
         ) -> std::task::Poll<
             Option<Result<crate::transport::TransportFrame, crate::error::SignalFishError>>,
         > {
+            let reconnect_response_is_gated = self.incoming.front().is_some_and(|item| {
+                let Some(Ok(json)) = item else {
+                    return false;
+                };
+                matches!(
+                    serde_json::from_str::<ServerMessage>(json),
+                    Ok(ServerMessage::Reconnected(_) | ServerMessage::ReconnectionFailed { .. })
+                )
+            });
+            let reconnect_was_sent = self.sent.lock().unwrap().iter().any(|json| {
+                matches!(
+                    serde_json::from_str::<crate::protocol::ClientMessage>(json),
+                    Ok(crate::protocol::ClientMessage::Reconnect { .. })
+                )
+            });
+            if reconnect_response_is_gated && !reconnect_was_sent {
+                return std::task::Poll::Pending;
+            }
             if let Some(item) = self.incoming.pop_front() {
                 std::task::Poll::Ready(
                     item.map(|result| result.map(crate::transport::TransportFrame::Text)),
@@ -1151,7 +1175,7 @@ mod tests {
     }
 
     fn protocol_info_v3() -> String {
-        r#"{"type":"ProtocolInfo","data":{"capabilities":[],"game_data_formats":[],"protocol_version":3,"min_protocol_version":2,"max_protocol_version":3}}"#.to_string()
+        r#"{"type":"ProtocolInfo","data":{"capabilities":[],"game_data_formats":["json","message_pack"],"protocol_version":3,"min_protocol_version":2,"max_protocol_version":3,"transports":["websocket"]}}"#.to_string()
     }
 
     fn session_plan(peer: PlayerId, initiate: bool) -> String {
@@ -1315,7 +1339,7 @@ mod tests {
     }
 
     fn reconnected_with_players(players: &[PlayerId]) -> String {
-        use crate::protocol::ReconnectedPayload;
+        use crate::protocol::{ReconnectedPayload, ReplayStatus};
         let payload = ReconnectedPayload {
             room_id: uuid(0),
             room_code: "R".into(),
@@ -1343,7 +1367,7 @@ mod tests {
             current_spectators: vec![],
             ice_servers: vec![],
             missed_events: vec![],
-            replay: None,
+            replay: Some(ReplayStatus::Complete),
             sender_watermarks: players
                 .iter()
                 .map(|id| crate::protocol::SenderWatermark {
@@ -1352,7 +1376,7 @@ mod tests {
                     seq: 0,
                 })
                 .collect(),
-            reconnection_token: None,
+            reconnection_token: Some("rotated-token".into()),
         };
         serde_json::to_string(&ServerMessage::Reconnected(Box::new(payload))).unwrap()
     }
@@ -2820,6 +2844,9 @@ mod tests {
         ]);
         let mut mesh =
             MeshController::start(transport, SignalFishConfig::new("app"), driver.clone());
+        mesh.client_mut()
+            .reconnect(uuid(0), uuid(0), "submitted-token".into())
+            .unwrap();
         let ok = pump_until(&mut mesh, &driver, |c| {
             c.contains(&DriverCall::Connect(a, true)) && c.contains(&DriverCall::Connect(b, false))
         })
@@ -2829,8 +2856,75 @@ mod tests {
             "the post-reconnect SessionPlan/NewPeer must drive verbatim initiate flags: {:?}",
             driver.calls()
         );
-        // The replayed plan is also reflected in the session view.
+        // The fresh live plan is also reflected in the session view.
         assert_eq!(mesh.session().topology(), Some(Topology::Mesh));
+        mesh.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn reconnect_fences_stale_driver_output_until_the_replacement_plan() {
+        let peer = uuid(53);
+        let old_generation = uuid(12);
+        let new_generation = uuid(13);
+        let driver = SharedDriver::default();
+        let (transport, sent) = MockTransport::new(vec![]);
+        let mut mesh =
+            MeshController::start(transport, SignalFishConfig::new("app"), driver.clone());
+        assert!(matches!(
+            mesh.recv().await,
+            Some(MeshEvent::Signaling(event))
+                if matches!(*event, SignalFishEvent::Connected)
+        ));
+
+        let old_plan = SignalFishEvent::from(
+            serde_json::from_str::<ServerMessage>(&session_plan_with_generation(
+                peer,
+                false,
+                old_generation,
+            ))
+            .unwrap(),
+        );
+        mesh.handle_event(&old_plan);
+        assert!(driver
+            .calls()
+            .contains(&DriverCall::ConnectGeneration(peer, Some(old_generation))));
+
+        let reconnect = SignalFishEvent::from(
+            serde_json::from_str::<ServerMessage>(&reconnected_with_players(&[uuid(0), peer]))
+                .unwrap(),
+        );
+        mesh.handle_event(&reconnect);
+        assert!(mesh.session().topology().is_none());
+        assert!(mesh.session().peers().is_empty());
+        assert!(driver.calls().contains(&DriverCall::Disconnect(peer)));
+
+        driver.emit(DriverEvent::Signal {
+            peer,
+            generation: Some(old_generation),
+            signal: PeerSignal::Offer("stale-after-reconnect".into()),
+        });
+        let result = tokio::time::timeout(std::time::Duration::from_millis(60), mesh.recv()).await;
+        assert!(result.is_err(), "stale driver output surfaced: {result:?}");
+        assert!(sent.lock().unwrap().iter().all(|frame| {
+            !matches!(
+                serde_json::from_str::<crate::protocol::ClientMessage>(frame),
+                Ok(crate::protocol::ClientMessage::Signal { .. })
+            )
+        }));
+
+        let replacement = SignalFishEvent::from(
+            serde_json::from_str::<ServerMessage>(&session_plan_with_generation(
+                peer,
+                false,
+                new_generation,
+            ))
+            .unwrap(),
+        );
+        mesh.handle_event(&replacement);
+        assert!(driver
+            .calls()
+            .contains(&DriverCall::ConnectGeneration(peer, Some(new_generation))));
+        assert_eq!(mesh.session().generation(), Some(new_generation));
         mesh.shutdown().await;
     }
 

--- a/src/webrtc.rs
+++ b/src/webrtc.rs
@@ -343,7 +343,7 @@ mod controller {
                 if self.observed_session_plan_revision != self.client.session_plan_revision() {
                     match self.events.recv().await {
                         Some(event) => {
-                            self.handle_event(&event);
+                            self.handle_received_event(&event);
                             return Some(MeshEvent::Signaling(Box::new(event)));
                         }
                         None => return None,
@@ -365,7 +365,7 @@ mod controller {
                     incoming = self.events.recv() => {
                         match incoming {
                             Some(event) => {
-                                self.handle_event(&event);
+                                self.handle_received_event(&event);
                                 return Some(MeshEvent::Signaling(Box::new(event)));
                             }
                             None => return None,
@@ -388,15 +388,26 @@ mod controller {
         pub(super) fn handle_event(&mut self, event: &SignalFishEvent) {
             self.session.apply(event);
             self.choreograph(event);
+        }
+
+        fn handle_received_event(&mut self, event: &SignalFishEvent) {
+            self.handle_event(event);
             if matches!(
                 event,
                 SignalFishEvent::RoomJoined { .. }
                     | SignalFishEvent::Reconnected { .. }
+                    | SignalFishEvent::SpectatorJoined { .. }
                     | SignalFishEvent::SessionPlan { .. }
                     | SignalFishEvent::RoomLeft
+                    | SignalFishEvent::SpectatorLeft { .. }
                     | SignalFishEvent::Disconnected { .. }
             ) {
-                self.observed_session_plan_revision = self.client.session_plan_revision();
+                // The core can be several events ahead of this controller. Count
+                // the barrier represented by the event just consumed instead of
+                // copying the core's latest value and accidentally skipping
+                // later barriers that are still queued.
+                self.observed_session_plan_revision =
+                    self.observed_session_plan_revision.wrapping_add(1);
             }
         }
 
@@ -494,7 +505,10 @@ mod controller {
                 // the per-peer `PlayerLeft` path. On `Disconnected` the underlying
                 // send simply returns `NotConnected` and is harmlessly swallowed;
                 // `mark_disconnected` empties `connected_peers` as it goes.
-                SignalFishEvent::RoomLeft | SignalFishEvent::Disconnected { .. } => {
+                SignalFishEvent::RoomLeft
+                | SignalFishEvent::SpectatorJoined { .. }
+                | SignalFishEvent::SpectatorLeft { .. }
+                | SignalFishEvent::Disconnected { .. } => {
                     for peer in std::mem::take(&mut self.known_peers) {
                         self.disconnect_peer(peer.id);
                     }
@@ -2064,13 +2078,11 @@ mod tests {
         // directly and the server was never told WebRTC went down.
         let peer = uuid(31);
         let driver = SharedDriver::default();
-        let room_left = serde_json::to_string(&ServerMessage::RoomLeft).unwrap();
         let (transport, sent) = MockTransport::new_in_room(vec![
             Some(Ok(authed())),
             Some(Ok(protocol_info_v3())),
             Some(Ok(session_plan(peer, true))),
             Some(Ok(signal_from(peer, serde_json::json!({ "Answer": "r" })))),
-            Some(Ok(room_left)),
         ]);
         let mut mesh =
             MeshController::start(transport, SignalFishConfig::new("app"), driver.clone());
@@ -2090,11 +2102,9 @@ mod tests {
             "precondition: channel-up reports status true once"
         );
 
-        // Now reach the queued RoomLeft.
-        pump_until(&mut mesh, &driver, |c| {
-            c.contains(&DriverCall::Disconnect(peer))
-        })
-        .await;
+        // Fold RoomLeft only after the channel-open precondition; this test
+        // isolates teardown choreography from transport-loop scheduling.
+        mesh.handle_event(&SignalFishEvent::RoomLeft);
         wait_for_sent_count(&sent, &["TransportStatus", "webrtc", "false"], 1).await;
         assert_eq!(
             sent_count(&sent, &["TransportStatus", "webrtc", "false"]),
@@ -2344,9 +2354,15 @@ mod tests {
         .await
         .expect("core never observed replacement generation");
 
-        // recv() drains the driver's generation-12 offer before consuming the
-        // replacement event. The generation-bound send must refuse it rather
-        // than stamping generation 13.
+        driver.emit(DriverEvent::Data {
+            peer,
+            generation: Some(first),
+            data: vec![1, 2, 3],
+        });
+
+        // The core is already at generation 13, but its SessionPlan event is
+        // still queued behind the generation-12 session view. recv() must fold
+        // that barrier before draining either the old offer or application data.
         let event = mesh.recv().await;
         assert!(matches!(
             event,
@@ -2596,7 +2612,6 @@ mod tests {
             Some(Ok(protocol_info_v3())),
             Some(Ok(session_plan(p, true))),
             Some(Ok(signal_from(p, serde_json::json!({ "Answer": "r" })))),
-            Some(Ok(session_plan(p, false))),
         ]);
         let mut mesh =
             MeshController::start(transport, SignalFishConfig::new("app"), driver.clone());
@@ -2616,12 +2631,13 @@ mod tests {
             "precondition: the open channel reports status true once"
         );
 
-        // Reach the queued role-flip plan; the restart tears the open channel
-        // down (1->0) and reconnects P as the answerer.
-        pump_until(&mut mesh, &driver, |c| {
-            c.contains(&DriverCall::Connect(p, false))
-        })
-        .await;
+        // Fold the role-flip plan only after the channel-open precondition. The
+        // separate coalesced-event regression covers a core that is already
+        // ahead; this test isolates the restart's transport-status choreography.
+        let flip = SignalFishEvent::from(
+            serde_json::from_str::<ServerMessage>(&session_plan(p, false)).unwrap(),
+        );
+        mesh.handle_event(&flip);
         wait_for_sent_count(&sent, &["TransportStatus", "webrtc", "false"], 1).await;
         let calls = driver.calls();
         assert!(

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -1464,6 +1464,16 @@ mod ci_workflow_policy {
                 "e2e_server_070_generation_signal_and_host_replan",
             ),
             (
+                "signal-fish-server-v0.7.0-x86_64-unknown-linux-gnu.tar.gz",
+                "0.7.0",
+                "e2e_server_070_rkyv_request_resolves_to_json",
+            ),
+            (
+                "signal-fish-server-v0.7.0-x86_64-unknown-linux-gnu.tar.gz",
+                "0.7.0",
+                "e2e_reconnect_after_disconnect_uses_server_token",
+            ),
+            (
                 "signal-fish-server-v0.4.0-x86_64-unknown-linux-gnu.tar.gz",
                 "0.4.0",
                 "e2e_server_040_generationless_mesh_signal",

--- a/tests/client_tests.rs
+++ b/tests/client_tests.rs
@@ -1527,6 +1527,13 @@ async fn reconnection_failed_event() {
 
     drain_until_authenticated(&mut events).await;
     drain_until_protocol_info(&mut events).await;
+    client
+        .reconnect(
+            uuid::Uuid::from_u128(200),
+            uuid::Uuid::from_u128(100),
+            "submitted-token".into(),
+        )
+        .expect("reconnect must queue");
 
     let ev = events.recv().await.expect("event");
     if let SignalFishEvent::ReconnectionFailed { reason, error_code } = ev {
@@ -2624,6 +2631,13 @@ async fn reconnect_receives_fresh_authoritative_session_plan() {
         ],
         SignalFishConfig::new("mb_test_integration").enable_mesh(),
     );
+    client
+        .reconnect(
+            uuid::Uuid::from_u128(200),
+            uuid::Uuid::from_u128(100),
+            "submitted-token".into(),
+        )
+        .expect("reconnect must queue");
     drain_until_authenticated(&mut events).await;
     // Reconnection establishes the finalized room baseline; the server then
     // publishes a fresh authoritative plan as a separate room-ordered frame.
@@ -2654,7 +2668,7 @@ async fn reconnect_receives_fresh_authoritative_session_plan() {
     client
         .send_offer(peer, "sdp")
         .expect("send_offer after reconnect");
-    wait_for_sent_len(&sent, 2).await;
+    wait_for_sent_len(&sent, 3).await;
     assert!(sent_messages(&sent)
         .iter()
         .any(|m| matches!(m, ClientMessage::Signal { .. })));

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -17,12 +17,12 @@ use std::sync::{Arc, Mutex as StdMutex};
 
 use signal_fish_client::protocol::SpectatorJoinedPayload;
 use signal_fish_client::protocol::{
-    LobbyState, PlayerId, PlayerInfo, ProtocolInfoPayload, RateLimitInfo, ReconnectedPayload,
-    ReplayStatus, RoomJoinedPayload, SenderWatermark, ServerMessage, SessionPeer,
-    SessionPlanPayload, Topology, TransportKind,
+    GameDataEncoding, LobbyState, PlayerId, PlayerInfo, ProtocolInfoPayload, RateLimitInfo,
+    ReconnectedPayload, ReplayStatus, RoomJoinedPayload, SenderWatermark, ServerMessage,
+    SessionPeer, SessionPlanPayload, Topology, TransportKind,
 };
 use signal_fish_client::transport::TransportFrame;
-use signal_fish_client::{SignalFishError, Transport};
+use signal_fish_client::{ClientMessage, SignalFishError, Transport};
 
 // ── MockTransport ───────────────────────────────────────────────────
 
@@ -97,6 +97,24 @@ impl Transport for MockTransport {
         &mut self,
         _cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Option<Result<TransportFrame, SignalFishError>>> {
+        let reconnect_response_is_gated = self.incoming.front().is_some_and(|item| {
+            let Some(Ok(TransportFrame::Text(json))) = item else {
+                return false;
+            };
+            matches!(
+                serde_json::from_str::<ServerMessage>(json),
+                Ok(ServerMessage::Reconnected(_) | ServerMessage::ReconnectionFailed { .. })
+            )
+        });
+        let reconnect_was_sent = self.sent.lock().unwrap().iter().any(|json| {
+            matches!(
+                serde_json::from_str::<ClientMessage>(json),
+                Ok(ClientMessage::Reconnect { .. })
+            )
+        });
+        if reconnect_response_is_gated && !reconnect_was_sent {
+            return std::task::Poll::Pending;
+        }
         if let Some(item) = self.incoming.pop_front() {
             std::task::Poll::Ready(item)
         } else {
@@ -308,18 +326,19 @@ pub fn protocol_info_payload(protocol_version: Option<u16>) -> ProtocolInfoPaylo
         recommended_version: None,
         capabilities: vec![],
         notes: None,
-        game_data_formats: vec![],
+        game_data_formats: vec![GameDataEncoding::Json, GameDataEncoding::MessagePack],
         player_name_rules: None,
         protocol_version,
         min_protocol_version: protocol_version.map(|_| 2),
-        max_protocol_version: protocol_version.map(|_| 3),
-        transports: None,
+        max_protocol_version: protocol_version.map(|version| version.max(3)),
+        transports: protocol_version
+            .map(|_| vec![signal_fish_client::protocol::MessageTransport::Websocket]),
     }
 }
 
 /// Returns the JSON for a `ProtocolInfo` message with the given negotiated
-/// protocol version. `Some(3)` advertises v3 (min 2, max 3); `None` is a v2
-/// negotiation (version fields omitted).
+/// protocol version. Versioned fixtures advertise a coherent `2..=version`
+/// range (with v3 as the minimum maximum); `None` is a v2 negotiation.
 pub fn protocol_info_json(protocol_version: Option<u16>) -> String {
     serde_json::to_string(&ServerMessage::ProtocolInfo(protocol_info_payload(
         protocol_version,
@@ -382,7 +401,7 @@ pub fn finalized_reconnected_json() -> String {
                 seq: 0,
             },
         ],
-        reconnection_token: None,
+        reconnection_token: Some("rotated-token".into()),
     };
     serde_json::to_string(&ServerMessage::Reconnected(Box::new(payload)))
         .expect("finalized_reconnected_json serialization")

--- a/tests/negotiation_robustness_tests.rs
+++ b/tests/negotiation_robustness_tests.rs
@@ -170,6 +170,13 @@ async fn reconnect_rejects_protocol_info_without_downgrading_active_v3() {
         Some(Ok(protocol_info_json(Some(3)))), // negotiate v3
         Some(Ok(reconnected_with_missed(vec![protocol_info_msg(None)]))),
     ]);
+    client
+        .reconnect(
+            uuid::Uuid::from_u128(200),
+            uuid::Uuid::from_u128(100),
+            "submitted-token".into(),
+        )
+        .expect("reconnect must queue");
     drain_until_authenticated(&mut events).await;
     drain_until_protocol_info(&mut events).await;
     assert_eq!(client.negotiated_protocol_version(), Some(3));
@@ -196,6 +203,13 @@ async fn reconnect_multiple_protocol_info_is_rejected() {
             protocol_info_msg(Some(4)),
         ]))),
     ]);
+    client
+        .reconnect(
+            uuid::Uuid::from_u128(200),
+            uuid::Uuid::from_u128(100),
+            "submitted-token".into(),
+        )
+        .expect("reconnect must queue");
     drain_until_authenticated(&mut events).await;
     drain_until_protocol_info(&mut events).await;
     drain_until_violation(&mut events).await;
@@ -220,6 +234,13 @@ async fn reconnect_versioned_then_v2_keeps_version() {
             protocol_info_msg(None),
         ]))),
     ]);
+    client
+        .reconnect(
+            uuid::Uuid::from_u128(200),
+            uuid::Uuid::from_u128(100),
+            "submitted-token".into(),
+        )
+        .expect("reconnect must queue");
     drain_until_authenticated(&mut events).await;
     drain_until_protocol_info(&mut events).await;
     drain_until_violation(&mut events).await;
@@ -243,6 +264,13 @@ async fn reconnect_without_protocol_info_preserves_prior_v3() {
         Some(Ok(reconnected_with_missed(vec![]))),
         Some(Ok(serde_json::to_string(&session_plan_msg()).unwrap())),
     ]);
+    client
+        .reconnect(
+            uuid::Uuid::from_u128(200),
+            uuid::Uuid::from_u128(100),
+            "submitted-token".into(),
+        )
+        .expect("reconnect must queue");
     drain_until_authenticated(&mut events).await;
     drain_until_protocol_info(&mut events).await;
     assert_eq!(client.negotiated_protocol_version(), Some(3));
@@ -259,7 +287,7 @@ async fn reconnect_without_protocol_info_preserves_prior_v3() {
         .send_offer(uuid::Uuid::from_u128(9), "sdp")
         .expect("mesh must survive a reconnect that omits ProtocolInfo");
 
-    wait_for_sent_len(&sent, 2).await;
+    wait_for_sent_len(&sent, 3).await;
     let signal_sent = sent.lock().unwrap().iter().any(|m| m.contains("Signal"));
     assert!(signal_sent, "Signal should have reached the wire");
     client.shutdown().await;

--- a/tests/polling_parity_tests.rs
+++ b/tests/polling_parity_tests.rs
@@ -23,11 +23,11 @@ use signal_fish_client::client::{SignalFishClient, SignalFishConfig};
 use signal_fish_client::error::SignalFishError;
 use signal_fish_client::polling_client::SignalFishPollingClient;
 use signal_fish_client::protocol::{
-    ConnectionInfo, DeliveryClass, DeliveryCountersByClass, DeliveryGap, DeliveryGapReason,
-    DeliveryReportPayload, GameDataEncoding, LatestDeliveryCounters, LobbyState, PlayerId,
-    PlayerInfo, ProtocolInfoPayload, ReconnectedPayload, ReliableDeliveryCounters,
-    RoomJoinedPayload, SenderWatermark, ServerMessage, SpectatorJoinedPayload, TransportKind,
-    V2BinaryGameDataFrame, V3BinaryGameDataFrame,
+    ClientMessage, ConnectionInfo, DeliveryClass, DeliveryCountersByClass, DeliveryGap,
+    DeliveryGapReason, DeliveryReportPayload, GameDataEncoding, LatestDeliveryCounters, LobbyState,
+    PlayerId, PlayerInfo, ProtocolInfoPayload, ReconnectedPayload, ReliableDeliveryCounters,
+    ReplayStatus, RoomJoinedPayload, SenderWatermark, ServerMessage, SpectatorJoinedPayload,
+    TransportKind, V2BinaryGameDataFrame, V3BinaryGameDataFrame,
 };
 use signal_fish_client::transport::TransportFrame;
 use signal_fish_client::{ErrorCode, ProtocolViolationPolicy};
@@ -212,10 +212,10 @@ impl CommonCommandCase {
 
 const PEER_UUID: &str = "00000000-0000-0000-0000-000000000007";
 const AUTH: &str = r#"{"type":"Authenticated","data":{"app_name":"test","rate_limits":{"per_minute":60,"per_hour":1000,"per_day":10000}}}"#;
-const PI_V3: &str = r#"{"type":"ProtocolInfo","data":{"capabilities":[],"game_data_formats":[],"protocol_version":3,"min_protocol_version":2,"max_protocol_version":3}}"#;
+const PI_V3: &str = r#"{"type":"ProtocolInfo","data":{"capabilities":[],"game_data_formats":["json","message_pack"],"protocol_version":3,"min_protocol_version":2,"max_protocol_version":3,"transports":["websocket"]}}"#;
 // A v2 negotiation omits the version fields, so it deserializes to
 // `protocol_version: None` — a terminal relay floor.
-const PI_V2: &str = r#"{"type":"ProtocolInfo","data":{"capabilities":[],"game_data_formats":[]}}"#;
+const PI_V2: &str = r#"{"type":"ProtocolInfo","data":{"capabilities":[],"game_data_formats":["json","message_pack"]}}"#;
 
 // ── Shared mock transport (works for both async + polling drivers) ────
 
@@ -284,12 +284,14 @@ fn pi_v3_payload() -> ProtocolInfoPayload {
         recommended_version: None,
         capabilities: vec![],
         notes: None,
-        game_data_formats: vec![],
+        game_data_formats: vec![GameDataEncoding::Json, GameDataEncoding::MessagePack],
         player_name_rules: None,
         protocol_version: Some(3),
         min_protocol_version: Some(2),
         max_protocol_version: Some(3),
-        transports: None,
+        transports: Some(vec![
+            signal_fish_client::protocol::MessageTransport::Websocket,
+        ]),
     }
 }
 
@@ -327,13 +329,13 @@ fn reconnected_with_missed(missed: Vec<ServerMessage>) -> String {
         current_spectators: vec![],
         ice_servers: vec![],
         missed_events: missed,
-        replay: None,
+        replay: Some(ReplayStatus::Complete),
         sender_watermarks: vec![SenderWatermark {
             player_id: local,
             epoch: 1,
             seq: 0,
         }],
-        reconnection_token: None,
+        reconnection_token: Some("rotated-token".into()),
     };
     serde_json::to_string(&ServerMessage::Reconnected(Box::new(payload))).unwrap()
 }
@@ -680,10 +682,27 @@ async fn assert_frame_trace_parity(
     frames: Vec<TransportFrame>,
     config: SignalFishConfig,
 ) -> Vec<String> {
+    assert_frame_trace_parity_with_reconnect(frames, config, false).await
+}
+
+async fn assert_frame_trace_parity_with_reconnect(
+    frames: Vec<TransportFrame>,
+    config: SignalFishConfig,
+    admit_reconnect: bool,
+) -> Vec<String> {
     let make_mock = || TraceMock::new(frames.clone());
 
     let async_mock = make_mock();
-    let (async_client, mut async_rx) = SignalFishClient::start(async_mock, config.clone());
+    let (mut async_client, mut async_rx) = SignalFishClient::start(async_mock, config.clone());
+    if admit_reconnect {
+        async_client
+            .reconnect(
+                uuid::Uuid::from_u128(200),
+                uuid::Uuid::from_u128(100),
+                "submitted-token".into(),
+            )
+            .expect("async reconnect must queue");
+    }
     let mut async_events = Vec::new();
     tokio::time::timeout(std::time::Duration::from_secs(1), async {
         while let Some(event) = async_rx.recv().await {
@@ -695,6 +714,15 @@ async fn assert_frame_trace_parity(
 
     let polling_mock = make_mock();
     let mut polling_client = SignalFishPollingClient::new(polling_mock, config);
+    if admit_reconnect {
+        polling_client
+            .reconnect(
+                uuid::Uuid::from_u128(200),
+                uuid::Uuid::from_u128(100),
+                "submitted-token".into(),
+            )
+            .expect("polling reconnect must queue");
+    }
     let polling_events = polling_client.poll();
 
     let async_events = async_events
@@ -720,6 +748,100 @@ async fn assert_server_trace_parity(lines: &str, config: SignalFishConfig) {
         .map(|line| TransportFrame::Text(line.to_owned()))
         .collect();
     let _ = assert_frame_trace_parity(frames, config).await;
+}
+
+async fn assert_open_text_trace_parity(
+    messages: Vec<String>,
+    config: SignalFishConfig,
+) -> (Vec<String>, signal_fish_client::ClientSnapshot) {
+    assert_open_text_trace_parity_with_reconnect(messages, config, false).await
+}
+
+async fn assert_open_reconnect_trace_parity(
+    messages: Vec<String>,
+    config: SignalFishConfig,
+) -> (Vec<String>, signal_fish_client::ClientSnapshot) {
+    assert_open_text_trace_parity_with_reconnect(messages, config, true).await
+}
+
+async fn assert_open_text_trace_parity_with_reconnect(
+    messages: Vec<String>,
+    config: SignalFishConfig,
+    admit_reconnect: bool,
+) -> (Vec<String>, signal_fish_client::ClientSnapshot) {
+    let expected_events = messages.len() + 1;
+    let make_mock = || {
+        SharedMock::from_msgs(
+            messages
+                .iter()
+                .cloned()
+                .map(|message| Some(Ok(message)))
+                .collect(),
+        )
+    };
+
+    let async_mock = make_mock();
+    let (mut async_client, mut async_rx) = SignalFishClient::start(async_mock, config.clone());
+    if admit_reconnect {
+        async_client
+            .reconnect(
+                uuid::Uuid::from_u128(200),
+                uuid::Uuid::from_u128(100),
+                "submitted-token".into(),
+            )
+            .expect("async reconnect must queue");
+    }
+    let mut async_events = Vec::with_capacity(expected_events);
+    tokio::time::timeout(std::time::Duration::from_secs(1), async {
+        while async_events.len() < expected_events {
+            async_events.push(
+                async_rx
+                    .recv()
+                    .await
+                    .expect("open async trace should emit every scripted outcome"),
+            );
+        }
+    })
+    .await
+    .expect("open async trace should process every scripted frame");
+    let async_snapshot = async_client.snapshot();
+
+    let polling_mock = make_mock();
+    let mut polling_client = SignalFishPollingClient::new(polling_mock, config);
+    if admit_reconnect {
+        polling_client
+            .reconnect(
+                uuid::Uuid::from_u128(200),
+                uuid::Uuid::from_u128(100),
+                "submitted-token".into(),
+            )
+            .expect("polling reconnect must queue");
+    }
+    let polling_events = polling_client.poll();
+    let polling_snapshot = polling_client.snapshot();
+
+    let async_events = async_events
+        .iter()
+        .filter(|event| !matches!(event, SignalFishEvent::Connected))
+        .map(canonical_event)
+        .collect::<Vec<_>>();
+    let polling_events = polling_events
+        .iter()
+        .filter(|event| !matches!(event, SignalFishEvent::Connected))
+        .map(canonical_event)
+        .collect::<Vec<_>>();
+    assert_eq!(async_events, polling_events);
+    assert_eq!(async_snapshot, polling_snapshot);
+    assert_eq!(async_client.stats(), polling_client.stats());
+    async_client.shutdown().await;
+    (async_events, async_snapshot)
+}
+
+fn protocol_info_with_formats(formats: Vec<GameDataEncoding>) -> String {
+    let mut payload = pi_v3_payload();
+    payload.game_data_formats = formats;
+    serde_json::to_string(&ServerMessage::ProtocolInfo(payload))
+        .expect("ProtocolInfo fixture should serialize")
 }
 
 // ── PARITY 1: relay-floor Authenticate byte-identity ─────────────────
@@ -784,6 +906,282 @@ async fn vendored_v2_and_v3_server_message_traces_have_complete_parity() {
         )
         .await;
     }
+}
+
+#[tokio::test]
+async fn requested_and_effective_game_data_formats_have_complete_parity() {
+    let cases = [
+        (
+            None,
+            vec![GameDataEncoding::Json, GameDataEncoding::MessagePack],
+            GameDataEncoding::Json,
+        ),
+        (
+            Some(GameDataEncoding::MessagePack),
+            vec![GameDataEncoding::Json, GameDataEncoding::MessagePack],
+            GameDataEncoding::MessagePack,
+        ),
+        (
+            Some(GameDataEncoding::MessagePack),
+            vec![GameDataEncoding::Json],
+            GameDataEncoding::Json,
+        ),
+        (
+            Some(GameDataEncoding::Rkyv),
+            vec![GameDataEncoding::Json, GameDataEncoding::MessagePack],
+            GameDataEncoding::Json,
+        ),
+    ];
+
+    for (requested, advertised, effective) in cases {
+        let mut config = SignalFishConfig::new("app").enable_v3();
+        config.game_data_format = requested;
+        let (_events, snapshot) = assert_open_text_trace_parity(
+            vec![AUTH.into(), protocol_info_with_formats(advertised)],
+            config,
+        )
+        .await;
+        assert_eq!(snapshot.requested_game_data_format, requested);
+        assert_eq!(snapshot.effective_game_data_format, Some(effective));
+    }
+}
+
+#[tokio::test]
+async fn malformed_duplicate_and_around_negotiation_frames_have_complete_parity() {
+    let mut config = SignalFishConfig::new("app").enable_v3();
+    config.game_data_format = Some(GameDataEncoding::MessagePack);
+    let reconnect = reconnected_with_missed(vec![]);
+    let (events, snapshot) = assert_open_reconnect_trace_parity(
+        vec![
+            AUTH.into(),
+            reconnect.clone(),
+            protocol_info_with_formats(vec![]),
+            protocol_info_with_formats(vec![GameDataEncoding::Json, GameDataEncoding::MessagePack]),
+            protocol_info_with_formats(vec![GameDataEncoding::Json]),
+            reconnect,
+        ],
+        config,
+    )
+    .await;
+
+    assert_eq!(
+        events
+            .iter()
+            .map(|event| event.split('|').next().expect("event kind"))
+            .collect::<Vec<_>>(),
+        [
+            "Authenticated",
+            "ProtocolViolation",
+            "ProtocolViolation",
+            "ProtocolInfo",
+            "ProtocolViolation",
+            "Reconnected",
+        ]
+    );
+    assert_eq!(
+        snapshot.requested_game_data_format,
+        Some(GameDataEncoding::MessagePack)
+    );
+    assert_eq!(
+        snapshot.effective_game_data_format,
+        Some(GameDataEncoding::MessagePack),
+        "invalid or duplicate negotiation must not partially replace effective state"
+    );
+    assert!(snapshot.room_id.is_some());
+}
+
+#[tokio::test]
+async fn json_fallback_is_enforced_before_outbound_transport_admission_in_both_drivers() {
+    let fallback_error = serde_json::to_string(&ServerMessage::Error {
+        message: "rkyv is unsupported; falling back to JSON".into(),
+        error_code: Some(ErrorCode::UnsupportedGameDataFormat),
+    })
+    .expect("fallback Error fixture should serialize");
+    let protocol_info =
+        protocol_info_with_formats(vec![GameDataEncoding::Json, GameDataEncoding::MessagePack]);
+    let messages = vec![fallback_error, AUTH.into(), protocol_info];
+    let mut config = SignalFishConfig::new("app").enable_v3();
+    config.game_data_format = Some(GameDataEncoding::Rkyv);
+
+    let async_mock = SharedMock::from_msgs(
+        messages
+            .iter()
+            .cloned()
+            .map(|message| Some(Ok(message)))
+            .collect(),
+    );
+    let (mut async_client, mut async_events) =
+        SignalFishClient::start(async_mock.clone(), config.clone());
+    for _ in 0..=messages.len() {
+        tokio::time::timeout(std::time::Duration::from_secs(1), async_events.recv())
+            .await
+            .expect("async fallback handshake event should arrive")
+            .expect("async fallback event stream should remain open");
+    }
+    async_mock.sent.lock().unwrap().clear();
+    assert!(matches!(
+        async_client.send_binary_game_data(vec![1, 2, 3]),
+        Err(SignalFishError::BinaryFormatNotNegotiated)
+    ));
+    assert!(async_mock.sent.lock().unwrap().is_empty());
+    async_client
+        .send_game_data(serde_json::json!({"fallback": true}))
+        .expect("JSON send should remain valid after fallback");
+    wait_for_sent_len(&async_mock, 1).await;
+    assert!(matches!(
+        serde_json::from_str::<ClientMessage>(&async_mock.sent.lock().unwrap()[0])
+            .expect("async fallback send should be a ClientMessage"),
+        ClientMessage::GameData { .. }
+    ));
+
+    let polling_mock = SharedMock::from_msgs(
+        messages
+            .into_iter()
+            .map(|message| Some(Ok(message)))
+            .collect(),
+    );
+    let mut polling_client = SignalFishPollingClient::new(polling_mock.clone(), config);
+    let _ = polling_client.poll();
+    polling_mock.sent.lock().unwrap().clear();
+    assert!(matches!(
+        polling_client.send_binary_game_data(vec![1, 2, 3]),
+        Err(SignalFishError::BinaryFormatNotNegotiated)
+    ));
+    let _ = polling_client.poll();
+    assert!(polling_mock.sent.lock().unwrap().is_empty());
+    polling_client
+        .send_game_data(serde_json::json!({"fallback": true}))
+        .expect("polling JSON send should remain valid after fallback");
+    let _ = polling_client.poll();
+    assert_eq!(polling_mock.sent.lock().unwrap().len(), 1);
+
+    assert_eq!(async_client.snapshot(), polling_client.snapshot());
+    assert_eq!(
+        async_client.effective_game_data_format(),
+        Some(GameDataEncoding::Json)
+    );
+    async_client.shutdown().await;
+}
+
+#[tokio::test]
+async fn fallback_json_is_delivered_and_binary_is_rejected_with_driver_parity() {
+    let sender = uuid::Uuid::from_u128(365);
+    let mut frames = binary_accountability_prefix(sender);
+    frames[1] = TransportFrame::Text(protocol_info_with_formats(vec![
+        GameDataEncoding::Json,
+        GameDataEncoding::MessagePack,
+    ]));
+    frames.push(text_server_frame(ServerMessage::GameData {
+        from_player: sender,
+        data: serde_json::json!({"fallback": true}),
+        seq: Some(1),
+        epoch: Some(1),
+        class: Some(DeliveryClass::Reliable),
+        key: None,
+    }));
+    frames.push(TransportFrame::Binary(
+        rmp_serde::to_vec_named(&V3BinaryGameDataFrame {
+            from_player: sender,
+            encoding: GameDataEncoding::MessagePack,
+            payload: vec![1, 2, 3],
+            seq: 2,
+            epoch: 1,
+        })
+        .expect("binary fallback fixture should serialize"),
+    ));
+    let mut config = SignalFishConfig::new("app").enable_v3();
+    config.game_data_format = Some(GameDataEncoding::Rkyv);
+
+    let events = assert_frame_trace_parity(frames, config).await;
+    let kinds = events
+        .iter()
+        .map(|event| event.split('|').next().expect("event kind"))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        kinds,
+        [
+            "Authenticated",
+            "ProtocolInfo",
+            "RoomJoined",
+            "GameData",
+            "ProtocolViolation",
+            "Disconnected",
+        ]
+    );
+}
+
+#[tokio::test]
+async fn message_pack_receiver_accepts_json_origin_text_relay_with_driver_parity() {
+    let sender = uuid::Uuid::from_u128(366);
+    let mut frames = binary_accountability_prefix(sender);
+    frames[1] = TransportFrame::Text(protocol_info_with_formats(vec![
+        GameDataEncoding::Json,
+        GameDataEncoding::MessagePack,
+    ]));
+    frames.push(text_server_frame(ServerMessage::GameData {
+        from_player: sender,
+        data: serde_json::json!({"json_origin": true}),
+        seq: Some(1),
+        epoch: Some(1),
+        class: Some(DeliveryClass::Reliable),
+        key: None,
+    }));
+    let mut config = SignalFishConfig::new("app").enable_v3();
+    config.game_data_format = Some(GameDataEncoding::MessagePack);
+
+    let events = assert_frame_trace_parity(frames, config).await;
+    assert!(events.iter().any(|event| event.starts_with("GameData|")));
+    assert!(!events
+        .iter()
+        .any(|event| event.starts_with("ProtocolViolation|")));
+}
+
+#[tokio::test]
+async fn observe_advances_text_binary_representation_violation_with_driver_parity() {
+    let sender = uuid::Uuid::from_u128(367);
+    let mut frames = binary_accountability_prefix(sender);
+    frames[1] = TransportFrame::Text(protocol_info_with_formats(vec![
+        GameDataEncoding::Json,
+        GameDataEncoding::MessagePack,
+    ]));
+    frames.push(text_server_frame(ServerMessage::GameDataBinary {
+        from_player: sender,
+        encoding: GameDataEncoding::MessagePack,
+        payload: vec![1],
+        seq: Some(1),
+        epoch: Some(1),
+    }));
+    frames.push(TransportFrame::Binary(
+        rmp_serde::to_vec_named(&V3BinaryGameDataFrame {
+            from_player: sender,
+            encoding: GameDataEncoding::MessagePack,
+            payload: vec![2],
+            seq: 2,
+            epoch: 1,
+        })
+        .expect("binary fixture should serialize"),
+    ));
+    let mut config = SignalFishConfig::new("app")
+        .enable_v3()
+        .with_protocol_violation_policy(ProtocolViolationPolicy::Observe);
+    config.game_data_format = Some(GameDataEncoding::MessagePack);
+
+    let events = assert_frame_trace_parity(frames, config).await;
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| event.starts_with("ProtocolViolation|"))
+            .count(),
+        1,
+        "the following seq=2 frame must not see a synthetic gap"
+    );
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| event.starts_with("GameDataBinary|"))
+            .count(),
+        2
+    );
 }
 
 fn binary_accountability_prefix(player_id: PlayerId) -> Vec<TransportFrame> {
@@ -1825,8 +2223,15 @@ async fn parity_reconnect_preserves_outer_v3_negotiation() {
     let recon = reconnected_with_missed(vec![]);
 
     let async_mock = SharedMock::new(vec![AUTH, PI_V3, &recon]);
-    let (client, mut events) =
+    let (mut client, mut events) =
         SignalFishClient::start(async_mock, SignalFishConfig::new("app").enable_mesh());
+    client
+        .reconnect(
+            uuid::Uuid::from_u128(200),
+            uuid::Uuid::from_u128(100),
+            "submitted-token".into(),
+        )
+        .expect("async reconnect must queue");
     for _ in 0..4 {
         let _ = tokio::time::timeout(std::time::Duration::from_millis(100), events.recv()).await;
     }
@@ -1838,6 +2243,13 @@ async fn parity_reconnect_preserves_outer_v3_negotiation() {
 
     let poll_mock = SharedMock::new(vec![AUTH, PI_V3, &recon]);
     let mut poll_client = SignalFishPollingClient::new(poll_mock, SignalFishConfig::new("app"));
+    poll_client
+        .reconnect(
+            uuid::Uuid::from_u128(200),
+            uuid::Uuid::from_u128(100),
+            "submitted-token".into(),
+        )
+        .expect("polling reconnect must queue");
     poll_client.poll();
     assert_eq!(
         poll_client.negotiated_protocol_version(),
@@ -1851,7 +2263,7 @@ async fn parity_reconnect_preserves_outer_v3_negotiation() {
 #[tokio::test]
 async fn parity_reconnect_rejects_nested_protocol_info_without_downgrade() {
     let recon_v2 = reconnected_with_missed(vec![ServerMessage::ProtocolInfo(pi_v2_payload())]);
-    let events = assert_frame_trace_parity(
+    let events = assert_frame_trace_parity_with_reconnect(
         vec![
             TransportFrame::Text(AUTH.into()),
             TransportFrame::Text(PI_V3.into()),
@@ -1860,6 +2272,7 @@ async fn parity_reconnect_rejects_nested_protocol_info_without_downgrade() {
         SignalFishConfig::new("app")
             .enable_v3()
             .with_protocol_violation_policy(ProtocolViolationPolicy::Observe),
+        true,
     )
     .await;
     assert!(events.iter().any(|event| {
@@ -1867,6 +2280,53 @@ async fn parity_reconnect_rejects_nested_protocol_info_without_downgrade() {
             && event.contains("non-replayable ProtocolInfo")
     }));
     assert!(!events.iter().any(|event| event.starts_with("Reconnected")));
+}
+
+#[tokio::test]
+async fn malformed_reconnect_baselines_have_complete_driver_parity() {
+    let valid = reconnected_with_missed(vec![]);
+    let ServerMessage::Reconnected(mut invalid_payload) =
+        serde_json::from_str::<ServerMessage>(&valid).unwrap()
+    else {
+        unreachable!("reconnect fixture must decode as Reconnected")
+    };
+    invalid_payload.reconnection_token = None;
+    let invalid = serde_json::to_string(&ServerMessage::Reconnected(invalid_payload)).unwrap();
+
+    for policy in [
+        ProtocolViolationPolicy::Observe,
+        ProtocolViolationPolicy::Quarantine,
+    ] {
+        let (events, snapshot) = assert_open_reconnect_trace_parity(
+            vec![AUTH.into(), PI_V3.into(), invalid.clone(), valid.clone()],
+            SignalFishConfig::new("app")
+                .enable_v3()
+                .with_protocol_violation_policy(policy),
+        )
+        .await;
+        assert!(events[2].starts_with("ProtocolViolation|Lifecycle|"));
+        assert!(events[3].starts_with("Reconnected|"));
+        assert_eq!(snapshot.room_id, Some(uuid::Uuid::from_u128(100)));
+        assert_eq!(
+            snapshot.reconnection_token.as_deref(),
+            Some("rotated-token")
+        );
+        assert!(!snapshot.quarantined);
+    }
+
+    let events = assert_frame_trace_parity_with_reconnect(
+        vec![
+            TransportFrame::Text(AUTH.into()),
+            TransportFrame::Text(PI_V3.into()),
+            TransportFrame::Text(invalid),
+        ],
+        SignalFishConfig::new("app")
+            .enable_v3()
+            .with_protocol_violation_policy(ProtocolViolationPolicy::Disconnect),
+        true,
+    )
+    .await;
+    assert!(events[2].starts_with("ProtocolViolation|Lifecycle|"));
 }
 
 // ── PARITY 6: enable_mesh advertises v3 identically ──────────────────

--- a/tests/real_server_e2e.rs
+++ b/tests/real_server_e2e.rs
@@ -27,9 +27,10 @@
 use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
 
+use signal_fish_client::protocol::GameDataEncoding;
 use signal_fish_client::{
-    ErrorCode, JoinRoomParams, SignalFishClient, SignalFishConfig, SignalFishEvent,
-    WebSocketTransport,
+    ErrorCode, JoinRoomParams, SignalFishClient, SignalFishConfig, SignalFishError,
+    SignalFishEvent, WebSocketTransport,
 };
 
 // ── Harness ─────────────────────────────────────────────────────────
@@ -153,7 +154,103 @@ async fn wait_for_event(
     }
 }
 
+async fn recv_next_event(
+    events: &mut tokio::sync::mpsc::Receiver<SignalFishEvent>,
+    what: &str,
+) -> SignalFishEvent {
+    match tokio::time::timeout(Duration::from_secs(5), events.recv()).await {
+        Ok(Some(event)) => event,
+        Ok(None) => panic!("event stream ended while waiting for {what}"),
+        Err(_) => panic!("timed out waiting for {what}"),
+    }
+}
+
 // ── Tests ───────────────────────────────────────────────────────────
+
+/// Server 0.7 fallback smoke: an unsupported Rkyv preference produces the
+/// warning-before-authentication sequence, then resolves coherently to JSON.
+#[tokio::test]
+#[ignore = "requires Signal Fish Server 0.7; set SIGNAL_FISH_SERVER_BIN or SIGNAL_FISH_E2E_URL"]
+async fn e2e_server_070_rkyv_request_resolves_to_json() {
+    let (_guard, url): (Option<ServerGuard>, String) = match external_url() {
+        Some(url) => (None, url),
+        None => match spawn_server(&[]).await {
+            Some((guard, url)) => (Some(guard), url),
+            None => {
+                eprintln!("skipping: neither SIGNAL_FISH_E2E_URL nor SIGNAL_FISH_SERVER_BIN set");
+                return;
+            }
+        },
+    };
+
+    let transport = WebSocketTransport::connect(&url)
+        .await
+        .expect("connect to real Server 0.7");
+    let mut config = SignalFishConfig::new(app_id()).enable_v3();
+    config.game_data_format = Some(GameDataEncoding::Rkyv);
+    let (mut client, mut events) = SignalFishClient::start(transport, config);
+
+    assert!(matches!(
+        recv_next_event(&mut events, "Connected").await,
+        SignalFishEvent::Connected
+    ));
+    assert!(matches!(
+        recv_next_event(&mut events, "unsupported-format Error").await,
+        SignalFishEvent::Error {
+            error_code: Some(ErrorCode::UnsupportedGameDataFormat),
+            ..
+        }
+    ));
+    assert!(matches!(
+        recv_next_event(&mut events, "Authenticated").await,
+        SignalFishEvent::Authenticated { .. }
+    ));
+    let protocol_info = recv_next_event(&mut events, "ProtocolInfo").await;
+    let SignalFishEvent::ProtocolInfo(protocol_info) = protocol_info else {
+        panic!("expected ProtocolInfo after authentication, got {protocol_info:?}")
+    };
+    assert_eq!(
+        protocol_info.game_data_formats,
+        vec![GameDataEncoding::Json, GameDataEncoding::MessagePack]
+    );
+    assert_eq!(
+        client.requested_game_data_format(),
+        Some(GameDataEncoding::Rkyv)
+    );
+    assert_eq!(
+        client.effective_game_data_format(),
+        Some(GameDataEncoding::Json)
+    );
+    assert!(matches!(
+        client.send_binary_game_data(vec![1, 2, 3]),
+        Err(SignalFishError::BinaryFormatNotNegotiated)
+    ));
+
+    client
+        .join_room(JoinRoomParams::new("e2e-format-fallback", "json-client"))
+        .expect("fallback client should queue JoinRoom");
+    wait_for_event(&mut events, "RoomJoined", Duration::from_secs(5), |event| {
+        matches!(event, SignalFishEvent::RoomJoined { .. })
+    })
+    .await;
+    client
+        .send_game_data(serde_json::json!({"fallback": "json"}))
+        .expect("fallback client should send JSON game data");
+    client.ping().expect("queue fallback send fence");
+    let fence = wait_for_event(
+        &mut events,
+        "fallback send fence",
+        Duration::from_secs(5),
+        |event| matches!(event, SignalFishEvent::Pong | SignalFishEvent::Error { .. }),
+    )
+    .await;
+    assert!(
+        matches!(fence, SignalFishEvent::Pong),
+        "Server 0.7 must accept JSON after Rkyv fallback, got {fence:?}"
+    );
+    assert_eq!(client.stats().game_data_sent, 1);
+    client.shutdown().await;
+}
 
 /// A fully stalled consumer is evicted loudly: the room observes
 /// `PlayerLeft`, and the victim — once it resumes draining — observes what
@@ -297,7 +394,7 @@ async fn e2e_reconnect_after_disconnect_uses_server_token() {
     // Join a v3 room, retain the server-issued token, then drop the connection
     // abruptly (no LeaveRoom and no graceful shutdown).
     let (mut a, mut a_events) =
-        connect_authenticated(&url, SignalFishConfig::new(app_id()).enable_v3()).await;
+        connect_authenticated(&url, SignalFishConfig::new(app_id()).enable_mesh()).await;
     a.join_room(JoinRoomParams::new("e2e-reconnect", "alpha"))
         .expect("join_room");
     let joined = wait_for_event(&mut a_events, "RoomJoined", Duration::from_secs(5), |e| {
@@ -314,12 +411,37 @@ async fn e2e_reconnect_after_disconnect_uses_server_token() {
         .snapshot()
         .reconnection_token
         .expect("v3 RoomJoined must issue a reconnection token");
+
+    a.set_ready().expect("set ready before finalizing room");
+    a.ping().expect("queue readiness fence ping");
+    wait_for_event(
+        &mut a_events,
+        "readiness fence Pong",
+        Duration::from_secs(5),
+        |e| matches!(e, SignalFishEvent::Pong),
+    )
+    .await;
+    a.start_game().expect("finalize room before reconnect");
+    let first_plan = wait_for_event(
+        &mut a_events,
+        "initial SessionPlan",
+        Duration::from_secs(5),
+        |e| matches!(e, SignalFishEvent::SessionPlan { .. }),
+    )
+    .await;
+    let SignalFishEvent::SessionPlan {
+        generation: Some(first_generation),
+        ..
+    } = first_plan
+    else {
+        panic!("server 0.7 initial SessionPlan must carry a generation")
+    };
     drop(a);
     drop(a_events);
 
     // Fresh v3 connection consumes the token.
     let (mut b, mut b_events) =
-        connect_authenticated(&url, SignalFishConfig::new(app_id()).enable_v3()).await;
+        connect_authenticated(&url, SignalFishConfig::new(app_id()).enable_mesh()).await;
     b.reconnect(player_id, room_id, first_token.clone())
         .expect("queue Reconnect");
 
@@ -339,6 +461,8 @@ async fn e2e_reconnect_after_disconnect_uses_server_token() {
     .await;
 
     let SignalFishEvent::Reconnected {
+        current_players,
+        replay,
         reconnection_token,
         sender_watermarks,
         ..
@@ -347,17 +471,41 @@ async fn e2e_reconnect_after_disconnect_uses_server_token() {
         panic!("a compatible server must accept its issued reconnect token")
     };
     let rotated_token = reconnection_token.expect("Reconnected must rotate the token");
-    assert_ne!(rotated_token, first_token, "reconnect token must rotate");
-    assert!(
-        sender_watermarks
-            .iter()
-            .any(|watermark| watermark.player_id == player_id),
-        "Reconnected must carry the reconnecting player's watermark"
-    );
+    assert!(rotated_token != first_token, "reconnect token must rotate");
+    assert!(replay.is_some(), "v3 Reconnected must report replay status");
+    let player_ids = current_players
+        .iter()
+        .map(|player| player.id)
+        .collect::<std::collections::BTreeSet<_>>();
+    let watermark_ids = sender_watermarks
+        .iter()
+        .map(|watermark| watermark.player_id)
+        .collect::<std::collections::BTreeSet<_>>();
     assert_eq!(
-        b.snapshot().reconnection_token.as_deref(),
-        Some(rotated_token.as_str()),
+        watermark_ids, player_ids,
+        "Reconnected watermarks must exactly cover the current-player snapshot"
+    );
+    assert!(
+        b.snapshot().reconnection_token.as_deref() == Some(rotated_token.as_str()),
         "snapshot must expose the replacement token"
+    );
+
+    let replacement_plan = wait_for_event(
+        &mut b_events,
+        "replacement SessionPlan",
+        Duration::from_secs(5),
+        |e| matches!(e, SignalFishEvent::SessionPlan { .. }),
+    )
+    .await;
+    assert!(
+        matches!(
+            replacement_plan,
+            SignalFishEvent::SessionPlan {
+                generation: Some(generation),
+                ..
+            } if generation != first_generation
+        ),
+        "a finalized reconnect must receive a fresh plan generation"
     );
     b.shutdown().await;
 }


### PR DESCRIPTION
## Summary

- separate the requested game-data preference from the effective Server 0.7-negotiated format across the shared core, snapshots, async/polling clients, and object-safe API
- validate and commit the first canonical `ProtocolInfo` atomically; enforce JSON fallback before transport admission while preserving JSON-origin text relays for MessagePack recipients
- make reconnect terminal responses causally match an admitted player/room/token request, validate v2/v3 replay-accountability baselines transactionally under every policy, and fence the old WebRTC plan until the server's fresh live plan
- add async/polling parity matrices, malformed-state rollback tests, pinned Server 0.7 acceptance tests, blocking CI rows, public docs, changelog, PLAN, and session evidence

## Compatibility

This adds two fields to the exhaustive `ClientSnapshot` struct and is therefore recorded as a breaking public-API change for the forthcoming 0.11 release. `SignalFishClientApi` supplies default accessors through `snapshot()`.

## Verification

- `cargo fmt`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- no-default, polling-only, and Tokio-only feature checks
- rustdoc with warnings denied
- local docs validation
- all 18 pre-commit and all 6 pre-push checks
- pinned Server 0.7 ARM64 binary:
  - `e2e_server_070_rkyv_request_resolves_to_json`
  - `e2e_reconnect_after_disconnect_uses_server_token`
- three independent audits plus adversarial re-review; final review reported no remaining findings

Closes #100.
Closes #101.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches shared protocol state, reconnect credentials, mesh/WebRTC fencing, and breaking public snapshot APIs—incorrect validation or barrier ordering could break live sessions or mis-route signals.
> 
> **Overview**
> **Game-data negotiation** now keeps **requested** vs **effective** formats separate on `ClientSnapshot` and async/polling/`SignalFishClientApi` accessors. The shared core resolves the first canonical Server 0.7 `ProtocolInfo` atomically (unsupported or omitted requests → JSON); `UnsupportedGameDataFormat` no longer mutates negotiated state. Binary admission and frame validation use the effective format, while **JSON-origin text relays stay valid** for MessagePack peers.
> 
> **Reconnect** is stricter and causally bound: terminal `Reconnected` / `ReconnectionFailed` must follow an admitted `Reconnect`; v3 baselines require replay, rotated token, stamps, and complete watermarks, and invalid baselines never apply (including under `Observe`). **`Reconnected` fences the WebRTC plan**—`MeshSession` and `MeshController` drop the old plan/peers until a fresh live `SessionPlan`; the mesh controller advances plan barriers per consumed event to avoid coalesced replan races.
> 
> Docs, changelog, CI e2e rows (Rkyv→JSON, reconnect token), and broad parity/core/mesh tests cover the above; `ClientSnapshot` gains two fields (breaking for 0.11).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b61b173247f191e84ff9580cb63c7245bb974554. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->