### PR TITLE
fix!: separate mesh capability and active plan state

### DIFF
--- a/.llm/context.md
+++ b/.llm/context.md
@@ -231,8 +231,8 @@ complete compiling example is `examples/basic_lobby.rs`.
 
 Required second argument to `SignalFishClient::start`. Only `app_id` is required.
 Opt into protocol v3 relay/accountability with `.enable_v3()`. Use
-`.enable_mesh()` only when a WebRTC driver is present; it calls `enable_v3()`
-and additionally advertises WebRTC mesh/host support.
+`.enable_mesh()` only with a WebRTC driver. `MeshController::start` preserves
+compatible choices while ensuring v3, WebRTC, and a Host or Mesh topology.
 
 ```rust,ignore
 pub struct SignalFishConfig {
@@ -297,12 +297,12 @@ client.shutdown().await      // async, graceful
 WebRTC signaling also requires an authoritative `SessionPlan`. Server 0.7
 plans/signals carry a UUID generation; the shared core stamps outgoing signals,
 suppresses stale/unknown inbound generations, rejects self/off-plan/departed
-peers in both directions, and exposes the current value in the snapshot.
+peers, and snapshots the generation plus selected topology/transport atomically.
 Accepted plans are finalized-room, current-roster shapes limited to the four
 Server 0.7 topology/transport pairs and replace prior peer authority atomically.
-`MeshController` generation-binds driver work and rebuilds every retained pair
-when the generation changes. Optional generation fields exist only for 0.4.
-Retired peer identity fences late generation-less signals across 0.4 re-plans.
+`supports_mesh()` reports negotiated WebRTC + Host/Mesh capability, not the
+selected plan. `MeshController` rebuilds retained pairs across generations or
+offerer-role changes. `MeshSession` accepts liveness only for the selected transport.
 
 Sync sends return `SignalFishError::NotConnected` when the transport is closed
 and `SignalFishError::SendBufferFull { capacity }` when the bounded queue is

--- a/.llm/skills/protocol-versioning-and-negotiation/SKILL.md
+++ b/.llm/skills/protocol-versioning-and-negotiation/SKILL.md
@@ -36,9 +36,11 @@ MUST be `Option` + `skip_serializing_if` (or `Vec` + `default` + `skip_if-empty`
 3. If the negotiation is < v3, or transports/topologies were omitted, the server
    keeps the room on the relay floor and emits no v3 messages.
 
-The client tracks the negotiated version from `ProtocolInfo`:
-`SignalFishClient::negotiated_protocol_version()` and `supports_mesh()` (true
-when WebRTC mesh was advertised and the negotiated version is ≥ 3).
+The client tracks the negotiated version from `ProtocolInfo`.
+`supports_mesh()` reports negotiated local capability and requires WebRTC plus
+at least one advertised P2P topology (`Host` or `Mesh`) and version ≥ 3. It does
+not report the server-selected plan. Read `ClientSnapshot::session_topology` and
+`session_transport` together for that, or use `is_p2p_active()`.
 
 ## Never Advertise What You Cannot Fulfill
 
@@ -50,6 +52,9 @@ can't honor. So:
 - `SignalFishConfig::enable_mesh()` is the opt-in for consumers who HAVE a WebRTC
   stack (or use `MeshController`). It advertises v3 + `[webrtc, relay]` +
   `[mesh, host, relay]`.
+- `MeshController::start` ensures those minimum classes even when v3 was already
+  selected, while preserving compatible explicit transports, topologies, and
+  future protocol versions.
 
 ## The Fail-Fast Guard
 

--- a/.llm/skills/public-api-design/SKILL.md
+++ b/.llm/skills/public-api-design/SKILL.md
@@ -268,11 +268,11 @@ close details come from `Transport::close_info()`.
   from relabeling stale output; `SignalFishError::SessionPlanUnavailable`,
   `SignalFishError::StaleSessionGeneration`, and
   `ErrorCode::UnsupportedProtocolVersion` are new exhaustive variants.
-- **Client policy/state API.** `GameDataDelivery` makes class/key combinations
-  valid by construction; `ProtocolViolationPolicy` defaults to `Quarantine`;
-  `ProtocolViolationKind` categorizes the emitted event; `ClientSnapshot`
-  synchronously exposes negotiated/session/token/quarantine state on both
-  drivers. New exhaustive variants/fields require a MINOR bump for this 0.x crate.
+- **Client policy/state API.** `ClientSnapshot` synchronously exposes negotiated,
+  selected topology/transport, session, token, and quarantine state on both
+  drivers. `supports_mesh()` is capability-only; `is_p2p_active()` and the
+  selected-plan fields describe current routing. New exhaustive variants/fields
+  require a MINOR bump for this 0.x crate.
 - **The mesh surface is feature-gated** behind `mesh` (and the async controller
   additionally behind `tokio-runtime`), keeping the default build minimal. See
   [webrtc-mesh-signaling](../webrtc-mesh-signaling/SKILL.md).

--- a/.llm/skills/testing-async/SKILL.md
+++ b/.llm/skills/testing-async/SKILL.md
@@ -298,8 +298,8 @@ Not every `.unwrap()` needs to become `.expect()`. These cases are acceptable:
   server samples — see [protocol-wire-conformance](../protocol-wire-conformance/SKILL.md).
 - **Negotiation**: script `protocol_info_json(Some(3))` after `authenticated_json()`
   through `MockTransport`; assert the negotiated version, v3 sends, and the
-  pre-negotiation error. Assert `supports_mesh()` only with `enable_mesh()`;
-  relay-only `enable_v3()` must remain false.
+  pre-negotiation error. Assert `supports_mesh()` requires advertised WebRTC,
+  a Host/Mesh topology, and v3; distinguish it from selected plan state.
 - **Frames/accountability**: keep text and binary frames in one scripted order;
   assert malformed binary becomes `DecodeFailed`, while valid accountability
   failures become `ProtocolViolation` and follow the configured policy.
@@ -307,4 +307,5 @@ Not every `.unwrap()` needs to become `.expect()`. These cases are acceptable:
   (see `src/webrtc.rs` tests) — drive the handshake, assert
   `connect(peer, generation, initiate)`
   obeys the server, signals are relayed, and `PeerConnected`/`PeerDisconnected`
-  surface with correct transport-status reports.
+  surface with correct transport-status reports. Cross-test controller config
+  augmentation and selected topology/transport against both client drivers.

--- a/.llm/skills/webrtc-mesh-signaling/SKILL.md
+++ b/.llm/skills/webrtc-mesh-signaling/SKILL.md
@@ -52,10 +52,10 @@ signals, and rejects late driver output from the prior generation.
 ## MeshSession Tracker (no WebRTC)
 
 `MeshSession` folds the v3 events into a consistent view (`topology`/`transport`/
-`generation`/`host`/`direct_endpoint`/`peers`/`ice_servers`, each peer with `initiate` + `connected`). It handles
-late joins (`NewPeer`), host re-election (a new `SessionPlan` **replaces** peers and
-ICE wholesale, never merges), `PlayerLeft` removal, and reconnect replay
-idempotently. `apply(&event) -> bool` returns whether the view changed.
+`generation`/`host`/`direct_endpoint`/`peers`/`ice_servers`, each peer with
+`initiate` + selected-path `connected`). A peer status mutates liveness only
+when its transport matches the plan; generation, transport, or offerer-role
+changes clear stale liveness. Plans replace peers and ICE wholesale.
 
 ## WebRtcDriver Seam
 
@@ -86,9 +86,9 @@ on `SignalReceived` it feeds `on_signal`; it relays the driver's outbound `Signa
 via the client, reports `TransportStatus` on the 0↔1 connected boundary, tears down
 peers on re-election/`PlayerLeft`/`RoomLeft`/`Disconnected`, and surfaces a
 `MeshEvent` stream (`Signaling`, `PeerConnected`, `PeerDisconnected`, `Data`).
-`start` auto-enables mesh if the config didn't. `MeshController<D>` is `Send` when
-`D` is (spawnable); a `!Send` driver must be driven on the current task. See
-`examples/mesh_session.rs` for the full runnable flow.
+`start` ensures v3, WebRTC, and a P2P topology even for a preselected v3 config;
+compatible explicit lists and future versions remain intact. `MeshController<D>`
+is `Send` when `D` is; drive a `!Send` driver on the current task.
 
 Direct and Relay plans never drive `WebRtcDriver`; they clear controller WebRTC
 state. Applications may implement Direct separately from the validated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   effective_game_data_format}` and matching async, polling, and
   `SignalFishClientApi` accessors. Configuration omission now remains visible
   separately from the format selected by the server.
+- Added `ClientSnapshot::{session_topology, session_transport}` plus
+  `session_topology()`, `session_transport()`, and `is_p2p_active()` to the
+  async client, polling client, and `SignalFishClientApi`. Applications can now
+  distinguish negotiated local capability from the server-selected active path.
 
 ### Changed
 
@@ -50,12 +54,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Breaking:** the exhaustive `ClientSnapshot` struct has two new game-data
   negotiation fields. `SignalFishClientApi` provides corresponding default
   requested/effective format accessors through `snapshot()`.
+- **Breaking:** the exhaustive `ClientSnapshot` gains selected topology and
+  transport fields. `supports_mesh()` now precisely means negotiated v3 plus
+  advertised WebRTC and at least one `Host` or `Mesh` topology; custom
+  WebRTC + relay-only configurations now return `false`. Use the selected-plan
+  snapshot fields or `is_p2p_active()` for routing decisions.
 - Reconnect is now a hard WebRTC plan boundary: `MeshSession` and
   `MeshController` clear the previous plan and driver peers at `Reconnected`,
   then wait for Server 0.7's fresh live `SessionPlan` before authorizing new
   signaling.
 
 ### Fixed
+
+- Fixed `MeshController::start` leaving an `enable_v3()` configuration
+  relay-only despite owning a WebRTC driver. Controller startup now preserves
+  compatible explicit and future-version choices while adding any missing
+  WebRTC/P2P capability. `MeshSession` also ignores peer status for transports
+  other than the selected path and clears stale liveness when that path or the
+  server-assigned offerer role changes.
 
 - Fixed game-data encoding being treated as one mutable requested/effective
   value. The shared core now resolves the first canonical Server 0.7

--- a/PLAN.md
+++ b/PLAN.md
@@ -118,10 +118,10 @@ Lifecycle/plan/signaling-invalid frames are observable but transactional under
 every policy; async and polling drivers retain identical behavior. Session 027
 records the rule-to-test/source matrix and verification evidence.
 
-## Current Correctness Milestone — Negotiation and Reconnect State
+## Completed Correctness Milestone — Negotiation and Reconnect State
 
-Issues #100 and #101 are implemented together for review because both depend on
-the first authoritative `ProtocolInfo` and reconnect state transaction.
+Issues #100 and #101 shipped together in PR #111 because both depend on the
+first authoritative `ProtocolInfo` and reconnect state transaction.
 
 - Requested and effective game-data formats are distinct public state. The
   shared core resolves Server 0.7's canonical format advertisement atomically,
@@ -131,12 +131,20 @@ the first authoritative `ProtocolInfo` and reconnect state transaction.
   token rotation, accountability, membership, and plan state under every
   violation policy. The old WebRTC plan is fenced until Server 0.7's fresh live
   post-reconnect plan arrives.
-- Session 028 records the rule-to-source-to-test matrix and local pinned-server
-  evidence. Hosted review and aggregate checks remain the completion gate.
+- Session 028 records the rule-to-source-to-test matrix, pinned-server evidence,
+  hosted review fixes, and green aggregate checks.
 
-## Next Correctness Milestone — Delivery Semantics and Liveness
+## Current Correctness Milestone — Mesh Capability and Liveness
 
-Continue with #102, then #105, #103, #104, #106, and #107 before usability,
+[Issue #102](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/issues/102)
+separates negotiated local capability from the authoritative selected plan,
+normalizes controller-owned WebRTC configuration, and makes peer liveness
+transport-specific. Session 029 records the configuration, state, transition,
+and async/polling/controller parity evidence.
+
+## Next Correctness Milestone — WebSocket Liveness
+
+Continue with #105, then #103, #104, #106, and #107 before usability,
 performance, token binding, or presentation milestones.
 
 ## Following Milestone — Negotiated Token Binding

--- a/docs/client.md
+++ b/docs/client.md
@@ -560,7 +560,9 @@ Useful for keeping the connection alive through proxies or load balancers.
 connection/authentication state, room/player IDs, room code, the latest
 reconnection token, requested and effective game-data formats, negotiated
 protocol version, current session generation, and whether delivery is
-quarantined. Prefer it whenever multiple fields must describe the same instant.
+quarantined. It also carries the latest selected `session_topology` and
+`session_transport`. Prefer it whenever multiple fields must describe the same
+instant.
 
 Synchronous snapshot and negotiation accessors briefly lock the shared core;
 the async room-ID accessors acquire the same internal mutex.
@@ -572,6 +574,10 @@ the async room-ID accessors acquire the same internal mutex.
 | `snapshot()` | `fn snapshot(&self) -> ClientSnapshot` | Returns coherent session, reconnect-token, negotiation, and quarantine state. |
 | `requested_game_data_format()` | `fn requested_game_data_format(&self) -> Option<GameDataEncoding>` | Exact preference supplied in `SignalFishConfig`, preserving omission. |
 | `effective_game_data_format()` | `fn effective_game_data_format(&self) -> Option<GameDataEncoding>` | Server-selected format; `None` before valid `ProtocolInfo` or after disconnect. |
+| `supports_mesh()` | `fn supports_mesh(&self) -> bool` | Negotiated local capability: v3 plus advertised WebRTC and a Host or Mesh topology. This does not describe the active plan. |
+| `session_topology()` | `fn session_topology(&self) -> Option<Topology>` | Topology selected by the latest authoritative plan. |
+| `session_transport()` | `fn session_transport(&self) -> Option<TransportKind>` | Transport selected by the latest authoritative plan. |
+| `is_p2p_active()` | `fn is_p2p_active(&self) -> bool` | Whether the selected plan uses a Host or Mesh topology. |
 | `current_room_id()` | `async fn current_room_id(&self) -> Option<RoomId>` | Returns the current room ID, if in a room. |
 | `current_player_id()` | `async fn current_player_id(&self) -> Option<PlayerId>` | Returns the current player ID, if assigned by the server. |
 | `current_room_code()` | `async fn current_room_code(&self) -> Option<String>` | Returns the current room code, if in a room. |
@@ -774,14 +780,17 @@ All accessors are **synchronous** (no async, no mutex):
 | `negotiated_protocol_version()` | `Option<u16>` | Negotiated v3-or-newer version; `None` before `ProtocolInfo` or on the v2 floor. |
 | `requested_game_data_format()` | `Option<GameDataEncoding>` | Exact configured preference, preserving omission. |
 | `effective_game_data_format()` | `Option<GameDataEncoding>` | Server-selected format; `None` before valid `ProtocolInfo` or after disconnect. |
-| `supports_mesh()` | `bool` | Whether WebRTC was advertised and protocol v3 was negotiated. |
+| `supports_mesh()` | `bool` | Negotiated v3 + WebRTC + Host/Mesh capability; not active-plan state. |
+| `session_topology()` | `Option<Topology>` | Topology selected by the latest authoritative plan. |
+| `session_transport()` | `Option<TransportKind>` | Transport selected by the latest authoritative plan. |
+| `is_p2p_active()` | `bool` | Whether the selected plan uses a Host or Mesh topology. |
 | `current_player_id()` | `Option<PlayerId>` | Current player ID, if assigned. |
 | `current_room_id()` | `Option<RoomId>` | Current room ID, if in a room. |
 | `current_room_code()` | `Option<&str>` | Current room code, if in a room. |
 | `send_capacity()` | `usize` | Messages that can still be queued before `SendBufferFull`. |
 | `max_send_capacity()` | `usize` | Configured command-queue capacity. |
 | `stats()` | `ClientStats` | Cumulative `game_data_sent` / `game_data_received` / `messages_undecodable` counters (see [Send Queue and Traffic Stats](#send-queue-and-traffic-stats)). |
-| `snapshot()` | `ClientSnapshot` | Coherent connection, room, reconnect-token, negotiation, and quarantine state. |
+| `snapshot()` | `ClientSnapshot` | Coherent connection, room, reconnect-token, negotiation, selected-plan, and quarantine state. |
 | `polling_stats()` | `PollingStats` | Client-owned queue depth, budget exhaustion, abandoned-command, and deadline counters. |
 | `queue_age_stats()` | `PollingQueueAgeStats` | Sampled current/peak age of the oldest client-owned outbound item. |
 | `reset_queue_age_peak()` | `()` | Refresh current age and reset its sampled peak; useful after setup. |

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -118,8 +118,9 @@ that a v2 connection never sees.
    (`protocol_version`, `supported_transports`, `supported_topologies`).
 2. The server clamps to its own range and echoes the negotiated
    `protocol_version` (plus min/max) back in `ProtocolInfo`.
-3. The client records it; read it via `negotiated_protocol_version()` and
-   `supports_mesh()` (true after `enable_mesh()` and v3 negotiation).
+3. The client records it; `supports_mesh()` reports negotiated local capability
+   only when WebRTC and a Host or Mesh topology were advertised. It does not say
+   which plan the server selected.
 
 v3-only sends (`send_signal`, `report_transport_status`, …) **fail fast** with
 [`SignalFishError::ProtocolUnsupported`](errors.md) until v3 is negotiated —
@@ -315,12 +316,16 @@ simultaneous send + receive pressure.
 | `is_authenticated()` | No | `bool` |
 | `snapshot()` | No | `ClientSnapshot` |
 | `negotiated_protocol_version()` | No | `Option<u16>` |
-| `supports_mesh()` | No | `bool` |
+| `supports_mesh()` | No | `bool` (negotiated WebRTC + Host/Mesh capability) |
+| `session_topology()` | No | `Option<Topology>` |
+| `session_transport()` | No | `Option<TransportKind>` |
+| `is_p2p_active()` | No | `bool` (selected plan is Host or Mesh) |
 | `current_player_id()` | Yes (`async`) | `Option<PlayerId>` |
 | `current_room_id()` | Yes (`async`) | `Option<RoomId>` |
 | `current_room_code()` | Yes (`async`) | `Option<String>` |
 
-Use `snapshot()` when multiple values must describe one instant. The individual
+Use `snapshot()` when multiple values must describe one instant, especially the
+selected `session_topology`/`session_transport` pair. The individual
 async room/player accessors are convenient for one-off reads but are not one
 coherent multi-field observation.
 

--- a/docs/events.md
+++ b/docs/events.md
@@ -362,8 +362,8 @@ shows that complete pattern.
 
 !!! warning "v3-negotiated connections only"
     These four events arrive **only** when the connection has negotiated
-    protocol v3 — i.e. you opted in with `SignalFishConfig::enable_mesh()` and the
-    server agreed. A v2 relay-floor connection never emits them. See the
+    protocol v3 and the server emits the corresponding plan/signaling state.
+    A v2 relay-floor connection never emits them. See the
     [Mesh Guide](mesh-guide.md) for the full peer-to-peer flow and
     [Protocol Versioning](protocol-versioning.md) for how negotiation works.
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -502,9 +502,10 @@ A **real** driver wraps str0m, webrtc-rs, or the browser's `RtcPeerConnection`
 
 #### 2. Start the `MeshController`
 
-`MeshController::start` enables mesh automatically if the config didn't, then
-drives the handshake. Note the config is the plain relay-floor
-`SignalFishConfig::new("demo-app")` — `start` upgrades it to mesh for you.
+`MeshController::start` ensures the config advertises v3, WebRTC, and at least
+one P2P topology, then drives the handshake. Compatible explicit transport,
+topology, and future-version choices are preserved. The plain relay-floor
+`SignalFishConfig::new("demo-app")` therefore works directly.
 
 ```rust,ignore
 let mut mesh = MeshController::start(

--- a/docs/mesh-guide.md
+++ b/docs/mesh-guide.md
@@ -168,7 +168,7 @@ generation.
 use signal_fish_client::webrtc::{MeshController, MeshEvent};
 use signal_fish_client::{JoinRoomParams, SignalFishConfig, SignalFishEvent};
 
-// `start` auto-enables mesh if the config didn't.
+// `start` ensures v3 + WebRTC + a P2P topology while preserving compatible choices.
 let mut mesh = MeshController::start(transport, SignalFishConfig::new("app"), my_driver);
 
 while let Some(event) = mesh.recv().await {
@@ -196,7 +196,7 @@ mesh.shutdown().await;
 
 | API | Purpose |
 |-----|---------|
-| `MeshController::start(transport, config, driver)` | Build the controller; auto-enables mesh if the config didn't. |
+| `MeshController::start(transport, config, driver)` | Build the controller; ensure v3, WebRTC, and a P2P topology while preserving compatible custom choices. |
 | `recv().await -> Option<MeshEvent>` | Drive the handshake and yield the next high-level event. `None` once the transport closes. |
 | `send_to(peer, &[u8])` | Send application bytes to a peer over its data channel. |
 | `with_pump_interval(Duration)` | Tune the periodic driver pump (default 20 ms). |
@@ -292,7 +292,8 @@ If you don't want the full `MeshController`, `MeshSession` is a zero-dependency,
 no-I/O state tracker. Fold every event into it with `apply(&event) -> bool` (which
 returns whether the view changed) and read the accessors (`topology`,
 `generation`, `transport`, `host`, `direct_endpoint`, `peers`, `ice_servers`,
-`is_p2p`). It handles late joins,
+`is_p2p`). Peer `connected` state describes only the transport selected by the
+current plan; status reports for other transports are ignored. It handles late joins,
 host re-election, `PlayerLeft` removal, and reconnect replay idempotently — but it
 contains no WebRTC and does no signaling. You still "obey the server": every
 `initiate` flag is copied verbatim.

--- a/docs/protocol-versioning.md
+++ b/docs/protocol-versioning.md
@@ -128,14 +128,32 @@ match client.negotiated_protocol_version() {
 }
 
 if client.supports_mesh() {
-    // enable_mesh() advertised WebRTC and protocol v3 was negotiated.
+    // This client negotiated v3 after advertising WebRTC plus Host or Mesh.
+    // The server may still select an explicit Relay plan.
 }
+
+let snapshot = client.snapshot();
+println!("selected path: {:?} / {:?}", snapshot.session_topology, snapshot.session_transport);
 ```
 
 | Accessor | Returns |
 |----------|---------|
 | `negotiated_protocol_version()` | `Option<u16>` — `None` before `ProtocolInfo`, or for a v2 negotiation. |
-| `supports_mesh()` | `bool` — `true` when WebRTC mesh was advertised and the negotiated version is ≥ 3. |
+| `supports_mesh()` | `bool` — negotiated local capability: v3 plus advertised WebRTC and at least one P2P topology (`Host` or `Mesh`). It does not mean the active plan is P2P. |
+| `session_topology()` / `session_transport()` | The topology and transport selected by the latest authoritative plan, or `None` outside a plan. Read both from `snapshot()` when they must describe one instant. |
+| `is_p2p_active()` | `bool` — whether the selected topology is currently `Host` or `Mesh`, independent of local capability. |
+
+### 0.11 migration: capability versus active plan
+
+`supports_mesh()` is retained for source compatibility, but its meaning is now
+precise: it requires advertised WebRTC, an advertised `Host` or `Mesh` topology,
+and negotiated v3. A custom WebRTC + relay-only configuration therefore changes
+from `true` to `false`. It never guarantees that the server selected P2P.
+
+`ClientSnapshot` is exhaustive and gains `session_topology` and
+`session_transport`, so 0.11 consumers constructing snapshots must initialize
+both fields. Routing code should read those fields from one `snapshot()` (or use
+`is_p2p_active()` for a one-value query); do not substitute `supports_mesh()`.
 
 ---
 
@@ -167,7 +185,7 @@ The `mode` field tells you why:
 match client.send_offer(peer, sdp) {
     Ok(()) => {}
     Err(SignalFishError::ProtocolUnsupported { mode }) => {
-        eprintln!("not in mesh mode ({mode}) — did you enable_mesh()?");
+        eprintln!("protocol v3 was not negotiated ({mode})");
     }
     Err(e) => eprintln!("send failed: {e}"),
 }

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -652,7 +652,7 @@ safely ignores any of these it doesn't recognize.
 
 | Message | New field(s) | Purpose |
 |---------|--------------|---------|
-| `ClientMessage::Authenticate` | `protocol_version`, `supported_transports`, `supported_topologies` | Advertise the highest version, data-path transports, and topologies the client can fulfill. Set by `SignalFishConfig::enable_mesh()`. |
+| `ClientMessage::Authenticate` | `protocol_version`, `supported_transports`, `supported_topologies` | Advertise the highest version, data-path transports, and topologies the client can fulfill. `enable_v3()` sets the version; `enable_mesh()` additionally supplies WebRTC/P2P defaults; power-user builders and `MeshController` can preserve or augment explicit choices. |
 | `ServerMessage::ProtocolInfo` | `protocol_version`, `min_protocol_version`, `max_protocol_version` | The negotiated version (plus the deployment's accepted range). |
 | `RoomJoinedPayload` / `ReconnectedPayload` | `ice_servers: Vec<IceServer>` | ICE pre-gather: STUN/TURN servers delivered during the lobby wait so WebRTC candidate gathering can start early. Empty (and absent from the wire) for v2. |
 | `ReconnectedPayload` | `replay`, `sender_watermarks`, `reconnection_token` | Required v3 authoritative replay/accountability baseline and rotated reconnect credential. All are absent/empty under v2. |

--- a/docs/wasm.md
+++ b/docs/wasm.md
@@ -431,7 +431,10 @@ environment).
 | `current_room_id()` | `fn current_room_id(&self) -> Option<RoomId>` | The current room ID, if in a room. |
 | `current_room_code()` | `fn current_room_code(&self) -> Option<&str>` | The current room code, if in a room. |
 | `negotiated_protocol_version()` | `fn negotiated_protocol_version(&self) -> Option<u16>` | Negotiated protocol version; `None` before negotiation or for the v2 relay floor. |
-| `supports_mesh()` | `fn supports_mesh(&self) -> bool` | Whether protocol v3 and advertised WebRTC mesh support are both active. |
+| `supports_mesh()` | `fn supports_mesh(&self) -> bool` | Negotiated v3 + WebRTC + Host/Mesh capability; not active-plan state. |
+| `session_topology()` | `fn session_topology(&self) -> Option<Topology>` | Topology selected by the latest authoritative plan. |
+| `session_transport()` | `fn session_transport(&self) -> Option<TransportKind>` | Transport selected by the latest authoritative plan. |
+| `is_p2p_active()` | `fn is_p2p_active(&self) -> bool` | Whether the selected plan uses a Host or Mesh topology. |
 | `send_capacity()` | `fn send_capacity(&self) -> usize` | Remaining slots in the bounded command queue. |
 | `max_send_capacity()` | `fn max_send_capacity(&self) -> usize` | Configured command-queue capacity. |
 | `stats()` | `fn stats(&self) -> ClientStats` | Cumulative game-data and undecodable-message counters. |
@@ -440,7 +443,7 @@ environment).
 | `reset_queue_age_peak()` | `fn reset_queue_age_peak(&mut self)` | Refresh current age and reset the sampled peak to it. |
 | `transport_diagnostics()` | `fn transport_diagnostics(&self) -> TransportDiagnostics` | Backend acceptance, buffering, watermark, and capacity diagnostics. |
 | `transport()` | `fn transport(&self) -> &T` | Borrow transport-specific read-only diagnostics; I/O still advances only through `poll()`. |
-| `snapshot()` | `fn snapshot(&self) -> ClientSnapshot` | Return coherent connection, room, token, negotiation, current session generation, and quarantine state. |
+| `snapshot()` | `fn snapshot(&self) -> ClientSnapshot` | Return coherent connection, room, token, negotiation, selected plan, generation, and quarantine state. |
 
 !!! tip "Comparison with `SignalFishClient`"
     `SignalFishPollingClient` mirrors `SignalFishClient`'s common synchronous

--- a/examples/mesh_session.rs
+++ b/examples/mesh_session.rs
@@ -186,7 +186,8 @@ async fn main() -> Result<(), SignalFishError> {
         started: false,
     };
 
-    // `MeshController::start` enables the mesh automatically.
+    // `MeshController::start` preserves compatible explicit choices and adds
+    // the minimum WebRTC/P2P advertisement needed by the controller.
     let mut mesh = MeshController::start(
         transport,
         SignalFishConfig::new("demo-app"),

--- a/progress/session-029-mesh-capability-and-liveness.md
+++ b/progress/session-029-mesh-capability-and-liveness.md
@@ -1,0 +1,47 @@
+# Session 029 — Mesh Capability and Liveness
+
+## Scope
+
+Issue #102 separates three facts that were previously conflated: locally
+advertised and negotiated WebRTC/P2P capability, the topology and transport in
+the server's authoritative plan, and peer liveness on that selected transport.
+
+## Invariant → Source → Evidence
+
+| Invariant | Source | Executable evidence |
+| --- | --- | --- |
+| A controller that owns a WebRTC driver advertises v3, WebRTC, and at least one Host/Mesh topology even when the input config already selected v3. Compatible explicit lists and future versions remain intact. | `SignalFishConfig::enable_controller_mesh`; `MeshController::start`. | `client::tests::controller_mesh_configuration_preserves_compatible_choices`; `webrtc::tests::controller_authentication_adds_missing_mesh_capability_without_overwrite`. |
+| `supports_mesh()` reports negotiated local WebRTC + Host/Mesh capability, never the server-selected path. | `SignalFishConfig::advertises_mesh_capability`; `ClientCore::supports_mesh`. | `client::tests::mesh_capability_requires_webrtc_and_a_p2p_topology`; `polling_parity_tests::parity_mesh_capability_requires_webrtc_and_p2p_topology`. |
+| The latest authoritative topology and transport form one coherent snapshot, update atomically with a valid plan, and clear at room/connection boundaries. | `ClientSnapshot::{session_topology, session_transport}`; `ClientCore::replace_session_plan`, `clear_room`, and `clear_session`. | `polling_parity_tests::parity_selected_plan_accessors_follow_ordered_canonical_transitions`; `parity_selected_plan_resets_at_room_and_connection_boundaries`; `parity_reconnected_baseline_is_planless_until_fresh_session_plan`. |
+| Peer `connected` describes only the current selected transport. A transport, generation, or offerer-role change clears stale liveness. | `MeshSession::apply`. | `mesh::tests::liveness_tracks_only_the_selected_transport_across_plan_transitions`; `generation_change_clears_surviving_peer_liveness`; `replan_replaces_peers_and_ice_not_merges`; `new_peer_for_known_peer_updates_latest_wins`. |
+| Async, polling, object-safe API, and controller views agree on selected plan state. Direct and Relay plans never invoke WebRTC work. | Shared `ClientCore`; `MeshController::session`. | `polling_parity_tests::parity_selected_plan_accessors_follow_ordered_canonical_transitions`; `parity_selected_plan_resets_at_room_and_connection_boundaries`; `webrtc::tests::direct_and_relay_plans_never_connect_through_webrtc_driver`. |
+
+## Public API and Migration
+
+- `ClientSnapshot` adds exhaustive `session_topology` and `session_transport`
+  fields. Both clients and `SignalFishClientApi` add matching accessors and
+  `is_p2p_active()`.
+- `supports_mesh()` remains source-compatible but is capability-only. It now
+  returns `false` for custom WebRTC + relay-only advertisements. Routing code
+  migrates to one `snapshot()` read or `is_p2p_active()`.
+- `MeshController::start` preserves compatible custom choices instead of
+  replacing them with the convenience defaults.
+
+## Review and Verification
+
+- Parallel local, hosted-state, and adversarial audits found the configuration,
+  API, state-duplication, stale-liveness, documentation, and test risks.
+- The first adversarial pass drove a single authoritative snapshot transport,
+  offerer-role liveness reset, exact controller wire tests, accessor/controller
+  parity, and consumer migration documentation.
+- Two final adversarial passes reported zero remaining implementation, API,
+  test, changelog, roadmap, or consumer-documentation findings.
+- The mandatory `cargo fmt && cargo clippy --workspace --all-targets
+  --all-features -- -D warnings && cargo test --workspace --all-features`
+  workflow passes: 323 library tests, 31 async/polling parity tests, 126 protocol
+  tests, 35 Godot adapter tests, and every other workspace target are green;
+  six live-server tests remain intentionally ignored outside their pinned jobs.
+- Default and all-feature rustdoc pass with warnings denied. No-default and
+  feature-isolated builds/tests, workflow policy validation, LLM drift checks,
+  and `git diff --check` also pass. MkDocs is not installed locally, so the
+  hosted Docs Validation aggregate is the strict documentation-build evidence.

--- a/src/client.rs
+++ b/src/client.rs
@@ -193,8 +193,10 @@ pub struct SignalFishConfig {
     ///
     /// `None` (the default) keeps the client on the v2 **relay floor**: the
     /// `Authenticate` message omits all negotiation fields and is byte-identical
-    /// to v2. Opt into the mesh with
-    /// [`enable_mesh`](Self::enable_mesh) or [`with_protocol_version`](Self::with_protocol_version).
+    /// to v2. Opt into v3 with [`enable_v3`](Self::enable_v3), or advertise
+    /// WebRTC/P2P capability with [`enable_mesh`](Self::enable_mesh). The
+    /// [`with_protocol_version`](Self::with_protocol_version) builder is the
+    /// power-user form and does not add transport or topology capabilities.
     pub protocol_version: Option<u16>,
     /// Data-path transports the client can actually fulfill (protocol v3+).
     ///
@@ -327,6 +329,61 @@ impl SignalFishConfig {
         self.supported_transports = Some(vec![TransportKind::WebRtc, TransportKind::Relay]);
         self.supported_topologies = Some(vec![Topology::Mesh, Topology::Host, Topology::Relay]);
         self
+    }
+
+    /// Ensure a controller-owned WebRTC driver is represented in negotiation.
+    ///
+    /// Unlike [`enable_mesh`](Self::enable_mesh), this preserves compatible
+    /// power-user transport and topology choices. Missing lists receive the
+    /// normal mesh-with-relay defaults; explicit lists gain only a missing
+    /// WebRTC transport or P2P topology.
+    #[cfg(all(feature = "mesh", feature = "tokio-runtime"))]
+    pub(crate) fn enable_controller_mesh(mut self) -> Self {
+        if self.protocol_version.is_none_or(|version| version < 3) {
+            self.protocol_version = Some(crate::PROTOCOL_VERSION.max(3));
+        }
+
+        match &mut self.supported_transports {
+            Some(transports) if !transports.contains(&TransportKind::WebRtc) => {
+                transports.push(TransportKind::WebRtc);
+            }
+            None => {
+                self.supported_transports = Some(vec![TransportKind::WebRtc, TransportKind::Relay]);
+            }
+            Some(_) => {}
+        }
+
+        match &mut self.supported_topologies {
+            Some(topologies)
+                if !topologies
+                    .iter()
+                    .any(|topology| matches!(topology, Topology::Host | Topology::Mesh)) =>
+            {
+                topologies.push(Topology::Mesh);
+            }
+            None => {
+                self.supported_topologies =
+                    Some(vec![Topology::Mesh, Topology::Host, Topology::Relay]);
+            }
+            Some(_) => {}
+        }
+
+        self
+    }
+
+    #[cfg(any(feature = "tokio-runtime", feature = "polling-client"))]
+    pub(crate) fn advertises_mesh_capability(&self) -> bool {
+        self.supported_transports
+            .as_ref()
+            .is_some_and(|transports| transports.contains(&TransportKind::WebRtc))
+            && self
+                .supported_topologies
+                .as_ref()
+                .is_some_and(|topologies| {
+                    topologies
+                        .iter()
+                        .any(|topology| matches!(topology, Topology::Host | Topology::Mesh))
+                })
     }
 
     /// Opt into protocol-v3 relay features without advertising WebRTC.
@@ -548,6 +605,16 @@ pub struct ClientSnapshot {
     ///
     /// `None` before a plan and for legacy Server 0.4 protocol-v3 plans.
     pub session_generation: Option<crate::protocol::SessionGeneration>,
+    /// Topology selected by the latest authoritative session plan.
+    ///
+    /// This is distinct from locally advertised capability. It is `None`
+    /// before the first plan and after leaving the room or disconnecting.
+    pub session_topology: Option<Topology>,
+    /// Data-path transport selected by the latest authoritative session plan.
+    ///
+    /// Read this together with [`session_topology`](Self::session_topology) from
+    /// the same snapshot when making routing decisions.
+    pub session_transport: Option<TransportKind>,
     /// Latest server-issued room reconnection token.
     pub reconnection_token: Option<String>,
     /// Whether accountability policy currently suppresses room game data.
@@ -575,6 +642,8 @@ impl std::fmt::Debug for ClientSnapshot {
             .field("room_id", &self.room_id)
             .field("room_code", &self.room_code)
             .field("session_generation", &self.session_generation)
+            .field("session_topology", &self.session_topology)
+            .field("session_transport", &self.session_transport)
             .field(
                 "reconnection_token",
                 &self.reconnection_token.as_ref().map(|_| "<redacted>"),
@@ -656,14 +725,11 @@ impl SignalFishClient {
         let (event_tx, event_rx) = mpsc::channel::<SignalFishEvent>(capacity);
         let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
 
-        let mesh_enabled = config
-            .supported_transports
-            .as_ref()
-            .is_some_and(|transports| transports.contains(&TransportKind::WebRtc));
+        let mesh_capable = config.advertises_mesh_capability();
         let state = Arc::new(Mutex::new(ClientCore::new(
             config.game_data_format,
             config.protocol_violation_policy,
-            mesh_enabled,
+            mesh_capable,
         )));
         let loop_state = Arc::clone(&state);
 
@@ -993,7 +1059,7 @@ impl SignalFishClient {
     ///
     /// Driver integrations should use this generation-bound form so an offer
     /// or ICE candidate produced just before a re-plan can never be relabeled
-    /// with the new generation. [`MeshController`](crate::MeshController) uses
+    /// with the new generation. `MeshController` uses
     /// this automatically.
     ///
     /// # Errors
@@ -1137,9 +1203,9 @@ impl SignalFishClient {
     /// negotiated or negotiated as v2 (the relay floor).
     ///
     /// Set from the server's [`ProtocolInfo`](SignalFishEvent::ProtocolInfo)
-    /// message. A value of `Some(3)` or higher means v3 was negotiated; mesh
-    /// availability additionally requires local [`SignalFishConfig::enable_mesh`]
-    /// advertisement and can be queried with [`Self::supports_mesh`].
+    /// message. A value of `Some(3)` or higher means v3 was negotiated; local
+    /// WebRTC/P2P capability additionally requires the corresponding transport
+    /// and topology advertisement and can be queried with [`Self::supports_mesh`].
     pub fn negotiated_protocol_version(&self) -> Option<u16> {
         lock_core(&self.state).negotiated_protocol_version()
     }
@@ -1160,13 +1226,37 @@ impl SignalFishClient {
         lock_core(&self.state).session_plan_revision()
     }
 
-    /// Returns `true` once the connection has negotiated protocol v3 and this
-    /// client advertised WebRTC support through [`SignalFishConfig::enable_mesh`].
+    /// Whether protocol v3 was negotiated after this client advertised both
+    /// WebRTC and at least one P2P topology (`host` or `mesh`).
     ///
-    /// This is the "am I in mesh mode?" check; it returns `false` both before
-    /// negotiation completes and on a v2 relay-floor connection.
+    /// This reports local negotiated capability, not the server-selected active
+    /// plan. Use [`session_topology`](Self::session_topology),
+    /// [`session_transport`](Self::session_transport), or
+    /// [`is_p2p_active`](Self::is_p2p_active) for current plan state.
     pub fn supports_mesh(&self) -> bool {
         lock_core(&self.state).supports_mesh()
+    }
+
+    /// Topology selected by the latest authoritative session plan.
+    ///
+    /// This reports active plan state, not local capability. Read it together
+    /// with [`session_transport`](Self::session_transport) from one
+    /// [`snapshot`](Self::snapshot) when an atomic pair is required.
+    pub fn session_topology(&self) -> Option<Topology> {
+        lock_core(&self.state).session_topology()
+    }
+
+    /// Data-path transport selected by the latest authoritative session plan.
+    pub fn session_transport(&self) -> Option<TransportKind> {
+        lock_core(&self.state).session_transport()
+    }
+
+    /// Whether the latest authoritative plan selects a peer-to-peer topology.
+    ///
+    /// This active-plan query is independent of [`supports_mesh`](Self::supports_mesh),
+    /// which reports negotiated local capability.
+    pub fn is_p2p_active(&self) -> bool {
+        lock_core(&self.state).is_p2p_active()
     }
 
     /// Returns `true` if the transport is believed to be connected.
@@ -2257,6 +2347,94 @@ mod tests {
             config.supported_topologies,
             Some(vec![Topology::Mesh, Topology::Relay])
         );
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "mesh")]
+    async fn controller_mesh_configuration_preserves_compatible_choices() {
+        let cases = [
+            (
+                "default",
+                SignalFishConfig::new("app"),
+                crate::PROTOCOL_VERSION.max(3),
+                vec![TransportKind::WebRtc, TransportKind::Relay],
+                vec![Topology::Mesh, Topology::Host, Topology::Relay],
+            ),
+            (
+                "relay-v3",
+                SignalFishConfig::new("app").enable_v3(),
+                crate::PROTOCOL_VERSION,
+                vec![TransportKind::Relay, TransportKind::WebRtc],
+                vec![Topology::Relay, Topology::Mesh],
+            ),
+            (
+                "future-direct-host",
+                SignalFishConfig::new("app")
+                    .with_protocol_version(4)
+                    .with_transports([TransportKind::Direct])
+                    .with_topologies([Topology::Host]),
+                4,
+                vec![TransportKind::Direct, TransportKind::WebRtc],
+                vec![Topology::Host],
+            ),
+            (
+                "existing-webrtc-missing-p2p-topology",
+                SignalFishConfig::new("app")
+                    .with_protocol_version(3)
+                    .with_transports([TransportKind::WebRtc, TransportKind::Relay])
+                    .with_topologies([Topology::Relay]),
+                3,
+                vec![TransportKind::WebRtc, TransportKind::Relay],
+                vec![Topology::Relay, Topology::Mesh],
+            ),
+            (
+                "compatible-existing-webrtc-host",
+                SignalFishConfig::new("app")
+                    .with_protocol_version(3)
+                    .with_transports([TransportKind::Direct, TransportKind::WebRtc])
+                    .with_topologies([Topology::Host, Topology::Relay]),
+                3,
+                vec![TransportKind::Direct, TransportKind::WebRtc],
+                vec![Topology::Host, Topology::Relay],
+            ),
+            (
+                "pre-v3-custom",
+                SignalFishConfig::new("app")
+                    .with_protocol_version(2)
+                    .with_transports([TransportKind::Relay])
+                    .with_topologies([Topology::Mesh, Topology::Relay]),
+                crate::PROTOCOL_VERSION.max(3),
+                vec![TransportKind::Relay, TransportKind::WebRtc],
+                vec![Topology::Mesh, Topology::Relay],
+            ),
+        ];
+
+        for (name, config, protocol, transports, topologies) in cases {
+            let config = config.enable_controller_mesh();
+            assert_eq!(config.protocol_version, Some(protocol), "{name}");
+            assert_eq!(config.supported_transports, Some(transports), "{name}");
+            assert_eq!(config.supported_topologies, Some(topologies), "{name}");
+            assert!(config.advertises_mesh_capability(), "{name}");
+        }
+    }
+
+    #[tokio::test]
+    async fn mesh_capability_requires_webrtc_and_a_p2p_topology() {
+        let cases = [
+            (vec![TransportKind::WebRtc], vec![Topology::Mesh], true),
+            (vec![TransportKind::WebRtc], vec![Topology::Host], true),
+            (vec![TransportKind::WebRtc], vec![Topology::Relay], false),
+            (vec![TransportKind::Relay], vec![Topology::Mesh], false),
+            (vec![], vec![Topology::Mesh], false),
+            (vec![TransportKind::WebRtc], vec![], false),
+        ];
+
+        for (transports, topologies, expected) in cases {
+            let config = SignalFishConfig::new("app")
+                .with_transports(transports)
+                .with_topologies(topologies);
+            assert_eq!(config.advertises_mesh_capability(), expected);
+        }
     }
 
     #[tokio::test]

--- a/src/client_api.rs
+++ b/src/client_api.rs
@@ -3,7 +3,7 @@
 use crate::client::{ClientSnapshot, ClientStats, GameDataDelivery, JoinRoomParams};
 use crate::error::Result;
 use crate::protocol::{
-    ConnectionInfo, GameDataEncoding, PlayerId, RoomId, SessionGeneration, TransportKind,
+    ConnectionInfo, GameDataEncoding, PlayerId, RoomId, SessionGeneration, Topology, TransportKind,
 };
 use crate::signal::PeerSignal;
 
@@ -106,8 +106,27 @@ pub trait SignalFishClientApi {
         self.snapshot().effective_game_data_format
     }
 
-    /// Whether WebRTC mesh was advertised and protocol v3 was negotiated.
+    /// Whether WebRTC plus a P2P topology were advertised and v3 was negotiated.
+    /// This reports capability, not the selected session plan.
     fn supports_mesh(&self) -> bool;
+
+    /// Topology selected by the latest authoritative session plan.
+    fn session_topology(&self) -> Option<Topology> {
+        self.snapshot().session_topology
+    }
+
+    /// Data-path transport selected by the latest authoritative session plan.
+    fn session_transport(&self) -> Option<TransportKind> {
+        self.snapshot().session_transport
+    }
+
+    /// Whether the latest authoritative plan selects a peer-to-peer topology.
+    fn is_p2p_active(&self) -> bool {
+        matches!(
+            self.session_topology(),
+            Some(Topology::Host | Topology::Mesh)
+        )
+    }
 
     /// Send an SDP offer.
     fn send_offer(&mut self, to: PlayerId, sdp: String) -> Result<()> {

--- a/src/client_core.rs
+++ b/src/client_core.rs
@@ -86,7 +86,7 @@ impl FrameOutcome {
 pub(crate) struct ClientCore {
     snapshot: ClientSnapshot,
     protocol_info_seen: bool,
-    mesh_enabled: bool,
+    mesh_capable: bool,
     stats: ClientStats,
     last_server_error: Option<ServerErrorInfo>,
     violation_policy: ProtocolViolationPolicy,
@@ -96,7 +96,6 @@ pub(crate) struct ClientCore {
     room_players: HashSet<PlayerId>,
     session_plan_seen: bool,
     session_peers: HashSet<PlayerId>,
-    session_transport: Option<TransportKind>,
     retired_generationless_signal_peers: HashSet<PlayerId>,
     pending_reconnects: VecDeque<PendingReconnect>,
     #[cfg(feature = "tokio-runtime")]
@@ -145,7 +144,7 @@ impl ClientCore {
     pub(crate) fn new(
         requested_game_data_format: Option<GameDataEncoding>,
         violation_policy: ProtocolViolationPolicy,
-        mesh_enabled: bool,
+        mesh_capable: bool,
     ) -> Self {
         Self {
             snapshot: ClientSnapshot {
@@ -154,7 +153,7 @@ impl ClientCore {
                 ..ClientSnapshot::default()
             },
             protocol_info_seen: false,
-            mesh_enabled,
+            mesh_capable,
             stats: ClientStats::default(),
             last_server_error: None,
             violation_policy,
@@ -164,7 +163,6 @@ impl ClientCore {
             room_players: HashSet::new(),
             session_plan_seen: false,
             session_peers: HashSet::new(),
-            session_transport: None,
             retired_generationless_signal_peers: HashSet::new(),
             pending_reconnects: VecDeque::new(),
             #[cfg(feature = "tokio-runtime")]
@@ -208,10 +206,25 @@ impl ClientCore {
     }
 
     pub(crate) fn supports_mesh(&self) -> bool {
-        self.mesh_enabled
+        self.mesh_capable
             && self
                 .negotiated_protocol_version()
                 .is_some_and(|version| version >= 3)
+    }
+
+    pub(crate) fn session_topology(&self) -> Option<Topology> {
+        self.snapshot.session_topology
+    }
+
+    pub(crate) fn session_transport(&self) -> Option<TransportKind> {
+        self.snapshot.session_transport
+    }
+
+    pub(crate) fn is_p2p_active(&self) -> bool {
+        matches!(
+            self.session_topology(),
+            Some(Topology::Host | Topology::Mesh)
+        )
     }
 
     #[cfg(feature = "polling-client")]
@@ -283,7 +296,7 @@ impl ClientCore {
                 if !self.session_peers.contains(peer_id) {
                     return Err(crate::SignalFishError::SessionPlanUnavailable);
                 }
-                if self.session_transport != Some(TransportKind::WebRtc)
+                if self.snapshot.session_transport != Some(TransportKind::WebRtc)
                     || !self.room_players.contains(peer_id)
                     || Some(*peer_id) == self.snapshot.player_id
                 {
@@ -463,6 +476,8 @@ impl ClientCore {
         self.snapshot.room_code = None;
         self.snapshot.reconnection_token = None;
         self.snapshot.session_generation = None;
+        self.snapshot.session_topology = None;
+        self.snapshot.session_transport = None;
         self.snapshot.quarantined = false;
         self.protocol_info_seen = false;
         self.membership = Membership::None;
@@ -470,7 +485,6 @@ impl ClientCore {
         self.room_players.clear();
         self.session_plan_seen = false;
         self.session_peers.clear();
-        self.session_transport = None;
         self.retired_generationless_signal_peers.clear();
         self.pending_reconnects.clear();
         #[cfg(feature = "tokio-runtime")]
@@ -853,7 +867,7 @@ impl ClientCore {
                 if self.should_suppress_inbound_signal(*from, *generation) {
                     return Ok(());
                 }
-                if self.session_transport != Some(TransportKind::WebRtc) {
+                if self.snapshot.session_transport != Some(TransportKind::WebRtc) {
                     return Err(
                         "lifecycle violation: Signal requires an authoritative WebRTC SessionPlan"
                             .into(),
@@ -871,7 +885,7 @@ impl ClientCore {
             }
             ServerMessage::NewPeer { .. }
                 if !(self.session_plan_seen
-                    && self.session_transport == Some(TransportKind::WebRtc)) =>
+                    && self.snapshot.session_transport == Some(TransportKind::WebRtc)) =>
             {
                 Err(
                     "lifecycle violation: NewPeer requires an authoritative WebRTC SessionPlan"
@@ -998,7 +1012,7 @@ impl ClientCore {
             || (generation.is_none()
                 && self.snapshot.session_generation.is_none()
                 && self.retired_generationless_signal_peers.contains(&from)
-                && !(self.session_transport == Some(TransportKind::WebRtc)
+                && !(self.snapshot.session_transport == Some(TransportKind::WebRtc)
                     && self.session_peers.contains(&from)))
     }
 
@@ -1203,20 +1217,21 @@ impl ClientCore {
                 self.replace_session_plan(
                     payload.generation,
                     payload.peers.iter().map(|peer| peer.player_id),
+                    payload.topology,
                     payload.transport,
                 );
             }
             ServerMessage::NewPeer { peer_id, .. } => {
                 self.session_peers.insert(*peer_id);
                 if self.snapshot.session_generation.is_none()
-                    && self.session_transport == Some(TransportKind::WebRtc)
+                    && self.snapshot.session_transport == Some(TransportKind::WebRtc)
                 {
                     self.retired_generationless_signal_peers.remove(peer_id);
                 }
             }
             ServerMessage::PlayerLeft { player_id, .. } => {
                 if self.snapshot.session_generation.is_none()
-                    && self.session_transport == Some(TransportKind::WebRtc)
+                    && self.snapshot.session_transport == Some(TransportKind::WebRtc)
                     && self.session_peers.contains(player_id)
                 {
                     self.retired_generationless_signal_peers.insert(*player_id);
@@ -1246,13 +1261,14 @@ impl ClientCore {
         self.snapshot.room_code = Some(baseline.room_code);
         self.snapshot.reconnection_token = baseline.reconnection_token;
         self.snapshot.session_generation = None;
+        self.snapshot.session_topology = None;
+        self.snapshot.session_transport = None;
         self.snapshot.quarantined = false;
         self.membership = baseline.membership;
         self.room_finalized = baseline.finalized;
         self.room_players = baseline.players;
         self.session_plan_seen = false;
         self.session_peers.clear();
-        self.session_transport = None;
         self.retired_generationless_signal_peers.clear();
         #[cfg(feature = "tokio-runtime")]
         self.advance_room_revision();
@@ -1264,13 +1280,14 @@ impl ClientCore {
         self.snapshot.room_code = None;
         self.snapshot.reconnection_token = None;
         self.snapshot.session_generation = None;
+        self.snapshot.session_topology = None;
+        self.snapshot.session_transport = None;
         self.snapshot.quarantined = false;
         self.membership = Membership::None;
         self.room_finalized = false;
         self.room_players.clear();
         self.session_plan_seen = false;
         self.session_peers.clear();
-        self.session_transport = None;
         self.retired_generationless_signal_peers.clear();
         #[cfg(feature = "tokio-runtime")]
         self.advance_room_revision();
@@ -1280,11 +1297,12 @@ impl ClientCore {
         &mut self,
         generation: Option<SessionGeneration>,
         peers: impl IntoIterator<Item = PlayerId>,
+        topology: Topology,
         transport: TransportKind,
     ) {
         if self.session_plan_seen
             && self.snapshot.session_generation.is_none()
-            && self.session_transport == Some(TransportKind::WebRtc)
+            && self.snapshot.session_transport == Some(TransportKind::WebRtc)
         {
             self.retired_generationless_signal_peers
                 .extend(self.session_peers.iter().copied());
@@ -1295,9 +1313,10 @@ impl ClientCore {
                 .retain(|peer| !peers.contains(peer));
         }
         self.snapshot.session_generation = generation;
+        self.snapshot.session_topology = Some(topology);
+        self.snapshot.session_transport = Some(transport);
         self.session_plan_seen = true;
         self.session_peers = peers;
-        self.session_transport = Some(transport);
         #[cfg(feature = "tokio-runtime")]
         self.advance_session_plan_revision();
     }
@@ -1824,12 +1843,12 @@ mod tests {
             );
             let before = core.snapshot();
             let peers_before = core.session_peers.clone();
-            let transport_before = core.session_transport;
+            let transport_before = core.snapshot().session_transport;
             let outcome = process(&mut core, ServerMessage::SessionPlan(Box::new(invalid)));
             assert_lifecycle_violation(&outcome);
             assert_eq!(core.snapshot(), before);
             assert_eq!(core.session_peers, peers_before);
-            assert_eq!(core.session_transport, transport_before);
+            assert_eq!(core.snapshot().session_transport, transport_before);
         }
     }
 
@@ -2613,9 +2632,33 @@ mod tests {
         relay.generation = None;
         let _ = process(&mut core, ServerMessage::SessionPlan(Box::new(relay)));
         assert!(!core.retired_generationless_signal_peers.is_empty());
+        assert_eq!(core.snapshot().session_topology, Some(Topology::Relay));
+        assert_eq!(
+            core.snapshot().session_transport,
+            Some(TransportKind::Relay)
+        );
 
         let _ = process(&mut core, ServerMessage::RoomLeft);
         assert!(core.retired_generationless_signal_peers.is_empty());
+        assert!(core.snapshot().session_topology.is_none());
+        assert!(core.snapshot().session_transport.is_none());
+
+        let mut disconnecting = v3_room(ProtocolViolationPolicy::Observe);
+        let _ = process(
+            &mut disconnecting,
+            ServerMessage::SessionPlan(Box::new(plan(Topology::Mesh, TransportKind::WebRtc))),
+        );
+        assert_eq!(
+            disconnecting.snapshot().session_topology,
+            Some(Topology::Mesh)
+        );
+        assert_eq!(
+            disconnecting.snapshot().session_transport,
+            Some(TransportKind::WebRtc)
+        );
+        let _ = disconnecting.disconnect(None);
+        assert!(disconnecting.snapshot().session_topology.is_none());
+        assert!(disconnecting.snapshot().session_transport.is_none());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,21 +43,22 @@
 //!   v3 capabilities, the server relays all traffic through itself, and the
 //!   `Authenticate` bytes are byte-identical to the old v2 client. This is the
 //!   *relay-floor guarantee*: opt into nothing and nothing changes.
-//! - **v3 — additive mesh (opt-in).** [`SignalFishConfig::enable_mesh`] advertises
-//!   the WebRTC/relay transports and mesh/host/relay topologies, letting the
-//!   server form a peer-to-peer session. v3 capabilities are additive to the
-//!   v2 relay floor, and the server falls back to relay whenever it cannot form
-//!   a session. On current servers, an eligible client explicitly calls
+//! - **v3 — additive negotiation (opt-in).** [`SignalFishConfig::enable_v3`]
+//!   enables v3 relay/accountability semantics. [`SignalFishConfig::enable_mesh`]
+//!   additionally advertises WebRTC plus mesh/host topologies, letting the server
+//!   form a peer-to-peer session when appropriate. v3 capabilities are additive
+//!   to the v2 relay floor, and the server falls back to relay whenever it cannot
+//!   form a session. On current servers, an eligible client explicitly calls
 //!   [`SignalFishClient::start_game`] after readiness instead of relying on
 //!   automatic start.
 //!
-//! The negotiated version comes back in the server's `ProtocolInfo`; check it via
-//! [`SignalFishClient::negotiated_protocol_version`] /
-//! [`SignalFishClient::supports_mesh`]. v3-only sends fail fast with
+//! The negotiated version comes back in the server's `ProtocolInfo`;
+//! [`SignalFishClient::supports_mesh`] reports negotiated WebRTC plus Host/Mesh
+//! capability, while `snapshot()` exposes the server-selected plan. v3-only sends fail fast with
 //! [`SignalFishError::ProtocolUnsupported`] until v3 is negotiated. The SDK is
 //! *signaling-only* — it bundles no WebRTC stack; with the `mesh` feature you
-//! implement the [`webrtc::WebRtcDriver`] seam (or use
-//! [`webrtc::MeshController`]) against str0m / webrtc-rs / web-sys. The highest
+//! implement the `webrtc::WebRtcDriver` seam (or use
+//! `webrtc::MeshController`) against str0m / webrtc-rs / web-sys. The highest
 //! version this SDK speaks is [`PROTOCOL_VERSION`].
 //!
 //! ## Quick Start
@@ -123,8 +124,11 @@ pub mod transports;
 
 /// Highest signaling protocol version this SDK speaks.
 ///
-/// Advertised in `Authenticate` when a consumer opts into the mesh via
-/// [`SignalFishConfig::enable_mesh`](crate::SignalFishConfig::enable_mesh).
+/// Advertised in `Authenticate` when a consumer opts into v3 via
+/// [`SignalFishConfig::enable_v3`](crate::SignalFishConfig::enable_v3),
+/// [`SignalFishConfig::enable_mesh`](crate::SignalFishConfig::enable_mesh), or
+/// the lower-level configuration builders. A `webrtc::MeshController` also
+/// ensures its owned client advertises the capabilities its driver fulfills.
 pub const PROTOCOL_VERSION: u16 = 3;
 
 // Re-export primary types for ergonomic imports.

--- a/src/mesh.rs
+++ b/src/mesh.rs
@@ -3,7 +3,7 @@
 //! [`MeshSession`] folds the v3 [`SignalFishEvent`]s into an always-consistent
 //! view of the current peer-to-peer session: the chosen topology/transport, the
 //! peers this client should connect to (each with its server-assigned `initiate`
-//! flag and last-known liveness), the elected host, and the ICE servers. It does
+//! flag and selected-path liveness), the elected host, and the ICE servers. It does
 //! the fiddly bookkeeping — late joins, host re-election, and reconnect replay —
 //! correctly and idempotently, so consumers don't each re-implement it.
 //!
@@ -19,7 +19,7 @@ use crate::protocol::{
     DirectEndpoint, IceServer, PlayerId, SessionGeneration, Topology, TransportKind,
 };
 
-/// A peer within a [`MeshSession`], enriched with last-known data-path liveness.
+/// A peer within a [`MeshSession`], enriched with selected-path liveness.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MeshPeer {
     /// The peer's identifier.
@@ -31,7 +31,8 @@ pub struct MeshPeer {
     /// Whether **this client** sends the WebRTC offer to this peer
     /// (server-assigned; obey verbatim).
     pub initiate: bool,
-    /// Last-known data-path liveness for this peer (from `PeerTransportStatus`).
+    /// Last-known liveness reported for the session's selected transport.
+    /// Status for any other transport is ignored.
     pub connected: bool,
 }
 
@@ -77,7 +78,8 @@ impl MeshSession {
                 ice_servers,
                 fallback,
             } => {
-                let generation_changed = self.generation != *generation;
+                let selected_path_changed =
+                    self.generation != *generation || self.transport != Some(*transport);
                 self.generation = *generation;
                 self.topology = Some(*topology);
                 self.transport = Some(*transport);
@@ -85,8 +87,9 @@ impl MeshSession {
                 self.host = *host;
                 self.direct_endpoint = direct_endpoint.clone();
                 // A plan fully REPLACES the peer set (handles host re-election
-                // and topology change), preserving each surviving peer's
-                // liveness; peers absent from the new plan are dropped.
+                // and topology change). Surviving liveness is preserved only
+                // when generation, selected transport, and offerer role are
+                // unchanged; peers absent from the new plan are dropped.
                 self.peers = peers
                     .iter()
                     .map(|p| MeshPeer {
@@ -94,8 +97,10 @@ impl MeshSession {
                         player_name: p.player_name.clone(),
                         is_authority: p.is_authority,
                         initiate: p.initiate,
-                        connected: !generation_changed
-                            && self.peer(p.player_id).is_some_and(|e| e.connected),
+                        connected: !selected_path_changed
+                            && self.peer(p.player_id).is_some_and(|existing| {
+                                existing.connected && existing.initiate == p.initiate
+                            }),
                     })
                     .collect();
                 // Every SessionPlan is authoritative. In particular, an
@@ -111,6 +116,11 @@ impl MeshSession {
                 if let Some(existing) = self.peers.iter_mut().find(|p| p.player_id == *peer_id) {
                     let changed = existing.initiate != *you_initiate;
                     existing.initiate = *you_initiate;
+                    if changed {
+                        // The controller restarts the handshake when the server
+                        // changes the offerer role, so prior liveness is stale.
+                        existing.connected = false;
+                    }
                     changed
                 } else {
                     self.peers.push(MeshPeer {
@@ -124,8 +134,13 @@ impl MeshSession {
                 }
             }
             SignalFishEvent::PeerTransportStatus {
-                peer_id, connected, ..
+                peer_id,
+                transport,
+                connected,
             } => {
+                if self.transport != Some(*transport) {
+                    return false;
+                }
                 // Only mutate liveness; never invent a peer the server's plan
                 // didn't include.
                 if let Some(p) = self.peers.iter_mut().find(|p| p.player_id == *peer_id) {
@@ -436,9 +451,10 @@ mod tests {
         assert_eq!(s.host(), Some(uuid(3)));
         assert!(s.peer(uuid(1)).is_none(), "peer 1 dropped on re-plan");
         assert!(s.peer(uuid(3)).is_some());
-        // Surviving peer 2 keeps its liveness across the re-plan...
-        assert!(s.peer(uuid(2)).unwrap().connected);
-        // ...but its `initiate` is taken from the NEW plan.
+        // The controller restarts peer 2 because its offerer role changed, so
+        // selected-path liveness must reset until that new handshake connects.
+        assert!(!s.peer(uuid(2)).unwrap().connected);
+        // Its `initiate` is taken from the NEW plan.
         assert!(!s.peer(uuid(2)).unwrap().initiate);
         // ICE replaced, not merged.
         assert_eq!(s.ice_servers(), &[ice("stun:b")]);
@@ -463,6 +479,12 @@ mod tests {
     fn new_peer_for_known_peer_updates_latest_wins() {
         let mut s = MeshSession::new();
         s.apply(&plan(Topology::Mesh, None, vec![peer(2, true)], vec![]));
+        s.apply(&SignalFishEvent::PeerTransportStatus {
+            peer_id: uuid(2),
+            transport: TransportKind::WebRtc,
+            connected: true,
+        });
+        assert!(s.peer(uuid(2)).unwrap().connected);
         // A later NewPeer for the same id overrides the initiate flag.
         s.apply(&SignalFishEvent::NewPeer {
             peer_id: uuid(2),
@@ -470,6 +492,10 @@ mod tests {
         });
         assert_eq!(s.peers().len(), 1);
         assert!(!s.peer(uuid(2)).unwrap().initiate);
+        assert!(
+            !s.peer(uuid(2)).unwrap().connected,
+            "offerer-role changes restart the selected-path handshake"
+        );
     }
 
     #[test]
@@ -498,6 +524,70 @@ mod tests {
         let p = s.peer(uuid(1)).unwrap();
         assert!(p.connected);
         assert!(p.initiate, "initiate is server-authoritative, untouched");
+    }
+
+    #[test]
+    fn liveness_tracks_only_the_selected_transport_across_plan_transitions() {
+        let mut session = MeshSession::new();
+        let peer_id = uuid(1);
+
+        session.apply(&plan(
+            Topology::Host,
+            Some(peer_id),
+            vec![peer(1, false)],
+            vec![],
+        ));
+        assert!(!session.apply(&SignalFishEvent::PeerTransportStatus {
+            peer_id,
+            transport: TransportKind::Direct,
+            connected: true,
+        }));
+        assert!(!session.peer(peer_id).unwrap().connected);
+        assert!(session.apply(&SignalFishEvent::PeerTransportStatus {
+            peer_id,
+            transport: TransportKind::WebRtc,
+            connected: true,
+        }));
+        assert!(session.peer(peer_id).unwrap().connected);
+
+        session.apply(&SignalFishEvent::SessionPlan {
+            generation: None,
+            topology: Topology::Host,
+            transport: TransportKind::Direct,
+            host: Some(peer_id),
+            direct_endpoint: Some(DirectEndpoint {
+                host: "192.0.2.1".into(),
+                port: 7_777,
+            }),
+            peers: vec![peer(1, false)],
+            ice_servers: vec![],
+            fallback: TransportKind::Relay,
+        });
+        assert!(!session.peer(peer_id).unwrap().connected);
+        assert!(!session.apply(&SignalFishEvent::PeerTransportStatus {
+            peer_id,
+            transport: TransportKind::WebRtc,
+            connected: true,
+        }));
+        assert!(session.apply(&SignalFishEvent::PeerTransportStatus {
+            peer_id,
+            transport: TransportKind::Direct,
+            connected: true,
+        }));
+        assert!(session.peer(peer_id).unwrap().connected);
+
+        session.apply(&SignalFishEvent::SessionPlan {
+            generation: None,
+            topology: Topology::Relay,
+            transport: TransportKind::Relay,
+            host: None,
+            direct_endpoint: None,
+            peers: vec![],
+            ice_servers: vec![],
+            fallback: TransportKind::Relay,
+        });
+        assert!(session.peers().is_empty());
+        assert!(!session.is_p2p());
     }
 
     #[test]

--- a/src/polling_client.rs
+++ b/src/polling_client.rs
@@ -231,10 +231,7 @@ impl<T: Transport> SignalFishPollingClient<T> {
         mut options: PollingClientOptions,
     ) -> Self {
         options.work_budget = options.work_budget.clamped();
-        let mesh_enabled = config
-            .supported_transports
-            .as_ref()
-            .is_some_and(|transports| transports.contains(&TransportKind::WebRtc));
+        let mesh_capable = config.advertises_mesh_capability();
         let auth_msg = ClientCore::authenticate(&config);
 
         let now = Instant::now();
@@ -252,7 +249,7 @@ impl<T: Transport> SignalFishPollingClient<T> {
             core: ClientCore::new(
                 config.game_data_format,
                 config.protocol_violation_policy,
-                mesh_enabled,
+                mesh_capable,
             ),
             options,
             polling_stats: PollingStats {
@@ -716,11 +713,29 @@ impl<T: Transport> SignalFishPollingClient<T> {
         self.core.effective_game_data_format()
     }
 
-    /// Returns `true` once the connection has negotiated protocol v3 and this
-    /// client advertised WebRTC support through [`SignalFishConfig::enable_mesh`].
-    /// This is the "am I in mesh mode?" check.
+    /// Whether protocol v3 was negotiated after this client advertised both
+    /// WebRTC and at least one P2P topology (`host` or `mesh`).
+    ///
+    /// This is a capability query; use [`session_topology`](Self::session_topology),
+    /// [`session_transport`](Self::session_transport), or
+    /// [`is_p2p_active`](Self::is_p2p_active) for selected plan state.
     pub fn supports_mesh(&self) -> bool {
         self.core.supports_mesh()
+    }
+
+    /// Topology selected by the latest authoritative session plan.
+    pub fn session_topology(&self) -> Option<crate::protocol::Topology> {
+        self.core.session_topology()
+    }
+
+    /// Data-path transport selected by the latest authoritative session plan.
+    pub fn session_transport(&self) -> Option<TransportKind> {
+        self.core.session_transport()
+    }
+
+    /// Whether the latest authoritative plan selects a peer-to-peer topology.
+    pub fn is_p2p_active(&self) -> bool {
+        self.core.is_p2p_active()
     }
 
     /// Whether the transport connection is still alive.

--- a/src/webrtc.rs
+++ b/src/webrtc.rs
@@ -216,8 +216,9 @@ mod controller {
     /// Drives a [`WebRtcDriver`] through the full v3 mesh signaling handshake on
     /// top of a [`SignalFishClient`], surfacing a [`MeshEvent`] stream.
     ///
-    /// `MeshController::start` enables the mesh automatically (if the config did
-    /// not already opt in), so the canonical usage is a few lines:
+    /// `MeshController::start` ensures the config advertises v3, WebRTC, and at
+    /// least one P2P topology while preserving compatible explicit choices, so
+    /// the canonical usage is a few lines:
     ///
     /// ```rust,ignore
     /// let (mut mesh) = MeshController::start(transport, SignalFishConfig::new("app"), my_driver);
@@ -273,19 +274,15 @@ mod controller {
     impl<D: WebRtcDriver> MeshController<D> {
         /// Start a mesh-driving client over `transport` using `driver`.
         ///
-        /// If `config` has not opted into the mesh, this enables it (so the
-        /// server can form a P2P session). The driver is engaged automatically as
-        /// the server's `SessionPlan`/`NewPeer` directives arrive.
+        /// Ensures `config` advertises v3, WebRTC, and at least one P2P topology
+        /// while preserving compatible explicit choices. The driver is engaged
+        /// automatically as the server's `SessionPlan`/`NewPeer` directives arrive.
         pub fn start(
             transport: impl Transport + Send + 'static,
             config: SignalFishConfig,
             driver: D,
         ) -> Self {
-            let config = if config.protocol_version.is_none() {
-                config.enable_mesh()
-            } else {
-                config
-            };
+            let config = config.enable_controller_mesh();
             let (client, events) = SignalFishClient::start(transport, config);
             // Hand the driver a waker so it can pump on demand (eliminating up to
             // one pump-interval of trickle-ICE / data latency). Drivers that do not
@@ -821,7 +818,7 @@ mod controller {
 mod tests {
     use super::*;
     use crate::client::SignalFishConfig;
-    use crate::protocol::TransportKind;
+    use crate::protocol::{ClientMessage, Topology, TransportKind};
     use std::collections::VecDeque;
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::{Arc, Mutex};
@@ -1451,6 +1448,70 @@ mod tests {
         });
     }
 
+    #[tokio::test]
+    async fn controller_authentication_adds_missing_mesh_capability_without_overwrite() {
+        let cases = [
+            (
+                "relay-v3",
+                SignalFishConfig::new("app").enable_v3(),
+                crate::PROTOCOL_VERSION,
+                vec![TransportKind::Relay, TransportKind::WebRtc],
+                vec![Topology::Relay, Topology::Mesh],
+            ),
+            (
+                "future-direct-host",
+                SignalFishConfig::new("app")
+                    .with_protocol_version(4)
+                    .with_transports([TransportKind::Direct])
+                    .with_topologies([Topology::Host]),
+                4,
+                vec![TransportKind::Direct, TransportKind::WebRtc],
+                vec![Topology::Host],
+            ),
+            (
+                "existing-webrtc-missing-p2p-topology",
+                SignalFishConfig::new("app")
+                    .with_protocol_version(3)
+                    .with_transports([TransportKind::WebRtc, TransportKind::Relay])
+                    .with_topologies([Topology::Relay]),
+                3,
+                vec![TransportKind::WebRtc, TransportKind::Relay],
+                vec![Topology::Relay, Topology::Mesh],
+            ),
+            (
+                "compatible-existing-webrtc-host",
+                SignalFishConfig::new("app")
+                    .with_protocol_version(3)
+                    .with_transports([TransportKind::Direct, TransportKind::WebRtc])
+                    .with_topologies([Topology::Host, Topology::Relay]),
+                3,
+                vec![TransportKind::Direct, TransportKind::WebRtc],
+                vec![Topology::Host, Topology::Relay],
+            ),
+        ];
+
+        for (name, config, protocol, transports, topologies) in cases {
+            let (transport, sent) = MockTransport::new(vec![]);
+            let controller = MeshController::start(transport, config, SharedDriver::default());
+            wait_for_sent_count(&sent, &["Authenticate"], 1).await;
+            let authenticate = serde_json::from_str::<ClientMessage>(&sent.lock().unwrap()[0])
+                .expect("controller Authenticate frame should decode");
+            let ClientMessage::Authenticate {
+                protocol_version,
+                supported_transports,
+                supported_topologies,
+                ..
+            } = authenticate
+            else {
+                panic!("{name}: first frame should be Authenticate");
+            };
+            assert_eq!(protocol_version, Some(protocol), "{name}");
+            assert_eq!(supported_transports, Some(transports), "{name}");
+            assert_eq!(supported_topologies, Some(topologies), "{name}");
+            controller.shutdown().await;
+        }
+    }
+
     async fn recv_until_peer_connected(
         mesh: &mut MeshController<SharedDriver>,
     ) -> Option<PlayerId> {
@@ -1796,6 +1857,19 @@ mod tests {
             });
         assert!(relayed_offer, "the local offer should be relayed");
         assert!(reported_status, "transport status should be reported up");
+        assert_eq!(mesh.session().topology(), Some(Topology::Mesh));
+        assert_eq!(mesh.session().transport(), Some(TransportKind::WebRtc));
+        assert_eq!(
+            mesh.session().topology(),
+            mesh.client().session_topology(),
+            "the controller and core must expose the same active WebRTC topology"
+        );
+        assert_eq!(
+            mesh.session().transport(),
+            mesh.client().session_transport(),
+            "the controller and core must expose the same active WebRTC transport"
+        );
+        assert_eq!(mesh.session().is_p2p(), mesh.client().is_p2p_active());
         mesh.shutdown().await;
     }
 
@@ -2442,6 +2516,17 @@ mod tests {
             assert!(!calls
                 .iter()
                 .any(|call| matches!(call, DriverCall::OnSignal(id, _) if *id == late_peer)));
+            assert_eq!(
+                mesh.session().topology(),
+                mesh.client().session_topology(),
+                "controller and shared core must expose one selected topology"
+            );
+            assert_eq!(
+                mesh.session().transport(),
+                mesh.client().session_transport(),
+                "controller and shared core must expose one selected transport"
+            );
+            assert_eq!(mesh.session().is_p2p(), mesh.client().is_p2p_active());
             mesh.shutdown().await;
         }
     }

--- a/tests/polling_parity_tests.rs
+++ b/tests/polling_parity_tests.rs
@@ -27,7 +27,7 @@ use signal_fish_client::protocol::{
     DeliveryGapReason, DeliveryReportPayload, GameDataEncoding, LatestDeliveryCounters, LobbyState,
     PlayerId, PlayerInfo, ProtocolInfoPayload, ReconnectedPayload, ReliableDeliveryCounters,
     ReplayStatus, RoomJoinedPayload, SenderWatermark, ServerMessage, SpectatorJoinedPayload,
-    TransportKind, V2BinaryGameDataFrame, V3BinaryGameDataFrame,
+    Topology, TransportKind, V2BinaryGameDataFrame, V3BinaryGameDataFrame,
 };
 use signal_fish_client::transport::TransportFrame;
 use signal_fish_client::{ErrorCode, ProtocolViolationPolicy};
@@ -36,6 +36,16 @@ use signal_fish_client::{
 };
 
 fn assert_common_api_is_object_safe(_client: &mut dyn signal_fish_client::SignalFishClientApi) {}
+
+fn selected_plan_through_common_api(
+    client: &dyn SignalFishClientApi,
+) -> (Option<Topology>, Option<TransportKind>, bool) {
+    (
+        client.session_topology(),
+        client.session_transport(),
+        client.is_p2p_active(),
+    )
+}
 
 #[derive(Clone)]
 struct FrameMock {
@@ -833,6 +843,35 @@ async fn assert_open_text_trace_parity_with_reconnect(
     assert_eq!(async_events, polling_events);
     assert_eq!(async_snapshot, polling_snapshot);
     assert_eq!(async_client.stats(), polling_client.stats());
+    assert_eq!(
+        async_client.session_topology(),
+        polling_client.session_topology()
+    );
+    assert_eq!(
+        async_client.session_transport(),
+        polling_client.session_transport()
+    );
+    assert_eq!(async_client.is_p2p_active(), polling_client.is_p2p_active());
+    assert_eq!(
+        async_client.session_topology(),
+        async_snapshot.session_topology
+    );
+    assert_eq!(
+        async_client.session_transport(),
+        async_snapshot.session_transport
+    );
+    assert_eq!(
+        selected_plan_through_common_api(&async_client),
+        selected_plan_through_common_api(&polling_client)
+    );
+    assert_eq!(
+        selected_plan_through_common_api(&async_client),
+        (
+            async_snapshot.session_topology,
+            async_snapshot.session_transport,
+            async_client.is_p2p_active(),
+        )
+    );
     async_client.shutdown().await;
     (async_events, async_snapshot)
 }
@@ -2352,6 +2391,307 @@ async fn parity_enable_mesh_authenticate_is_byte_identical() {
     assert_eq!(
         async_sent[0], poll_sent[0],
         "enable_mesh Authenticate must be byte-identical between clients"
+    );
+}
+
+#[tokio::test]
+async fn parity_mesh_capability_requires_webrtc_and_p2p_topology() {
+    let cases = [
+        (vec![TransportKind::WebRtc], vec![Topology::Mesh], true),
+        (vec![TransportKind::WebRtc], vec![Topology::Host], true),
+        (vec![TransportKind::WebRtc], vec![Topology::Relay], false),
+        (vec![TransportKind::Relay], vec![Topology::Mesh], false),
+    ];
+
+    for (transports, topologies, expected) in cases {
+        let config = SignalFishConfig::new("app")
+            .with_protocol_version(3)
+            .with_transports(transports)
+            .with_topologies(topologies);
+
+        let async_mock = SharedMock::new(vec![AUTH, PI_V3]);
+        let (mut async_client, mut events) = SignalFishClient::start(async_mock, config.clone());
+        for _ in 0..3 {
+            let _ = tokio::time::timeout(std::time::Duration::from_secs(1), events.recv())
+                .await
+                .expect("async capability trace should make progress");
+        }
+
+        let poll_mock = SharedMock::new(vec![AUTH, PI_V3]);
+        let mut polling_client = SignalFishPollingClient::new(poll_mock, config);
+        let _ = polling_client.poll();
+
+        assert_eq!(async_client.supports_mesh(), expected);
+        assert_eq!(polling_client.supports_mesh(), expected);
+        async_client.shutdown().await;
+    }
+}
+
+#[tokio::test]
+async fn parity_selected_plan_accessors_follow_ordered_canonical_transitions() {
+    use signal_fish_client::protocol::{DirectEndpoint, SessionPeer, SessionPlanPayload};
+
+    fn plan(
+        topology: Topology,
+        transport: TransportKind,
+        generation: u128,
+        peer: PlayerId,
+    ) -> ServerMessage {
+        ServerMessage::SessionPlan(Box::new(SessionPlanPayload {
+            generation: Some(uuid::Uuid::from_u128(generation)),
+            topology,
+            transport,
+            host: (topology == Topology::Host).then_some(peer),
+            direct_endpoint: (transport == TransportKind::Direct).then_some(DirectEndpoint {
+                host: "192.0.2.10".into(),
+                port: 7_777,
+            }),
+            peers: if topology == Topology::Relay {
+                vec![]
+            } else {
+                vec![SessionPeer {
+                    player_id: peer,
+                    player_name: "peer".into(),
+                    is_authority: false,
+                    initiate: false,
+                }]
+            },
+            ice_servers: vec![],
+            fallback: TransportKind::Relay,
+        }))
+    }
+
+    let peer = uuid::Uuid::from_u128(350);
+    let transitions = [
+        (Topology::Relay, TransportKind::Relay, false, 351),
+        (Topology::Mesh, TransportKind::WebRtc, true, 352),
+        (Topology::Host, TransportKind::Direct, true, 353),
+        (Topology::Host, TransportKind::WebRtc, true, 354),
+    ];
+
+    let mut messages = binary_accountability_prefix(peer)
+        .into_iter()
+        .map(|frame| match frame {
+            TransportFrame::Text(text) => text,
+            TransportFrame::Binary(_) => unreachable!("prefix is text-only"),
+        })
+        .collect::<Vec<_>>();
+    messages.push(
+        serde_json::to_string(&ServerMessage::LobbyStateChanged {
+            lobby_state: LobbyState::Finalized,
+            ready_players: vec![],
+            all_ready: true,
+        })
+        .expect("finalized lobby event should serialize"),
+    );
+
+    for (index, (topology, transport, p2p_active, generation)) in
+        transitions.into_iter().enumerate()
+    {
+        messages.push(
+            serde_json::to_string(&plan(topology, transport, generation, peer))
+                .expect("session plan should serialize"),
+        );
+
+        let (events, snapshot) = assert_open_text_trace_parity(
+            messages.clone(),
+            SignalFishConfig::new("app").enable_mesh(),
+        )
+        .await;
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| event.starts_with("SessionPlan|"))
+                .count(),
+            index + 1,
+            "every ordered plan transition must surface exactly once"
+        );
+        assert_eq!(snapshot.session_topology, Some(topology));
+        assert_eq!(snapshot.session_transport, Some(transport));
+        assert_eq!(
+            matches!(
+                snapshot.session_topology,
+                Some(Topology::Host | Topology::Mesh)
+            ),
+            p2p_active
+        );
+    }
+}
+
+#[tokio::test]
+async fn parity_selected_plan_resets_at_room_and_connection_boundaries() {
+    use signal_fish_client::protocol::{SessionPeer, SessionPlanPayload};
+
+    let peer = uuid::Uuid::from_u128(350);
+    let plan = ServerMessage::SessionPlan(Box::new(SessionPlanPayload {
+        generation: Some(uuid::Uuid::from_u128(351)),
+        topology: Topology::Mesh,
+        transport: TransportKind::WebRtc,
+        host: None,
+        direct_endpoint: None,
+        peers: vec![SessionPeer {
+            player_id: peer,
+            player_name: "peer".into(),
+            is_authority: false,
+            initiate: false,
+        }],
+        ice_servers: vec![],
+        fallback: TransportKind::Relay,
+    }));
+    let mut populated = binary_accountability_prefix(peer)
+        .into_iter()
+        .map(|frame| match frame {
+            TransportFrame::Text(text) => text,
+            TransportFrame::Binary(_) => unreachable!("prefix is text-only"),
+        })
+        .collect::<Vec<_>>();
+    populated.extend([
+        serde_json::to_string(&ServerMessage::LobbyStateChanged {
+            lobby_state: LobbyState::Finalized,
+            ready_players: vec![],
+            all_ready: true,
+        })
+        .expect("finalized lobby event should serialize"),
+        serde_json::to_string(&plan).expect("session plan should serialize"),
+    ]);
+
+    let (events, snapshot) = assert_open_text_trace_parity(
+        populated.clone(),
+        SignalFishConfig::new("app").enable_mesh(),
+    )
+    .await;
+    assert!(events.iter().any(|event| event.starts_with("SessionPlan|")));
+    assert_eq!(snapshot.session_topology, Some(Topology::Mesh));
+    assert_eq!(snapshot.session_transport, Some(TransportKind::WebRtc));
+
+    let mut room_exit = populated.clone();
+    room_exit
+        .push(serde_json::to_string(&ServerMessage::RoomLeft).expect("RoomLeft should serialize"));
+    let (events, snapshot) =
+        assert_open_text_trace_parity(room_exit, SignalFishConfig::new("app").enable_mesh()).await;
+    let lifecycle = events
+        .iter()
+        .filter_map(|event| {
+            if event.starts_with("SessionPlan|") {
+                Some("SessionPlan")
+            } else if event == "RoomLeft" {
+                Some("RoomLeft")
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(lifecycle, ["SessionPlan", "RoomLeft"]);
+    assert!(snapshot.session_topology.is_none());
+    assert!(snapshot.session_transport.is_none());
+
+    let polling_mock = SharedMock::from_msgs(
+        populated
+            .iter()
+            .cloned()
+            .map(|message| Some(Ok(message)))
+            .collect(),
+    );
+    let mut polling_client =
+        SignalFishPollingClient::new(polling_mock, SignalFishConfig::new("app").enable_mesh());
+    let _ = polling_client.poll();
+    assert_eq!(polling_client.session_topology(), Some(Topology::Mesh));
+    assert_eq!(
+        polling_client.session_transport(),
+        Some(TransportKind::WebRtc)
+    );
+    polling_client.close();
+    assert!(polling_client.session_topology().is_none());
+    assert!(polling_client.session_transport().is_none());
+
+    let async_mock = SharedMock::from_msgs(
+        populated
+            .into_iter()
+            .map(|message| Some(Ok(message)))
+            .chain(std::iter::once(Some(Err(
+                SignalFishError::TransportReceive("reset".into()),
+            ))))
+            .collect(),
+    );
+    let (async_client, mut events) =
+        SignalFishClient::start(async_mock, SignalFishConfig::new("app").enable_mesh());
+    let mut saw_plan = false;
+    loop {
+        match tokio::time::timeout(std::time::Duration::from_secs(1), events.recv())
+            .await
+            .expect("async disconnect trace should make progress")
+        {
+            Some(SignalFishEvent::SessionPlan { .. }) => saw_plan = true,
+            Some(SignalFishEvent::Disconnected { .. }) => break,
+            Some(_) => {}
+            None => panic!("async event stream ended before Disconnected"),
+        }
+    }
+    assert!(saw_plan, "the disconnect must follow a populated plan");
+    assert!(async_client.session_topology().is_none());
+    assert!(async_client.session_transport().is_none());
+}
+
+#[tokio::test]
+async fn parity_reconnected_baseline_is_planless_until_fresh_session_plan() {
+    use signal_fish_client::protocol::SessionPlanPayload;
+
+    let (events, snapshot) = assert_open_reconnect_trace_parity(
+        vec![AUTH.into(), PI_V3.into(), reconnected_with_missed(vec![])],
+        SignalFishConfig::new("app").enable_mesh(),
+    )
+    .await;
+    assert!(events.iter().any(|event| event.starts_with("Reconnected|")));
+    assert!(snapshot.session_topology.is_none());
+    assert!(snapshot.session_transport.is_none());
+    assert!(snapshot.session_generation.is_none());
+
+    let ServerMessage::Reconnected(mut finalized) =
+        serde_json::from_str::<ServerMessage>(&reconnected_with_missed(vec![]))
+            .expect("Reconnected fixture should decode")
+    else {
+        unreachable!("reconnect fixture is Reconnected")
+    };
+    finalized.lobby_state = LobbyState::Finalized;
+    let fresh_plan = ServerMessage::SessionPlan(Box::new(SessionPlanPayload {
+        generation: Some(uuid::Uuid::from_u128(355)),
+        topology: Topology::Relay,
+        transport: TransportKind::Relay,
+        host: None,
+        direct_endpoint: None,
+        peers: vec![],
+        ice_servers: vec![],
+        fallback: TransportKind::Relay,
+    }));
+    let (events, snapshot) = assert_open_reconnect_trace_parity(
+        vec![
+            AUTH.into(),
+            PI_V3.into(),
+            serde_json::to_string(&ServerMessage::Reconnected(finalized))
+                .expect("finalized Reconnected fixture should serialize"),
+            serde_json::to_string(&fresh_plan).expect("fresh SessionPlan should serialize"),
+        ],
+        SignalFishConfig::new("app").enable_mesh(),
+    )
+    .await;
+    let lifecycle = events
+        .iter()
+        .filter_map(|event| {
+            if event.starts_with("Reconnected|") {
+                Some("Reconnected")
+            } else if event.starts_with("SessionPlan|") {
+                Some("SessionPlan")
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(lifecycle, ["Reconnected", "SessionPlan"]);
+    assert_eq!(snapshot.session_topology, Some(Topology::Relay));
+    assert_eq!(snapshot.session_transport, Some(TransportKind::Relay));
+    assert_eq!(
+        snapshot.session_generation,
+        Some(uuid::Uuid::from_u128(355))
     );
 }
 


### PR DESCRIPTION
## Summary

- normalize controller-owned configs so preselected v3/future versions still advertise WebRTC plus a compatible P2P topology without overwriting explicit choices
- separate negotiated local capability from the authoritative active plan through selected topology/transport snapshot and client accessors
- make mesh peer liveness transport-specific and clear stale status when the selected path, generation, or server-assigned offerer role changes
- add exhaustive async, polling, object-safe API, controller, transition, reset, and exact Authenticate-wire coverage
- update the changelog, migration guidance, roadmap, canonical context, focused skills, consumer docs, and Session 029 evidence

## Breaking change

`ClientSnapshot` is exhaustive and gains `session_topology` and `session_transport`. Also, `supports_mesh()` now precisely reports negotiated v3 plus advertised WebRTC and a Host/Mesh topology; WebRTC + relay-only configurations return `false`.

For routing decisions, migrate to one `snapshot()` read or use `session_topology()`, `session_transport()`, and `is_p2p_active()`.

## Validation

- `cargo fmt && cargo clippy --workspace --all-targets --all-features -- -D warnings && cargo test --workspace --all-features`
- default and all-feature rustdoc with warnings denied
- no-default and feature-isolated builds/tests
- workflow policy, LLM drift, pre-commit, and pre-push checks
- two final adversarial review passes with zero findings

Closes #102

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking public snapshot/API and mesh routing semantics: `supports_mesh()` meaning changes, and selected topology/transport now drive routing and peer liveness.
> 
> **Overview**
> **Separates local mesh capability from the server-selected session plan**, so routing no longer treats `supports_mesh()` as “P2P is active.”
> 
> `ClientSnapshot` now carries `session_topology` and `session_transport`. Async, polling, and `SignalFishClientApi` expose those plus `is_p2p_active()`. `supports_mesh()` is capability-only: negotiated v3 **and** advertised WebRTC plus Host/Mesh. Custom WebRTC + relay-only configs now return `false`.
> 
> `MeshController::start` no longer blindly `enable_mesh()`s. It uses `enable_controller_mesh()` so preselected v3/future versions still advertise WebRTC and a P2P topology without overwriting compatible explicit lists.
> 
> `MeshSession` peer `connected` tracks only the selected transport. Generation, transport, or offerer-role changes clear stale liveness. Plan fields reset at room/disconnect/reconnect until a fresh `SessionPlan`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa507ed078c5463b28804178c08991c961d1fa62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->