### PR TITLE
fix!: enforce client room membership state

### DIFF
--- a/.llm/context.md
+++ b/.llm/context.md
@@ -290,7 +290,7 @@ client.ping() -> Result<()>
 client.send_signal_reliable(to, signal).await // v3 only; waiting send_signal
 client.send_capacity() / client.max_send_capacity() -> usize // queue diagnostics
 client.stats() -> ClientStats  // cumulative game_data_sent/received counters
-client.snapshot() -> ClientSnapshot // coherent state/token/quarantine view
+client.snapshot() -> ClientSnapshot // coherent role/state/token/quarantine view
 client.shutdown().await      // async, graceful
 ```
 
@@ -304,12 +304,12 @@ Server 0.7 topology/transport pairs and replace prior peer authority atomically.
 selected plan. `MeshController` rebuilds retained pairs across generations or
 offerer-role changes. `MeshSession` accepts liveness only for the selected transport.
 
-Sync sends return `SignalFishError::NotConnected` when the transport is closed
-and `SignalFishError::SendBufferFull { capacity }` when the bounded queue is
-full (message refused, never silently dropped). Events are never dropped either:
-a full event channel pauses the transport loop (backpressure); undecodable
-frames surface as `DecodeFailed` events; events are missed only on receiver
-drop, handle drop without `shutdown()`, or shutdown (abandons ≤1 in-flight).
+Membership pairs `room_role` with room/participant IDs. Commands validate
+connection, transition, role, authority, protocol/session, then queue capacity.
+Admitted joins/leaves/reconnects fence later work until a matching typed terminal
+response; generic errors/absence stay fenced until teardown. Events are never dropped: a full event
+channel backpressures; undecodable frames surface as `DecodeFailed`; events are
+missed only on receiver/handle drop or shutdown (abandons ≤1 in-flight).
 `SignalFishPollingClient` shares the classified/binary sends, queue bound,
 capacity accessors, `stats()`, and coherent `snapshot()`. Its default per-poll
 work budget is 64 frames/64 KiB in each direction, and its default close policy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `session_topology()`, `session_transport()`, and `is_p2p_active()` to the
   async client, polling client, and `SignalFishClientApi`. Applications can now
   distinguish negotiated local capability from the server-selected active path.
+- Added the public `RoomRole::{Player, Spectator}` state,
+  `ClientSnapshot::room_role`, matching async/polling/trait accessors, and
+  `SignalFishError::{AlreadyInRoom, RoomOperationPending, WrongRoomRole,
+  AuthorityRequired}` for synchronous membership-safe command admission.
 
 ### Changed
 
@@ -63,8 +67,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `MeshController` clear the previous plan and driver peers at `Reconnected`,
   then wait for Server 0.7's fresh live `SessionPlan` before authorizing new
   signaling.
+- **Breaking:** room commands now enforce the Server 0.7 player, spectator,
+  no-membership, and authority matrix before protocol and bounded-queue checks.
+  An admitted join, leave, or reconnect fences subsequent room work until a
+  matching typed terminal response, while `ping` remains available. Generic
+  errors and absent responses stay fail-closed until connection teardown. The
+  exhaustive `ClientSnapshot`
+  and `SignalFishError` types gain the membership fields and variants above.
+  `ClientSnapshot::player_id` and `current_player_id()` now consistently mean
+  the local player-or-spectator participant ID and clear on confirmed exit.
 
 ### Fixed
+
+- Fixed player-only commands being queued before join, after leave, or by a
+  spectator, where Server 0.7 could silently discard gameplay data. Authority
+  baselines and changes are validated before they affect local guards,
+  attributable typed room-transition failures roll back their admission fence,
+  and both drivers preserve identical error precedence without consuming queue
+  capacity.
+- Fixed `MeshController` attempting a room-scoped transport-status update after
+  a confirmed room/spectator exit; peer drivers still tear down immediately.
 
 - Fixed the built-in `WebSocketTransport` allowing buffered Ping/Pong floods to
   monopolize one receive poll and leaving EOF or socket errors logically open.

--- a/PLAN.md
+++ b/PLAN.md
@@ -149,15 +149,17 @@ bounds native WebSocket control-frame work, preserves automatic Pong/Close
 flush ordering, and makes EOF and socket errors terminal for direct Transport
 callers. Session 030 records socket, ownership, wake, and terminal-state evidence.
 
-## Current Correctness Milestone — Client Membership and Operation State
+## Active PR — Client Membership and Operation State
 
 [Issue #103](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/issues/103)
+is implemented in [PR #114](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/pull/114). It
 exposes authoritative player/spectator role state, clears room-scoped identity
 on exit, and enforces one shared operation matrix across async and polling
 drivers. Admission-time room transitions fence later FIFO commands, authority
 state is validated and tracked, and invalid calls fail before consuming bounded
-queue capacity. Session 031 records the operation/state matrix, pinned-server
-contract, and verification evidence.
+queue capacity. The code-bearing head passed all twelve hosted workflow suites;
+Session 031 records the operation/state matrix, pinned-server contract, review
+fixes, and exact verification evidence.
 
 ## Next Correctness Milestones — Readiness, Counters, and Transport Deadlines
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -142,16 +142,26 @@ normalizes controller-owned WebRTC configuration, and makes peer liveness
 transport-specific. Session 029 records the configuration, state, transition,
 and async/polling/controller parity evidence.
 
-## Current Correctness Milestone — WebSocket Liveness
+## Completed Correctness Milestone — WebSocket Liveness
 
 [Issue #105](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/issues/105)
 bounds native WebSocket control-frame work, preserves automatic Pong/Close
 flush ordering, and makes EOF and socket errors terminal for direct Transport
 callers. Session 030 records socket, ownership, wake, and terminal-state evidence.
 
-## Next Correctness Milestones — Client State and Transport Deadlines
+## Current Correctness Milestone — Client Membership and Operation State
 
-Continue with #103, #104, #106, and #107 before usability, performance, token
+[Issue #103](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/issues/103)
+exposes authoritative player/spectator role state, clears room-scoped identity
+on exit, and enforces one shared operation matrix across async and polling
+drivers. Admission-time room transitions fence later FIFO commands, authority
+state is validated and tracked, and invalid calls fail before consuming bounded
+queue capacity. Session 031 records the operation/state matrix, pinned-server
+contract, and verification evidence.
+
+## Next Correctness Milestones — Readiness, Counters, and Transport Deadlines
+
+Continue with #104, #106, and #107 before usability, performance, token
 binding, or presentation milestones.
 
 ## Following Milestone — Negotiated Token Binding

--- a/docs/client.md
+++ b/docs/client.md
@@ -557,7 +557,7 @@ Useful for keeping the connection alive through proxies or load balancers.
 ### State Accessors
 
 `snapshot()` synchronously returns one coherent `ClientSnapshot`, including
-connection/authentication state, room/player IDs, room code, the latest
+connection/authentication state, room role/participant ID, room code, the latest
 reconnection token, requested and effective game-data formats, negotiated
 protocol version, current session generation, and whether delivery is
 quarantined. It also carries the latest selected `session_topology` and
@@ -572,6 +572,7 @@ the async room-ID accessors acquire the same internal mutex.
 | `is_connected()` | `fn is_connected(&self) -> bool` | Returns `true` if the transport is believed to be connected. |
 | `is_authenticated()` | `fn is_authenticated(&self) -> bool` | Returns `true` if the server has confirmed authentication. |
 | `snapshot()` | `fn snapshot(&self) -> ClientSnapshot` | Returns coherent session, reconnect-token, negotiation, and quarantine state. |
+| `room_role()` | `fn room_role(&self) -> Option<RoomRole>` | Server-confirmed `Player` or `Spectator` role; `None` outside a room. |
 | `requested_game_data_format()` | `fn requested_game_data_format(&self) -> Option<GameDataEncoding>` | Exact preference supplied in `SignalFishConfig`, preserving omission. |
 | `effective_game_data_format()` | `fn effective_game_data_format(&self) -> Option<GameDataEncoding>` | Server-selected format; `None` before valid `ProtocolInfo` or after disconnect. |
 | `supports_mesh()` | `fn supports_mesh(&self) -> bool` | Negotiated local capability: v3 plus advertised WebRTC and a Host or Mesh topology. This does not describe the active plan. |
@@ -579,16 +580,46 @@ the async room-ID accessors acquire the same internal mutex.
 | `session_transport()` | `fn session_transport(&self) -> Option<TransportKind>` | Transport selected by the latest authoritative plan. |
 | `is_p2p_active()` | `fn is_p2p_active(&self) -> bool` | Whether the selected plan uses a Host or Mesh topology. |
 | `current_room_id()` | `async fn current_room_id(&self) -> Option<RoomId>` | Returns the current room ID, if in a room. |
-| `current_player_id()` | `async fn current_player_id(&self) -> Option<PlayerId>` | Returns the current player ID, if assigned by the server. |
+| `current_player_id()` | `async fn current_player_id(&self) -> Option<PlayerId>` | Legacy name for the local room participant ID (player or spectator). Interpret it with `room_role()`. |
 | `current_room_code()` | `async fn current_room_code(&self) -> Option<String>` | Returns the current room code, if in a room. |
 
 ```rust,ignore
-if client.is_connected() && client.is_authenticated() {
-    if let Some(room_id) = client.current_room_id().await {
-        println!("In room: {room_id}");
+let state = client.snapshot();
+match (state.room_role, state.player_id, state.room_id.as_ref()) {
+    (Some(RoomRole::Player), Some(player_id), Some(room_id)) => {
+        println!("Player {player_id} is in room {room_id}");
     }
+    (Some(RoomRole::Spectator), Some(spectator_id), Some(room_id)) => {
+        println!("Spectator {spectator_id} is watching room {room_id}");
+    }
+    (None, None, None) => println!("Outside a room"),
+    _ => unreachable!("ClientSnapshot preserves the membership invariant"),
 }
 ```
+
+Read these fields from one `snapshot()` as above; separate accessor calls can
+observe different instants while the background task applies a transition.
+`room_role`, `player_id`, `room_id`, and `room_code` form one invariant: all
+four are absent outside a room, and a confirmed player or spectator membership
+sets all four. A confirmed exit clears all four. Admission of a join, leave, or
+reconnect fences later room commands until a matching typed success or failure
+response, preventing FIFO commands from running against obsolete membership.
+An uncorrelated generic server error or an absent response cannot safely release
+that fence; the client stays fail-closed until transport teardown, after which
+a new connection may retry.
+
+Room command admission is role-specific:
+
+| Local state | Allowed room operations |
+|---|---|
+| Outside a room | `join_room`, `join_as_spectator`, or `reconnect` |
+| `RoomRole::Player` | leave, game-data, readiness/game-start, authority, connection-info, signaling, and transport-status operations |
+| `RoomRole::Spectator` | `leave_spectator` |
+| Any nonterminal connection | `ping` |
+
+Wrong-state errors are deterministic: `NotConnected` wins first, then
+`RoomOperationPending`, membership/role and authority errors, protocol/format
+or session-plan errors, and finally `SendBufferFull` at queue admission.
 
 ---
 
@@ -776,6 +807,7 @@ All accessors are **synchronous** (no async, no mutex):
 |---|---|---|
 | `is_connected()` | `bool` | Whether the transport is believed connected. |
 | `is_authenticated()` | `bool` | Whether the server confirmed authentication. |
+| `room_role()` | `Option<RoomRole>` | Server-confirmed player/spectator role. |
 | `is_closing()` | `bool` | Whether `poll()` must continue driving a close lifecycle. |
 | `negotiated_protocol_version()` | `Option<u16>` | Negotiated v3-or-newer version; `None` before `ProtocolInfo` or on the v2 floor. |
 | `requested_game_data_format()` | `Option<GameDataEncoding>` | Exact configured preference, preserving omission. |
@@ -784,7 +816,7 @@ All accessors are **synchronous** (no async, no mutex):
 | `session_topology()` | `Option<Topology>` | Topology selected by the latest authoritative plan. |
 | `session_transport()` | `Option<TransportKind>` | Transport selected by the latest authoritative plan. |
 | `is_p2p_active()` | `bool` | Whether the selected plan uses a Host or Mesh topology. |
-| `current_player_id()` | `Option<PlayerId>` | Current player ID, if assigned. |
+| `current_player_id()` | `Option<PlayerId>` | Legacy name for the local player-or-spectator participant ID. |
 | `current_room_id()` | `Option<RoomId>` | Current room ID, if in a room. |
 | `current_room_code()` | `Option<&str>` | Current room code, if in a room. |
 | `send_capacity()` | `usize` | Messages that can still be queued before `SendBufferFull`. |

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -315,6 +315,7 @@ simultaneous send + receive pressure.
 | `is_connected()` | No | `bool` |
 | `is_authenticated()` | No | `bool` |
 | `snapshot()` | No | `ClientSnapshot` |
+| `room_role()` | No | `Option<RoomRole>` |
 | `negotiated_protocol_version()` | No | `Option<u16>` |
 | `supports_mesh()` | No | `bool` (negotiated WebRTC + Host/Mesh capability) |
 | `session_topology()` | No | `Option<Topology>` |
@@ -356,7 +357,8 @@ loop as server messages arrive:
 |-------|------|-------------|
 | `connected` | `bool` | Transport opens / closes |
 | `authenticated` | `bool` | `Authenticated` event received |
-| `player_id` | `Option<PlayerId>` | `RoomJoined` / `Reconnected` / `SpectatorJoined` |
+| `room_role` | `Option<RoomRole>` | Confirmed player/spectator join, reconnect, or exit |
+| `player_id` | `Option<PlayerId>` | Confirmed player/spectator join or reconnect; cleared on every exit |
 | `room_id` | `Option<RoomId>` | `RoomJoined` / `RoomLeft` / `Reconnected` / spectator lifecycle |
 | `room_code` | `Option<String>` | `RoomJoined` / `RoomLeft` / `Reconnected` / spectator lifecycle |
 | `reconnection_token` | `Option<String>` | `RoomJoined` / `Reconnected` / room exit |
@@ -365,6 +367,22 @@ loop as server messages arrive:
 
 State flows **one direction**: the background task writes, your code reads
 through the accessors. You never set state directly.
+
+`room_role`, `player_id`, `room_id`, and `room_code` are one coherent
+membership invariant. They are all absent outside a room and all present for a
+confirmed player or spectator. `current_player_id()` is a legacy name for the
+participant ID. When interpreting the role and ID together, match both from one
+`snapshot()`; separate accessor calls can straddle a background transition.
+
+Client commands are checked against this state before queue capacity: join and
+reconnect commands require no membership; gameplay, player-leave, readiness,
+authority, connection-info, signaling, and transport-status commands require
+`RoomRole::Player`; `leave_spectator` requires `RoomRole::Spectator`; and
+`ping` is role-independent. Once a room transition is admitted, later room
+commands return `RoomOperationPending` until a matching typed terminal
+response, so FIFO work cannot silently cross a pending leave or join. Generic
+server errors and absent responses remain fail-closed until transport teardown;
+start a new connection to retry after teardown.
 
 ```mermaid
 graph LR
@@ -434,6 +452,10 @@ directly from client methods as `Result<(), SignalFishError>`.
 | `NotConnected` | Attempted an operation without an active connection. |
 | `SendBufferFull { capacity }` | The bounded outgoing command queue is full; the message was refused, not queued. See [Non-Blocking Command Sending](#non-blocking-command-sending). |
 | `NotInRoom` | Attempted a room operation without being in a room. |
+| `AlreadyInRoom` | Attempted to join or reconnect while already a player or spectator. |
+| `RoomOperationPending` | A prior admitted join, leave, or reconnect still awaits a matching typed terminal response. Generic errors and absent responses stay fenced until transport teardown. |
+| `WrongRoomRole { required, actual }` | The operation requires player or spectator membership of a different kind. |
+| `AuthorityRequired` | The current player is not authorized for an authority-only command. |
 | `ServerError { message, error_code }` | The server returned an error; `error_code` is `Option<ErrorCode>` and may be absent. |
 | `ProtocolUnsupported { mode }` | A protocol-v3-only send was attempted before v3 was negotiated. See [Protocol versioning and topology](#protocol-versioning-and-topology). |
 | `BinaryFormatNotNegotiated` | Binary game data was requested while the connection uses JSON. |

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -19,7 +19,7 @@ All fallible client methods return `Result<T>`, which is an alias for
 pub type Result<T> = std::result::Result<T, SignalFishError>;
 ```
 
-`SignalFishError` derives `Debug` and `Error` (via `thiserror`). It has **14
+`SignalFishError` derives `Debug` and `Error` (via `thiserror`). It has **18
 variants**:
 
 | Variant | Fields | When it occurs |
@@ -31,6 +31,10 @@ variants**:
 | `NotConnected` | — | Attempted an operation requiring an active connection but the client is not connected. |
 | `SendBufferFull` | `capacity: usize` | The bounded outgoing command queue is full — the caller is producing messages faster than the transport can drain them. The message was refused, **not** queued; nothing is silently dropped. See [Handling `SendBufferFull`](#handling-sendbufferfull). |
 | `NotInRoom` | — | Attempted a room operation but the client is not in a room. |
+| `AlreadyInRoom` | — | Attempted to join as a player/spectator or reconnect while already in a room. |
+| `RoomOperationPending` | — | A previously admitted join, leave, or reconnect still awaits a matching typed terminal response. `ping` remains available; generic errors and absent responses stay fenced until transport teardown, after which a new connection may retry. |
+| `WrongRoomRole` | `required: RoomRole`, `actual: RoomRole` | Attempted a player-only command as a spectator, or `leave_spectator` as a player. |
+| `AuthorityRequired` | — | Attempted `start_game` while another player is authority, or attempted to relinquish authority without currently holding it. |
 | `ServerError` | `message: String`, `error_code: Option<ErrorCode>` | The server returned an error message. |
 | `ProtocolUnsupported` | `mode: &'static str` | A protocol-v3-only operation (classified latest/volatile JSON, binary game data, signaling, or transport-status reporting) was attempted before v3 was negotiated. `mode` is `"pre-negotiation"` (no `ProtocolInfo` yet — negotiation still in flight) or `"relay-only"` (a `ProtocolInfo` arrived but negotiated v2, the terminal relay floor). See [Protocol Versioning](protocol-versioning.md#the-fail-fast-guard). |
 | `SessionPlanUnavailable` | — | No authoritative WebRTC plan currently authorizes the signal: no plan has arrived, or the target is self, unknown, departed, or absent from the replace-on-plan peer set/current room roster. The set may be extended by a valid compatibility `NewPeer`; the frame is refused locally. |
@@ -38,6 +42,11 @@ variants**:
 | `BinaryFormatNotNegotiated` | — | A binary send was attempted after negotiation resolved to JSON. Request `MessagePack` and confirm `effective_game_data_format() == Some(MessagePack)`; unsupported requests resolve to JSON and are refused before transport admission. Before `ProtocolInfo`, v3-only sends return `ProtocolUnsupported` instead. |
 | `Timeout` | — | An operation timed out. |
 | `Io` | `std::io::Error` | An I/O error occurred. Implements `From<std::io::Error>`. |
+
+Local validation has stable precedence: connection state, an admitted pending
+room transition, membership/role, authority, protocol version, format/session
+plan, and then bounded-queue capacity. Invalid state therefore does not consume
+queue capacity and is not hidden by `SendBufferFull`.
 
 ### Handling errors from client methods
 

--- a/docs/protocol-versioning.md
+++ b/docs/protocol-versioning.md
@@ -159,13 +159,19 @@ both fields. Routing code should read those fields from one `snapshot()` (or use
 
 ## The fail-fast guard
 
-The v3-only send methods — classified non-reliable JSON sends, binary sends,
+After connection and room-role validation, the v3-only send methods —
+classified non-reliable JSON sends, binary sends,
 `send_signal`, `send_offer`, `send_answer`,
 `send_ice_candidate`, `send_raw_signal`, and `report_transport_status` — check
 the negotiated version **before** sending. If v3 has not been negotiated, they
 return [`SignalFishError::ProtocolUnsupported`](errors.md) immediately rather
 than letting the server reject the message asynchronously (an unattributed
 `Error` event would be much harder to debug).
+
+This ordering is intentional: a player-only command attempted outside a room
+returns `NotInRoom` (or `WrongRoomRole` for a spectator) even if negotiation is
+still in flight. Once player membership is valid, `ProtocolUnsupported`
+describes the remaining version failure precisely.
 
 Signaling has a second guard: every send requires an authoritative WebRTC
 `SessionPlan` that authorizes its target. Otherwise it returns

--- a/docs/wasm.md
+++ b/docs/wasm.md
@@ -389,7 +389,9 @@ Command methods queue protocol work for a later `poll()` cycle. They return
 `SignalFishError::SendBufferFull` without queuing when the bounded command queue
 is full, or `SignalFishError::NotConnected` if the transport has closed.
 Protocol-v3-only methods also return `SignalFishError::ProtocolUnsupported`
-until v3 is negotiated.
+until v3 is negotiated. Room commands additionally fail fast with
+`NotInRoom`, `AlreadyInRoom`, `WrongRoomRole`, `RoomOperationPending`, or
+`AuthorityRequired` as appropriate; these checks happen before queue capacity.
 
 | Method | Signature | Description |
 |--------|-----------|-------------|
@@ -427,7 +429,8 @@ environment).
 | `is_connected()` | `fn is_connected(&self) -> bool` | Whether the transport is still alive. |
 | `is_closing()` | `fn is_closing(&self) -> bool` | Whether the bounded close lifecycle still needs polling. |
 | `is_authenticated()` | `fn is_authenticated(&self) -> bool` | Whether the server confirmed authentication. |
-| `current_player_id()` | `fn current_player_id(&self) -> Option<PlayerId>` | The local player's ID, if assigned. |
+| `room_role()` | `fn room_role(&self) -> Option<RoomRole>` | Server-confirmed player/spectator role, or `None` outside a room. |
+| `current_player_id()` | `fn current_player_id(&self) -> Option<PlayerId>` | Legacy name for the local player-or-spectator participant ID; use one `snapshot()` to interpret it atomically with `room_role`. |
 | `current_room_id()` | `fn current_room_id(&self) -> Option<RoomId>` | The current room ID, if in a room. |
 | `current_room_code()` | `fn current_room_code(&self) -> Option<&str>` | The current room code, if in a room. |
 | `negotiated_protocol_version()` | `fn negotiated_protocol_version(&self) -> Option<u16>` | Negotiated protocol version; `None` before negotiation or for the v2 relay floor. |

--- a/progress/session-031-client-membership-state.md
+++ b/progress/session-031-client-membership-state.md
@@ -81,4 +81,16 @@ while v3-only protocol checks still occur after valid player membership.
   `mkdocs` is not installed in the local image and Python lacks `pip`/`venv`,
   so strict rendered-doc validation remains delegated to the blocking hosted
   Docs Validation workflow.
-- Hosted PR evidence is recorded here after completion.
+- [PR #114](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/pull/114)
+  is open and non-draft. Its code-bearing head `bd272d9` completed all twelve
+  workflow suites successfully: CI 32411518446, Coverage 32411518471, Deep
+  Safety 32411518476, Docs Validation 32411518382, Examples Validation
+  32411518478, Godot Web 32411518415, No Panics 32411518376, Security
+  32411518466, Semver Checks 32411518414, Unused Deps 32411518506, WASM
+  32411518567, and Workflow Lint 32411518495.
+- The first hosted pass found a spelling violation, the intended breaking API
+  classification, and a pre-join live-server expectation that predated the new
+  error precedence. Commits `349d85a` and `bd272d9` fixed the tests, and the PR
+  title now carries the required `fix!:` marker. The final review surface had no
+  actionable conversation comments or inline threads; Copilot posted only its
+  quota-limit notice.

--- a/progress/session-031-client-membership-state.md
+++ b/progress/session-031-client-membership-state.md
@@ -1,0 +1,84 @@
+# Session 031 — Client Membership and Operation State
+
+## Scope and Priority
+
+Issue #103 is the highest-impact open gameplay correctness issue. Server 0.7
+silently ignores game data from a connection without player membership, while
+the client previously admitted player commands before join, after leave, and as
+a spectator. The next dependency order is #104 (readiness/stat counters), #106
+(custom transport abort contract), then #107 (datagram scope). None belongs in
+this PR.
+
+The hosted audit found no open or draft PR and no Dependabot PR to incorporate.
+At base `ad3e728`, ten required `main` workflows were green and Godot Web was
+still running. Issue #90 remains an administrative governance blocker: live
+ruleset #14801090 still lacks pull-request and required-status-check rules, and
+Repository Policy run 32006639556 correctly fails on that drift.
+
+## Membership and Command Contract
+
+`ClientSnapshot::room_role` is the authoritative `Player`/`Spectator`
+dimension. `room_role`, `player_id` (the local room participant ID), `room_id`,
+and `room_code` are all absent outside a room and all present in confirmed room
+membership. Confirmed player and spectator exits clear the complete identity.
+
+| Operation category | Required state |
+| --- | --- |
+| `JoinRoom`, `JoinAsSpectator`, `Reconnect` | no room membership |
+| `LeaveRoom`, JSON/binary game data, readiness/start, authority, connection info, typed/raw signaling, transport status | player |
+| `LeaveSpectator` | spectator |
+| `Ping` | any nonterminal connection |
+
+`request_authority(false)` requires current authority. `start_game` requires
+current authority when the room has one, and remains available to any player
+when no authority has been assigned, matching pinned Server 0.7 behavior.
+
+Validation order is deterministic: `NotConnected`, a pending admitted room
+transition, membership/role, authority, protocol version, format/session plan,
+then bounded queue admission. Queue refusal never creates pending state. A
+successfully admitted join, leave, or reconnect does create it, fencing later
+room commands until a matching typed terminal response; `Ping` remains usable.
+Generic errors and absent responses stay fail-closed until connection teardown,
+after which a new connection may retry.
+
+## Invariant → Source → Evidence
+
+| Invariant | Source | Executable evidence |
+| --- | --- | --- |
+| Shared role/authority/no-membership matrix and stable error precedence. | `ClientCore::{validate, set_room, clear_room}`. | `client_core::tests::operation_membership_matrix_is_exhaustive_and_role_specific`; async client guard tests; polling parity command fixtures. |
+| Pending transitions mutate only after successful queue admission, accept only matching response types, and roll back only on attributable typed failures. Unattributed errors remain fenced. | `ClientOperationAdmission`; both drivers' queue admission paths; `validate_pending_room_response`. | `client_core::tests::{admitted_room_transitions_fence_fifo_commands_and_failures_roll_back,pending_room_responses_are_correlated_and_unattributed_errors_stay_fenced}`; `admitted_leave_fences_following_player_commands_in_both_drivers`; full-queue recovery tests. |
+| Player/spectator identity is coherent and clears on every exit/disconnect. | `RoomBaseline`; `ClientSnapshot::room_role`; `clear_room`. | Async and polling room/spectator lifecycle state tests. |
+| Authority used by local guards is roster-consistent and transactional. | `validate_local_player_snapshot`; `validate_authority_snapshot`; `AuthorityChanged` semantic validation. | Baseline-validation policy tests and authority command tests. |
+| Confirmed exit tears down WebRTC peers without sending obsolete room-scoped status. | `MeshController::handle_event`. | `webrtc::tests::room_left_tears_down_open_channel_without_post_exit_status`. |
+
+## Server Contract Evidence
+
+Pinned Signal Fish Server 0.7 commit `3f7f43d` returns `NOT_IN_ROOM` for player
+readiness/start and connection-info operations, requires current authority to
+relinquish it, returns `NOT_A_SPECTATOR` for spectator leave, and rejects joins
+from either existing player or spectator membership as `ALREADY_IN_ROOM`.
+Its signaling-path game-data handler silently returns when the sender has no
+player room. The local matrix therefore prevents both noisy server errors and
+the more dangerous silent gameplay-loss path without changing wire shapes.
+
+Server 0.4 compatibility remains adaptive: join and role semantics are shared,
+while v3-only protocol checks still occur after valid player membership.
+
+## Review and Verification
+
+- The shared-core and driver-parity implementation was adversarially audited
+  against every operation variant, pending FIFO transitions, queue-full
+  precedence, authority semantics, identity documentation, and mesh teardown.
+  The exhaustive async/polling matrix runs every command outside a room, as a
+  player and spectator, and after confirmed leave and rejoin for both roles.
+- The mandatory `cargo fmt && cargo clippy --workspace --all-targets
+  --all-features -- -D warnings && cargo test --workspace --all-features` gate
+  passes: 336 library tests, 33 driver-parity tests, 214 policy tests, 68 async
+  integration tests, 126 protocol tests, and 35 Godot adapter tests are green;
+  six live-server tests remain intentionally isolated to pinned hosted jobs.
+- The no-default workspace check/test, all-feature workspace rustdoc,
+  `.llm/` validation, workflow policy, and `git diff --check` pass locally.
+  `mkdocs` is not installed in the local image and Python lacks `pip`/`venv`,
+  so strict rendered-doc validation remains delegated to the blocking hosted
+  Docs Validation workflow.
+- Hosted PR evidence is recorded here after completion.

--- a/src/client.rs
+++ b/src/client.rs
@@ -462,6 +462,28 @@ pub enum ProtocolViolationPolicy {
     Observe,
 }
 
+/// The local client's authoritative role in its current room.
+///
+/// A client outside a room has no role, represented by `None` in
+/// [`ClientSnapshot::room_role`]. The role changes only when the server
+/// confirms a player or spectator join, reconnect, or departure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RoomRole {
+    /// A room player that may send game data and participate in gameplay.
+    Player,
+    /// A read-only spectator.
+    Spectator,
+}
+
+impl std::fmt::Display for RoomRole {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::Player => "player",
+            Self::Spectator => "spectator",
+        })
+    }
+}
+
 // ── JoinRoomParams ──────────────────────────────────────────────────
 
 /// Parameters for joining (or creating) a room.
@@ -598,6 +620,16 @@ pub struct ClientSnapshot {
     /// unsupported preference resolves to `Some(GameDataEncoding::Json)` in
     /// accordance with the Signal Fish Server 0.7 fallback contract.
     pub effective_game_data_format: Option<GameDataEncoding>,
+    /// Authoritative local room role, or `None` outside a room.
+    ///
+    /// This changes only on server-confirmed room, reconnect, and spectator
+    /// lifecycle messages. When it is `None`, `player_id`, `room_id`, and
+    /// `room_code` are also `None`.
+    pub room_role: Option<RoomRole>,
+    /// Local room participant ID, whether the role is player or spectator.
+    ///
+    /// Cleared together with [`room_role`](Self::room_role) on every confirmed
+    /// room or spectator exit.
     pub player_id: Option<PlayerId>,
     pub room_id: Option<RoomId>,
     pub room_code: Option<String>,
@@ -638,6 +670,7 @@ impl std::fmt::Debug for ClientSnapshot {
                 "effective_game_data_format",
                 &self.effective_game_data_format,
             )
+            .field("room_role", &self.room_role)
             .field("player_id", &self.player_id)
             .field("room_id", &self.room_id)
             .field("room_code", &self.room_code)
@@ -814,7 +847,9 @@ impl SignalFishClient {
     ///
     /// # Errors
     ///
-    /// Returns [`SignalFishError::NotConnected`] if the transport has closed,
+    /// Returns [`SignalFishError::AlreadyInRoom`] when membership already
+    /// exists, [`SignalFishError::RoomOperationPending`] during another room
+    /// transition, [`SignalFishError::NotConnected`] if the transport has closed,
     /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
     /// is full (the message is **not** queued; nothing is silently dropped).
     pub fn join_room(&mut self, params: JoinRoomParams) -> Result<()> {
@@ -825,7 +860,10 @@ impl SignalFishClient {
     ///
     /// # Errors
     ///
-    /// Returns [`SignalFishError::NotConnected`] if the transport has closed,
+    /// Returns [`SignalFishError::NotInRoom`] outside a room,
+    /// [`SignalFishError::WrongRoomRole`] as a spectator,
+    /// [`SignalFishError::RoomOperationPending`] during another room transition,
+    /// [`SignalFishError::NotConnected`] if the transport has closed,
     /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
     /// is full (the message is **not** queued; nothing is silently dropped).
     pub fn leave_room(&mut self) -> Result<()> {
@@ -841,7 +879,10 @@ impl SignalFishClient {
     ///
     /// # Errors
     ///
-    /// Returns [`SignalFishError::NotConnected`] if the transport has closed,
+    /// Returns [`SignalFishError::NotInRoom`] outside a room,
+    /// [`SignalFishError::WrongRoomRole`] as a spectator,
+    /// [`SignalFishError::RoomOperationPending`] during a room transition,
+    /// [`SignalFishError::NotConnected`] if the transport has closed,
     /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
     /// is full (the message is **not** queued; nothing is silently dropped).
     pub fn send_game_data(&mut self, data: serde_json::Value) -> Result<()> {
@@ -849,6 +890,13 @@ impl SignalFishClient {
     }
 
     /// Send JSON game data with an explicit protocol-v3 delivery policy.
+    ///
+    /// # Errors
+    ///
+    /// Returns the membership/queue errors documented by
+    /// [`send_game_data`](Self::send_game_data), or
+    /// [`SignalFishError::ProtocolUnsupported`] for a non-reliable delivery
+    /// class before protocol v3 is negotiated.
     pub fn send_game_data_with_delivery(
         &mut self,
         data: serde_json::Value,
@@ -881,13 +929,21 @@ impl SignalFishClient {
     ///
     /// # Errors
     ///
-    /// Returns [`SignalFishError::NotConnected`] if the transport has closed.
+    /// Returns the membership errors documented by
+    /// [`send_game_data`](Self::send_game_data), or
+    /// [`SignalFishError::NotConnected`] if the transport closes while waiting.
     pub async fn send_game_data_reliable(&self, data: serde_json::Value) -> Result<()> {
         self.send_operation_reliable(ClientOperation::GameData(data, GameDataDelivery::Reliable))
             .await
     }
 
     /// Waiting counterpart to [`send_game_data_with_delivery`](Self::send_game_data_with_delivery).
+    ///
+    /// # Errors
+    ///
+    /// Returns the same membership and protocol errors as
+    /// [`send_game_data_with_delivery`](Self::send_game_data_with_delivery), or
+    /// [`SignalFishError::NotConnected`] if the transport closes while waiting.
     pub async fn send_game_data_with_delivery_reliable(
         &self,
         data: serde_json::Value,
@@ -898,11 +954,24 @@ impl SignalFishClient {
     }
 
     /// Send opaque binary game data over the negotiated protocol-v3 relay.
+    ///
+    /// # Errors
+    ///
+    /// Returns the membership errors documented by
+    /// [`send_game_data`](Self::send_game_data),
+    /// [`SignalFishError::ProtocolUnsupported`] before v3 negotiation, or
+    /// [`SignalFishError::BinaryFormatNotNegotiated`] in JSON mode.
     pub fn send_binary_game_data(&mut self, payload: Vec<u8>) -> Result<()> {
         self.send_operation(ClientOperation::Binary(payload))
     }
 
     /// Waiting binary send that paces on command-queue capacity.
+    ///
+    /// # Errors
+    ///
+    /// Returns the same state, protocol, and format errors as
+    /// [`send_binary_game_data`](Self::send_binary_game_data), or
+    /// [`SignalFishError::NotConnected`] if the transport closes while waiting.
     pub async fn send_binary_game_data_reliable(&self, payload: Vec<u8>) -> Result<()> {
         self.send_operation_reliable(ClientOperation::Binary(payload))
             .await
@@ -912,7 +981,10 @@ impl SignalFishClient {
     ///
     /// # Errors
     ///
-    /// Returns [`SignalFishError::NotConnected`] if the transport has closed,
+    /// Returns [`SignalFishError::NotInRoom`] outside a room,
+    /// [`SignalFishError::WrongRoomRole`] as a spectator,
+    /// [`SignalFishError::RoomOperationPending`] during a room transition,
+    /// [`SignalFishError::NotConnected`] if the transport has closed,
     /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
     /// is full (the message is **not** queued; nothing is silently dropped).
     pub fn set_ready(&mut self) -> Result<()> {
@@ -923,7 +995,12 @@ impl SignalFishClient {
     ///
     /// # Errors
     ///
-    /// Returns [`SignalFishError::NotConnected`] if the transport has closed,
+    /// Returns [`SignalFishError::NotInRoom`],
+    /// [`SignalFishError::WrongRoomRole`], or
+    /// [`SignalFishError::RoomOperationPending`] for invalid membership state,
+    /// [`SignalFishError::AuthorityRequired`]
+    /// when relinquishing authority without holding it,
+    /// [`SignalFishError::NotConnected`] if the transport has closed,
     /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
     /// is full (the message is **not** queued; nothing is silently dropped).
     pub fn request_authority(&mut self, become_authority: bool) -> Result<()> {
@@ -934,7 +1011,10 @@ impl SignalFishClient {
     ///
     /// # Errors
     ///
-    /// Returns [`SignalFishError::NotConnected`] if the transport has closed,
+    /// Returns [`SignalFishError::NotInRoom`],
+    /// [`SignalFishError::WrongRoomRole`], or
+    /// [`SignalFishError::RoomOperationPending`] for invalid membership state,
+    /// [`SignalFishError::NotConnected`] if the transport has closed,
     /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
     /// is full (the message is **not** queued; nothing is silently dropped).
     pub fn provide_connection_info(&mut self, connection_info: ConnectionInfo) -> Result<()> {
@@ -945,7 +1025,9 @@ impl SignalFishClient {
     ///
     /// # Errors
     ///
-    /// Returns [`SignalFishError::NotConnected`] if the transport has closed,
+    /// Returns [`SignalFishError::AlreadyInRoom`] when membership already
+    /// exists, [`SignalFishError::RoomOperationPending`] during another room
+    /// transition, [`SignalFishError::NotConnected`] if the transport has closed,
     /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
     /// is full (the message is **not** queued; nothing is silently dropped).
     pub fn reconnect(
@@ -961,7 +1043,9 @@ impl SignalFishClient {
     ///
     /// # Errors
     ///
-    /// Returns [`SignalFishError::NotConnected`] if the transport has closed,
+    /// Returns [`SignalFishError::AlreadyInRoom`] when membership already
+    /// exists, [`SignalFishError::RoomOperationPending`] during another room
+    /// transition, [`SignalFishError::NotConnected`] if the transport has closed,
     /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
     /// is full (the message is **not** queued; nothing is silently dropped).
     pub fn join_as_spectator(
@@ -981,7 +1065,10 @@ impl SignalFishClient {
     ///
     /// # Errors
     ///
-    /// Returns [`SignalFishError::NotConnected`] if the transport has closed,
+    /// Returns [`SignalFishError::NotInRoom`] outside a room,
+    /// [`SignalFishError::WrongRoomRole`] as a player,
+    /// [`SignalFishError::RoomOperationPending`] during another room transition,
+    /// [`SignalFishError::NotConnected`] if the transport has closed,
     /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
     /// is full (the message is **not** queued; nothing is silently dropped).
     pub fn leave_spectator(&mut self) -> Result<()> {
@@ -1015,7 +1102,11 @@ impl SignalFishClient {
     ///
     /// # Errors
     ///
-    /// Returns [`SignalFishError::NotConnected`] if the transport has closed,
+    /// Returns [`SignalFishError::NotInRoom`],
+    /// [`SignalFishError::WrongRoomRole`], or
+    /// [`SignalFishError::RoomOperationPending`] for invalid membership state,
+    /// [`SignalFishError::AuthorityRequired`] when another authority is assigned,
+    /// [`SignalFishError::NotConnected`] if the transport has closed,
     /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
     /// is full (the message is **not** queued; nothing is silently dropped).
     pub fn start_game(&mut self) -> Result<()> {
@@ -1042,6 +1133,9 @@ impl SignalFishClient {
     /// [`SignalFishError::SessionPlanUnavailable`] when no authoritative WebRTC
     /// plan authorizes `to` (including no plan, a non-WebRTC plan, self, or a
     /// target absent from the latest plan/current room roster),
+    /// [`SignalFishError::NotInRoom`] outside a room,
+    /// [`SignalFishError::WrongRoomRole`] as a spectator,
+    /// [`SignalFishError::RoomOperationPending`] during a room transition,
     /// [`SignalFishError::NotConnected`] if the transport has closed, or
     /// [`SignalFishError::SendBufferFull`] if the outgoing command queue is
     /// full (see [`send_signal_reliable`](Self::send_signal_reliable) for a
@@ -1094,7 +1188,8 @@ impl SignalFishClient {
     /// # Errors
     ///
     /// Returns [`SignalFishError::ProtocolUnsupported`] if the connection has
-    /// not negotiated protocol v3, [`SignalFishError::SessionPlanUnavailable`]
+    /// not negotiated protocol v3, the membership errors documented by
+    /// [`send_signal`](Self::send_signal), [`SignalFishError::SessionPlanUnavailable`]
     /// when no authoritative WebRTC plan authorizes `to`, or
     /// [`SignalFishError::NotConnected`] if the transport has closed.
     pub async fn send_signal_reliable(
@@ -1186,7 +1281,8 @@ impl SignalFishClient {
     /// # Errors
     ///
     /// Returns [`SignalFishError::ProtocolUnsupported`] if the connection has not
-    /// negotiated protocol v3, [`SignalFishError::NotConnected`] if the
+    /// negotiated protocol v3, the membership errors documented by
+    /// [`send_signal`](Self::send_signal), [`SignalFishError::NotConnected`] if the
     /// transport has closed, or [`SignalFishError::SendBufferFull`] if the
     /// outgoing command queue is full.
     pub fn report_transport_status(
@@ -1274,9 +1370,18 @@ impl SignalFishClient {
         lock_core(&self.state).snapshot().room_id
     }
 
-    /// Returns the current player ID, if assigned by the server.
+    /// Returns the local room participant ID, for either a player or spectator.
+    ///
+    /// This legacy accessor name is retained for compatibility. Use one
+    /// [`snapshot`](Self::snapshot) and match its `room_role` with `player_id`
+    /// when the interpretation must be atomic. Both values clear on exit.
     pub async fn current_player_id(&self) -> Option<PlayerId> {
         lock_core(&self.state).snapshot().player_id
+    }
+
+    /// Returns the server-confirmed local role in the current room.
+    pub fn room_role(&self) -> Option<RoomRole> {
+        lock_core(&self.state).snapshot().room_role
     }
 
     /// Returns the current room code, if the client is in a room.
@@ -1316,19 +1421,12 @@ impl SignalFishClient {
         // Keep the state lock through nonblocking queue admission. In
         // particular, an exact-generation signal must not pass validation and
         // then race with a replacement SessionPlan before it is queued.
-        let reconnect_request = match &operation {
-            ClientOperation::Reconnect(player_id, room_id, token) => {
-                Some((*player_id, *room_id, token.clone()))
-            }
-            _ => None,
-        };
+        let admission = ClientCore::admission_for(&operation);
         let mut core = lock_core(&self.state);
         let command = core.prepare(operation)?;
         let result = match self.cmd_tx.try_send(command) {
             Ok(()) => {
-                if let Some((player_id, room_id, token)) = reconnect_request {
-                    core.record_reconnect_admitted(player_id, room_id, token);
-                }
+                core.record_admission(admission);
                 Ok(())
             }
             Err(mpsc::error::TrySendError::Full(_)) => Err(SignalFishError::SendBufferFull {
@@ -2073,7 +2171,7 @@ mod tests {
                 player(uuid::Uuid::from_u128(7), "peer-7"),
                 player(uuid::Uuid::from_u128(9), "peer-9"),
             ],
-            is_authority: false,
+            is_authority: true,
             lobby_state: LobbyState::Waiting,
             ready_players: vec![],
             relay_type: "auto".into(),
@@ -2082,6 +2180,13 @@ mod tests {
             reconnection_token: None,
         };
         serde_json::to_string(&ServerMessage::RoomJoined(Box::new(payload))).unwrap()
+    }
+
+    fn prime_player_room(client: &SignalFishClient) {
+        let mut core = lock_core(&client.state);
+        let _ = core.process_frame(TransportFrame::Text(authenticated_json()));
+        let _ = core.process_frame(TransportFrame::Text(protocol_info_v2_json()));
+        let _ = core.process_frame(TransportFrame::Text(room_joined_json()));
     }
 
     // ── Tests ───────────────────────────────────────────────────────
@@ -3040,6 +3145,7 @@ mod tests {
 
         // Wait until the loop has pulled Authenticate and stalled in send().
         wait_until(|| entered_send.load(Ordering::Acquire)).await;
+        prime_player_room(&client);
         assert_eq!(client.max_send_capacity(), 2);
 
         // Fill the queue to capacity, then observe the loud refusal.
@@ -3080,6 +3186,7 @@ mod tests {
 
         let _ = events.recv().await; // Connected
         wait_until(|| entered_send.load(Ordering::Acquire)).await;
+        prime_player_room(&client);
 
         client
             .send_game_data(serde_json::json!({ "seq": 0 }))
@@ -3130,6 +3237,7 @@ mod tests {
             Some(SignalFishEvent::Connected)
         ));
         wait_until(|| entered_send.load(Ordering::Acquire)).await;
+        prime_player_room(&client);
 
         client
             .send_game_data(serde_json::json!({ "fills": "queue" }))
@@ -3241,6 +3349,27 @@ mod tests {
                 .unwrap();
                 let _ = core.process_frame(TransportFrame::Text(room_a));
             }
+        }
+
+        if !initially_in_room {
+            let result = if binary {
+                client
+                    .send_binary_game_data_reliable(b"pre-room-binary".to_vec())
+                    .await
+            } else {
+                client
+                    .send_game_data_reliable(serde_json::json!({ "value": "pre-room-json" }))
+                    .await
+            };
+            assert!(
+                matches!(result, Err(SignalFishError::NotInRoom)),
+                "pre-room game data must fail locally: {result:?}"
+            );
+            permits.add_permits(16);
+            wait_for_sent_len(&sent, 1).await;
+            assert_eq!(sent.lock().unwrap().len(), 1);
+            client.shutdown().await;
+            return;
         }
 
         client
@@ -3380,12 +3509,14 @@ mod tests {
         let (transport, _sent, _closed) = MockTransport::new(vec![
             Some(Ok(authenticated_json())),
             Some(Ok(protocol_info_v3_json())),
+            Some(Ok(finalized_room_v3_json(uuid::Uuid::from_u128(7)))),
         ]);
         let (mut client, mut events) =
             SignalFishClient::start(transport, SignalFishConfig::new("mb_test").enable_v3());
         let _ = events.recv().await; // Connected
         let _ = events.recv().await; // Authenticated
         let _ = events.recv().await; // ProtocolInfo
+        let _ = events.recv().await; // RoomJoined
 
         assert!(matches!(
             client.send_binary_game_data(vec![1, 2, 3]),
@@ -3477,7 +3608,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn send_signal_reliable_fails_fast_pre_negotiation_even_when_queue_full() {
+    async fn send_signal_reliable_fails_fast_outside_room_even_when_queue_full() {
         // Saturate the capacity-1 command queue behind a stalled transport.
         let (transport, entered_send, permits, _sent) = GatedSendTransport::new(0);
         let config = SignalFishConfig::new("mb_test").with_command_channel_capacity(1);
@@ -3485,13 +3616,11 @@ mod tests {
 
         let _ = events.recv().await; // Connected
         wait_until(|| entered_send.load(Ordering::Acquire)).await;
-        client
-            .send_game_data(serde_json::json!({ "seq": 0 }))
-            .unwrap();
+        client.ping().unwrap();
         assert_eq!(client.send_capacity(), 0);
 
-        // The v3 guard must be evaluated BEFORE waiting for queue capacity:
-        // pre-negotiation, this returns immediately (nothing is queued)
+        // Membership must be evaluated BEFORE waiting for queue capacity:
+        // outside a room this returns immediately (nothing is queued)
         // instead of blocking on the full queue.
         let result = tokio::time::timeout(
             std::time::Duration::from_secs(1),
@@ -3500,13 +3629,8 @@ mod tests {
         .await
         .expect("guard must fail fast, not wait for capacity");
         assert!(
-            matches!(
-                result,
-                Err(SignalFishError::ProtocolUnsupported {
-                    mode: "pre-negotiation"
-                })
-            ),
-            "expected ProtocolUnsupported, got {result:?}"
+            matches!(result, Err(SignalFishError::NotInRoom)),
+            "expected NotInRoom, got {result:?}"
         );
 
         permits.add_permits(16);
@@ -3934,13 +4058,19 @@ mod tests {
 
     #[tokio::test]
     async fn leave_room_sends_message() {
-        let (transport, sent, _closed) = MockTransport::new(vec![Some(Ok(authenticated_json()))]);
+        let (transport, sent, _closed) = MockTransport::new(vec![
+            Some(Ok(authenticated_json())),
+            Some(Ok(protocol_info_v2_json())),
+            Some(Ok(room_joined_json())),
+        ]);
 
         let config = SignalFishConfig::new("mb_test");
         let (mut client, mut events) = SignalFishClient::start(transport, config);
 
         let _ = events.recv().await; // Connected
         let _ = events.recv().await; // Authenticated
+        let _ = events.recv().await; // ProtocolInfo
+        let _ = events.recv().await; // RoomJoined
         client.leave_room().unwrap();
 
         wait_for_sent_len(&sent, 2).await;
@@ -3956,13 +4086,19 @@ mod tests {
 
     #[tokio::test]
     async fn set_ready_sends_player_ready() {
-        let (transport, sent, _closed) = MockTransport::new(vec![Some(Ok(authenticated_json()))]);
+        let (transport, sent, _closed) = MockTransport::new(vec![
+            Some(Ok(authenticated_json())),
+            Some(Ok(protocol_info_v2_json())),
+            Some(Ok(room_joined_json())),
+        ]);
 
         let config = SignalFishConfig::new("mb_test");
         let (mut client, mut events) = SignalFishClient::start(transport, config);
 
         let _ = events.recv().await; // Connected
         let _ = events.recv().await; // Authenticated
+        let _ = events.recv().await; // ProtocolInfo
+        let _ = events.recv().await; // RoomJoined
         client.set_ready().unwrap();
 
         wait_for_sent_len(&sent, 2).await;
@@ -4126,13 +4262,19 @@ mod tests {
 
     #[tokio::test]
     async fn send_game_data_sends_correct_message() {
-        let (transport, sent, _closed) = MockTransport::new(vec![Some(Ok(authenticated_json()))]);
+        let (transport, sent, _closed) = MockTransport::new(vec![
+            Some(Ok(authenticated_json())),
+            Some(Ok(protocol_info_v2_json())),
+            Some(Ok(room_joined_json())),
+        ]);
 
         let config = SignalFishConfig::new("mb_test");
         let (mut client, mut events) = SignalFishClient::start(transport, config);
 
         let _ = events.recv().await; // Connected
         let _ = events.recv().await; // Authenticated
+        let _ = events.recv().await; // ProtocolInfo
+        let _ = events.recv().await; // RoomJoined
 
         let data = serde_json::json!({ "action": "move", "x": 10, "y": 20 });
         client.send_game_data(data.clone()).unwrap();

--- a/src/client_api.rs
+++ b/src/client_api.rs
@@ -1,6 +1,6 @@
 //! Common synchronous API implemented by both Signal Fish client drivers.
 
-use crate::client::{ClientSnapshot, ClientStats, GameDataDelivery, JoinRoomParams};
+use crate::client::{ClientSnapshot, ClientStats, GameDataDelivery, JoinRoomParams, RoomRole};
 use crate::error::Result;
 use crate::protocol::{
     ConnectionInfo, GameDataEncoding, PlayerId, RoomId, SessionGeneration, Topology, TransportKind,
@@ -79,6 +79,11 @@ pub trait SignalFishClientApi {
     fn stats(&self) -> ClientStats;
     /// Coherent connection and room snapshot.
     fn snapshot(&self) -> ClientSnapshot;
+
+    /// Server-confirmed local role in the current room.
+    fn room_role(&self) -> Option<RoomRole> {
+        self.snapshot().room_role
+    }
 
     /// Whether the physical connection is active.
     fn is_connected(&self) -> bool {

--- a/src/client_core.rs
+++ b/src/client_core.rs
@@ -9,7 +9,7 @@ use std::collections::{HashSet, VecDeque};
 use crate::accountability::{self, DeliveryAccountability, GameDataDisposition};
 use crate::client::{
     bounded_binary_preview, decode_binary_server_message, ClientSnapshot, ClientStats,
-    GameDataDelivery, JoinRoomParams, ProtocolViolationPolicy, SignalFishConfig,
+    GameDataDelivery, JoinRoomParams, ProtocolViolationPolicy, RoomRole, SignalFishConfig,
 };
 use crate::event::{ProtocolViolationKind, ServerErrorInfo, SignalFishEvent};
 use crate::protocol::{
@@ -91,12 +91,13 @@ pub(crate) struct ClientCore {
     last_server_error: Option<ServerErrorInfo>,
     violation_policy: ProtocolViolationPolicy,
     accountability: DeliveryAccountability,
-    membership: Membership,
+    authority_player: Option<PlayerId>,
     room_finalized: bool,
     room_players: HashSet<PlayerId>,
     session_plan_seen: bool,
     session_peers: HashSet<PlayerId>,
     retired_generationless_signal_peers: HashSet<PlayerId>,
+    pending_room_operation: Option<PendingRoomOperation>,
     pending_reconnects: VecDeque<PendingReconnect>,
     #[cfg(feature = "tokio-runtime")]
     session_plan_revision: u64,
@@ -104,28 +105,35 @@ pub(crate) struct ClientCore {
     room_revision: u64,
 }
 
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-enum Membership {
-    #[default]
-    None,
-    Player,
-    Spectator,
-}
-
 struct RoomBaseline {
     player_id: PlayerId,
     room_id: RoomId,
     room_code: String,
     reconnection_token: Option<String>,
-    membership: Membership,
+    room_role: RoomRole,
+    authority_player: Option<PlayerId>,
     finalized: bool,
     players: HashSet<PlayerId>,
 }
 
-struct PendingReconnect {
+pub(crate) struct PendingReconnect {
     player_id: PlayerId,
     room_id: RoomId,
     token: String,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum PendingRoomOperation {
+    JoinPlayer,
+    LeavePlayer,
+    ReconnectPlayer,
+    JoinSpectator,
+    LeaveSpectator,
+}
+
+pub(crate) enum ClientOperationAdmission {
+    Room(PendingRoomOperation),
+    Reconnect(PendingReconnect),
 }
 
 impl ClientCore {
@@ -158,12 +166,13 @@ impl ClientCore {
             last_server_error: None,
             violation_policy,
             accountability: DeliveryAccountability::new(false),
-            membership: Membership::None,
+            authority_player: None,
             room_finalized: false,
             room_players: HashSet::new(),
             session_plan_seen: false,
             session_peers: HashSet::new(),
             retired_generationless_signal_peers: HashSet::new(),
+            pending_room_operation: None,
             pending_reconnects: VecDeque::new(),
             #[cfg(feature = "tokio-runtime")]
             session_plan_revision: 0,
@@ -227,6 +236,10 @@ impl ClientCore {
         )
     }
 
+    pub(crate) fn room_role(&self) -> Option<RoomRole> {
+        self.snapshot.room_role
+    }
+
     #[cfg(feature = "polling-client")]
     pub(crate) fn current_player_id(&self) -> Option<PlayerId> {
         self.snapshot.player_id
@@ -245,6 +258,50 @@ impl ClientCore {
     pub(crate) fn validate(&self, operation: &ClientOperation) -> crate::error::Result<()> {
         if !self.is_connected() {
             return Err(crate::SignalFishError::NotConnected);
+        }
+        if self.pending_room_operation.is_some() && !matches!(operation, ClientOperation::Ping) {
+            return Err(crate::SignalFishError::RoomOperationPending);
+        }
+        if matches!(
+            operation,
+            ClientOperation::JoinRoom(_)
+                | ClientOperation::Reconnect(..)
+                | ClientOperation::JoinAsSpectator(..)
+        ) && self.room_role().is_some()
+        {
+            return Err(crate::SignalFishError::AlreadyInRoom);
+        }
+        let required_role = match operation {
+            ClientOperation::LeaveRoom
+            | ClientOperation::GameData(..)
+            | ClientOperation::Binary(_)
+            | ClientOperation::SetReady
+            | ClientOperation::StartGame
+            | ClientOperation::RequestAuthority(_)
+            | ClientOperation::ProvideConnectionInfo(_)
+            | ClientOperation::Signal(..)
+            | ClientOperation::RawSignal(..)
+            | ClientOperation::TransportStatus(..) => Some(RoomRole::Player),
+            ClientOperation::LeaveSpectator => Some(RoomRole::Spectator),
+            ClientOperation::JoinRoom(_)
+            | ClientOperation::Reconnect(..)
+            | ClientOperation::JoinAsSpectator(..)
+            | ClientOperation::Ping => None,
+        };
+        if let Some(required) = required_role {
+            match self.room_role() {
+                None => return Err(crate::SignalFishError::NotInRoom),
+                Some(actual) if actual != required => {
+                    return Err(crate::SignalFishError::WrongRoomRole { required, actual });
+                }
+                Some(_) => {}
+            }
+        }
+        let local_player = self.snapshot.player_id;
+        let authority_required = matches!(operation, ClientOperation::RequestAuthority(false))
+            || (matches!(operation, ClientOperation::StartGame) && self.authority_player.is_some());
+        if authority_required && self.authority_player != local_player {
+            return Err(crate::SignalFishError::AuthorityRequired);
         }
         match operation {
             ClientOperation::GameData(_, GameDataDelivery::Latest { .. })
@@ -460,11 +517,55 @@ impl ClientCore {
         room_id: RoomId,
         token: String,
     ) {
+        self.pending_room_operation = Some(PendingRoomOperation::ReconnectPlayer);
         self.pending_reconnects.push_back(PendingReconnect {
             player_id,
             room_id,
             token,
         });
+    }
+
+    pub(crate) fn admission_for(operation: &ClientOperation) -> Option<ClientOperationAdmission> {
+        match operation {
+            ClientOperation::JoinRoom(_) => Some(ClientOperationAdmission::Room(
+                PendingRoomOperation::JoinPlayer,
+            )),
+            ClientOperation::LeaveRoom => Some(ClientOperationAdmission::Room(
+                PendingRoomOperation::LeavePlayer,
+            )),
+            ClientOperation::Reconnect(player_id, room_id, token) => {
+                Some(ClientOperationAdmission::Reconnect(PendingReconnect {
+                    player_id: *player_id,
+                    room_id: *room_id,
+                    token: token.clone(),
+                }))
+            }
+            ClientOperation::JoinAsSpectator(..) => Some(ClientOperationAdmission::Room(
+                PendingRoomOperation::JoinSpectator,
+            )),
+            ClientOperation::LeaveSpectator => Some(ClientOperationAdmission::Room(
+                PendingRoomOperation::LeaveSpectator,
+            )),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn record_admission(&mut self, admission: Option<ClientOperationAdmission>) {
+        let Some(admission) = admission else {
+            return;
+        };
+        match admission {
+            ClientOperationAdmission::Room(operation) => {
+                self.pending_room_operation = Some(operation);
+            }
+            ClientOperationAdmission::Reconnect(reconnect) => {
+                self.record_reconnect_admitted(
+                    reconnect.player_id,
+                    reconnect.room_id,
+                    reconnect.token,
+                );
+            }
+        }
     }
 
     pub(crate) fn clear_session(&mut self) {
@@ -480,12 +581,14 @@ impl ClientCore {
         self.snapshot.session_transport = None;
         self.snapshot.quarantined = false;
         self.protocol_info_seen = false;
-        self.membership = Membership::None;
+        self.snapshot.room_role = None;
+        self.authority_player = None;
         self.room_finalized = false;
         self.room_players.clear();
         self.session_plan_seen = false;
         self.session_peers.clear();
         self.retired_generationless_signal_peers.clear();
+        self.pending_room_operation = None;
         self.pending_reconnects.clear();
         #[cfg(feature = "tokio-runtime")]
         self.advance_session_plan_revision();
@@ -638,12 +741,13 @@ impl ClientCore {
 
     fn process_binary(&mut self, bytes: Vec<u8>) -> FrameOutcome {
         let mut outcome = FrameOutcome::new();
-        if !self.snapshot.authenticated || self.membership == Membership::None {
+        if !self.snapshot.authenticated || self.room_role().is_none() {
             self.reject_inbound(
                 &mut outcome,
                 format!(
                     "lifecycle violation: binary game data is invalid while authenticated={} and membership={:?}",
-                    self.snapshot.authenticated, self.membership
+                    self.snapshot.authenticated,
+                    self.room_role()
                 ),
             );
             return outcome;
@@ -758,7 +862,7 @@ impl ClientCore {
 
     fn validate_inbound_message(&self, message: &ServerMessage) -> Result<(), String> {
         let authenticated = self.snapshot.authenticated;
-        let membership = self.membership;
+        let membership = self.room_role();
         let message_name = server_message_name(message);
 
         let requires_negotiation = !matches!(
@@ -777,20 +881,20 @@ impl ClientCore {
 
         let phase_valid = match message {
             ServerMessage::Authenticated { .. } | ServerMessage::AuthenticationError { .. } => {
-                !authenticated && membership == Membership::None
+                !authenticated && membership.is_none()
             }
             ServerMessage::ProtocolInfo(_) => {
-                authenticated && membership == Membership::None && !self.protocol_info_seen
+                authenticated && membership.is_none() && !self.protocol_info_seen
             }
             ServerMessage::RoomJoined(_)
             | ServerMessage::Reconnected(_)
-            | ServerMessage::SpectatorJoined(_) => authenticated && membership == Membership::None,
+            | ServerMessage::SpectatorJoined(_) => authenticated && membership.is_none(),
             ServerMessage::RoomJoinFailed { .. }
             | ServerMessage::ReconnectionFailed { .. }
             | ServerMessage::SpectatorJoinFailed { .. } => authenticated,
-            ServerMessage::RoomLeft => authenticated && membership == Membership::Player,
+            ServerMessage::RoomLeft => authenticated && membership == Some(RoomRole::Player),
             ServerMessage::SpectatorLeft { .. } => {
-                authenticated && membership == Membership::Spectator
+                authenticated && membership == Some(RoomRole::Spectator)
             }
             ServerMessage::PlayerJoined { .. }
             | ServerMessage::PlayerLeft { .. }
@@ -802,12 +906,12 @@ impl ClientCore {
             | ServerMessage::PlayerReconnected { .. }
             | ServerMessage::NewSpectatorJoined { .. }
             | ServerMessage::SpectatorDisconnected { .. }
-            | ServerMessage::DeliveryReport(_) => authenticated && membership != Membership::None,
+            | ServerMessage::DeliveryReport(_) => authenticated && membership.is_some(),
             ServerMessage::Signal { .. }
             | ServerMessage::NewPeer { .. }
             | ServerMessage::SessionPlan(_)
             | ServerMessage::PeerTransportStatus { .. } => {
-                authenticated && membership == Membership::Player
+                authenticated && membership == Some(RoomRole::Player)
             }
             ServerMessage::AuthorityResponse { .. }
             | ServerMessage::GoingAway { .. }
@@ -845,7 +949,51 @@ impl ClientCore {
         match message {
             ServerMessage::ProtocolInfo(payload) => validate_protocol_info_formats(payload),
             ServerMessage::RoomJoined(payload) => {
-                validate_local_player_snapshot(payload.player_id, &payload.current_players)
+                self.validate_pending_room_response(
+                    PendingRoomOperation::JoinPlayer,
+                    "RoomJoined",
+                )?;
+                validate_local_player_snapshot(
+                    payload.player_id,
+                    payload.is_authority,
+                    &payload.current_players,
+                )
+            }
+            ServerMessage::RoomJoinFailed { .. } => self.validate_pending_room_response(
+                PendingRoomOperation::JoinPlayer,
+                "RoomJoinFailed",
+            ),
+            ServerMessage::RoomLeft => self
+                .validate_pending_room_response(PendingRoomOperation::LeavePlayer, "RoomLeft"),
+            ServerMessage::SpectatorJoined(payload) => {
+                self.validate_pending_room_response(
+                    PendingRoomOperation::JoinSpectator,
+                    "SpectatorJoined",
+                )?;
+                validate_authority_snapshot(&payload.current_players)
+            }
+            ServerMessage::SpectatorJoinFailed { .. } => self.validate_pending_room_response(
+                PendingRoomOperation::JoinSpectator,
+                "SpectatorJoinFailed",
+            ),
+            ServerMessage::SpectatorLeft {
+                room_id, room_code, ..
+            } => {
+                self.validate_pending_room_response(
+                    PendingRoomOperation::LeaveSpectator,
+                    "SpectatorLeft",
+                )?;
+                if room_id.is_some_and(|room_id| Some(room_id) != self.snapshot.room_id)
+                    || room_code
+                        .as_ref()
+                        .is_some_and(|room_code| Some(room_code) != self.snapshot.room_code.as_ref())
+                {
+                    return Err(
+                        "lifecycle violation: SpectatorLeft identifies a different room"
+                            .into(),
+                    );
+                }
+                Ok(())
             }
             ServerMessage::SessionPlan(plan) => {
                 if !self.room_finalized {
@@ -908,8 +1056,47 @@ impl ClientCore {
                     "lifecycle violation: PeerTransportStatus {peer_id} is not another current room player"
                 ))
             }
+            ServerMessage::PlayerJoined { player }
+                if player.is_authority
+                    && self
+                        .authority_player
+                        .is_some_and(|authority| authority != player.id) =>
+            {
+                Err(
+                    "lifecycle violation: PlayerJoined introduces a second authority player"
+                        .into(),
+                )
+            }
+            ServerMessage::AuthorityChanged {
+                authority_player,
+                you_are_authority,
+            } => {
+                if authority_player
+                    .is_some_and(|player_id| !self.room_players.contains(&player_id))
+                {
+                    return Err(format!(
+                        "lifecycle violation: AuthorityChanged names a player outside the current room roster: {authority_player:?}"
+                    ));
+                }
+                let local_is_authority = *authority_player == self.snapshot.player_id;
+                if *you_are_authority != local_is_authority {
+                    return Err(
+                        "lifecycle violation: AuthorityChanged local authority flag disagrees with the authority player"
+                            .into(),
+                    );
+                }
+                Ok(())
+            }
             ServerMessage::Reconnected(payload) => {
-                validate_local_player_snapshot(payload.player_id, &payload.current_players)?;
+                self.validate_pending_room_response(
+                    PendingRoomOperation::ReconnectPlayer,
+                    "Reconnected",
+                )?;
+                validate_local_player_snapshot(
+                    payload.player_id,
+                    payload.is_authority,
+                    &payload.current_players,
+                )?;
                 self.validate_reconnected_payload(payload)
             }
             ServerMessage::ReconnectionFailed { .. } if self.pending_reconnects.is_empty() => Err(
@@ -918,6 +1105,23 @@ impl ClientCore {
             ),
             _ => Ok(()),
         }
+    }
+
+    fn validate_pending_room_response(
+        &self,
+        expected: PendingRoomOperation,
+        response: &str,
+    ) -> Result<(), String> {
+        if self
+            .pending_room_operation
+            .is_some_and(|pending| pending != expected)
+        {
+            return Err(format!(
+                "lifecycle violation: {response} conflicts with pending room operation {:?}",
+                self.pending_room_operation
+            ));
+        }
+        Ok(())
     }
 
     fn validate_session_plan(
@@ -1168,7 +1372,12 @@ impl ClientCore {
                     room_id: payload.room_id,
                     room_code: payload.room_code.clone(),
                     reconnection_token: payload.reconnection_token.clone(),
-                    membership: Membership::Player,
+                    room_role: RoomRole::Player,
+                    authority_player: payload
+                        .current_players
+                        .iter()
+                        .find(|player| player.is_authority)
+                        .map(|player| player.id),
                     finalized: payload.lobby_state == crate::protocol::LobbyState::Finalized,
                     players: payload
                         .current_players
@@ -1176,6 +1385,11 @@ impl ClientCore {
                         .map(|player| player.id)
                         .collect(),
                 });
+            }
+            ServerMessage::RoomJoinFailed { .. } => {
+                if self.pending_room_operation == Some(PendingRoomOperation::JoinPlayer) {
+                    self.pending_room_operation = None;
+                }
             }
             ServerMessage::RoomLeft => self.clear_room(),
             ServerMessage::Reconnected(payload) => {
@@ -1185,7 +1399,12 @@ impl ClientCore {
                     room_id: payload.room_id,
                     room_code: payload.room_code.clone(),
                     reconnection_token: payload.reconnection_token.clone(),
-                    membership: Membership::Player,
+                    room_role: RoomRole::Player,
+                    authority_player: payload
+                        .current_players
+                        .iter()
+                        .find(|player| player.is_authority)
+                        .map(|player| player.id),
                     finalized: payload.lobby_state == crate::protocol::LobbyState::Finalized,
                     players: payload
                         .current_players
@@ -1200,7 +1419,12 @@ impl ClientCore {
                     room_id: payload.room_id,
                     room_code: payload.room_code.clone(),
                     reconnection_token: None,
-                    membership: Membership::Spectator,
+                    room_role: RoomRole::Spectator,
+                    authority_player: payload
+                        .current_players
+                        .iter()
+                        .find(|player| player.is_authority)
+                        .map(|player| player.id),
                     finalized: payload.lobby_state == crate::protocol::LobbyState::Finalized,
                     players: payload
                         .current_players
@@ -1209,9 +1433,17 @@ impl ClientCore {
                         .collect(),
                 });
             }
+            ServerMessage::SpectatorJoinFailed { .. } => {
+                if self.pending_room_operation == Some(PendingRoomOperation::JoinSpectator) {
+                    self.pending_room_operation = None;
+                }
+            }
             ServerMessage::SpectatorLeft { .. } => self.clear_room(),
             ServerMessage::ReconnectionFailed { .. } => {
                 self.pending_reconnects.pop_front();
+                if self.pending_room_operation == Some(PendingRoomOperation::ReconnectPlayer) {
+                    self.pending_room_operation = None;
+                }
             }
             ServerMessage::SessionPlan(payload) => {
                 self.replace_session_plan(
@@ -1230,6 +1462,9 @@ impl ClientCore {
                 }
             }
             ServerMessage::PlayerLeft { player_id, .. } => {
+                if self.authority_player == Some(*player_id) {
+                    self.authority_player = None;
+                }
                 if self.snapshot.session_generation.is_none()
                     && self.snapshot.session_transport == Some(TransportKind::WebRtc)
                     && self.session_peers.contains(player_id)
@@ -1241,6 +1476,14 @@ impl ClientCore {
             }
             ServerMessage::PlayerJoined { player } => {
                 self.room_players.insert(player.id);
+                if player.is_authority {
+                    self.authority_player = Some(player.id);
+                }
+            }
+            ServerMessage::AuthorityChanged {
+                authority_player, ..
+            } => {
+                self.authority_player = *authority_player;
             }
             ServerMessage::LobbyStateChanged { lobby_state, .. } => {
                 self.room_finalized = *lobby_state == crate::protocol::LobbyState::Finalized;
@@ -1259,36 +1502,41 @@ impl ClientCore {
         self.snapshot.player_id = Some(baseline.player_id);
         self.snapshot.room_id = Some(baseline.room_id);
         self.snapshot.room_code = Some(baseline.room_code);
+        self.snapshot.room_role = Some(baseline.room_role);
         self.snapshot.reconnection_token = baseline.reconnection_token;
         self.snapshot.session_generation = None;
         self.snapshot.session_topology = None;
         self.snapshot.session_transport = None;
         self.snapshot.quarantined = false;
-        self.membership = baseline.membership;
+        self.authority_player = baseline.authority_player;
         self.room_finalized = baseline.finalized;
         self.room_players = baseline.players;
         self.session_plan_seen = false;
         self.session_peers.clear();
         self.retired_generationless_signal_peers.clear();
+        self.pending_room_operation = None;
         #[cfg(feature = "tokio-runtime")]
         self.advance_room_revision();
     }
 
     fn clear_room(&mut self) {
         self.accountability.reset_room();
+        self.snapshot.player_id = None;
         self.snapshot.room_id = None;
         self.snapshot.room_code = None;
+        self.snapshot.room_role = None;
         self.snapshot.reconnection_token = None;
         self.snapshot.session_generation = None;
         self.snapshot.session_topology = None;
         self.snapshot.session_transport = None;
         self.snapshot.quarantined = false;
-        self.membership = Membership::None;
+        self.authority_player = None;
         self.room_finalized = false;
         self.room_players.clear();
         self.session_plan_seen = false;
         self.session_peers.clear();
         self.retired_generationless_signal_peers.clear();
+        self.pending_room_operation = None;
         #[cfg(feature = "tokio-runtime")]
         self.advance_room_revision();
     }
@@ -1375,17 +1623,35 @@ fn resolve_effective_game_data_format(
 
 fn validate_local_player_snapshot(
     local_player_id: PlayerId,
+    local_is_authority: bool,
     players: &[crate::protocol::PlayerInfo],
 ) -> Result<(), String> {
-    if players
-        .iter()
-        .filter(|player| player.id == local_player_id)
-        .count()
-        != 1
-    {
+    let mut local_players = players.iter().filter(|player| player.id == local_player_id);
+    let Some(local_player) = local_players.next() else {
         return Err(format!(
             "lifecycle violation: authoritative player snapshot must contain local player {local_player_id} exactly once"
         ));
+    };
+    if local_players.next().is_some() {
+        return Err(format!(
+            "lifecycle violation: authoritative player snapshot must contain local player {local_player_id} exactly once"
+        ));
+    }
+    if local_player.is_authority != local_is_authority {
+        return Err(format!(
+            "lifecycle violation: local authority flag for {local_player_id} disagrees with the authoritative player roster"
+        ));
+    }
+    validate_authority_snapshot(players)
+}
+
+fn validate_authority_snapshot(players: &[crate::protocol::PlayerInfo]) -> Result<(), String> {
+    let authority_count = players.iter().filter(|player| player.is_authority).count();
+    if authority_count > 1 {
+        return Err(
+            "lifecycle violation: authoritative player snapshot contains multiple authority players"
+                .into(),
+        );
     }
     Ok(())
 }
@@ -1468,7 +1734,7 @@ mod tests {
     use crate::protocol::{
         DirectEndpoint, IceServer, LobbyState, MessageTransport, PlayerInfo, ProtocolInfoPayload,
         RateLimitInfo, ReconnectedPayload, ReplayStatus, RoomJoinedPayload, SenderWatermark,
-        SessionPeer,
+        SessionPeer, SpectatorJoinedPayload,
     };
 
     const LOCAL: u128 = 1;
@@ -1602,6 +1868,322 @@ mod tests {
         assert_eq!(process(&mut core, protocol_info(Some(3))).events.len(), 1);
         assert_eq!(process(&mut core, room_joined()).events.len(), 1);
         core
+    }
+
+    fn v3_spectator(policy: ProtocolViolationPolicy) -> ClientCore {
+        let mut core = ClientCore::new(Some(GameDataEncoding::Json), policy, true);
+        let _ = process(&mut core, authenticated());
+        let _ = process(&mut core, protocol_info(Some(3)));
+        let _ = process(&mut core, spectator_joined());
+        core
+    }
+
+    fn spectator_joined() -> ServerMessage {
+        ServerMessage::SpectatorJoined(Box::new(SpectatorJoinedPayload {
+            room_id: RoomId::from_u128(10),
+            room_code: "ROOM".into(),
+            spectator_id: PlayerId::from_u128(99),
+            game_name: "game".into(),
+            current_players: vec![player(LOCAL), player(PEER)],
+            current_spectators: vec![],
+            lobby_state: LobbyState::Lobby,
+            reason: None,
+        }))
+    }
+
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    enum MembershipError {
+        None,
+        NotInRoom,
+        AlreadyInRoom,
+        NeedsPlayer,
+        NeedsSpectator,
+    }
+
+    fn membership_error(result: crate::error::Result<()>) -> MembershipError {
+        match result {
+            Err(crate::SignalFishError::NotInRoom) => MembershipError::NotInRoom,
+            Err(crate::SignalFishError::AlreadyInRoom) => MembershipError::AlreadyInRoom,
+            Err(crate::SignalFishError::WrongRoomRole {
+                required: RoomRole::Player,
+                actual: RoomRole::Spectator,
+            }) => MembershipError::NeedsPlayer,
+            Err(crate::SignalFishError::WrongRoomRole {
+                required: RoomRole::Spectator,
+                actual: RoomRole::Player,
+            }) => MembershipError::NeedsSpectator,
+            _ => MembershipError::None,
+        }
+    }
+
+    fn operation_matrix() -> Vec<(
+        &'static str,
+        ClientOperation,
+        MembershipError,
+        MembershipError,
+        MembershipError,
+    )> {
+        let player_only = |name, operation| {
+            (
+                name,
+                operation,
+                MembershipError::NotInRoom,
+                MembershipError::None,
+                MembershipError::NeedsPlayer,
+            )
+        };
+        vec![
+            (
+                "join room",
+                ClientOperation::JoinRoom(JoinRoomParams::new("game", "local")),
+                MembershipError::None,
+                MembershipError::AlreadyInRoom,
+                MembershipError::AlreadyInRoom,
+            ),
+            player_only("leave room", ClientOperation::LeaveRoom),
+            player_only(
+                "reliable data",
+                ClientOperation::GameData(
+                    serde_json::json!({"value": 1}),
+                    GameDataDelivery::Reliable,
+                ),
+            ),
+            player_only(
+                "latest data",
+                ClientOperation::GameData(
+                    serde_json::json!({"value": 1}),
+                    GameDataDelivery::Latest { key: 7 },
+                ),
+            ),
+            player_only("binary data", ClientOperation::Binary(vec![1])),
+            player_only("ready", ClientOperation::SetReady),
+            player_only("start", ClientOperation::StartGame),
+            player_only("request authority", ClientOperation::RequestAuthority(true)),
+            player_only(
+                "connection info",
+                ClientOperation::ProvideConnectionInfo(ConnectionInfo::Direct {
+                    host: "127.0.0.1".into(),
+                    port: 7_777,
+                }),
+            ),
+            (
+                "reconnect",
+                ClientOperation::Reconnect(
+                    PlayerId::from_u128(LOCAL),
+                    RoomId::from_u128(10),
+                    "token".into(),
+                ),
+                MembershipError::None,
+                MembershipError::AlreadyInRoom,
+                MembershipError::AlreadyInRoom,
+            ),
+            (
+                "join spectator",
+                ClientOperation::JoinAsSpectator("game".into(), "ROOM".into(), "viewer".into()),
+                MembershipError::None,
+                MembershipError::AlreadyInRoom,
+                MembershipError::AlreadyInRoom,
+            ),
+            (
+                "leave spectator",
+                ClientOperation::LeaveSpectator,
+                MembershipError::NotInRoom,
+                MembershipError::NeedsSpectator,
+                MembershipError::None,
+            ),
+            (
+                "ping",
+                ClientOperation::Ping,
+                MembershipError::None,
+                MembershipError::None,
+                MembershipError::None,
+            ),
+            player_only(
+                "signal",
+                ClientOperation::Signal(
+                    PlayerId::from_u128(PEER),
+                    SignalGeneration::Current,
+                    PeerSignal::Offer("sdp".into()),
+                ),
+            ),
+            player_only(
+                "raw signal",
+                ClientOperation::RawSignal(
+                    PlayerId::from_u128(PEER),
+                    SignalGeneration::Current,
+                    serde_json::json!({"Custom": true}),
+                ),
+            ),
+            player_only(
+                "transport status",
+                ClientOperation::TransportStatus(TransportKind::WebRtc, true),
+            ),
+        ]
+    }
+
+    #[test]
+    fn operation_membership_matrix_is_exhaustive_and_role_specific() {
+        for (name, operation, outside, player, spectator) in operation_matrix() {
+            let outside_core = ClientCore::new(
+                Some(GameDataEncoding::Json),
+                ProtocolViolationPolicy::Observe,
+                true,
+            );
+            assert_eq!(
+                membership_error(outside_core.validate(&operation)),
+                outside,
+                "{name}"
+            );
+
+            let player_core = v3_room(ProtocolViolationPolicy::Observe);
+            assert_eq!(
+                membership_error(player_core.validate(&operation)),
+                player,
+                "{name}"
+            );
+
+            let spectator_core = v3_spectator(ProtocolViolationPolicy::Observe);
+            assert_eq!(
+                membership_error(spectator_core.validate(&operation)),
+                spectator,
+                "{name}"
+            );
+        }
+    }
+
+    #[test]
+    fn admitted_room_transitions_fence_fifo_commands_and_failures_roll_back() {
+        let mut joining = ClientCore::new(
+            Some(GameDataEncoding::Json),
+            ProtocolViolationPolicy::Observe,
+            true,
+        );
+        let _ = process(&mut joining, authenticated());
+        let _ = process(&mut joining, protocol_info(Some(3)));
+        let join = ClientOperation::JoinRoom(JoinRoomParams::new("game", "local"));
+        joining.validate(&join).expect("first join is valid");
+        joining.record_admission(ClientCore::admission_for(&join));
+        assert!(matches!(
+            joining.validate(&ClientOperation::JoinRoom(JoinRoomParams::new(
+                "game", "local"
+            ))),
+            Err(crate::SignalFishError::RoomOperationPending)
+        ));
+        let _ = process(
+            &mut joining,
+            ServerMessage::RoomJoinFailed {
+                reason: "full".into(),
+                error_code: None,
+            },
+        );
+        joining
+            .validate(&ClientOperation::JoinRoom(JoinRoomParams::new(
+                "game", "local",
+            )))
+            .expect("failed join clears the admission fence");
+
+        let mut leaving = v3_room(ProtocolViolationPolicy::Observe);
+        let leave = ClientOperation::LeaveRoom;
+        leaving.validate(&leave).expect("player may leave");
+        leaving.record_admission(ClientCore::admission_for(&leave));
+        assert!(matches!(
+            leaving.validate(&ClientOperation::GameData(
+                serde_json::json!({"after": "leave"}),
+                GameDataDelivery::Reliable,
+            )),
+            Err(crate::SignalFishError::RoomOperationPending)
+        ));
+        let _ = process(&mut leaving, ServerMessage::RoomLeft);
+        assert_eq!(leaving.room_role(), None);
+        assert!(leaving.snapshot().player_id.is_none());
+        assert!(matches!(
+            leaving.validate(&ClientOperation::GameData(
+                serde_json::json!({"after": "left"}),
+                GameDataDelivery::Reliable,
+            )),
+            Err(crate::SignalFishError::NotInRoom)
+        ));
+    }
+
+    #[test]
+    fn pending_room_responses_are_correlated_and_unattributed_errors_stay_fenced() {
+        let mut player_join = ClientCore::new(
+            Some(GameDataEncoding::Json),
+            ProtocolViolationPolicy::Observe,
+            true,
+        );
+        let _ = process(&mut player_join, authenticated());
+        let _ = process(&mut player_join, protocol_info(Some(3)));
+        let join = ClientOperation::JoinRoom(JoinRoomParams::new("game", "local"));
+        player_join.record_admission(ClientCore::admission_for(&join));
+        let before = player_join.snapshot();
+        let outcome = process(&mut player_join, spectator_joined());
+        assert_lifecycle_violation(&outcome);
+        assert_eq!(player_join.snapshot(), before);
+        assert_eq!(
+            player_join.pending_room_operation,
+            Some(PendingRoomOperation::JoinPlayer)
+        );
+
+        let mut spectator_join = ClientCore::new(
+            Some(GameDataEncoding::Json),
+            ProtocolViolationPolicy::Observe,
+            true,
+        );
+        let _ = process(&mut spectator_join, authenticated());
+        let _ = process(&mut spectator_join, protocol_info(Some(3)));
+        let join = ClientOperation::JoinAsSpectator("game".into(), "ROOM".into(), "viewer".into());
+        spectator_join.record_admission(ClientCore::admission_for(&join));
+        let before = spectator_join.snapshot();
+        let outcome = process(&mut spectator_join, room_joined());
+        assert_lifecycle_violation(&outcome);
+        assert_eq!(spectator_join.snapshot(), before);
+        assert_eq!(
+            spectator_join.pending_room_operation,
+            Some(PendingRoomOperation::JoinSpectator)
+        );
+
+        let mut player_leave = v3_room(ProtocolViolationPolicy::Observe);
+        player_leave.record_admission(ClientCore::admission_for(&ClientOperation::LeaveRoom));
+        let outcome = process(
+            &mut player_leave,
+            ServerMessage::Error {
+                message: "leave failed; retry".into(),
+                error_code: Some(crate::ErrorCode::NotInRoom),
+            },
+        );
+        assert!(matches!(
+            outcome.events.as_slice(),
+            [SignalFishEvent::Error { .. }]
+        ));
+        assert_eq!(player_leave.room_role(), Some(RoomRole::Player));
+        assert!(matches!(
+            player_leave.validate(&ClientOperation::GameData(
+                serde_json::json!({"after": "unattributed-error"}),
+                GameDataDelivery::Reliable,
+            )),
+            Err(crate::SignalFishError::RoomOperationPending)
+        ));
+
+        let mut spectator_leave = v3_spectator(ProtocolViolationPolicy::Observe);
+        spectator_leave
+            .record_admission(ClientCore::admission_for(&ClientOperation::LeaveSpectator));
+        let before = spectator_leave.snapshot();
+        let outcome = process(
+            &mut spectator_leave,
+            ServerMessage::SpectatorLeft {
+                room_id: Some(RoomId::from_u128(999)),
+                room_code: Some("OTHER".into()),
+                reason: None,
+                current_spectators: vec![],
+            },
+        );
+        assert_lifecycle_violation(&outcome);
+        assert_eq!(spectator_leave.snapshot(), before);
+        assert_eq!(
+            spectator_leave.pending_room_operation,
+            Some(PendingRoomOperation::LeaveSpectator)
+        );
     }
 
     fn peer(id: u128) -> SessionPeer {
@@ -1899,6 +2481,101 @@ mod tests {
     }
 
     #[test]
+    fn authority_baselines_and_changes_are_cross_field_validated_transactionally() {
+        let invalid_baselines = [
+            {
+                let ServerMessage::RoomJoined(mut payload) = room_joined() else {
+                    unreachable!("room_joined helper always returns RoomJoined")
+                };
+                payload.is_authority = false;
+                ServerMessage::RoomJoined(payload)
+            },
+            {
+                let ServerMessage::RoomJoined(mut payload) = room_joined() else {
+                    unreachable!("room_joined helper always returns RoomJoined")
+                };
+                payload.current_players[1].is_authority = true;
+                ServerMessage::RoomJoined(payload)
+            },
+        ];
+        for message in invalid_baselines {
+            let mut core = ClientCore::new(
+                Some(GameDataEncoding::Json),
+                ProtocolViolationPolicy::Observe,
+                true,
+            );
+            let _ = process(&mut core, authenticated());
+            let _ = process(&mut core, protocol_info(Some(3)));
+            let before = core.snapshot();
+            let outcome = process(&mut core, message);
+            assert_lifecycle_violation(&outcome);
+            assert_eq!(core.snapshot(), before);
+            assert_eq!(core.authority_player, None);
+        }
+
+        let mut core = v3_room(ProtocolViolationPolicy::Observe);
+        let invalid_changes = [
+            ServerMessage::AuthorityChanged {
+                authority_player: Some(PlayerId::from_u128(PEER)),
+                you_are_authority: true,
+            },
+            ServerMessage::AuthorityChanged {
+                authority_player: Some(PlayerId::from_u128(999)),
+                you_are_authority: false,
+            },
+        ];
+        for message in invalid_changes {
+            let outcome = process(&mut core, message);
+            assert_lifecycle_violation(&outcome);
+            assert_eq!(core.authority_player, Some(PlayerId::from_u128(LOCAL)));
+            core.validate(&ClientOperation::RequestAuthority(false))
+                .expect("invalid change must not revoke local authority");
+        }
+
+        let mut second_authority = player(99);
+        second_authority.is_authority = true;
+        let outcome = process(
+            &mut core,
+            ServerMessage::PlayerJoined {
+                player: second_authority,
+            },
+        );
+        assert_lifecycle_violation(&outcome);
+        assert_eq!(core.authority_player, Some(PlayerId::from_u128(LOCAL)));
+
+        let outcome = process(
+            &mut core,
+            ServerMessage::AuthorityChanged {
+                authority_player: Some(PlayerId::from_u128(PEER)),
+                you_are_authority: false,
+            },
+        );
+        assert!(matches!(
+            outcome.events.as_slice(),
+            [SignalFishEvent::AuthorityChanged { .. }]
+        ));
+        assert!(matches!(
+            core.validate(&ClientOperation::RequestAuthority(false)),
+            Err(crate::SignalFishError::AuthorityRequired)
+        ));
+        assert!(matches!(
+            core.validate(&ClientOperation::StartGame),
+            Err(crate::SignalFishError::AuthorityRequired)
+        ));
+
+        let _ = process(
+            &mut core,
+            ServerMessage::PlayerLeft {
+                player_id: PlayerId::from_u128(PEER),
+                epoch: Some(1),
+                final_seq: Some(0),
+            },
+        );
+        core.validate(&ClientOperation::StartGame)
+            .expect("any player may start when the room has no authority");
+    }
+
+    #[test]
     fn generationless_server_04_plan_remains_valid_when_its_shape_is_canonical() {
         let mut core = v3_room(ProtocolViolationPolicy::Observe);
         let mut legacy = plan(Topology::Mesh, TransportKind::WebRtc);
@@ -2160,7 +2837,7 @@ mod tests {
                 let mut expected = before;
                 expected.quarantined = policy == ProtocolViolationPolicy::Quarantine;
                 assert_eq!(core.snapshot(), expected, "{name}");
-                assert_eq!(core.membership, Membership::None, "{name}");
+                assert_eq!(core.room_role(), None, "{name}");
                 assert!(!core.session_plan_seen, "{name}");
                 assert!(core.session_peers.is_empty(), "{name}");
             }
@@ -2227,7 +2904,7 @@ mod tests {
                 outcome.events.as_slice(),
                 [SignalFishEvent::Reconnected { .. }]
             ));
-            assert_eq!(core.membership, Membership::Player);
+            assert_eq!(core.room_role(), Some(RoomRole::Player));
         }
     }
 
@@ -2377,7 +3054,6 @@ mod tests {
             ));
             let before = core.snapshot();
             let peers_before = core.session_peers.clone();
-            core.membership = Membership::None;
             core.record_reconnect_admitted(
                 PlayerId::from_u128(LOCAL),
                 RoomId::from_u128(10),
@@ -2398,7 +3074,6 @@ mod tests {
             assert_eq!(core.snapshot(), expected);
             assert_eq!(core.session_peers, peers_before);
 
-            core.membership = Membership::Player;
             core.snapshot.quarantined = false;
             let next = process(
                 &mut core,

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,6 +2,7 @@
 
 use crate::error_codes::ErrorCode;
 use crate::protocol::SessionGeneration;
+use crate::RoomRole;
 use thiserror::Error;
 
 /// Errors that can occur when using the Signal Fish client.
@@ -50,6 +51,29 @@ pub enum SignalFishError {
     /// Attempted a room operation but the client is not in a room.
     #[error("not in a room")]
     NotInRoom,
+
+    /// Attempted to join or reconnect while already in a room.
+    #[error("already in a room")]
+    AlreadyInRoom,
+
+    /// Attempted a room operation while a prior room transition awaits a
+    /// matching typed terminal response. Generic errors stay fenced until
+    /// connection teardown.
+    #[error("a room join, leave, or reconnect operation is already pending")]
+    RoomOperationPending,
+
+    /// Attempted an operation that is not valid for the current room role.
+    #[error("operation requires the {required} room role, but the current role is {actual}")]
+    WrongRoomRole {
+        /// Role required by the attempted operation.
+        required: RoomRole,
+        /// Current server-confirmed role.
+        actual: RoomRole,
+    },
+
+    /// Attempted an operation reserved for the room's current authority.
+    #[error("operation requires the room's current authority role")]
+    AuthorityRequired,
 
     /// The server returned an error message.
     #[error("server error: {message}")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,7 +134,7 @@ pub const PROTOCOL_VERSION: u16 = 3;
 // Re-export primary types for ergonomic imports.
 pub use client::{
     ClientSnapshot, ClientStats, GameDataDelivery, JoinRoomParams, ProtocolViolationPolicy,
-    SignalFishClient, SignalFishConfig,
+    RoomRole, SignalFishClient, SignalFishConfig,
 };
 pub use client_api::SignalFishClientApi;
 pub use error::SignalFishError;

--- a/src/polling_client.rs
+++ b/src/polling_client.rs
@@ -23,7 +23,7 @@ use std::time::{Duration, Instant};
 
 use tracing::{debug, error};
 
-use crate::client::{ClientSnapshot, GameDataDelivery, JoinRoomParams, SignalFishConfig};
+use crate::client::{ClientSnapshot, GameDataDelivery, JoinRoomParams, RoomRole, SignalFishConfig};
 use crate::client_core::{
     ClientCore, ClientOperation, CoreCommand as PollingCommand, SignalGeneration,
 };
@@ -420,7 +420,9 @@ impl<T: Transport> SignalFishPollingClient<T> {
     ///
     /// # Errors
     ///
-    /// Returns [`SignalFishError::NotConnected`] if the transport has closed,
+    /// Returns [`SignalFishError::AlreadyInRoom`] when membership already
+    /// exists, [`SignalFishError::RoomOperationPending`] during another room
+    /// transition, [`SignalFishError::NotConnected`] if the transport has closed,
     /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
     /// is full (the message is **not** queued; nothing is silently dropped).
     pub fn join_room(&mut self, params: JoinRoomParams) -> Result<()> {
@@ -431,7 +433,10 @@ impl<T: Transport> SignalFishPollingClient<T> {
     ///
     /// # Errors
     ///
-    /// Returns [`SignalFishError::NotConnected`] if the transport has closed,
+    /// Returns [`SignalFishError::NotInRoom`] outside a room,
+    /// [`SignalFishError::WrongRoomRole`] as a spectator,
+    /// [`SignalFishError::RoomOperationPending`] during another room transition,
+    /// [`SignalFishError::NotConnected`] if the transport has closed,
     /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
     /// is full (the message is **not** queued; nothing is silently dropped).
     pub fn leave_room(&mut self) -> Result<()> {
@@ -442,7 +447,10 @@ impl<T: Transport> SignalFishPollingClient<T> {
     ///
     /// # Errors
     ///
-    /// Returns [`SignalFishError::NotConnected`] if the transport has closed,
+    /// Returns [`SignalFishError::NotInRoom`] outside a room,
+    /// [`SignalFishError::WrongRoomRole`] as a spectator,
+    /// [`SignalFishError::RoomOperationPending`] during a room transition,
+    /// [`SignalFishError::NotConnected`] if the transport has closed,
     /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
     /// is full (the message is **not** queued; nothing is silently dropped).
     pub fn send_game_data(&mut self, data: serde_json::Value) -> Result<()> {
@@ -450,6 +458,13 @@ impl<T: Transport> SignalFishPollingClient<T> {
     }
 
     /// Send JSON game data with an explicit protocol-v3 delivery policy.
+    ///
+    /// # Errors
+    ///
+    /// Returns the membership/queue errors documented by
+    /// [`send_game_data`](Self::send_game_data), or
+    /// [`SignalFishError::ProtocolUnsupported`] for a non-reliable delivery
+    /// class before protocol v3 is negotiated.
     pub fn send_game_data_with_delivery(
         &mut self,
         data: serde_json::Value,
@@ -459,6 +474,13 @@ impl<T: Transport> SignalFishPollingClient<T> {
     }
 
     /// Queue opaque binary game data for the negotiated protocol-v3 relay.
+    ///
+    /// # Errors
+    ///
+    /// Returns the membership errors documented by
+    /// [`send_game_data`](Self::send_game_data),
+    /// [`SignalFishError::ProtocolUnsupported`] before v3 negotiation, or
+    /// [`SignalFishError::BinaryFormatNotNegotiated`] in JSON mode.
     pub fn send_binary_game_data(&mut self, payload: Vec<u8>) -> Result<()> {
         self.queue_operation(ClientOperation::Binary(payload))
     }
@@ -467,7 +489,10 @@ impl<T: Transport> SignalFishPollingClient<T> {
     ///
     /// # Errors
     ///
-    /// Returns [`SignalFishError::NotConnected`] if the transport has closed,
+    /// Returns [`SignalFishError::NotInRoom`],
+    /// [`SignalFishError::WrongRoomRole`], or
+    /// [`SignalFishError::RoomOperationPending`] for invalid membership state,
+    /// [`SignalFishError::NotConnected`] if the transport has closed,
     /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
     /// is full (the message is **not** queued; nothing is silently dropped).
     pub fn set_ready(&mut self) -> Result<()> {
@@ -478,7 +503,12 @@ impl<T: Transport> SignalFishPollingClient<T> {
     ///
     /// # Errors
     ///
-    /// Returns [`SignalFishError::NotConnected`] if the transport has closed,
+    /// Returns [`SignalFishError::NotInRoom`],
+    /// [`SignalFishError::WrongRoomRole`], or
+    /// [`SignalFishError::RoomOperationPending`] for invalid membership state,
+    /// [`SignalFishError::AuthorityRequired`]
+    /// when relinquishing authority without holding it,
+    /// [`SignalFishError::NotConnected`] if the transport has closed,
     /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
     /// is full (the message is **not** queued; nothing is silently dropped).
     pub fn request_authority(&mut self, become_authority: bool) -> Result<()> {
@@ -489,7 +519,10 @@ impl<T: Transport> SignalFishPollingClient<T> {
     ///
     /// # Errors
     ///
-    /// Returns [`SignalFishError::NotConnected`] if the transport has closed,
+    /// Returns [`SignalFishError::NotInRoom`],
+    /// [`SignalFishError::WrongRoomRole`], or
+    /// [`SignalFishError::RoomOperationPending`] for invalid membership state,
+    /// [`SignalFishError::NotConnected`] if the transport has closed,
     /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
     /// is full (the message is **not** queued; nothing is silently dropped).
     pub fn provide_connection_info(&mut self, connection_info: ConnectionInfo) -> Result<()> {
@@ -500,7 +533,9 @@ impl<T: Transport> SignalFishPollingClient<T> {
     ///
     /// # Errors
     ///
-    /// Returns [`SignalFishError::NotConnected`] if the transport has closed,
+    /// Returns [`SignalFishError::AlreadyInRoom`] when membership already
+    /// exists, [`SignalFishError::RoomOperationPending`] during another room
+    /// transition, [`SignalFishError::NotConnected`] if the transport has closed,
     /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
     /// is full (the message is **not** queued; nothing is silently dropped).
     pub fn reconnect(
@@ -516,7 +551,9 @@ impl<T: Transport> SignalFishPollingClient<T> {
     ///
     /// # Errors
     ///
-    /// Returns [`SignalFishError::NotConnected`] if the transport has closed,
+    /// Returns [`SignalFishError::AlreadyInRoom`] when membership already
+    /// exists, [`SignalFishError::RoomOperationPending`] during another room
+    /// transition, [`SignalFishError::NotConnected`] if the transport has closed,
     /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
     /// is full (the message is **not** queued; nothing is silently dropped).
     pub fn join_as_spectator(
@@ -536,7 +573,10 @@ impl<T: Transport> SignalFishPollingClient<T> {
     ///
     /// # Errors
     ///
-    /// Returns [`SignalFishError::NotConnected`] if the transport has closed,
+    /// Returns [`SignalFishError::NotInRoom`] outside a room,
+    /// [`SignalFishError::WrongRoomRole`] as a player,
+    /// [`SignalFishError::RoomOperationPending`] during another room transition,
+    /// [`SignalFishError::NotConnected`] if the transport has closed,
     /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
     /// is full (the message is **not** queued; nothing is silently dropped).
     pub fn leave_spectator(&mut self) -> Result<()> {
@@ -564,7 +604,11 @@ impl<T: Transport> SignalFishPollingClient<T> {
     ///
     /// # Errors
     ///
-    /// Returns [`SignalFishError::NotConnected`] if the transport has closed,
+    /// Returns [`SignalFishError::NotInRoom`],
+    /// [`SignalFishError::WrongRoomRole`], or
+    /// [`SignalFishError::RoomOperationPending`] for invalid membership state,
+    /// [`SignalFishError::AuthorityRequired`] when another authority is assigned,
+    /// [`SignalFishError::NotConnected`] if the transport has closed,
     /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
     /// is full (the message is **not** queued; nothing is silently dropped).
     pub fn start_game(&mut self) -> Result<()> {
@@ -586,6 +630,9 @@ impl<T: Transport> SignalFishPollingClient<T> {
     /// no authoritative WebRTC plan authorizes `to` (including no plan, a
     /// non-WebRTC plan, self, or a target absent from the latest plan/current
     /// room roster),
+    /// [`SignalFishError::NotInRoom`] outside a room,
+    /// [`SignalFishError::WrongRoomRole`] as a spectator,
+    /// [`SignalFishError::RoomOperationPending`] during a room transition,
     /// [`SignalFishError::NotConnected`] if the transport has closed, or
     /// [`SignalFishError::SendBufferFull`] if the outgoing command queue is full.
     pub fn send_signal(&mut self, to: PlayerId, signal: impl Into<PeerSignal>) -> Result<()> {
@@ -683,7 +730,8 @@ impl<T: Transport> SignalFishPollingClient<T> {
     /// # Errors
     ///
     /// Returns [`SignalFishError::ProtocolUnsupported`] if the connection has not
-    /// negotiated protocol v3, [`SignalFishError::NotConnected`] if the
+    /// negotiated protocol v3, the membership errors documented by
+    /// [`send_signal`](Self::send_signal), [`SignalFishError::NotConnected`] if the
     /// transport has closed, or [`SignalFishError::SendBufferFull`] if the
     /// outgoing command queue is full.
     pub fn report_transport_status(
@@ -757,9 +805,18 @@ impl<T: Transport> SignalFishPollingClient<T> {
         self.core.is_authenticated()
     }
 
-    /// The local player's ID, set after joining a room.
+    /// The local room participant ID, for either a player or spectator.
+    ///
+    /// This legacy accessor name is retained for compatibility. Use one
+    /// [`snapshot`](Self::snapshot) and match its `room_role` with `player_id`
+    /// when the interpretation must be atomic. Both values clear on exit.
     pub fn current_player_id(&self) -> Option<PlayerId> {
         self.core.current_player_id()
+    }
+
+    /// The server-confirmed local role in the current room.
+    pub fn room_role(&self) -> Option<RoomRole> {
+        self.core.room_role()
     }
 
     /// The current room ID, set after joining a room.
@@ -874,18 +931,10 @@ impl<T: Transport> SignalFishPollingClient<T> {
     // ── Private helpers ─────────────────────────────────────────────
 
     fn queue_operation(&mut self, operation: ClientOperation) -> Result<()> {
-        let reconnect_request = match &operation {
-            ClientOperation::Reconnect(player_id, room_id, token) => {
-                Some((*player_id, *room_id, token.clone()))
-            }
-            _ => None,
-        };
+        let admission = ClientCore::admission_for(&operation);
         let command = self.core.prepare(operation)?;
         self.queue_command_at(command, Instant::now())?;
-        if let Some((player_id, room_id, token)) = reconnect_request {
-            self.core
-                .record_reconnect_admitted(player_id, room_id, token);
-        }
+        self.core.record_admission(admission);
         Ok(())
     }
 
@@ -1572,7 +1621,7 @@ mod tests {
                     seq: Some(0),
                 },
             ],
-            is_authority: false,
+            is_authority: true,
             lobby_state: crate::protocol::LobbyState::Lobby,
             ready_players: vec![],
             relay_type: "matchbox".into(),
@@ -1695,6 +1744,23 @@ mod tests {
             .expect("room fixture")
             .expect("valid room fixture");
         let _ = client.core.process_frame(TransportFrame::Text(room));
+    }
+
+    fn prime_v3_room<T: Transport>(client: &mut SignalFishPollingClient<T>) {
+        for item in finalized_v3_room_incoming(uuid::Uuid::from_u128(7), []) {
+            let frame = item
+                .expect("v3 room fixture item")
+                .expect("valid v3 room fixture");
+            let _ = client.core.process_frame(TransportFrame::Text(frame));
+        }
+    }
+
+    fn prime_spectator<T: Transport>(client: &mut SignalFishPollingClient<T>) {
+        prime_connection(client);
+        let joined = r#"{"type":"SpectatorJoined","data":{"room_id":"00000000-0000-0000-0000-000000000001","room_code":"SPEC1","spectator_id":"00000000-0000-0000-0000-000000000004","game_name":"test-game","current_players":[],"current_spectators":[],"lobby_state":"waiting"}}"#;
+        let _ = client
+            .core
+            .process_frame(TransportFrame::Text(joined.to_string()));
     }
 
     fn v2_player(id: PlayerId) -> crate::protocol::PlayerInfo {
@@ -1822,14 +1888,7 @@ mod tests {
     fn binary_send_requires_a_negotiated_binary_format() {
         let transport = MockTransport::new();
         let mut client = SignalFishPollingClient::new(transport, default_config().enable_v3());
-        let protocol_info = serde_json::to_string(&ServerMessage::ProtocolInfo(protocol_info_v3()))
-            .expect("serialize protocol negotiation fixture");
-        let _ = client
-            .core
-            .process_frame(TransportFrame::Text(authenticated_json_str().to_string()));
-        let _ = client
-            .core
-            .process_frame(TransportFrame::Text(protocol_info));
+        prime_v3_room(&mut client);
         assert!(matches!(
             client.send_binary_game_data(vec![1, 2, 3]),
             Err(SignalFishError::BinaryFormatNotNegotiated)
@@ -1839,14 +1898,7 @@ mod tests {
         let mut config = default_config().enable_v3();
         config.game_data_format = Some(GameDataEncoding::MessagePack);
         let mut client = SignalFishPollingClient::new(transport, config);
-        let protocol_info = serde_json::to_string(&ServerMessage::ProtocolInfo(protocol_info_v3()))
-            .expect("serialize protocol negotiation fixture");
-        let _ = client
-            .core
-            .process_frame(TransportFrame::Text(authenticated_json_str().to_string()));
-        let _ = client
-            .core
-            .process_frame(TransportFrame::Text(protocol_info));
+        prime_v3_room(&mut client);
         client
             .send_binary_game_data(vec![1, 2, 3])
             .expect("MessagePack negotiation permits binary sends");
@@ -2156,9 +2208,9 @@ mod tests {
 
     #[test]
     fn start_game_queues_start_game_message() {
-        let transport = MockTransport::new()
-            .with_incoming(vec![Some(Ok(authenticated_json_str().to_string()))]);
+        let transport = MockTransport::new();
         let mut client = SignalFishPollingClient::new(transport, default_config());
+        prime_room(&mut client);
         client.poll();
         client.start_game().expect("start_game");
         client.poll();
@@ -2168,7 +2220,7 @@ mod tests {
     }
 
     #[test]
-    fn send_signal_before_v3_returns_protocol_unsupported() {
+    fn send_signal_outside_room_returns_not_in_room_before_negotiation() {
         let transport = MockTransport::new()
             .with_incoming(vec![Some(Ok(authenticated_json_str().to_string()))]);
         let mut client = SignalFishPollingClient::new(transport, default_config().enable_mesh());
@@ -2176,14 +2228,10 @@ mod tests {
         assert!(client.negotiated_protocol_version().is_none());
         assert!(!client.supports_mesh());
         let peer: PlayerId = PEER_UUID.parse().unwrap();
-        // Authenticated but no `ProtocolInfo` yet → negotiation in flight, so
-        // the guard reports "pre-negotiation" (NOT "relay-only", which requires
-        // an observed v2 `ProtocolInfo` — see `v2_protocol_info_is_relay_only`).
+        // Membership validity takes precedence over protocol negotiation.
         assert!(matches!(
             client.send_offer(peer, "sdp"),
-            Err(SignalFishError::ProtocolUnsupported {
-                mode: "pre-negotiation"
-            })
+            Err(SignalFishError::NotInRoom)
         ));
         // Nothing v3 reached the wire (the guard runs before enqueue).
         client.poll();
@@ -2193,7 +2241,7 @@ mod tests {
     }
 
     #[test]
-    fn v2_protocol_info_is_relay_only() {
+    fn v2_protocol_guard_runs_after_player_membership_guard() {
         // A v2 `ProtocolInfo` (no version field) is a terminal relay floor: the
         // guard reports "relay-only", distinct from the "pre-negotiation" state
         // before any `ProtocolInfo` arrives.
@@ -2203,6 +2251,7 @@ mod tests {
         ]);
         let mut client = SignalFishPollingClient::new(transport, default_config());
         client.poll();
+        prime_room(&mut client);
         assert!(client.negotiated_protocol_version().is_none());
         let peer: PlayerId = PEER_UUID.parse().unwrap();
         assert!(matches!(
@@ -2232,16 +2281,15 @@ mod tests {
     }
 
     #[test]
-    fn send_signal_before_authentication_is_pre_negotiation() {
-        // The `mode: "pre-negotiation"` branch: no poll/auth before the send.
+    fn send_signal_before_authentication_is_not_in_room() {
+        // The handle accepts queued commands before authentication, but
+        // player-only operations still require confirmed membership.
         let transport = MockTransport::new();
         let mut client = SignalFishPollingClient::new(transport, default_config());
         let peer: PlayerId = PEER_UUID.parse().unwrap();
         assert!(matches!(
             client.send_offer(peer, "sdp"),
-            Err(SignalFishError::ProtocolUnsupported {
-                mode: "pre-negotiation"
-            })
+            Err(SignalFishError::NotInRoom)
         ));
     }
 
@@ -2294,11 +2342,9 @@ mod tests {
 
     #[test]
     fn report_transport_status_after_v3_is_queued() {
-        let transport = MockTransport::new().with_incoming(vec![
-            Some(Ok(authenticated_json_str().to_string())),
-            Some(Ok(PROTOCOL_INFO_V3.to_string())),
-        ]);
+        let transport = MockTransport::new();
         let mut client = SignalFishPollingClient::new(transport, default_config());
+        prime_v3_room(&mut client);
         client.poll();
         client
             .report_transport_status(TransportKind::WebRtc, true)
@@ -2361,7 +2407,7 @@ mod tests {
                     seq: Some(0),
                 },
             ],
-            is_authority: false,
+            is_authority: true,
             lobby_state: LobbyState::Finalized,
             ready_players: vec![],
             relay_type: "tcp".into(),
@@ -2616,6 +2662,7 @@ mod tests {
         let mut client = SignalFishPollingClient::new(transport, default_config());
 
         assert_eq!(client.stats(), crate::client::ClientStats::default());
+        let _ = client.poll();
 
         for seq in 0..3 {
             client
@@ -2905,7 +2952,8 @@ mod tests {
 
         assert!(client.current_room_id().is_none());
         assert!(client.current_room_code().is_none());
-        assert!(client.current_player_id().is_some());
+        assert!(client.current_player_id().is_none());
+        assert_eq!(client.room_role(), None);
     }
 
     #[test]
@@ -3001,7 +3049,8 @@ mod tests {
 
         assert!(client.current_room_id().is_none());
         assert!(client.current_room_code().is_none());
-        assert!(client.current_player_id().is_some());
+        assert!(client.current_player_id().is_none());
+        assert_eq!(client.room_role(), None);
     }
 
     #[test]
@@ -3290,6 +3339,7 @@ mod tests {
     fn leave_room_queues_command() {
         let transport = MockTransport::new();
         let mut client = SignalFishPollingClient::new(transport, default_config());
+        prime_room(&mut client);
         client.poll(); // flush auth
 
         client
@@ -3311,6 +3361,7 @@ mod tests {
     fn send_game_data_queues_command() {
         let transport = MockTransport::new();
         let mut client = SignalFishPollingClient::new(transport, default_config());
+        prime_room(&mut client);
         client.poll(); // flush auth
 
         client
@@ -3333,6 +3384,7 @@ mod tests {
     fn set_ready_queues_command() {
         let transport = MockTransport::new();
         let mut client = SignalFishPollingClient::new(transport, default_config());
+        prime_room(&mut client);
         client.poll(); // flush auth
 
         client
@@ -3354,6 +3406,7 @@ mod tests {
     fn request_authority_queues_command() {
         let transport = MockTransport::new();
         let mut client = SignalFishPollingClient::new(transport, default_config());
+        prime_room(&mut client);
         client.poll(); // flush auth
 
         client
@@ -3376,6 +3429,7 @@ mod tests {
     fn provide_connection_info_queues_command() {
         let transport = MockTransport::new();
         let mut client = SignalFishPollingClient::new(transport, default_config());
+        prime_room(&mut client);
         client.poll(); // flush auth
 
         client
@@ -3402,6 +3456,7 @@ mod tests {
     fn provide_relay_connection_info_queues_command() {
         let transport = MockTransport::new();
         let mut client = SignalFishPollingClient::new(transport, default_config());
+        prime_room(&mut client);
         client.poll(); // flush auth
 
         client
@@ -3487,6 +3542,7 @@ mod tests {
     fn leave_spectator_queues_command() {
         let transport = MockTransport::new();
         let mut client = SignalFishPollingClient::new(transport, default_config());
+        prime_spectator(&mut client);
         client.poll(); // flush auth
 
         client
@@ -3747,7 +3803,7 @@ mod tests {
 
     #[test]
     fn poll_receives_authority_changed_event() {
-        let auth_player = uuid::Uuid::from_u128(14);
+        let auth_player = uuid::Uuid::from_u128(9_001);
         let json = serde_json::to_string(&ServerMessage::AuthorityChanged {
             authority_player: Some(auth_player),
             you_are_authority: true,
@@ -4201,6 +4257,7 @@ mod tests {
         };
         let config = default_config().with_command_channel_capacity(3);
         let mut client = SignalFishPollingClient::new(transport, config);
+        prime_room(&mut client);
 
         // Authenticate occupies one of the three slots.
         assert_eq!(client.max_send_capacity(), 3);
@@ -4450,6 +4507,7 @@ mod tests {
             transport,
             default_config().with_command_channel_capacity(2),
         );
+        prime_room(&mut client);
 
         let _ = client.poll();
         assert!(client.send_in_flight, "Authenticate should be in flight");
@@ -5212,7 +5270,7 @@ mod tests {
                 max_players: 6,
                 supports_authority: true,
                 current_players: vec![v2_player(player_id2)],
-                is_authority: true,
+                is_authority: false,
                 lobby_state: crate::protocol::LobbyState::Lobby,
                 ready_players: vec![],
                 relay_type: "tcp".into(),
@@ -5253,35 +5311,35 @@ mod tests {
     fn multiple_commands_in_one_poll() {
         let transport = MockTransport::new();
         let mut client = SignalFishPollingClient::new(transport, default_config());
+        prime_room(&mut client);
         client.poll(); // flush auth
 
         client
             .leave_room()
             .expect("leave_room must succeed on connected client");
-        client
-            .join_room(JoinRoomParams::new("game", "Player"))
-            .expect("join_room must succeed on connected client");
+        assert!(matches!(
+            client.join_room(JoinRoomParams::new("game", "Player")),
+            Err(SignalFishError::RoomOperationPending)
+        ));
         client
             .ping()
             .expect("ping must succeed on connected client");
 
         client.poll();
 
-        // After the initial auth message (index 0), we should have 3 more.
+        // Ping remains connection-scoped while the admitted leave fences all
+        // further room operations until the server confirms the transition.
         assert_eq!(
             client.transport.sent.len(),
-            4,
-            "expected 4 total sent messages (auth + 3 commands), got: {:?}",
+            3,
+            "expected auth, leave, and ping frames, got: {:?}",
             client.transport.sent
         );
         let leave: serde_json::Value = serde_json::from_str(&client.transport.sent[1])
             .expect("leave_room sent message must be valid JSON");
-        let join: serde_json::Value = serde_json::from_str(&client.transport.sent[2])
-            .expect("join_room sent message must be valid JSON");
-        let ping: serde_json::Value = serde_json::from_str(&client.transport.sent[3])
+        let ping: serde_json::Value = serde_json::from_str(&client.transport.sent[2])
             .expect("ping sent message must be valid JSON");
         assert_eq!(leave["type"], "LeaveRoom");
-        assert_eq!(join["type"], "JoinRoom");
         assert_eq!(ping["type"], "Ping");
     }
 

--- a/src/webrtc.rs
+++ b/src/webrtc.rs
@@ -496,16 +496,15 @@ mod controller {
                     self.disconnect_peer(*player_id);
                     self.known_peers.retain(|k| k.id != *player_id);
                 }
-                // The session ended: tear down every peer connection. Route each
-                // through `mark_disconnected` so the 1->0 transport-status edge
-                // still fires a single `TransportStatus(WebRtc, false)` — matching
-                // the per-peer `PlayerLeft` path. On `Disconnected` the underlying
-                // send simply returns `NotConnected` and is harmlessly swallowed;
-                // `mark_disconnected` empties `connected_peers` as it goes.
+                // The session ended: tear down every peer connection. The
+                // authoritative role is already gone when these events surface,
+                // so suppress the obsolete room-scoped TransportStatus(false)
+                // edge while retaining all driver cleanup.
                 SignalFishEvent::RoomLeft
                 | SignalFishEvent::SpectatorJoined { .. }
                 | SignalFishEvent::SpectatorLeft { .. }
                 | SignalFishEvent::Disconnected { .. } => {
+                    self.connected_peers.clear();
                     for peer in std::mem::take(&mut self.known_peers) {
                         self.disconnect_peer(peer.id);
                     }
@@ -2144,12 +2143,10 @@ mod tests {
     // ── Adversarial choreography tests (B1) ─────────────────────────
 
     #[tokio::test]
-    async fn room_left_reports_transport_status_false_when_channel_open() {
-        // Regression for the teardown asymmetry: once a peer's channel is open
-        // (TransportStatus(true) was reported), leaving the room must route the
-        // teardown through `mark_disconnected` so the 1->0 edge still reports
-        // TransportStatus(false). Previously RoomLeft cleared `connected_peers`
-        // directly and the server was never told WebRTC went down.
+    async fn room_left_tears_down_open_channel_without_post_exit_status() {
+        // RoomLeft clears authoritative membership before the controller sees
+        // the event. Driver teardown must still happen, but no now-invalid
+        // room-scoped TransportStatus(false) may be queued afterward.
         let peer = uuid(31);
         let driver = SharedDriver::default();
         let (transport, sent) = MockTransport::new_in_room(vec![
@@ -2179,12 +2176,12 @@ mod tests {
         // Fold RoomLeft only after the channel-open precondition; this test
         // isolates teardown choreography from transport-loop scheduling.
         mesh.handle_event(&SignalFishEvent::RoomLeft);
-        wait_for_sent_count(&sent, &["TransportStatus", "webrtc", "false"], 1).await;
         assert_eq!(
             sent_count(&sent, &["TransportStatus", "webrtc", "false"]),
-            1,
-            "RoomLeft with a live channel must report exactly one TransportStatus(false)"
+            0,
+            "RoomLeft must not emit a room-scoped status after membership ends"
         );
+        assert!(driver.calls().contains(&DriverCall::Disconnect(peer)));
         mesh.shutdown().await;
     }
 

--- a/tests/client_tests.rs
+++ b/tests/client_tests.rs
@@ -2558,7 +2558,7 @@ async fn unknown_server_message_type_surfaces_decode_failed_then_next_arrives() 
 
 #[tokio::test]
 async fn send_signal_before_authentication_is_not_in_room() {
-    // Command queueing remains available before authentication, but a
+    // Command queuing remains available before authentication, but a
     // player-only operation still requires confirmed membership.
     let (mut client, _events, sent, _closed) = start_client(vec![]);
 

--- a/tests/client_tests.rs
+++ b/tests/client_tests.rs
@@ -75,6 +75,27 @@ async fn drain_until_authenticated(rx: &mut tokio::sync::mpsc::Receiver<SignalFi
     );
 }
 
+async fn drain_player_room(rx: &mut tokio::sync::mpsc::Receiver<SignalFishEvent>) {
+    drain_until_authenticated(rx).await;
+    drain_until_protocol_info(rx).await;
+    assert!(matches!(
+        rx.recv().await,
+        Some(SignalFishEvent::RoomJoined { .. })
+    ));
+}
+
+fn player_room_script(
+    tail: impl IntoIterator<Item = Option<Result<String, SignalFishError>>>,
+) -> Vec<Option<Result<String, SignalFishError>>> {
+    let mut incoming = vec![
+        Some(Ok(authenticated_json())),
+        Some(Ok(protocol_info_json(None))),
+        Some(Ok(room_joined_json())),
+    ];
+    incoming.extend(tail);
+    incoming
+}
+
 fn v3_room_baseline_json(peer: uuid::Uuid) -> String {
     let local_player = uuid::Uuid::from_u128(1);
     let message =
@@ -107,7 +128,7 @@ fn v3_room_baseline_json(peer: uuid::Uuid) -> String {
                     seq: Some(0),
                 },
             ],
-            is_authority: false,
+            is_authority: true,
             lobby_state: signal_fish_client::protocol::LobbyState::Finalized,
             ready_players: vec![local_player, peer],
             relay_type: "websocket".into(),
@@ -257,10 +278,7 @@ async fn room_join_leave_rejoin_flow() {
     drain_until_authenticated(&mut events).await;
     drain_until_protocol_info(&mut events).await;
 
-    // Join room.
-    client
-        .join_room(JoinRoomParams::new("test-game", "Alice"))
-        .expect("join_room");
+    // Observe the server-confirmed transitions in order.
     let ev = events.recv().await.expect("event");
     if let SignalFishEvent::RoomJoined {
         room_code,
@@ -274,15 +292,11 @@ async fn room_join_leave_rejoin_flow() {
         panic!("expected RoomJoined, got {ev:?}");
     }
 
-    // Leave room (the RoomLeft event is received).
-    client.leave_room().expect("leave_room");
+    // Leave room.
     let ev = events.recv().await.expect("event");
     assert!(matches!(ev, SignalFishEvent::RoomLeft));
 
-    // Rejoin (the second RoomJoined event arrives immediately).
-    client
-        .join_room(JoinRoomParams::new("test-game", "Alice"))
-        .expect("rejoin");
+    // Rejoin.
     let ev = events.recv().await.expect("event");
     assert!(matches!(ev, SignalFishEvent::RoomJoined { .. }));
 
@@ -371,11 +385,7 @@ async fn spectator_join_and_leave_flow() {
     drain_until_authenticated(&mut events).await;
     drain_until_protocol_info(&mut events).await;
 
-    // Join as spectator.
-    client
-        .join_as_spectator("spec-game".into(), "SPEC1".into(), "Watcher".into())
-        .expect("join_as_spectator");
-
+    // Observe the server-confirmed spectator transitions.
     let ev = events.recv().await.expect("event");
     if let SignalFishEvent::SpectatorJoined {
         room_code,
@@ -392,7 +402,6 @@ async fn spectator_join_and_leave_flow() {
     }
 
     // Leave spectator.
-    client.leave_spectator().expect("leave_spectator");
     let ev = events.recv().await.expect("event");
     assert!(matches!(ev, SignalFishEvent::SpectatorLeft { .. }));
 
@@ -409,14 +418,11 @@ async fn spectator_join_and_leave_flow() {
 
 #[tokio::test]
 async fn authority_request_granted() {
-    let (mut client, mut events, sent, _closed) = start_client(vec![
-        Some(Ok(authenticated_json())),
-        Some(Ok(protocol_info_json(None))),
-        Some(Ok(authority_response_json(true, None))),
-    ]);
+    let (mut client, mut events, sent, _closed) = start_client(player_room_script([Some(Ok(
+        authority_response_json(true, None),
+    ))]));
 
-    drain_until_authenticated(&mut events).await;
-    drain_until_protocol_info(&mut events).await;
+    drain_player_room(&mut events).await;
 
     client.request_authority(true).expect("request_authority");
 
@@ -458,14 +464,11 @@ async fn authority_request_granted() {
 
 #[tokio::test]
 async fn authority_request_denied() {
-    let (mut client, mut events, _sent, _closed) = start_client(vec![
-        Some(Ok(authenticated_json())),
-        Some(Ok(protocol_info_json(None))),
-        Some(Ok(authority_response_json(false, Some("not allowed")))),
-    ]);
+    let (mut client, mut events, _sent, _closed) = start_client(player_room_script([Some(Ok(
+        authority_response_json(false, Some("not allowed")),
+    ))]));
 
-    drain_until_authenticated(&mut events).await;
-    drain_until_protocol_info(&mut events).await;
+    drain_player_room(&mut events).await;
 
     client.request_authority(true).expect("request_authority");
 
@@ -489,10 +492,9 @@ async fn authority_request_denied() {
 
 #[tokio::test]
 async fn provide_connection_info_sends_correct_message() {
-    let (mut client, mut events, sent, _closed) =
-        start_client(vec![Some(Ok(authenticated_json()))]);
+    let (mut client, mut events, sent, _closed) = start_client(player_room_script([]));
 
-    drain_until_authenticated(&mut events).await;
+    drain_player_room(&mut events).await;
 
     let conn_info = ConnectionInfo::Direct {
         host: "192.168.0.1".into(),
@@ -536,10 +538,9 @@ async fn provide_connection_info_sends_correct_message() {
 
 #[tokio::test]
 async fn provide_relay_connection_info() {
-    let (mut client, mut events, sent, _closed) =
-        start_client(vec![Some(Ok(authenticated_json()))]);
+    let (mut client, mut events, sent, _closed) = start_client(player_room_script([]));
 
-    drain_until_authenticated(&mut events).await;
+    drain_player_room(&mut events).await;
 
     let conn_info = ConnectionInfo::Relay {
         host: "relay.example.com".into(),
@@ -631,10 +632,18 @@ async fn join_as_spectator_sends_correct_message() {
 
 #[tokio::test]
 async fn leave_spectator_sends_correct_message() {
-    let (mut client, mut events, sent, _closed) =
-        start_client(vec![Some(Ok(authenticated_json()))]);
+    let (mut client, mut events, sent, _closed) = start_client(vec![
+        Some(Ok(authenticated_json())),
+        Some(Ok(protocol_info_json(None))),
+        Some(Ok(spectator_joined_json())),
+    ]);
 
     drain_until_authenticated(&mut events).await;
+    drain_until_protocol_info(&mut events).await;
+    assert!(matches!(
+        events.recv().await,
+        Some(SignalFishEvent::SpectatorJoined { .. })
+    ));
 
     client.leave_spectator().expect("leave_spectator");
 
@@ -1014,10 +1023,9 @@ async fn async_observe_advances_valid_wrong_representation_sequence() {
 
 #[tokio::test]
 async fn send_game_data_produces_correct_json() {
-    let (mut client, mut events, sent, _closed) =
-        start_client(vec![Some(Ok(authenticated_json()))]);
+    let (mut client, mut events, sent, _closed) = start_client(player_room_script([]));
 
-    drain_until_authenticated(&mut events).await;
+    drain_player_room(&mut events).await;
 
     let data = serde_json::json!({"type": "chat", "msg": "hello"});
     client.send_game_data(data.clone()).expect("send_game_data");
@@ -1055,10 +1063,9 @@ async fn send_game_data_produces_correct_json() {
 
 #[tokio::test]
 async fn set_ready_sends_player_ready_message() {
-    let (mut client, mut events, sent, _closed) =
-        start_client(vec![Some(Ok(authenticated_json()))]);
+    let (mut client, mut events, sent, _closed) = start_client(player_room_script([]));
 
-    drain_until_authenticated(&mut events).await;
+    drain_player_room(&mut events).await;
 
     client.set_ready().expect("set_ready");
 
@@ -1171,54 +1178,28 @@ async fn join_room_with_all_options_sends_correct_message() {
 
 #[tokio::test]
 async fn multiple_sequential_operations() {
-    let player = uuid::Uuid::from_u128(42);
-    let data_msg = game_data_json(player, serde_json::json!({"tick": 1}));
-    let (mut client, mut events, sent, _closed) = start_client(vec![
-        Some(Ok(authenticated_json())),
-        Some(Ok(protocol_info_json(None))),
-        Some(Ok(room_joined_json())),
-        Some(Ok(data_msg)),
-        Some(Ok(pong_json())),
-        Some(Ok(room_left_json())),
-    ]);
-
-    drain_until_authenticated(&mut events).await;
-    drain_until_protocol_info(&mut events).await;
-
-    // Join room.
-    client
-        .join_room(JoinRoomParams::new("game", "Player1"))
-        .expect("join");
-    let ev = events.recv().await.expect("event");
-    assert!(matches!(ev, SignalFishEvent::RoomJoined { .. }));
+    let (mut client, mut events, sent, _closed) = start_client(player_room_script([]));
+    drain_player_room(&mut events).await;
 
     // Send game data.
     client
         .send_game_data(serde_json::json!({"action": "jump"}))
         .expect("send_game_data");
 
-    // Receive server game data.
-    let ev = events.recv().await.expect("event");
-    assert!(matches!(ev, SignalFishEvent::GameData { .. }));
-
     // Ping.
     client.ping().expect("ping");
-    let ev = events.recv().await.expect("event");
-    assert!(matches!(ev, SignalFishEvent::Pong));
 
     // Leave room.
     client.leave_room().expect("leave");
-    let ev = events.recv().await.expect("event");
-    assert!(matches!(ev, SignalFishEvent::RoomLeft));
 
     // Verify all expected messages were sent.
-    wait_for_sent_len(&sent, 5).await;
+    wait_for_sent_len(&sent, 4).await;
     {
         let messages = sent.lock().unwrap();
-        // Should have: Authenticate, JoinRoom, GameData, Ping, LeaveRoom
+        // Should have: Authenticate, GameData, Ping, LeaveRoom.
         assert!(
-            messages.len() >= 5,
-            "expected at least 5 messages, got {}",
+            messages.len() >= 4,
+            "expected at least 4 messages, got {}",
             messages.len()
         );
     }
@@ -1384,7 +1365,7 @@ async fn authority_changed_event() {
     let auth_player = uuid::Uuid::from_u128(77);
     let ac_json = serde_json::to_string(&ServerMessage::AuthorityChanged {
         authority_player: Some(auth_player),
-        you_are_authority: true,
+        you_are_authority: false,
     })
     .expect("serialize");
 
@@ -1409,7 +1390,7 @@ async fn authority_changed_event() {
     } = ev
     {
         assert_eq!(authority_player, Some(auth_player));
-        assert!(you_are_authority);
+        assert!(!you_are_authority);
     } else {
         panic!("expected AuthorityChanged event, got {ev:?}");
     }
@@ -1760,10 +1741,9 @@ async fn shutdown_timeout_clears_state_even_when_disconnected_event_is_skipped()
 
 #[tokio::test]
 async fn leave_room_sends_leave_room_message() {
-    let (mut client, mut events, sent, _closed) =
-        start_client(vec![Some(Ok(authenticated_json()))]);
+    let (mut client, mut events, sent, _closed) = start_client(player_room_script([]));
 
-    drain_until_authenticated(&mut events).await;
+    drain_player_room(&mut events).await;
 
     client.leave_room().expect("leave_room");
 
@@ -2173,9 +2153,8 @@ fn sent_messages(sent: &std::sync::Arc<std::sync::Mutex<Vec<String>>>) -> Vec<Cl
 
 #[tokio::test]
 async fn start_game_sends_start_game_message() {
-    let (mut client, mut events, sent, _closed) =
-        start_client(vec![Some(Ok(authenticated_json()))]);
-    drain_until_authenticated(&mut events).await;
+    let (mut client, mut events, sent, _closed) = start_client(player_room_script([]));
+    drain_player_room(&mut events).await;
 
     client.start_game().expect("start_game");
     wait_for_sent_len(&sent, 2).await;
@@ -2189,9 +2168,8 @@ async fn start_game_sends_start_game_message() {
 #[tokio::test]
 async fn start_game_available_on_relay_floor() {
     // start_game is the universal v2 change — NOT gated behind v3 negotiation.
-    let (mut client, mut events, sent, _closed) =
-        start_client(vec![Some(Ok(authenticated_json()))]);
-    drain_until_authenticated(&mut events).await;
+    let (mut client, mut events, sent, _closed) = start_client(player_room_script([]));
+    drain_player_room(&mut events).await;
     assert!(client.negotiated_protocol_version().is_none());
 
     client
@@ -2205,28 +2183,20 @@ async fn start_game_available_on_relay_floor() {
 }
 
 #[tokio::test]
-async fn send_signal_before_v3_returns_protocol_unsupported() {
+async fn send_signal_outside_room_returns_not_in_room_before_protocol_guard() {
     let (mut client, mut events, sent, _closed) =
         start_client(vec![Some(Ok(authenticated_json()))]);
     drain_until_authenticated(&mut events).await;
 
-    // Authenticated but no `ProtocolInfo` yet → negotiation is still in flight,
-    // so the guard reports "pre-negotiation" (NOT "relay-only", which is
-    // reserved for a `ProtocolInfo` that resolved at the v2 floor — see
-    // `v2_protocol_info_keeps_relay_floor_guard`).
+    // Player membership is checked before protocol negotiation.
     let err = client
         .send_signal(uuid::Uuid::from_u128(2), PeerSignal::Offer("sdp".into()))
         .expect_err("send_signal must fail before negotiation completes");
-    assert!(matches!(
-        err,
-        SignalFishError::ProtocolUnsupported {
-            mode: "pre-negotiation"
-        }
-    ));
+    assert!(matches!(err, SignalFishError::NotInRoom));
     // report_transport_status fails fast too.
     assert!(matches!(
         client.report_transport_status(TransportKind::WebRtc, true),
-        Err(SignalFishError::ProtocolUnsupported { .. })
+        Err(SignalFishError::NotInRoom)
     ));
 
     // No v3 message ever reached the wire.
@@ -2280,9 +2250,14 @@ async fn send_signal_after_v3_but_before_plan_fails_locally() {
     let (mut client, mut events, sent, _closed) = start_client(vec![
         Some(Ok(authenticated_json())),
         Some(Ok(protocol_info_json(Some(3)))),
+        Some(Ok(v3_room_baseline_json(uuid::Uuid::from_u128(2)))),
     ]);
     drain_until_authenticated(&mut events).await;
     drain_until_protocol_info(&mut events).await;
+    assert!(matches!(
+        events.recv().await,
+        Some(SignalFishEvent::RoomJoined { .. })
+    ));
 
     assert!(matches!(
         client.send_offer(uuid::Uuid::from_u128(2), "too-early"),
@@ -2417,9 +2392,14 @@ async fn report_transport_status_after_v3_is_sent() {
     let (mut client, mut events, sent, _closed) = start_client(vec![
         Some(Ok(authenticated_json())),
         Some(Ok(protocol_info_json(Some(3)))),
+        Some(Ok(v3_room_baseline_json(uuid::Uuid::from_u128(2)))),
     ]);
     drain_until_authenticated(&mut events).await;
     drain_until_protocol_info(&mut events).await;
+    assert!(matches!(
+        events.recv().await,
+        Some(SignalFishEvent::RoomJoined { .. })
+    ));
 
     client
         .report_transport_status(TransportKind::WebRtc, true)
@@ -2445,9 +2425,14 @@ async fn v2_protocol_info_keeps_relay_floor_guard() {
     let (mut client, mut events, _sent, _closed) = start_client(vec![
         Some(Ok(authenticated_json())),
         Some(Ok(protocol_info_json(None))),
+        Some(Ok(v2_room_baseline_json(uuid::Uuid::from_u128(2)))),
     ]);
     drain_until_authenticated(&mut events).await;
     drain_until_protocol_info(&mut events).await;
+    assert!(matches!(
+        events.recv().await,
+        Some(SignalFishEvent::RoomJoined { .. })
+    ));
     assert!(client.negotiated_protocol_version().is_none());
     assert!(matches!(
         client.send_offer(uuid::Uuid::from_u128(2), "x"),
@@ -2572,20 +2557,15 @@ async fn unknown_server_message_type_surfaces_decode_failed_then_next_arrives() 
 }
 
 #[tokio::test]
-async fn send_signal_before_authentication_is_pre_negotiation() {
-    // The `mode: "pre-negotiation"` branch of the guard: no auth scripted, so the
-    // client is connected but has not authenticated/negotiated.
+async fn send_signal_before_authentication_is_not_in_room() {
+    // Command queueing remains available before authentication, but a
+    // player-only operation still requires confirmed membership.
     let (mut client, _events, sent, _closed) = start_client(vec![]);
 
     let err = client
         .send_offer(uuid::Uuid::from_u128(2), "sdp")
         .expect_err("send before negotiation must fail");
-    assert!(matches!(
-        err,
-        SignalFishError::ProtocolUnsupported {
-            mode: "pre-negotiation"
-        }
-    ));
+    assert!(matches!(err, SignalFishError::NotInRoom));
     assert!(!client.supports_mesh());
     assert!(sent_messages(&sent)
         .iter()

--- a/tests/polling_parity_tests.rs
+++ b/tests/polling_parity_tests.rs
@@ -30,7 +30,7 @@ use signal_fish_client::protocol::{
     Topology, TransportKind, V2BinaryGameDataFrame, V3BinaryGameDataFrame,
 };
 use signal_fish_client::transport::TransportFrame;
-use signal_fish_client::{ErrorCode, ProtocolViolationPolicy};
+use signal_fish_client::{ErrorCode, ProtocolViolationPolicy, RoomRole};
 use signal_fish_client::{
     GameDataDelivery, JoinRoomParams, PeerSignal, SignalFishClientApi, SignalFishEvent, Transport,
 };
@@ -56,12 +56,23 @@ struct FrameMock {
 #[derive(Clone)]
 struct NeverSendMock {
     attempted: Arc<std::sync::atomic::AtomicBool>,
+    allow: Arc<std::sync::atomic::AtomicBool>,
+    waker: Arc<Mutex<Option<std::task::Waker>>>,
 }
 
 impl NeverSendMock {
     fn new() -> Self {
         Self {
             attempted: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            allow: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            waker: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    fn release(&self) {
+        self.allow.store(true, std::sync::atomic::Ordering::Release);
+        if let Some(waker) = self.waker.lock().unwrap().take() {
+            waker.wake();
         }
     }
 }
@@ -69,11 +80,16 @@ impl NeverSendMock {
 impl Transport for NeverSendMock {
     fn poll_send(
         &mut self,
-        _cx: &mut std::task::Context<'_>,
-        _frame: &mut Option<TransportFrame>,
+        cx: &mut std::task::Context<'_>,
+        frame: &mut Option<TransportFrame>,
     ) -> std::task::Poll<Result<(), SignalFishError>> {
         self.attempted
             .store(true, std::sync::atomic::Ordering::Release);
+        if self.allow.load(std::sync::atomic::Ordering::Acquire) {
+            let _ = frame.take();
+            return std::task::Poll::Ready(Ok(()));
+        }
+        *self.waker.lock().unwrap() = Some(cx.waker().clone());
         std::task::Poll::Pending
     }
 
@@ -93,6 +109,16 @@ impl Transport for NeverSendMock {
 }
 
 impl FrameMock {
+    fn outside() -> Self {
+        Self {
+            incoming: Arc::new(Mutex::new(VecDeque::from([
+                TransportFrame::Text(AUTH.into()),
+                TransportFrame::Text(PI_V3.into()),
+            ]))),
+            sent: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
     fn v3() -> Self {
         Self {
             incoming: Arc::new(Mutex::new(VecDeque::from([
@@ -105,6 +131,80 @@ impl FrameMock {
                     r#"{"type":"SessionPlan","data":{"generation":"00000000-0000-0000-0000-00000000000c","topology":"mesh","transport":"webrtc","peers":[{"player_id":"00000000-0000-0000-0000-000000000007","player_name":"peer","is_authority":false,"initiate":true}],"fallback":"relay"}}"#.into(),
                 ),
             ]))),
+            sent: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn spectator() -> Self {
+        Self {
+            incoming: Arc::new(Mutex::new(VecDeque::from([
+                TransportFrame::Text(AUTH.into()),
+                TransportFrame::Text(PI_V3.into()),
+                TransportFrame::Text(
+                    r#"{"type":"SpectatorJoined","data":{"room_id":"00000000-0000-0000-0000-000000000008","room_code":"ROOM","spectator_id":"00000000-0000-0000-0000-000000000005","game_name":"game","current_players":[{"id":"00000000-0000-0000-0000-000000000009","name":"local","is_authority":true,"is_ready":true,"connected_at":"2026-01-01T00:00:00Z","epoch":1,"seq":0},{"id":"00000000-0000-0000-0000-000000000007","name":"peer","is_authority":false,"is_ready":true,"connected_at":"2026-01-01T00:00:00Z","epoch":1,"seq":0}],"current_spectators":[],"lobby_state":"lobby"}}"#.into(),
+                ),
+            ]))),
+            sent: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn membership_trace(phase: MembershipPhase) -> Self {
+        let base = match phase {
+            MembershipPhase::Outside => Self::outside(),
+            MembershipPhase::Player
+            | MembershipPhase::PlayerLeft
+            | MembershipPhase::PlayerRejoined => Self::v3(),
+            MembershipPhase::Spectator
+            | MembershipPhase::SpectatorLeft
+            | MembershipPhase::SpectatorRejoined => Self::spectator(),
+        };
+        let mut frames = base.incoming.lock().unwrap().clone();
+        match phase {
+            MembershipPhase::PlayerLeft => {
+                frames.push_back(text_server_frame(ServerMessage::RoomLeft));
+            }
+            MembershipPhase::PlayerRejoined => {
+                let rejoined = match &frames[2] {
+                    TransportFrame::Text(frame) => TransportFrame::Text(frame.replace(
+                        "00000000-0000-0000-0000-000000000009",
+                        "00000000-0000-0000-0000-00000000000f",
+                    )),
+                    TransportFrame::Binary(_) => unreachable!("room baseline must be text"),
+                };
+                let plan = frames[3].clone();
+                frames.push_back(text_server_frame(ServerMessage::RoomLeft));
+                frames.push_back(rejoined);
+                frames.push_back(plan);
+            }
+            MembershipPhase::SpectatorLeft => {
+                frames.push_back(text_server_frame(ServerMessage::SpectatorLeft {
+                    room_id: Some(uuid::Uuid::from_u128(8)),
+                    room_code: Some("ROOM".into()),
+                    reason: None,
+                    current_spectators: vec![],
+                }));
+            }
+            MembershipPhase::SpectatorRejoined => {
+                let rejoined = match &frames[2] {
+                    TransportFrame::Text(frame) => TransportFrame::Text(frame.replace(
+                        "00000000-0000-0000-0000-000000000005",
+                        "00000000-0000-0000-0000-00000000000f",
+                    )),
+                    TransportFrame::Binary(_) => unreachable!("spectator baseline must be text"),
+                };
+                frames.push_back(text_server_frame(ServerMessage::SpectatorLeft {
+                    room_id: Some(uuid::Uuid::from_u128(8)),
+                    room_code: Some("ROOM".into()),
+                    reason: None,
+                    current_spectators: vec![],
+                }));
+                frames.push_back(rejoined);
+            }
+            MembershipPhase::Outside | MembershipPhase::Player | MembershipPhase::Spectator => {}
+        }
+        frames.push_back(text_server_frame(ServerMessage::Pong));
+        Self {
+            incoming: Arc::new(Mutex::new(frames)),
             sent: Arc::new(Mutex::new(Vec::new())),
         }
     }
@@ -220,6 +320,167 @@ impl CommonCommandCase {
     }
 }
 
+const ALL_COMMON_COMMANDS: [CommonCommandCase; 22] = [
+    CommonCommandCase::JoinRoom,
+    CommonCommandCase::LeaveRoom,
+    CommonCommandCase::ReliableData,
+    CommonCommandCase::LatestData,
+    CommonCommandCase::VolatileData,
+    CommonCommandCase::BinaryData,
+    CommonCommandCase::SetReady,
+    CommonCommandCase::StartGame,
+    CommonCommandCase::RequestAuthority,
+    CommonCommandCase::ProvideConnectionInfo,
+    CommonCommandCase::Reconnect,
+    CommonCommandCase::JoinSpectator,
+    CommonCommandCase::LeaveSpectator,
+    CommonCommandCase::Ping,
+    CommonCommandCase::Signal,
+    CommonCommandCase::SignalForGeneration,
+    CommonCommandCase::Offer,
+    CommonCommandCase::Answer,
+    CommonCommandCase::IceCandidate,
+    CommonCommandCase::RawSignal,
+    CommonCommandCase::RawSignalForGeneration,
+    CommonCommandCase::TransportStatus,
+];
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum MembershipResult {
+    AdmittedOrLaterGuard,
+    NotInRoom,
+    AlreadyInRoom,
+    NeedsPlayer,
+    NeedsSpectator,
+}
+
+fn membership_result(result: Result<(), SignalFishError>) -> MembershipResult {
+    match result {
+        Err(SignalFishError::NotInRoom) => MembershipResult::NotInRoom,
+        Err(SignalFishError::AlreadyInRoom) => MembershipResult::AlreadyInRoom,
+        Err(SignalFishError::WrongRoomRole {
+            required: RoomRole::Player,
+            actual: RoomRole::Spectator,
+        }) => MembershipResult::NeedsPlayer,
+        Err(SignalFishError::WrongRoomRole {
+            required: RoomRole::Spectator,
+            actual: RoomRole::Player,
+        }) => MembershipResult::NeedsSpectator,
+        _ => MembershipResult::AdmittedOrLaterGuard,
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum MembershipPhase {
+    Outside,
+    Player,
+    PlayerLeft,
+    PlayerRejoined,
+    Spectator,
+    SpectatorLeft,
+    SpectatorRejoined,
+}
+
+fn expected_membership_result(phase: MembershipPhase, case: CommonCommandCase) -> MembershipResult {
+    let no_membership_only = matches!(
+        case,
+        CommonCommandCase::JoinRoom
+            | CommonCommandCase::Reconnect
+            | CommonCommandCase::JoinSpectator
+    );
+    let spectator_only = matches!(case, CommonCommandCase::LeaveSpectator);
+    let any_role = matches!(case, CommonCommandCase::Ping);
+    match phase {
+        MembershipPhase::Outside | MembershipPhase::PlayerLeft | MembershipPhase::SpectatorLeft
+            if no_membership_only || any_role =>
+        {
+            MembershipResult::AdmittedOrLaterGuard
+        }
+        MembershipPhase::Outside | MembershipPhase::PlayerLeft | MembershipPhase::SpectatorLeft => {
+            MembershipResult::NotInRoom
+        }
+        MembershipPhase::Player | MembershipPhase::PlayerRejoined if no_membership_only => {
+            MembershipResult::AlreadyInRoom
+        }
+        MembershipPhase::Player | MembershipPhase::PlayerRejoined if spectator_only => {
+            MembershipResult::NeedsSpectator
+        }
+        MembershipPhase::Player | MembershipPhase::PlayerRejoined => {
+            MembershipResult::AdmittedOrLaterGuard
+        }
+        MembershipPhase::Spectator | MembershipPhase::SpectatorRejoined if no_membership_only => {
+            MembershipResult::AlreadyInRoom
+        }
+        MembershipPhase::Spectator | MembershipPhase::SpectatorRejoined
+            if spectator_only || any_role =>
+        {
+            MembershipResult::AdmittedOrLaterGuard
+        }
+        MembershipPhase::Spectator | MembershipPhase::SpectatorRejoined => {
+            MembershipResult::NeedsPlayer
+        }
+    }
+}
+
+fn frame_mock_for_phase(phase: MembershipPhase) -> FrameMock {
+    FrameMock::membership_trace(phase)
+}
+
+fn expected_membership_state(phase: MembershipPhase) -> (Option<RoomRole>, Option<PlayerId>) {
+    match phase {
+        MembershipPhase::Outside | MembershipPhase::PlayerLeft | MembershipPhase::SpectatorLeft => {
+            (None, None)
+        }
+        MembershipPhase::Player => (Some(RoomRole::Player), Some(uuid::Uuid::from_u128(9))),
+        MembershipPhase::PlayerRejoined => {
+            (Some(RoomRole::Player), Some(uuid::Uuid::from_u128(15)))
+        }
+        MembershipPhase::Spectator => (Some(RoomRole::Spectator), Some(uuid::Uuid::from_u128(5))),
+        MembershipPhase::SpectatorRejoined => {
+            (Some(RoomRole::Spectator), Some(uuid::Uuid::from_u128(15)))
+        }
+    }
+}
+
+async fn async_membership_result(
+    phase: MembershipPhase,
+    case: CommonCommandCase,
+) -> MembershipResult {
+    let (mut client, mut events) = SignalFishClient::start(
+        frame_mock_for_phase(phase),
+        SignalFishConfig::new("app").enable_v3(),
+    );
+    while !matches!(events.recv().await, Some(SignalFishEvent::Pong)) {}
+    let (expected_role, expected_participant) = expected_membership_state(phase);
+    assert_eq!(client.room_role(), expected_role, "async {phase:?}");
+    assert_eq!(
+        client.snapshot().player_id,
+        expected_participant,
+        "async {phase:?}"
+    );
+    let result = membership_result(case.invoke(&mut client));
+    client.shutdown().await;
+    result
+}
+
+fn polling_membership_result(phase: MembershipPhase, case: CommonCommandCase) -> MembershipResult {
+    let mut client = SignalFishPollingClient::new(
+        frame_mock_for_phase(phase),
+        SignalFishConfig::new("app").enable_v3(),
+    );
+    let _ = client.poll();
+    let (expected_role, expected_participant) = expected_membership_state(phase);
+    assert_eq!(client.room_role(), expected_role, "polling {phase:?}");
+    assert_eq!(
+        client.snapshot().player_id,
+        expected_participant,
+        "polling {phase:?}"
+    );
+    let result = membership_result(case.invoke(&mut client));
+    client.close();
+    result
+}
+
 const PEER_UUID: &str = "00000000-0000-0000-0000-000000000007";
 const AUTH: &str = r#"{"type":"Authenticated","data":{"app_name":"test","rate_limits":{"per_minute":60,"per_hour":1000,"per_day":10000}}}"#;
 const PI_V3: &str = r#"{"type":"ProtocolInfo","data":{"capabilities":[],"game_data_formats":["json","message_pack"],"protocol_version":3,"min_protocol_version":2,"max_protocol_version":3,"transports":["websocket"]}}"#;
@@ -332,7 +593,7 @@ fn reconnected_with_missed(missed: Vec<ServerMessage>) -> String {
             epoch: Some(1),
             seq: Some(0),
         }],
-        is_authority: false,
+        is_authority: true,
         lobby_state: LobbyState::Waiting,
         ready_players: vec![],
         relay_type: "tcp".into(),
@@ -1038,7 +1299,11 @@ async fn json_fallback_is_enforced_before_outbound_transport_admission_in_both_d
     .expect("fallback Error fixture should serialize");
     let protocol_info =
         protocol_info_with_formats(vec![GameDataEncoding::Json, GameDataEncoding::MessagePack]);
-    let messages = vec![fallback_error, AUTH.into(), protocol_info];
+    let room = match binary_accountability_prefix(uuid::Uuid::from_u128(365)).remove(2) {
+        TransportFrame::Text(room) => room,
+        TransportFrame::Binary(_) => unreachable!("room baseline must be text"),
+    };
+    let messages = vec![fallback_error, AUTH.into(), protocol_info, room];
     let mut config = SignalFishConfig::new("app").enable_v3();
     config.game_data_format = Some(GameDataEncoding::Rkyv);
 
@@ -1263,7 +1528,7 @@ fn binary_accountability_prefix(player_id: PlayerId) -> Vec<TransportFrame> {
                 seq: Some(0),
             },
         ],
-        is_authority: false,
+        is_authority: true,
         lobby_state: LobbyState::Lobby,
         ready_players: vec![],
         relay_type: "websocket".into(),
@@ -1928,7 +2193,6 @@ async fn room_exit_clears_unsupported_advisory_authorization_in_both_drivers() {
 #[tokio::test]
 async fn every_common_command_produces_identical_physical_frames() {
     let cases = [
-        CommonCommandCase::JoinRoom,
         CommonCommandCase::LeaveRoom,
         CommonCommandCase::ReliableData,
         CommonCommandCase::LatestData,
@@ -1938,9 +2202,6 @@ async fn every_common_command_produces_identical_physical_frames() {
         CommonCommandCase::StartGame,
         CommonCommandCase::RequestAuthority,
         CommonCommandCase::ProvideConnectionInfo,
-        CommonCommandCase::Reconnect,
-        CommonCommandCase::JoinSpectator,
-        CommonCommandCase::LeaveSpectator,
         CommonCommandCase::Ping,
         CommonCommandCase::Signal,
         CommonCommandCase::SignalForGeneration,
@@ -2093,6 +2354,7 @@ async fn pending_transport_queue_capacity_and_errors_match() {
     let config = SignalFishConfig::new("app").with_command_channel_capacity(1);
 
     let async_mock = NeverSendMock::new();
+    let async_gate = async_mock.clone();
     let attempted = Arc::clone(&async_mock.attempted);
     let (mut async_client, _events) = SignalFishClient::start(async_mock, config.clone());
     tokio::time::timeout(std::time::Duration::from_secs(1), async {
@@ -2104,6 +2366,7 @@ async fn pending_transport_queue_capacity_and_errors_match() {
     .expect("async Authenticate should reach the stalled transport");
 
     let polling_mock = NeverSendMock::new();
+    let polling_gate = polling_mock.clone();
     let mut polling_client = SignalFishPollingClient::new(polling_mock, config);
     let _ = polling_client.poll();
 
@@ -2123,6 +2386,133 @@ async fn pending_transport_queue_capacity_and_errors_match() {
         .ping()
         .expect_err("polling queue must be full");
     assert_eq!(format!("{async_error:?}"), format!("{polling_error:?}"));
+
+    for case in [
+        CommonCommandCase::JoinRoom,
+        CommonCommandCase::Reconnect,
+        CommonCommandCase::JoinSpectator,
+    ] {
+        assert!(matches!(
+            case.invoke(&mut async_client),
+            Err(SignalFishError::SendBufferFull { capacity: 1 })
+        ));
+        assert!(matches!(
+            case.invoke(&mut polling_client),
+            Err(SignalFishError::SendBufferFull { capacity: 1 })
+        ));
+    }
+
+    // A locally invalid room operation wins over queue congestion and cannot
+    // consume additional capacity in either driver.
+    assert!(matches!(
+        async_client.send_game_data(serde_json::json!({"invalid": true})),
+        Err(SignalFishError::NotInRoom)
+    ));
+    assert!(matches!(
+        polling_client.send_game_data(serde_json::json!({"invalid": true})),
+        Err(SignalFishError::NotInRoom)
+    ));
+    assert_eq!(async_client.send_capacity(), 0);
+    assert_eq!(polling_client.send_capacity(), 0);
+
+    async_gate.release();
+    polling_gate.release();
+    let _ = polling_client.poll();
+    tokio::time::timeout(std::time::Duration::from_secs(1), async {
+        while async_client.send_capacity() == 0 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("async queue should recover after transport release");
+    assert_eq!(polling_client.send_capacity(), 1);
+    async_client
+        .join_room(JoinRoomParams::new("game", "async"))
+        .expect("full-queue refusal must not create an async pending fence");
+    polling_client
+        .join_room(JoinRoomParams::new("game", "polling"))
+        .expect("full-queue refusal must not create a polling pending fence");
+    assert!(matches!(
+        async_client.send_game_data(serde_json::json!({"after": "join"})),
+        Err(SignalFishError::RoomOperationPending)
+    ));
+    assert!(matches!(
+        polling_client.send_game_data(serde_json::json!({"after": "join"})),
+        Err(SignalFishError::RoomOperationPending)
+    ));
+    async_client.shutdown().await;
+}
+
+#[tokio::test]
+async fn every_common_command_has_membership_guard_parity_across_drivers() {
+    for phase in [
+        MembershipPhase::Outside,
+        MembershipPhase::Player,
+        MembershipPhase::PlayerLeft,
+        MembershipPhase::PlayerRejoined,
+        MembershipPhase::Spectator,
+        MembershipPhase::SpectatorLeft,
+        MembershipPhase::SpectatorRejoined,
+    ] {
+        for case in ALL_COMMON_COMMANDS {
+            let expected = expected_membership_result(phase, case);
+            let async_result = async_membership_result(phase, case).await;
+            let polling_result = polling_membership_result(phase, case);
+            assert_eq!(async_result, expected, "async {phase:?} {case:?}");
+            assert_eq!(polling_result, expected, "polling {phase:?} {case:?}");
+        }
+    }
+}
+
+#[tokio::test]
+async fn admitted_leave_fences_following_player_commands_in_both_drivers() {
+    let config = SignalFishConfig::new("app").enable_v3();
+
+    let async_mock = FrameMock::v3();
+    let async_sent = Arc::clone(&async_mock.sent);
+    let (mut async_client, mut async_events) = SignalFishClient::start(async_mock, config.clone());
+    while !matches!(
+        async_events.recv().await,
+        Some(SignalFishEvent::SessionPlan { .. })
+    ) {}
+    async_sent.lock().unwrap().clear();
+    async_client.leave_room().expect("async leave is admitted");
+    assert!(matches!(
+        async_client.send_game_data(serde_json::json!({"after": "leave"})),
+        Err(SignalFishError::RoomOperationPending)
+    ));
+
+    let polling_mock = FrameMock::v3();
+    let polling_sent = Arc::clone(&polling_mock.sent);
+    let mut polling_client = SignalFishPollingClient::new(polling_mock, config);
+    let _ = polling_client.poll();
+    polling_sent.lock().unwrap().clear();
+    polling_client
+        .leave_room()
+        .expect("polling leave is admitted");
+    assert!(matches!(
+        polling_client.send_game_data(serde_json::json!({"after": "leave"})),
+        Err(SignalFishError::RoomOperationPending)
+    ));
+
+    let _ = polling_client.poll();
+    tokio::time::timeout(std::time::Duration::from_secs(1), async {
+        while async_sent.lock().unwrap().is_empty() {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("async LeaveRoom frame");
+    assert_eq!(async_sent.lock().unwrap().len(), 1);
+    assert_eq!(polling_sent.lock().unwrap().len(), 1);
+    assert!(matches!(
+        &async_sent.lock().unwrap()[0],
+        TransportFrame::Text(frame) if frame.contains("LeaveRoom")
+    ));
+    assert!(matches!(
+        &polling_sent.lock().unwrap()[0],
+        TransportFrame::Text(frame) if frame.contains("LeaveRoom")
+    ));
     async_client.shutdown().await;
 }
 
@@ -2176,7 +2566,7 @@ async fn disconnected_common_commands_consistently_return_not_connected() {
 // ── PARITY 2: ensure_v3 guard modes ──────────────────────────────────
 
 #[tokio::test]
-async fn parity_ensure_v3_pre_negotiation_mode() {
+async fn parity_membership_precedes_v3_pre_negotiation_mode() {
     let peer: PlayerId = PEER_UUID.parse().unwrap();
 
     let async_mock = SharedMock::new(vec![]);
@@ -2188,18 +2578,8 @@ async fn parity_ensure_v3_pre_negotiation_mode() {
         SignalFishPollingClient::new(poll_mock, SignalFishConfig::new("app").enable_mesh());
     let poll_err = poll_client.send_offer(peer, "sdp").unwrap_err();
 
-    assert!(matches!(
-        async_err,
-        SignalFishError::ProtocolUnsupported {
-            mode: "pre-negotiation"
-        }
-    ));
-    assert!(matches!(
-        poll_err,
-        SignalFishError::ProtocolUnsupported {
-            mode: "pre-negotiation"
-        }
-    ));
+    assert!(matches!(async_err, SignalFishError::NotInRoom));
+    assert!(matches!(poll_err, SignalFishError::NotInRoom));
 }
 
 #[tokio::test]
@@ -2209,19 +2589,35 @@ async fn parity_ensure_v3_relay_only_mode_after_v2_negotiation() {
     // state before any `ProtocolInfo` arrives (see the parity test above).
     let peer: PlayerId = PEER_UUID.parse().unwrap();
 
-    let async_mock = SharedMock::new(vec![AUTH, PI_V2]);
+    let room = match finalized_v2_room_frame() {
+        TransportFrame::Text(room) => room,
+        TransportFrame::Binary(_) => unreachable!("room baseline must be text"),
+    };
+    let messages = [AUTH.to_string(), PI_V2.to_string(), room];
+    let async_mock = SharedMock::from_msgs(
+        messages
+            .iter()
+            .cloned()
+            .map(|message| Some(Ok(message)))
+            .collect(),
+    );
     let (mut client, mut events) =
         SignalFishClient::start(async_mock, SignalFishConfig::new("app"));
-    // Drain until the v2 ProtocolInfo has been processed into client state.
+    // Drain until the v2 room baseline has been processed into client state.
     loop {
         match events.recv().await {
-            Some(SignalFishEvent::ProtocolInfo(_)) | None => break,
+            Some(SignalFishEvent::RoomJoined { .. }) | None => break,
             _ => {}
         }
     }
     let async_err = client.send_offer(peer, "sdp").unwrap_err();
 
-    let poll_mock = SharedMock::new(vec![AUTH, PI_V2]);
+    let poll_mock = SharedMock::from_msgs(
+        messages
+            .into_iter()
+            .map(|message| Some(Ok(message)))
+            .collect(),
+    );
     let mut poll_client = SignalFishPollingClient::new(poll_mock, SignalFishConfig::new("app"));
     poll_client.poll();
     let poll_err = poll_client.send_offer(peer, "sdp").unwrap_err();

--- a/tests/real_server_e2e.rs
+++ b/tests/real_server_e2e.rs
@@ -223,7 +223,7 @@ async fn e2e_server_070_rkyv_request_resolves_to_json() {
     );
     assert!(matches!(
         client.send_binary_game_data(vec![1, 2, 3]),
-        Err(SignalFishError::BinaryFormatNotNegotiated)
+        Err(SignalFishError::NotInRoom)
     ));
 
     client
@@ -233,6 +233,10 @@ async fn e2e_server_070_rkyv_request_resolves_to_json() {
         matches!(event, SignalFishEvent::RoomJoined { .. })
     })
     .await;
+    assert!(matches!(
+        client.send_binary_game_data(vec![1, 2, 3]),
+        Err(SignalFishError::BinaryFormatNotNegotiated)
+    ));
     client
         .send_game_data(serde_json::json!({"fallback": "json"}))
         .expect("fallback client should send JSON game data");


### PR DESCRIPTION
Closes #103.

## Summary

- expose an explicit `RoomRole` in coherent client snapshots and clear participant identity on every confirmed exit
- enforce the Server 0.7 no-membership/player/spectator/authority command matrix in the shared core with deterministic error precedence
- transactionally fence admitted join, leave, and reconnect operations until matching typed terminal responses, including queue-full and reliable-send revalidation
- validate authority and pending-response baselines before state mutation, and avoid obsolete room-scoped WebRTC status sends during exit teardown
- document the breaking 0.11-facing API/error behavior across Rust, polling, WASM, concepts, and changelog surfaces

## Verification

- `cargo fmt`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- no-default workspace check/test
- all-feature workspace rustdoc with warnings denied
- repository pre-commit and pre-push policy suites
- adversarial shared-core/driver review: GO

The exhaustive async/polling matrix covers all common commands outside a room, as a player/spectator, and after confirmed leave/rejoin for both roles. This PR intentionally excludes #104, #106, and #107.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Breaking public snapshot/error APIs plus shared command-admission and room-identity logic that gates gameplay, authority, and WebRTC teardown. Exhaustive matches and previously queued pre-join commands will change behavior.
> 
> **Overview**
> Makes room membership an explicit, coherent client contract so player-only work cannot be queued before join, after leave, or as a spectator (Server 0.7 would silently drop gameplay).
> 
> Adds public `RoomRole` and `ClientSnapshot::room_role`, plus `AlreadyInRoom`, `RoomOperationPending`, `WrongRoomRole`, and `AuthorityRequired`. `player_id` is the local player-or-spectator ID and now clears with role/room on every confirmed exit. Async, polling, and `SignalFishClientApi` share the same accessors.
> 
> Shared `ClientCore` validates connection, pending transition, role, authority, then protocol/session, then queue capacity. Admitted join/leave/reconnect fences later room commands until a matching typed success/failure; generic errors stay fail-closed until teardown. `ping` remains available. Authority baselines/changes are validated before local guards update. `MeshController` still tears down peers on exit but no longer sends obsolete room-scoped transport status.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 741a26dd583d7349b2309898694f4a16d7566df1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->