### PR TITLE
fix: bound WebSocket receive liveness

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Install release tools
         uses: taiki-e/install-action@v2.85.13
         with:
-          tool: cargo-cyclonedx@0.5.7,cargo-semver-checks@0.46.0
+          tool: cargo-cyclonedx@0.5.7,cargo-semver-checks@0.50.0
 
       - name: Derive and validate release metadata
         id: release-metadata

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Install cargo-semver-checks
         uses: taiki-e/install-action@v2.85.13
         with:
-          tool: cargo-semver-checks@0.46.0
+          tool: cargo-semver-checks@0.50.0
 
       - name: Generate lockfile
         run: bash scripts/cargo-retry.sh generate-lockfile

--- a/.llm/context.md
+++ b/.llm/context.md
@@ -88,7 +88,7 @@ non-forgeable authorization emitted when native close was attempted or observed 
 possible and intentionally leaks the small state allocation after a terminal
 failure rather than allowing a late callback to access freed memory; logical
 receive errors do not skip the native close attempt. The host-tested ownership
-state machine and source checker with its 43-case self-test enforce that guard.
+state machine and source checker with its 50-case self-test enforce that guard.
 
 The change-scoped PR, scheduled, and manual Deep Safety workflow provides
 fail-closed evidence from Miri protocol tests, all three protocol fuzz targets,
@@ -373,12 +373,12 @@ Emscripten SDK version are independent compatibility axes.
 
 ### Low-Latency Socket Defaults
 
-Transports that own their TCP socket disable Nagle's algorithm (`TCP_NODELAY`)
-by default so small game messages avoid TCP's delayed-ACK stall (tens of ms per
-round trip). `WebSocketTransport::connect` does this; callers override with
-`WebSocketConnectOptions::with_disable_nagle(false)`. Backends that delegate the
-socket to a browser/engine (Emscripten, Godot) leave the tuning to the platform.
-See the `transport-abstraction` and `websocket-client` skills.
+Socket-owning transports disable Nagle's algorithm (`TCP_NODELAY`) by default;
+`WebSocketTransport` callers override with
+`WebSocketConnectOptions::with_disable_nagle(false)`. Its receive poll bounds
+skipped control frames, flushes automatic Pong/Close responses before further
+reads, and fuses EOF or terminal socket errors. Browser/engine backends leave
+tuning to the platform. See the `transport-abstraction` and `websocket-client` skills.
 
 ### Wire Compatibility
 

--- a/.llm/skills/transport-abstraction/SKILL.md
+++ b/.llm/skills/transport-abstraction/SKILL.md
@@ -215,6 +215,8 @@ dropping it each call.
 - records close code/reason in `TransportCloseInfo`;
 - drives `poll_close` idempotently;
 - flushes tungstenite's automatically queued Pong before reading again;
+- bounds skipped control frames per receive poll and self-wakes to resume;
+- fuses EOF and terminal socket errors while clearing retained poll state;
 - disables Nagle's algorithm (`TCP_NODELAY`) by default on the socket it owns.
 
 Do not treat Ping/Pong as application frames. Do not skip binary application

--- a/.llm/skills/websocket-client/SKILL.md
+++ b/.llm/skills/websocket-client/SKILL.md
@@ -62,15 +62,16 @@ Raw `Message::Frame` is not expected from the read half and is ignored.
 
 `poll_send` uses the `Sink` primitives directly:
 
-1. If no send is active, call `poll_ready`.
-2. On `Pending`, leave the caller's frame slot untouched.
+1. If no send is active and the caller slot is empty, return `Ready(Ok(()))`.
+2. Otherwise call `poll_ready`; on `Pending`, leave the caller slot untouched.
 3. On readiness, take exactly one `TransportFrame` and translate it to
    `Message::Text` or `Message::Binary`.
-4. Call `start_send` once and record that a send is active.
+4. Call `start_send` once and, on success, record that a send is active.
 5. Poll `poll_flush` until ready; do not take another frame while pending.
 
 This preserves an accepted frame across `Pending` and prevents duplicate
-`start_send` calls.
+`start_send` calls. If a custom stream rejects the message with
+`WriteBufferFull`, restore the exact Text/Binary frame to the caller slot.
 
 ```rust,ignore
 match frame {
@@ -90,8 +91,10 @@ output still needs a flush. After Ping, `WebSocketTransport` sets a
 application frame. If flushing is pending, it preserves the flag and returns
 `Pending` with the sink's waker registered.
 
-Do not manually enqueue a second Pong. Do not continue reading indefinitely
-without flushing the automatically queued reply.
+One receive call skips at most 64 Ping, Pong, or defensive raw Frame messages.
+After the boundary Ping's automatic Pong is flushed, budget exhaustion calls
+`cx.waker().wake_by_ref()` and returns `Pending`; already-buffered application
+traffic is resumed in a later poll. Do not manually enqueue a second Pong.
 
 ## Close Metadata and Idempotency
 
@@ -113,6 +116,11 @@ does not supply a separate clean-handshake boolean here, so `clean` remains
 `poll_close` calls the sink's `poll_close`, retains progress in the stream, and
 marks the transport closed on either terminal success or error. Once closed,
 later calls return `Ready(Ok(()))` without another close frame.
+
+EOF and terminal receive/send failures drop the stream, clear retained send and
+control state, and fuse the transport. Report the first receive failure as
+`TransportReceive`; later receives return `None`, sends return
+`TransportClosed` without taking their frame, and close remains idempotent.
 
 ## Wakers
 
@@ -148,7 +156,9 @@ closed WebSocket object.
 - Bare peer close is distinguishable from missing metadata where applicable.
 - Repeated `poll_close` after completion is harmless.
 - Ping causes the automatically queued Pong to be flushed.
+- Control-frame budget exhaustion self-wakes before buffered application data.
 - Transport send/receive errors map to the matching `SignalFishError` variant.
+- EOF and terminal socket errors produce exact fused follow-up behavior.
 - A real waker is notified when socket readiness changes.
 - The connected TCP socket has `TCP_NODELAY` set by default; `connect_with_options`
   can turn it off.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed the built-in `WebSocketTransport` allowing buffered Ping/Pong floods to
+  monopolize one receive poll and leaving EOF or socket errors logically open.
+  Control-frame work is now bounded with wake-driven continuation, automatic
+  Pong and Close responses still flush before further reads, and terminal
+  socket outcomes fuse subsequent receive/send/close operations.
+
 - Fixed `MeshController::start` leaving an `enable_v3()` configuration
   relay-only despite owning a WebRTC driver. Controller startup now preserves
   compatible explicit and future-version choices while adding any missing

--- a/PLAN.md
+++ b/PLAN.md
@@ -134,7 +134,7 @@ first authoritative `ProtocolInfo` and reconnect state transaction.
 - Session 028 records the rule-to-source-to-test matrix, pinned-server evidence,
   hosted review fixes, and green aggregate checks.
 
-## Current Correctness Milestone — Mesh Capability and Liveness
+## Completed Correctness Milestone — Mesh Capability and Liveness
 
 [Issue #102](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/issues/102)
 separates negotiated local capability from the authoritative selected plan,
@@ -142,10 +142,17 @@ normalizes controller-owned WebRTC configuration, and makes peer liveness
 transport-specific. Session 029 records the configuration, state, transition,
 and async/polling/controller parity evidence.
 
-## Next Correctness Milestone — WebSocket Liveness
+## Current Correctness Milestone — WebSocket Liveness
 
-Continue with #105, then #103, #104, #106, and #107 before usability,
-performance, token binding, or presentation milestones.
+[Issue #105](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/issues/105)
+bounds native WebSocket control-frame work, preserves automatic Pong/Close
+flush ordering, and makes EOF and socket errors terminal for direct Transport
+callers. Session 030 records socket, ownership, wake, and terminal-state evidence.
+
+## Next Correctness Milestones — Client State and Transport Deadlines
+
+Continue with #103, #104, #106, and #107 before usability, performance, token
+binding, or presentation milestones.
 
 ## Following Milestone — Negotiated Token Binding
 

--- a/docs/transport.md
+++ b/docs/transport.md
@@ -162,11 +162,15 @@ ignored frames.
 Tungstenite automatically queues a Pong while reading Ping. The transport
 explicitly drives `poll_flush` before reading further frames, ensuring that the
 automatic RFC 6455 response reaches the peer even when the application has no
-outbound message to send.
+outbound message to send. Each receive poll skips at most 64 control frames; if
+that budget is exhausted, it schedules another poll so buffered application
+traffic cannot be hidden behind unbounded control-frame work.
 
 Peer Close code and reason are copied into `TransportCloseInfo`; a bare Close
 still records that the peer initiated termination. WebSocket close polling is
-idempotent.
+idempotent. EOF and terminal socket errors release the stream and fuse the
+transport: the first receive error remains observable, later receives return
+`None`, sends fail with `TransportClosed`, and repeated close calls succeed.
 
 ## Implementing a channel transport
 

--- a/progress/session-030-websocket-liveness.md
+++ b/progress/session-030-websocket-liveness.md
@@ -43,5 +43,7 @@ socket terminal outcome leave one coherent, fused transport state.
   the upstream 0.50 pin (v60/v61 support), guarded by a repository policy test.
 - Hosted spelling validation also caught a partial-frame byte-string fragment;
   the fixture now expresses those remaining bytes individually.
-- Hosted PR aggregates and reviewer feedback remain to be recorded before
-  completion.
+- PR #113's code head `f05cf14` passed all 11 blocking aggregates: CI,
+  Coverage, Docs Validation, Examples Validation, Godot Web, No Panics,
+  Security, Semver Checks, Unused Deps, WASM, and Workflow Lint. GitHub
+  reported no review submissions, comments, or unresolved inline threads.

--- a/progress/session-030-websocket-liveness.md
+++ b/progress/session-030-websocket-liveness.md
@@ -38,5 +38,10 @@ socket terminal outcome leave one coherent, fused transport state.
 - The 29-test focused WebSocket suite, no-default and isolated WebSocket builds,
   stable all-feature rustdoc, nightly docs.rs simulation, workflow policy, FFI
   policy plus its 50-case self-test, LLM validation, and `git diff --check` pass.
+- The first hosted Semver run exposed `cargo-semver-checks` 0.46's rustdoc-v57
+  ceiling against stable's v60 output. Semver and publish workflows now share
+  the upstream 0.50 pin (v60/v61 support), guarded by a repository policy test.
+- Hosted spelling validation also caught a partial-frame byte-string fragment;
+  the fixture now expresses those remaining bytes individually.
 - Hosted PR aggregates and reviewer feedback remain to be recorded before
   completion.

--- a/progress/session-030-websocket-liveness.md
+++ b/progress/session-030-websocket-liveness.md
@@ -1,0 +1,42 @@
+# Session 030 — WebSocket Liveness
+
+## Scope
+
+Issue #105 bounds peer-controlled WebSocket receive work and makes every native
+socket terminal outcome leave one coherent, fused transport state.
+
+## Invariant → Source → Evidence
+
+| Invariant | Source | Executable evidence |
+| --- | --- | --- |
+| One receive call skips at most 64 Ping, Pong, or defensive raw Frame messages. A boundary Ping flushes its automatic Pong before the transport self-wakes and yields. | `MAX_SKIPPED_CONTROL_FRAMES_PER_POLL`; `WebSocketState::poll_recv`. | `websocket::tests::control_frame_budget_self_wakes_before_buffered_application_data`; `ping_auto_pong_is_flushed_before_later_application_reads`. |
+| Partial input and sink backpressure retain their exact state and real wakers. An accepted first send completes before a second caller frame is consumed. | `WebSocketState::{poll_recv, poll_send}`. | `partial_frame_registers_and_notifies_the_real_waker`; `pending_flush_retains_the_second_frame_and_preserves_fifo`. |
+| A custom tungstenite write-buffer refusal does not consume a frame the sink rejected. | `WebSocketState::poll_send` restores `WriteBufferFull` Text/Binary frames. | `rejected_write_buffer_full_restores_the_exact_caller_frame`. |
+| EOF, peer Close, and terminal receive/send errors drop the stream, clear retained poll state, and fuse later operations. The first receive failure remains observable. | `WebSocketState::mark_terminal`; receive/send/close terminal branches. | `raw_eof_fuses_receive_send_and_close_operations`; `socket_receive_error_is_reported_once_then_transport_is_terminal`; `socket_send_error_maps_to_transport_send_and_becomes_terminal`; `recv_returns_none_on_close_frame`; `recv_after_local_close_returns_exact_terminal_none`. |
+| Existing frame, metadata, TLS, and socket-latency behavior remains intact. | `WebSocketTransport` constructors and frame mapping. | Exact text/binary FIFO round trip; peer-close metadata/response tests; TLS provider test; default/override `TCP_NODELAY` tests. |
+
+## Same-Class Sweep
+
+- The Godot adapter processes at most one backend packet per receive poll.
+- The Emscripten transport consumes at most its one synthetic Open event before
+  returning an application or terminal result. Neither has a peer-controlled
+  ignored-control loop, so the native WebSocket fix does not apply there.
+- The FFI reclamation scanner exempts only tungstenite's exact
+  `WebSocketStream::from_raw_socket` constructor while retaining its broad
+  ownership-reclamation matches; negative alias/comment-split cases and a new
+  longer ownership-API fixture protect both sides.
+
+## Review and Verification
+
+- Three independent production, test, and adversarial audits agreed on the
+  bounded-work, flush-ordering, terminal-state, ownership, and evidence gaps.
+- The mandatory `cargo fmt && cargo clippy --workspace --all-targets
+  --all-features -- -D warnings && cargo test --workspace --all-features` gate
+  passes, including 332 core library tests, 31 driver-parity tests, 126 protocol
+  tests, and 35 Godot adapter tests; six live-server tests remain intentionally
+  ignored outside their pinned jobs.
+- The 29-test focused WebSocket suite, no-default and isolated WebSocket builds,
+  stable all-feature rustdoc, nightly docs.rs simulation, workflow policy, FFI
+  policy plus its 50-case self-test, LLM validation, and `git diff --check` pass.
+- Hosted PR aggregates and reviewer feedback remain to be recorded before
+  completion.

--- a/progress/session-030-websocket-liveness.md
+++ b/progress/session-030-websocket-liveness.md
@@ -45,5 +45,9 @@ socket terminal outcome leave one coherent, fused transport state.
   the fixture now expresses those remaining bytes individually.
 - PR #113's code head `f05cf14` passed all 11 blocking aggregates: CI,
   Coverage, Docs Validation, Examples Validation, Godot Web, No Panics,
-  Security, Semver Checks, Unused Deps, WASM, and Workflow Lint. GitHub
-  reported no review submissions, comments, or unresolved inline threads.
+  Security, Semver Checks, Unused Deps, WASM, and Workflow Lint. An
+  evidence-only follow-up repeated all 11 successfully.
+- Cursor Bugbot classified the change as medium risk without a finding.
+  Copilot could not review because its requester quota is exhausted (the known
+  governance limitation tracked by #90); no actionable comment or unresolved
+  inline thread remains.

--- a/scripts/check-ffi-safety.sh
+++ b/scripts/check-ffi-safety.sh
@@ -413,8 +413,17 @@ while IFS=: read -r file lineno line; do
     case "$trimmed" in
         '//'*) continue ;;
     esac
-    # Borrowed slice construction is not ownership reclamation.
-    if printf '%s\n' "$line" | grep -q 'std::slice::from_raw_parts'; then
+    # Remove only known borrowed/framing constructors, then audit any other
+    # ownership-looking token that remains on the same line. The tungstenite
+    # exception is intentionally limited to its exact crate-qualified path at
+    # the start of the trimmed line, so namespace lookalikes remain audited.
+    audited_line=$(printf '%s\n' "$line" |
+        sed -E 's/std::slice::from_raw_parts[[:space:]]*\(//g')
+    if printf '%s\n' "$trimmed" | grep -qE '^(let[[:space:]]+[[:alnum:]_]+[[:space:]]*=[[:space:]]*)?tokio_tungstenite::WebSocketStream::from_raw_socket[[:space:]]*\('; then
+        audited_line=$(printf '%s\n' "$audited_line" |
+            sed -E 's/tokio_tungstenite::WebSocketStream::from_raw_socket[[:space:]]*\(//')
+    fi
+    if ! printf '%s\n' "$audited_line" | grep -qE 'from_raw(_parts)?|drop_in_place|std::alloc::dealloc|std::mem::transmute|(^|[^[:alnum:]_])(dealloc|free|transmute)[[:space:]]*\('; then
         continue
     fi
     RECLAIM_FOUND=1

--- a/scripts/test_check_ffi_safety.sh
+++ b/scripts/test_check_ffi_safety.sh
@@ -548,6 +548,78 @@ assert_exit "block-comment cleanup lines must not satisfy poll_close" 1
 printf '\n'
 printf '%s\n' "=== callback-state reclamation tests ==="
 
+# -- Should PASS: tungstenite's exact framing constructor is not reclamation --
+setup_fake_repo
+cat > "$FAKE_REPO/src/from_raw_socket_constructor.rs" << 'RUST'
+async fn wrap_socket(socket: DuplexStream) {
+    let _stream =
+        tokio_tungstenite::WebSocketStream::from_raw_socket(socket, Role::Client, None).await;
+}
+RUST
+run_check
+assert_exit "from_raw_socket constructor is not ownership reclamation" 0
+
+# -- Should FAIL: a lookalike type is not the exact tungstenite constructor --
+setup_fake_repo
+cat > "$FAKE_REPO/src/lookalike_from_raw_socket.rs" << 'RUST'
+unsafe fn reconstruct(socket: RawSocket) {
+    let _stream = other_crate::WebSocketStream::from_raw_socket(socket);
+}
+RUST
+run_check
+assert_exit "lookalike from_raw_socket APIs must still FAIL" 1
+
+# -- Should FAIL: a crate-name suffix cannot impersonate tokio-tungstenite --
+setup_fake_repo
+cat > "$FAKE_REPO/src/suffix_lookalike_from_raw_socket.rs" << 'RUST'
+unsafe fn reconstruct(socket: RawSocket) {
+    let _stream = evil_tokio_tungstenite::WebSocketStream::from_raw_socket(socket);
+}
+RUST
+run_check
+assert_exit "suffix lookalike from_raw_socket APIs must still FAIL" 1
+
+# -- Should FAIL: whitespace after :: cannot impersonate the exact call line --
+setup_fake_repo
+cat > "$FAKE_REPO/src/whitespace_namespace_from_raw_socket.rs" << 'RUST'
+unsafe fn reconstruct(socket: RawSocket) {
+    let _stream = evil:: tokio_tungstenite::WebSocketStream::from_raw_socket(socket);
+}
+RUST
+run_check
+assert_exit "whitespace-qualified from_raw_socket APIs must still FAIL" 1
+
+# -- Should FAIL: longer from_raw ownership APIs remain audited --
+setup_fake_repo
+cat > "$FAKE_REPO/src/longer_from_raw_ownership_apis.rs" << 'RUST'
+unsafe fn reconstruct(fd: RawFd, socket: RawSocket, ptr: *mut u8) {
+    let _fd = OwnedFd::from_raw_fd(fd);
+    let _socket = OwnedSocket::from_raw_socket(socket);
+    let _boxed = Box::from_raw_in(ptr, Global);
+}
+RUST
+run_check
+assert_exit "longer from_raw ownership APIs must still FAIL" 1
+
+# -- Should FAIL: benign constructors cannot mask reclamation on one line --
+setup_fake_repo
+cat > "$FAKE_REPO/src/mixed_constructor_and_reclaim.rs" << 'RUST'
+unsafe fn mixed(socket: DuplexStream, ptr: *mut u8) {
+    let _ = (tokio_tungstenite::WebSocketStream::from_raw_socket(socket, Role::Client, None), Box::from_raw(ptr));
+}
+RUST
+run_check
+assert_exit "from_raw_socket cannot mask same-line ownership reclamation" 1
+
+setup_fake_repo
+cat > "$FAKE_REPO/src/mixed_slice_and_reclaim.rs" << 'RUST'
+unsafe fn mixed(ptr: *mut u8, len: usize) {
+    let _ = (std::slice::from_raw_parts(ptr, len), Box::from_raw(ptr));
+}
+RUST
+run_check
+assert_exit "from_raw_parts cannot mask same-line ownership reclamation" 1
+
 # -- Should FAIL: deletion failure can fall through to unconditional reclamation --
 setup_fake_repo
 cat > "$FAKE_REPO/src/unconditional_callback_reclaim.rs" << 'RUST'

--- a/src/transports/websocket.rs
+++ b/src/transports/websocket.rs
@@ -1059,7 +1059,7 @@ mod tests {
 
         wake_counter.count.store(0, Ordering::SeqCst);
         server_io
-            .write_all(b"ater")
+            .write_all(&[0x61, 0x74, 0x65, 0x72])
             .await
             .expect("server must finish the partial text frame");
         tokio::time::timeout(std::time::Duration::from_secs(1), async {

--- a/src/transports/websocket.rs
+++ b/src/transports/websocket.rs
@@ -30,7 +30,7 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use futures_util::{Sink, Stream};
-use tokio_tungstenite::tungstenite::protocol::Message;
+use tokio_tungstenite::tungstenite::{protocol::Message, Error as WebSocketError};
 
 use crate::error::SignalFishError;
 use crate::transport::{Transport, TransportCloseInfo, TransportFrame};
@@ -41,6 +41,8 @@ use crate::transport::{Transport, TransportCloseInfo, TransportFrame};
 /// existing stream via [`WebSocketTransport::from_stream`].
 pub type WsStream =
     tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>;
+
+const MAX_SKIPPED_CONTROL_FRAMES_PER_POLL: usize = 64;
 
 /// Options controlling how a [`WebSocketTransport`] connection is established.
 ///
@@ -124,9 +126,15 @@ impl WebSocketConnectOptions {
 /// # Polling Safety
 ///
 /// [`poll_recv`](Transport::poll_recv) preserves the WebSocket stream's partial
-/// receive state across `Poll::Pending` and registers the supplied waker.
+/// receive state across `Poll::Pending`, registers the supplied waker, and
+/// bounds skipped control-frame work. EOF and terminal socket errors fuse the
+/// transport so later receives, sends, and closes have deterministic outcomes.
 pub struct WebSocketTransport {
-    stream: Option<WsStream>,
+    state: WebSocketState<WsStream>,
+}
+
+struct WebSocketState<S> {
+    stream: Option<S>,
     closed: bool,
     close_info: Option<TransportCloseInfo>,
     send_started: bool,
@@ -139,13 +147,42 @@ impl std::fmt::Debug for WebSocketTransport {
         // The stream codec can retain raw inbound/outbound protocol frames,
         // and close reasons are peer-controlled. Expose state only.
         f.debug_struct("WebSocketTransport")
-            .field("has_stream", &self.stream.is_some())
-            .field("closed", &self.closed)
-            .field("has_close_info", &self.close_info.is_some())
-            .field("send_started", &self.send_started)
-            .field("control_flush_pending", &self.control_flush_pending)
-            .field("peer_close_pending", &self.peer_close_pending)
+            .field("has_stream", &self.state.stream.is_some())
+            .field("closed", &self.state.closed)
+            .field("has_close_info", &self.state.close_info.is_some())
+            .field("send_started", &self.state.send_started)
+            .field("control_flush_pending", &self.state.control_flush_pending)
+            .field("peer_close_pending", &self.state.peer_close_pending)
             .finish()
+    }
+}
+
+impl<S> WebSocketState<S> {
+    fn new(stream: S) -> Self {
+        Self {
+            stream: Some(stream),
+            closed: false,
+            close_info: None,
+            send_started: false,
+            control_flush_pending: false,
+            peer_close_pending: false,
+        }
+    }
+
+    fn mark_terminal(&mut self) {
+        self.stream = None;
+        self.closed = true;
+        self.send_started = false;
+        self.control_flush_pending = false;
+        self.peer_close_pending = false;
+    }
+
+    fn close_info(&self) -> Option<TransportCloseInfo> {
+        self.close_info.clone()
+    }
+
+    fn abort(&mut self) {
+        self.mark_terminal();
     }
 }
 
@@ -224,12 +261,7 @@ impl WebSocketTransport {
         );
 
         Ok(Self {
-            stream: Some(stream),
-            closed: false,
-            close_info: None,
-            send_started: false,
-            control_flush_pending: false,
-            peer_close_pending: false,
+            state: WebSocketState::new(stream),
         })
     }
 
@@ -243,12 +275,7 @@ impl WebSocketTransport {
     /// any other tuning on the underlying socket before wrapping it here.
     pub fn from_stream(stream: WsStream) -> Self {
         Self {
-            stream: Some(stream),
-            closed: false,
-            close_info: None,
-            send_started: false,
-            control_flush_pending: false,
-            peer_close_pending: false,
+            state: WebSocketState::new(stream),
         }
     }
 
@@ -276,7 +303,12 @@ impl WebSocketTransport {
     }
 }
 
-impl Transport for WebSocketTransport {
+impl<S> WebSocketState<S>
+where
+    S: Sink<Message, Error = WebSocketError>
+        + Stream<Item = Result<Message, WebSocketError>>
+        + Unpin,
+{
     fn poll_send(
         &mut self,
         cx: &mut Context<'_>,
@@ -285,37 +317,103 @@ impl Transport for WebSocketTransport {
         if self.closed || self.peer_close_pending {
             return Poll::Ready(Err(SignalFishError::TransportClosed));
         }
-        let Some(stream) = self.stream.as_mut() else {
-            self.closed = true;
+        if self.stream.is_none() {
+            self.mark_terminal();
             return Poll::Ready(Err(SignalFishError::TransportClosed));
-        };
+        }
+        if !self.send_started && frame.is_none() {
+            return Poll::Ready(Ok(()));
+        }
         if !self.send_started {
-            match Pin::new(&mut *stream).poll_ready(cx) {
+            let ready = {
+                let Some(stream) = self.stream.as_mut() else {
+                    self.mark_terminal();
+                    return Poll::Ready(Err(SignalFishError::TransportClosed));
+                };
+                Pin::new(stream).poll_ready(cx)
+            };
+            match ready {
                 Poll::Pending => return Poll::Pending,
                 Poll::Ready(Err(error)) => {
-                    return Poll::Ready(Err(SignalFishError::TransportSend(error.to_string())))
+                    self.mark_terminal();
+                    return Poll::Ready(Err(SignalFishError::TransportSend(error.to_string())));
                 }
                 Poll::Ready(Ok(())) => {}
             }
-            let Some(frame) = frame.take() else {
+            let Some(accepted_frame) = frame.take() else {
                 return Poll::Ready(Ok(()));
             };
-            let message = match frame {
+            let message = match accepted_frame {
                 TransportFrame::Text(text) => Message::Text(text.into()),
                 TransportFrame::Binary(bytes) => Message::Binary(bytes.into()),
             };
-            if let Err(error) = Pin::new(&mut *stream).start_send(message) {
-                return Poll::Ready(Err(SignalFishError::TransportSend(error.to_string())));
+            let send_result = {
+                let Some(stream) = self.stream.as_mut() else {
+                    self.mark_terminal();
+                    return Poll::Ready(Err(SignalFishError::TransportClosed));
+                };
+                Pin::new(stream).start_send(message)
+            };
+            if let Err(error) = send_result {
+                let detail = error.to_string();
+                if let WebSocketError::WriteBufferFull(message) = error {
+                    let restored = match *message {
+                        Message::Text(text) => {
+                            *frame = Some(TransportFrame::Text(text.to_string()));
+                            true
+                        }
+                        Message::Binary(bytes) => {
+                            *frame = Some(TransportFrame::Binary(bytes.to_vec()));
+                            true
+                        }
+                        Message::Frame(frame_data) => {
+                            use tokio_tungstenite::tungstenite::protocol::frame::coding::{
+                                Data, OpCode,
+                            };
+
+                            match frame_data.header().opcode {
+                                OpCode::Data(Data::Text) => match frame_data.into_text() {
+                                    Ok(text) => {
+                                        *frame = Some(TransportFrame::Text(text.to_string()));
+                                        true
+                                    }
+                                    Err(_) => false,
+                                },
+                                OpCode::Data(Data::Binary) => {
+                                    *frame = Some(TransportFrame::Binary(
+                                        frame_data.into_payload().to_vec(),
+                                    ));
+                                    true
+                                }
+                                _ => false,
+                            }
+                        }
+                        _ => false,
+                    };
+                    if !restored {
+                        self.mark_terminal();
+                    }
+                } else {
+                    self.mark_terminal();
+                }
+                return Poll::Ready(Err(SignalFishError::TransportSend(detail)));
             }
             self.send_started = true;
         }
-        match Pin::new(&mut *stream).poll_flush(cx) {
+        let flush = {
+            let Some(stream) = self.stream.as_mut() else {
+                self.mark_terminal();
+                return Poll::Ready(Err(SignalFishError::TransportClosed));
+            };
+            Pin::new(stream).poll_flush(cx)
+        };
+        match flush {
             Poll::Ready(Ok(())) => {
                 self.send_started = false;
                 Poll::Ready(Ok(()))
             }
             Poll::Ready(Err(error)) => {
-                self.send_started = false;
+                self.mark_terminal();
                 Poll::Ready(Err(SignalFishError::TransportSend(error.to_string())))
             }
             Poll::Pending => Poll::Pending,
@@ -329,18 +427,25 @@ impl Transport for WebSocketTransport {
         if self.closed {
             return Poll::Ready(None);
         }
-        let Some(stream) = self.stream.as_mut() else {
-            self.closed = true;
+        if self.stream.is_none() {
+            self.mark_terminal();
             return Poll::Ready(None);
-        };
+        }
+
+        let mut skipped_control_frames = 0;
         loop {
             if self.control_flush_pending {
-                match Pin::new(&mut *stream).poll_flush(cx) {
+                let flush = {
+                    let Some(stream) = self.stream.as_mut() else {
+                        self.mark_terminal();
+                        return Poll::Ready(None);
+                    };
+                    Pin::new(stream).poll_flush(cx)
+                };
+                match flush {
                     Poll::Pending => return Poll::Pending,
                     Poll::Ready(Err(error)) => {
-                        self.control_flush_pending = false;
-                        self.peer_close_pending = false;
-                        self.closed = true;
+                        self.mark_terminal();
                         return Poll::Ready(Some(Err(SignalFishError::TransportReceive(
                             error.to_string(),
                         ))));
@@ -348,23 +453,39 @@ impl Transport for WebSocketTransport {
                     Poll::Ready(Ok(())) => {
                         self.control_flush_pending = false;
                         if self.peer_close_pending {
-                            self.peer_close_pending = false;
-                            self.closed = true;
+                            self.mark_terminal();
                             return Poll::Ready(None);
                         }
                     }
                 }
             }
-            let msg = match Pin::new(&mut *stream).poll_next(cx) {
+
+            if skipped_control_frames == MAX_SKIPPED_CONTROL_FRAMES_PER_POLL {
+                cx.waker().wake_by_ref();
+                return Poll::Pending;
+            }
+
+            let next = {
+                let Some(stream) = self.stream.as_mut() else {
+                    self.mark_terminal();
+                    return Poll::Ready(None);
+                };
+                Pin::new(stream).poll_next(cx)
+            };
+            let msg = match next {
                 Poll::Pending => return Poll::Pending,
                 Poll::Ready(value) => match value {
                     Some(Ok(msg)) => msg,
                     Some(Err(e)) => {
+                        self.mark_terminal();
                         return Poll::Ready(Some(Err(SignalFishError::TransportReceive(
                             e.to_string(),
                         ))));
                     }
-                    None => return Poll::Ready(None),
+                    None => {
+                        self.mark_terminal();
+                        return Poll::Ready(None);
+                    }
                 },
             };
 
@@ -406,19 +527,20 @@ impl Transport for WebSocketTransport {
                     self.control_flush_pending = true;
                 }
                 Message::Ping(_) => {
-                    tracing::debug!("received WebSocket ping (auto-pong handled by tungstenite)");
+                    tracing::trace!("received WebSocket ping (auto-pong handled by tungstenite)");
                     self.control_flush_pending = true;
+                    skipped_control_frames += 1;
                 }
                 Message::Pong(_) => {
-                    tracing::debug!("received WebSocket pong (ignored)");
-                    // Continue the loop.
+                    tracing::trace!("received WebSocket pong (ignored)");
+                    skipped_control_frames += 1;
                 }
                 Message::Frame(_) => {
                     // This variant is never produced by the read half of the stream;
                     // it exists only for exhaustiveness against future `Message`
                     // variants. We keep the arm to satisfy exhaustiveness checks.
-                    tracing::debug!("received raw WebSocket frame, skipping");
-                    // Continue the loop.
+                    tracing::trace!("received raw WebSocket frame, skipping");
+                    skipped_control_frames += 1;
                 }
             }
         }
@@ -428,50 +550,77 @@ impl Transport for WebSocketTransport {
         if self.closed {
             return Poll::Ready(Ok(()));
         }
-        let Some(stream) = self.stream.as_mut() else {
-            self.closed = true;
+        if self.stream.is_none() {
+            self.mark_terminal();
             return Poll::Ready(Ok(()));
-        };
+        }
         if self.peer_close_pending {
-            return match Pin::new(&mut *stream).poll_flush(cx) {
+            let flush = {
+                let Some(stream) = self.stream.as_mut() else {
+                    self.mark_terminal();
+                    return Poll::Ready(Ok(()));
+                };
+                Pin::new(stream).poll_flush(cx)
+            };
+            return match flush {
                 Poll::Pending => Poll::Pending,
                 Poll::Ready(Ok(())) => {
-                    self.control_flush_pending = false;
-                    self.peer_close_pending = false;
-                    self.closed = true;
+                    self.mark_terminal();
                     Poll::Ready(Ok(()))
                 }
                 Poll::Ready(Err(error)) => {
-                    self.control_flush_pending = false;
-                    self.peer_close_pending = false;
-                    self.closed = true;
+                    self.mark_terminal();
                     Poll::Ready(Err(SignalFishError::TransportSend(error.to_string())))
                 }
             };
         }
-        match Pin::new(&mut *stream).poll_close(cx) {
+        let close = {
+            let Some(stream) = self.stream.as_mut() else {
+                self.mark_terminal();
+                return Poll::Ready(Ok(()));
+            };
+            Pin::new(stream).poll_close(cx)
+        };
+        match close {
             Poll::Ready(Ok(())) => {
-                self.closed = true;
+                self.mark_terminal();
                 Poll::Ready(Ok(()))
             }
             Poll::Ready(Err(error)) => {
-                self.closed = true;
+                self.mark_terminal();
                 Poll::Ready(Err(SignalFishError::TransportSend(error.to_string())))
             }
             Poll::Pending => Poll::Pending,
         }
     }
+}
+
+impl Transport for WebSocketTransport {
+    fn poll_send(
+        &mut self,
+        cx: &mut Context<'_>,
+        frame: &mut Option<TransportFrame>,
+    ) -> Poll<Result<(), SignalFishError>> {
+        self.state.poll_send(cx, frame)
+    }
+
+    fn poll_recv(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<TransportFrame, SignalFishError>>> {
+        self.state.poll_recv(cx)
+    }
+
+    fn poll_close(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), SignalFishError>> {
+        self.state.poll_close(cx)
+    }
 
     fn close_info(&self) -> Option<TransportCloseInfo> {
-        self.close_info.clone()
+        self.state.close_info()
     }
 
     fn abort(&mut self) {
-        self.stream = None;
-        self.closed = true;
-        self.send_started = false;
-        self.control_flush_pending = false;
-        self.peer_close_pending = false;
+        self.state.abort();
     }
 }
 
@@ -488,6 +637,10 @@ impl Transport for WebSocketTransport {
 mod tests {
     use super::*;
     use futures_util::{SinkExt, StreamExt};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+    use std::task::{Wake, Waker};
+    use tokio::io::AsyncWriteExt;
 
     #[test]
     fn websocket_transport_is_send() {
@@ -520,8 +673,8 @@ mod tests {
     use tokio::net::TcpListener;
 
     /// Start a local WebSocket server that runs `handler` on the accepted
-    /// connection and returns the address to connect to.
-    async fn start_mock_server<F, Fut>(handler: F) -> String
+    /// connection. Tests retain the task so handler panics cannot be hidden.
+    async fn start_mock_server<F, Fut>(handler: F) -> (String, tokio::task::JoinHandle<()>)
     where
         F: FnOnce(tokio_tungstenite::WebSocketStream<tokio::net::TcpStream>) -> Fut
             + Send
@@ -535,7 +688,7 @@ mod tests {
             .local_addr()
             .expect("TcpListener must have a local address");
 
-        tokio::spawn(async move {
+        let server_task = tokio::spawn(async move {
             let (tcp, _) = listener
                 .accept()
                 .await
@@ -546,39 +699,183 @@ mod tests {
             handler(ws).await;
         });
 
-        format!("ws://{addr}")
+        (format!("ws://{addr}"), server_task)
     }
 
-    /// Read `TCP_NODELAY` from the underlying socket of a `ws://` (non-TLS)
-    /// transport. The inline test module can reach the private `stream` field,
-    /// and a `ws://` client always resolves to the plain (non-TLS) variant.
-    fn plain_tcp_nodelay(transport: &WebSocketTransport) -> bool {
+    async fn finish_mock_server(server_task: tokio::task::JoinHandle<()>) {
+        tokio::time::timeout(std::time::Duration::from_secs(1), server_task)
+            .await
+            .expect("mock WebSocket server must finish promptly")
+            .expect("mock WebSocket server must not panic");
+    }
+
+    type MemoryWebSocket = tokio_tungstenite::WebSocketStream<tokio::io::DuplexStream>;
+
+    struct SyntheticWebSocket {
+        ended: bool,
+    }
+
+    impl Stream for SyntheticWebSocket {
+        type Item = Result<Message, WebSocketError>;
+
+        fn poll_next(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+            if self.ended {
+                Poll::Ready(None)
+            } else {
+                Poll::Pending
+            }
+        }
+    }
+
+    impl Sink<Message> for SyntheticWebSocket {
+        type Error = WebSocketError;
+
+        fn poll_ready(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Pending
+        }
+
+        fn start_send(self: Pin<&mut Self>, _item: Message) -> Result<(), Self::Error> {
+            Ok(())
+        }
+
+        fn poll_flush(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Pending
+        }
+
+        fn poll_close(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Pending
+        }
+    }
+
+    async fn memory_websocket_pair(
+        capacity: usize,
+    ) -> (WebSocketState<MemoryWebSocket>, MemoryWebSocket) {
+        use tokio_tungstenite::tungstenite::protocol::Role;
+
+        let (client_io, server_io) = tokio::io::duplex(capacity);
+        let (client, server) = tokio::join!(
+            tokio_tungstenite::WebSocketStream::from_raw_socket(client_io, Role::Client, None),
+            tokio_tungstenite::WebSocketStream::from_raw_socket(server_io, Role::Server, None),
+        );
+        (WebSocketState::new(client), server)
+    }
+
+    #[derive(Default)]
+    struct CountingWake {
+        count: AtomicUsize,
+    }
+
+    impl Wake for CountingWake {
+        fn wake(self: Arc<Self>) {
+            self.count.fetch_add(1, Ordering::SeqCst);
+        }
+
+        fn wake_by_ref(self: &Arc<Self>) {
+            self.count.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    fn counting_waker() -> (Arc<CountingWake>, Waker) {
+        let counter = Arc::new(CountingWake::default());
+        let waker = Waker::from(Arc::clone(&counter));
+        (counter, waker)
+    }
+
+    fn expect_received_frame(
+        result: Option<Result<TransportFrame, SignalFishError>>,
+    ) -> TransportFrame {
+        result
+            .expect("receive must produce a frame")
+            .expect("received frame must be valid")
+    }
+
+    async fn connect_to_reset_peer() -> WebSocketTransport {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("reset listener must bind to localhost");
+        let addr = listener
+            .local_addr()
+            .expect("reset listener must have a local address");
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+        let (reset_tx, reset_rx) = tokio::sync::oneshot::channel();
+
+        let server_task = tokio::spawn(async move {
+            let (tcp, _) = listener
+                .accept()
+                .await
+                .expect("reset listener must accept a connection");
+            let ws = tokio_tungstenite::accept_async(tcp)
+                .await
+                .expect("reset peer WebSocket handshake must succeed");
+            release_rx
+                .await
+                .expect("client must release the reset peer after connecting");
+            ws.get_ref()
+                .set_zero_linger()
+                .expect("reset peer must enable zero linger");
+            drop(ws);
+            let _ = reset_tx.send(());
+        });
+
+        let transport = WebSocketTransport::connect(&format!("ws://{addr}"))
+            .await
+            .expect("client must connect before the peer resets");
+        release_tx
+            .send(())
+            .expect("reset peer must still be waiting for the client");
+        reset_rx
+            .await
+            .expect("reset peer must report dropping the socket");
+        finish_mock_server(server_task).await;
+        transport
+    }
+
+    fn plain_tcp_stream(transport: &WebSocketTransport) -> &tokio::net::TcpStream {
         match transport
+            .state
             .stream
             .as_ref()
             .expect("transport must hold a live stream after connect")
             .get_ref()
         {
-            tokio_tungstenite::MaybeTlsStream::Plain(tcp) => tcp
-                .nodelay()
-                .expect("querying TCP_NODELAY on the loopback socket must succeed"),
+            tokio_tungstenite::MaybeTlsStream::Plain(tcp) => tcp,
             _ => panic!("a ws:// connection must use the plain (non-TLS) stream variant"),
         }
+    }
+
+    /// Read `TCP_NODELAY` from the underlying socket of a `ws://` (non-TLS)
+    /// transport. The inline test module can reach the private stream, and a
+    /// `ws://` client always resolves to the plain variant.
+    fn plain_tcp_nodelay(transport: &WebSocketTransport) -> bool {
+        plain_tcp_stream(transport)
+            .nodelay()
+            .expect("querying TCP_NODELAY on the loopback socket must succeed")
     }
 
     #[test]
     fn debug_omits_stream_contents_and_peer_close_reason() {
         let secret = "websocket-debug-secret";
         let transport = WebSocketTransport {
-            stream: None,
-            closed: true,
-            close_info: Some(TransportCloseInfo {
-                reason: Some(secret.into()),
-                ..TransportCloseInfo::default()
-            }),
-            send_started: false,
-            control_flush_pending: false,
-            peer_close_pending: false,
+            state: WebSocketState {
+                stream: None,
+                closed: true,
+                close_info: Some(TransportCloseInfo {
+                    reason: Some(secret.into()),
+                    ..TransportCloseInfo::default()
+                }),
+                send_started: false,
+                control_flush_pending: false,
+                peer_close_pending: false,
+            },
         };
 
         let output = format!("{transport:?}");
@@ -594,7 +891,7 @@ mod tests {
 
     #[tokio::test]
     async fn connect_disables_nagle_by_default() {
-        let url = start_mock_server(|mut ws| async move {
+        let (url, server_task) = start_mock_server(|mut ws| async move {
             // Hold the connection open until the client disconnects.
             while let Some(Ok(_)) = ws.next().await {}
         })
@@ -608,13 +905,15 @@ mod tests {
             plain_tcp_nodelay(&transport),
             "connect() must disable Nagle (TCP_NODELAY) by default for low-latency game traffic"
         );
+        drop(transport);
+        finish_mock_server(server_task).await;
     }
 
     #[tokio::test]
     async fn connect_with_options_controls_nagle() {
         // (disable_nagle requested, expected TCP_NODELAY on the socket)
         for (disable_nagle, expected_nodelay) in [(true, true), (false, false)] {
-            let url =
+            let (url, server_task) =
                 start_mock_server(
                     |mut ws| async move { while let Some(Ok(_)) = ws.next().await {} },
                 )
@@ -630,6 +929,8 @@ mod tests {
                 expected_nodelay,
                 "disable_nagle={disable_nagle} must produce TCP_NODELAY={expected_nodelay}"
             );
+            drop(transport);
+            finish_mock_server(server_task).await;
         }
     }
 
@@ -646,7 +947,7 @@ mod tests {
         let addr = listener
             .local_addr()
             .expect("listener must have an address");
-        tokio::spawn(async move {
+        let server_task = tokio::spawn(async move {
             // Accept one connection and drop it so the client's TLS handshake
             // fails cleanly instead of hanging.
             let _ = listener.accept().await;
@@ -658,11 +959,261 @@ mod tests {
             "wss:// to a non-TLS peer must fail via a TLS/IO error (proving the provider is wired), \
              not succeed"
         );
+        finish_mock_server(server_task).await;
+    }
+
+    #[tokio::test]
+    async fn control_frame_budget_self_wakes_before_buffered_application_data() {
+        let (mut state, mut server) = memory_websocket_pair(16 * 1024).await;
+        for _ in 0..MAX_SKIPPED_CONTROL_FRAMES_PER_POLL - 1 {
+            server
+                .send(Message::Pong(Vec::new().into()))
+                .await
+                .expect("server must buffer the control-frame flood");
+        }
+        server
+            .send(Message::Ping(b"boundary".to_vec().into()))
+            .await
+            .expect("server must buffer the boundary Ping");
+        server
+            .send(Message::Text("after-control-flood".into()))
+            .await
+            .expect("server must buffer application data after the control flood");
+
+        let (wake_counter, waker) = counting_waker();
+        let mut cx = Context::from_waker(&waker);
+        assert!(state.poll_recv(&mut cx).is_pending());
+        assert!(
+            wake_counter.count.load(Ordering::SeqCst) > 0,
+            "exhausting the control budget must self-wake for buffered work"
+        );
+        let response = tokio::time::timeout(std::time::Duration::from_secs(1), server.next())
+            .await
+            .expect("the boundary Ping response must be flushed before the bounded yield")
+            .expect("the server stream must remain open")
+            .expect("the boundary Ping response must be valid");
+        assert_eq!(response, Message::Pong(b"boundary".to_vec().into()));
+
+        let Poll::Ready(received) = state.poll_recv(&mut cx) else {
+            panic!("buffered application data must be ready after the bounded yield");
+        };
+        assert_eq!(
+            expect_received_frame(received),
+            TransportFrame::Text("after-control-flood".into())
+        );
+    }
+
+    #[tokio::test]
+    async fn ping_auto_pong_is_flushed_before_later_application_reads() {
+        let (mut state, mut server) = memory_websocket_pair(1024).await;
+        let server_task = tokio::spawn(async move {
+            server
+                .send(Message::Ping(b"heartbeat".to_vec().into()))
+                .await
+                .expect("server must send Ping");
+            let response = tokio::time::timeout(std::time::Duration::from_secs(1), server.next())
+                .await
+                .expect("client must flush the automatic Pong promptly")
+                .expect("client stream must remain open")
+                .expect("automatic Pong must be a valid WebSocket message");
+            assert_eq!(response, Message::Pong(b"heartbeat".to_vec().into()));
+            server
+                .send(Message::Text("after-pong".into()))
+                .await
+                .expect("server must send application data after observing Pong");
+        });
+
+        let received = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            std::future::poll_fn(|cx| state.poll_recv(cx)),
+        )
+        .await
+        .expect("client receive must make progress after Ping");
+        assert_eq!(
+            expect_received_frame(received),
+            TransportFrame::Text("after-pong".into())
+        );
+        server_task
+            .await
+            .expect("Ping/Pong server task must finish without panicking");
+    }
+
+    #[tokio::test]
+    async fn partial_frame_registers_and_notifies_the_real_waker() {
+        use tokio_tungstenite::tungstenite::protocol::Role;
+
+        let (client_io, mut server_io) = tokio::io::duplex(64);
+        let client =
+            tokio_tungstenite::WebSocketStream::from_raw_socket(client_io, Role::Client, None)
+                .await;
+        let mut state = WebSocketState::new(client);
+        let (wake_counter, waker) = counting_waker();
+        let mut cx = Context::from_waker(&waker);
+
+        assert!(state.poll_recv(&mut cx).is_pending());
+        server_io
+            .write_all(&[0x81, 0x05, b'l'])
+            .await
+            .expect("server must write a partial unmasked text frame");
+        assert!(state.poll_recv(&mut cx).is_pending());
+
+        wake_counter.count.store(0, Ordering::SeqCst);
+        server_io
+            .write_all(b"ater")
+            .await
+            .expect("server must finish the partial text frame");
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while wake_counter.count.load(Ordering::SeqCst) == 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("finishing a partial frame must notify the registered waker");
+
+        let Poll::Ready(received) = state.poll_recv(&mut cx) else {
+            panic!("completed partial frame must be ready after its waker fires");
+        };
+        assert_eq!(
+            expect_received_frame(received),
+            TransportFrame::Text("later".into())
+        );
+    }
+
+    #[tokio::test]
+    async fn pending_flush_retains_the_second_frame_and_preserves_fifo() {
+        let (mut state, mut server) = memory_websocket_pair(64).await;
+        let first_payload = vec![0xA5; 1024];
+        let mut first = Some(TransportFrame::Binary(first_payload.clone()));
+        let (_wake_counter, waker) = counting_waker();
+        let mut cx = Context::from_waker(&waker);
+
+        assert!(state.poll_send(&mut cx, &mut first).is_pending());
+        assert!(
+            first.is_none(),
+            "the first frame must be accepted exactly once"
+        );
+        assert!(state.send_started);
+
+        let mut second = Some(TransportFrame::Text("second".into()));
+        assert!(state.poll_send(&mut cx, &mut second).is_pending());
+        assert_eq!(
+            second,
+            Some(TransportFrame::Text("second".into())),
+            "a pending first flush must not consume the second caller frame"
+        );
+
+        let server_task = tokio::spawn(async move {
+            let first = server
+                .next()
+                .await
+                .expect("server must receive the first frame")
+                .expect("first frame must be valid");
+            let second = server
+                .next()
+                .await
+                .expect("server must receive the second frame")
+                .expect("second frame must be valid");
+            (first, second)
+        });
+
+        std::future::poll_fn(|cx| state.poll_send(cx, &mut second))
+            .await
+            .expect("the accepted first frame must finish flushing");
+        assert!(
+            second.is_some(),
+            "first completion must leave the second frame owned by its caller"
+        );
+        std::future::poll_fn(|cx| state.poll_send(cx, &mut second))
+            .await
+            .expect("the second frame must send after the first completes");
+        assert!(second.is_none());
+
+        let (first, second) = server_task
+            .await
+            .expect("FIFO server task must finish without panicking");
+        assert_eq!(first, Message::Binary(first_payload.into()));
+        assert_eq!(second, Message::Text("second".into()));
+    }
+
+    #[test]
+    fn empty_send_slot_completes_without_polling_backend_readiness() {
+        let mut state = WebSocketState::new(SyntheticWebSocket { ended: false });
+        let mut frame = None;
+        let (_wake_counter, waker) = counting_waker();
+        let mut cx = Context::from_waker(&waker);
+
+        assert!(matches!(
+            state.poll_send(&mut cx, &mut frame),
+            Poll::Ready(Ok(()))
+        ));
+    }
+
+    #[test]
+    fn raw_eof_fuses_receive_send_and_close_operations() {
+        let mut state = WebSocketState::new(SyntheticWebSocket { ended: true });
+        state.send_started = true;
+        let (_wake_counter, waker) = counting_waker();
+        let mut cx = Context::from_waker(&waker);
+
+        assert!(matches!(state.poll_recv(&mut cx), Poll::Ready(None)));
+        assert!(state.closed);
+        assert!(state.stream.is_none());
+        assert!(!state.send_started);
+        assert!(!state.control_flush_pending);
+        assert!(!state.peer_close_pending);
+        assert!(matches!(state.poll_recv(&mut cx), Poll::Ready(None)));
+
+        let expected = TransportFrame::Text("caller-owned-after-eof".into());
+        let mut offered = Some(expected.clone());
+        assert!(matches!(
+            state.poll_send(&mut cx, &mut offered),
+            Poll::Ready(Err(SignalFishError::TransportClosed))
+        ));
+        assert_eq!(offered, Some(expected));
+        assert!(matches!(state.poll_close(&mut cx), Poll::Ready(Ok(()))));
+        assert!(matches!(state.poll_close(&mut cx), Poll::Ready(Ok(()))));
+    }
+
+    #[tokio::test]
+    async fn rejected_write_buffer_full_restores_the_exact_caller_frame() {
+        use tokio_tungstenite::tungstenite::protocol::{Role, WebSocketConfig};
+
+        for expected in [
+            TransportFrame::Text("x".repeat(64)),
+            TransportFrame::Binary(vec![0x5A; 64]),
+        ] {
+            let (client_io, _server_io) = tokio::io::duplex(64);
+            let config = WebSocketConfig::default()
+                .write_buffer_size(0)
+                .max_write_buffer_size(16);
+            let client = tokio_tungstenite::WebSocketStream::from_raw_socket(
+                client_io,
+                Role::Client,
+                Some(config),
+            )
+            .await;
+            let mut state = WebSocketState::new(client);
+            let mut frame = Some(expected.clone());
+            let (_wake_counter, waker) = counting_waker();
+            let mut cx = Context::from_waker(&waker);
+
+            let result = state.poll_send(&mut cx, &mut frame);
+            assert!(matches!(
+                result,
+                Poll::Ready(Err(SignalFishError::TransportSend(_)))
+            ));
+            assert_eq!(frame, Some(expected));
+            assert!(
+                !state.closed,
+                "a per-message buffer refusal is not terminal"
+            );
+            assert!(!state.send_started);
+        }
     }
 
     #[tokio::test]
     async fn recv_receives_text_messages() {
-        let url = start_mock_server(|mut ws| async move {
+        let (url, server_task) = start_mock_server(|mut ws| async move {
             ws.send(Message::Text("hello".into()))
                 .await
                 .expect("server must send 'hello'");
@@ -688,11 +1239,13 @@ mod tests {
             .expect("recv must return Some")
             .expect("recv must return Ok");
         assert_eq!(msg2, TransportFrame::Text("world".into()));
+        drop(transport);
+        finish_mock_server(server_task).await;
     }
 
     #[tokio::test]
     async fn recv_returns_none_on_close_frame() {
-        let url = start_mock_server(|mut ws| async move {
+        let (url, server_task) = start_mock_server(|mut ws| async move {
             ws.close(None).await.expect("server must close cleanly");
         })
         .await;
@@ -702,8 +1255,26 @@ mod tests {
             .expect("WebSocket connect must succeed");
         let result = crate::transport::recv_frame(&mut transport).await;
         assert!(result.is_none());
-        // A bare close (today's server behavior) carries no explanation.
-        assert_eq!(transport.close_info().and_then(|info| info.reason), None);
+        assert_eq!(
+            transport.close_info(),
+            Some(TransportCloseInfo {
+                code: None,
+                reason: None,
+                clean: None,
+                initiated_by_peer: true,
+            })
+        );
+
+        assert!(crate::transport::recv_frame(&mut transport).await.is_none());
+        let expected = TransportFrame::Text("after-peer-close".into());
+        let mut offered = Some(expected.clone());
+        let send_result = std::future::poll_fn(|cx| transport.poll_send(cx, &mut offered)).await;
+        assert!(matches!(send_result, Err(SignalFishError::TransportClosed)));
+        assert_eq!(offered, Some(expected));
+        crate::transport::close_transport(&mut transport)
+            .await
+            .expect("close after peer close must remain idempotent");
+        finish_mock_server(server_task).await;
     }
 
     #[tokio::test]
@@ -711,7 +1282,7 @@ mod tests {
         use tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode;
         use tokio_tungstenite::tungstenite::protocol::frame::CloseFrame;
 
-        let url = start_mock_server(|mut ws| async move {
+        let (url, server_task) = start_mock_server(|mut ws| async move {
             ws.close(Some(CloseFrame {
                 code: CloseCode::Policy,
                 reason: "slow consumer".into(),
@@ -727,14 +1298,14 @@ mod tests {
         let result = crate::transport::recv_frame(&mut transport).await;
         assert!(result.is_none());
 
-        let reason = transport
+        let info = transport
             .close_info()
-            .and_then(|info| info.reason)
             .expect("close frame explanation must be captured");
-        assert!(
-            reason.contains("slow consumer"),
-            "captured reason should include the frame text: {reason}"
-        );
+        assert_eq!(info.code, Some(u16::from(CloseCode::Policy)));
+        assert_eq!(info.reason.as_deref(), Some("slow consumer"));
+        assert_eq!(info.clean, None);
+        assert!(info.initiated_by_peer);
+        finish_mock_server(server_task).await;
     }
 
     #[tokio::test]
@@ -743,7 +1314,7 @@ mod tests {
         use tokio_tungstenite::tungstenite::protocol::frame::CloseFrame;
 
         let (response_tx, response_rx) = tokio::sync::oneshot::channel();
-        let url = start_mock_server(move |mut ws| async move {
+        let (url, server_task) = start_mock_server(move |mut ws| async move {
             ws.send(Message::Close(Some(CloseFrame {
                 code: CloseCode::Away,
                 reason: "server draining".into(),
@@ -780,13 +1351,14 @@ mod tests {
                 .expect("server task must report whether it received the response"),
             "client must flush a matching close response before recv returns None"
         );
-        assert!(transport.closed);
-        assert!(!transport.peer_close_pending);
+        assert!(transport.state.closed);
+        assert!(!transport.state.peer_close_pending);
+        finish_mock_server(server_task).await;
     }
 
     #[tokio::test]
     async fn recv_passes_binary_frames_through() {
-        let url = start_mock_server(|mut ws| async move {
+        let (url, server_task) = start_mock_server(|mut ws| async move {
             ws.send(Message::Binary(vec![0xDE, 0xAD].into()))
                 .await
                 .expect("server must send binary frame");
@@ -811,11 +1383,78 @@ mod tests {
             .expect("recv must return Some")
             .expect("recv must return Ok");
         assert_eq!(next, TransportFrame::Text("after_binary".into()));
+        drop(transport);
+        finish_mock_server(server_task).await;
+    }
+
+    #[tokio::test]
+    async fn socket_receive_error_is_reported_once_then_transport_is_terminal() {
+        let mut transport = connect_to_reset_peer().await;
+        let first = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            crate::transport::recv_frame(&mut transport),
+        )
+        .await
+        .expect("reset socket must wake the receive poll");
+        assert!(matches!(
+            first,
+            Some(Err(SignalFishError::TransportReceive(_)))
+        ));
+        assert!(transport.state.closed);
+        assert!(transport.state.stream.is_none());
+        assert!(!transport.state.send_started);
+        assert!(!transport.state.control_flush_pending);
+        assert!(!transport.state.peer_close_pending);
+
+        assert!(crate::transport::recv_frame(&mut transport).await.is_none());
+        let expected = TransportFrame::Text("must-remain-caller-owned".into());
+        let mut offered = Some(expected.clone());
+        let send_result = std::future::poll_fn(|cx| transport.poll_send(cx, &mut offered)).await;
+        assert!(matches!(send_result, Err(SignalFishError::TransportClosed)));
+        assert_eq!(offered, Some(expected));
+        crate::transport::close_transport(&mut transport)
+            .await
+            .expect("close after receive failure must be idempotent");
+        crate::transport::close_transport(&mut transport)
+            .await
+            .expect("repeated close after receive failure must remain idempotent");
+    }
+
+    #[tokio::test]
+    async fn socket_send_error_maps_to_transport_send_and_becomes_terminal() {
+        let mut transport = connect_to_reset_peer().await;
+        tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            plain_tcp_stream(&transport).readable(),
+        )
+        .await
+        .expect("reset socket must become readable")
+        .expect("querying reset socket readiness must succeed");
+
+        let first = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            crate::transport::send_frame(&mut transport, TransportFrame::Binary(vec![0xC3; 1024])),
+        )
+        .await
+        .expect("reset socket must wake the send poll");
+        assert!(matches!(first, Err(SignalFishError::TransportSend(_))));
+        assert!(transport.state.closed);
+        assert!(transport.state.stream.is_none());
+
+        let expected = TransportFrame::Text("second".into());
+        let mut offered = Some(expected.clone());
+        let second = std::future::poll_fn(|cx| transport.poll_send(cx, &mut offered)).await;
+        assert!(matches!(second, Err(SignalFishError::TransportClosed)));
+        assert_eq!(offered, Some(expected));
+        assert!(crate::transport::recv_frame(&mut transport).await.is_none());
+        crate::transport::close_transport(&mut transport)
+            .await
+            .expect("close after send failure must be idempotent");
     }
 
     #[tokio::test]
     async fn send_after_close_returns_transport_closed() {
-        let url = start_mock_server(|mut ws| async move {
+        let (url, server_task) = start_mock_server(|mut ws| async move {
             // Read until the client closes.
             while let Some(Ok(_)) = ws.next().await {}
         })
@@ -832,11 +1471,12 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(err, SignalFishError::TransportClosed));
+        finish_mock_server(server_task).await;
     }
 
     #[tokio::test]
     async fn double_close_is_idempotent() {
-        let url =
+        let (url, server_task) =
             start_mock_server(|mut ws| async move { while let Some(Ok(_)) = ws.next().await {} })
                 .await;
 
@@ -850,12 +1490,13 @@ mod tests {
         crate::transport::close_transport(&mut transport)
             .await
             .expect("second close must succeed (idempotent)");
+        finish_mock_server(server_task).await;
     }
 
     #[tokio::test]
     async fn abort_drops_the_socket_without_waiting_for_a_close_handshake() {
         let (disconnected_tx, disconnected_rx) = tokio::sync::oneshot::channel();
-        let url = start_mock_server(move |mut ws| async move {
+        let (url, server_task) = start_mock_server(move |mut ws| async move {
             let disconnected = matches!(
                 tokio::time::timeout(std::time::Duration::from_secs(1), ws.next()).await,
                 Ok(None | Some(Err(_)))
@@ -869,32 +1510,57 @@ mod tests {
             .expect("WebSocket connect must succeed");
         transport.abort();
 
-        assert!(transport.closed);
-        assert!(transport.stream.is_none());
+        assert!(transport.state.closed);
+        assert!(transport.state.stream.is_none());
         assert!(
             disconnected_rx
                 .await
                 .expect("server task must report the disconnect"),
             "dropping the client stream must release the server connection"
         );
+        finish_mock_server(server_task).await;
     }
 
     #[tokio::test]
     async fn connect_with_timeout_times_out() {
-        // Use a non-routable address to guarantee a timeout.
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("TcpListener must bind to localhost");
+        let addr = listener
+            .local_addr()
+            .expect("TcpListener must have a local address");
+        let (accepted_tx, accepted_rx) = tokio::sync::oneshot::channel();
+        let server_task = tokio::spawn(async move {
+            let (_tcp, _) = listener
+                .accept()
+                .await
+                .expect("timeout server must accept the TCP connection");
+            let _ = accepted_tx.send(());
+            std::future::pending::<()>().await;
+        });
+
         let result = WebSocketTransport::connect_with_timeout(
-            "ws://192.0.2.1:1",
+            &format!("ws://{addr}"),
             std::time::Duration::from_millis(50),
         )
         .await;
 
         let err = result.unwrap_err();
         assert!(matches!(err, SignalFishError::Timeout));
+        tokio::time::timeout(std::time::Duration::from_secs(1), accepted_rx)
+            .await
+            .expect("timeout server must accept promptly")
+            .expect("timeout server must report acceptance");
+        server_task.abort();
+        assert!(matches!(
+            server_task.await,
+            Err(error) if error.is_cancelled()
+        ));
     }
 
     #[tokio::test]
     async fn from_stream_constructor_works() {
-        let url = start_mock_server(|mut ws| async move {
+        let (url, server_task) = start_mock_server(|mut ws| async move {
             ws.send(Message::Text("from_stream_msg".into()))
                 .await
                 .expect("server must send 'from_stream_msg'");
@@ -913,38 +1579,49 @@ mod tests {
             .expect("recv must return Some")
             .expect("recv must return Ok");
         assert_eq!(msg, TransportFrame::Text("from_stream_msg".into()));
+        drop(transport);
+        finish_mock_server(server_task).await;
     }
 
     #[tokio::test]
-    async fn send_round_trip() {
-        let url = start_mock_server(|mut ws| async move {
-            // Read one message and echo it back.
-            if let Some(Ok(Message::Text(text))) = ws.next().await {
-                ws.send(Message::Text(text))
+    async fn text_and_binary_send_round_trip_in_fifo_order() {
+        let (url, server_task) = start_mock_server(|mut ws| async move {
+            for _ in 0..2 {
+                let message = ws
+                    .next()
                     .await
-                    .expect("server must echo message back");
+                    .expect("server must receive each application message")
+                    .expect("application message must be valid");
+                ws.send(message)
+                    .await
+                    .expect("server must echo each application message");
             }
-            ws.close(None).await.expect("server must close cleanly");
         })
         .await;
 
-        let mut transport = WebSocketTransport::connect(&url)
-            .await
-            .expect("WebSocket connect must succeed");
-        crate::transport::send_frame(&mut transport, TransportFrame::Text("ping_echo".into()))
-            .await
-            .expect("send must succeed");
-
-        let msg = crate::transport::recv_frame(&mut transport)
-            .await
-            .expect("recv must return Some")
-            .expect("recv must return Ok");
-        assert_eq!(msg, TransportFrame::Text("ping_echo".into()));
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            let mut transport = WebSocketTransport::connect(&url)
+                .await
+                .expect("WebSocket connect must succeed");
+            for expected in [
+                TransportFrame::Text("ping_echo".into()),
+                TransportFrame::Binary(vec![0x00, 0x7F, 0xFF]),
+            ] {
+                crate::transport::send_frame(&mut transport, expected.clone())
+                    .await
+                    .expect("send must succeed");
+                let received = crate::transport::recv_frame(&mut transport).await;
+                assert_eq!(expect_received_frame(received), expected);
+            }
+        })
+        .await
+        .expect("text/binary round trip must complete promptly");
+        finish_mock_server(server_task).await;
     }
 
     #[tokio::test]
-    async fn recv_after_close_returns_none_or_error() {
-        let url =
+    async fn recv_after_local_close_returns_exact_terminal_none() {
+        let (url, server_task) =
             start_mock_server(|mut ws| async move { while let Some(Ok(_)) = ws.next().await {} })
                 .await;
 
@@ -955,12 +1632,7 @@ mod tests {
             .await
             .expect("close must succeed");
 
-        // After closing, recv must not hang — it should return None or an error.
-        let result = crate::transport::recv_frame(&mut transport).await;
-        match result {
-            None => {}         // stream ended — expected
-            Some(Err(_)) => {} // transport error — also acceptable
-            Some(Ok(msg)) => panic!("expected None or error after close, got Ok({msg:?})"),
-        }
+        assert!(crate::transport::recv_frame(&mut transport).await.is_none());
+        finish_mock_server(server_task).await;
     }
 }

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -1696,6 +1696,24 @@ mod ci_workflow_policy {
         );
     }
 
+    #[test]
+    fn semver_tool_supports_the_stable_rustdoc_format() {
+        for path in [
+            ".github/workflows/semver-checks.yml",
+            ".github/workflows/publish.yml",
+        ] {
+            let workflow = read_project_file(path);
+            assert!(
+                workflow.contains("cargo-semver-checks@0.50.0"),
+                "{path} must pin cargo-semver-checks 0.50.0, which supports rustdoc JSON v60/v61"
+            );
+            assert!(
+                !workflow.contains("cargo-semver-checks@0.46.0"),
+                "{path} must not use the rustdoc-v57-limited cargo-semver-checks 0.46.0"
+            );
+        }
+    }
+
     /// Verify that key documentation and config files reference the same MSRV
     /// as Cargo.toml. Prevents drift where Cargo.toml is bumped but docs or
     /// scripts are left with the old version.


### PR DESCRIPTION
## Summary

- bound peer-controlled Ping, Pong, and defensive raw-frame work to 64 skipped controls per receive poll, with explicit self-wake continuation
- flush tungstenite's automatic Pong and Close responses before further reads or terminal completion
- unify EOF and terminal socket failures into a fused state that drops the stream, clears retained send/control work, and preserves caller-owned frames
- preserve FIFO across pending flushes and restore Text/Binary frames rejected with `WriteBufferFull`
- add deterministic real-waker, loopback socket error, timeout, control-flood, EOF, metadata, TLS, TCP_NODELAY, and Text/Binary regression evidence
- update transport documentation, canonical agent context/skills, changelog, roadmap, and Session 030 evidence

## Verification

- `cargo fmt`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- 29 focused WebSocket tests
- `cargo check --no-default-features --features transport-websocket`
- `cargo test --lib --no-default-features --features transport-websocket`
- stable all-feature rustdoc and nightly docs.rs simulation
- FFI safety policy plus 50-case self-test
- three independent zero-finding production/test/adversarial audits

Closes #105

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core WebSocket poll_send/poll_recv/poll_close state machines, including terminal fusion and control-frame budgeting. Incorrect poll/waker behavior could stall or drop game traffic.
> 
> **Overview**
> Fixes native `WebSocketTransport` liveness: a receive poll now skips at most 64 Ping/Pong/raw frames, flushes automatic Pong/Close replies first, then self-wakes so buffered application data cannot hide behind a control flood.
> 
> EOF and terminal socket errors now drop the stream via `mark_terminal`, clear retained send/control state, report the first receive failure once, and fuse later recv/send/close (`None` / `TransportClosed` / idempotent close). `WriteBufferFull` restores the exact Text/Binary caller frame instead of consuming it.
> 
> Poll logic is extracted into generic `WebSocketState` for in-memory tests. Coverage adds control-budget, waker, FIFO flush, reset-peer, and fused-EOF cases. The FFI reclamation scanner exempts only the exact `tokio_tungstenite::WebSocketStream::from_raw_socket` constructor. Semver/publish workflows pin `cargo-semver-checks@0.50.0` for rustdoc JSON v60/v61.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 803c803a6f65a311364afb57c6f71ab328accc10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->