### PR TITLE
fix!: clarify readiness and traffic counter contracts

### DIFF
--- a/.llm/context.md
+++ b/.llm/context.md
@@ -159,13 +159,13 @@ pub trait Transport {
 }
 ```
 
-The trait itself has no `Send` bound, so main-thread transports work with the polling client. `SignalFishClient::start` separately requires
-`Transport + Send + 'static`. A `poll_send` implementation may take the frame
-only when the backend accepts ownership. That transfer is send completion for
-admission purposes; it is not peer delivery and never requires the socket-wide
-buffered byte count to reach zero. `Pending` before acceptance leaves the
-caller's `Option` intact. Close polling is idempotent. See
-`skills/transport-abstraction/SKILL.md`.
+The trait has no `Send` bound; `SignalFishClient::start` separately requires
+`Transport + Send + 'static`. `poll_send` may take a frame only at backend
+ownership transfer; that increments `game_data_sent` even if completion later
+fails, but never proves peer delivery. `Pending` before acceptance leaves the
+frame intact. Async readiness changes wake registered I/O; both drivers map the
+first `is_ready()` observation to `transport_ready` and `Connected`. Close is
+idempotent. See `skills/transport-abstraction/SKILL.md`.
 
 The async driver retains an in-flight send in its main select loop and polls
 send and receive with the same runtime waker, so outbound backpressure cannot
@@ -289,8 +289,8 @@ client.leave_spectator() -> Result<()>
 client.ping() -> Result<()>
 client.send_signal_reliable(to, signal).await // v3 only; waiting send_signal
 client.send_capacity() / client.max_send_capacity() -> usize // queue diagnostics
-client.stats() -> ClientStats  // cumulative game_data_sent/received counters
-client.snapshot() -> ClientSnapshot // coherent role/state/token/quarantine view
+client.stats() -> ClientStats  // accepted-send / decoded-receipt counters
+client.snapshot() -> ClientSnapshot // coherent readiness/role/session view
 client.shutdown().await      // async, graceful
 ```
 
@@ -310,6 +310,8 @@ Admitted joins/leaves/reconnects fence later work until a matching typed termina
 response; generic errors/absence stay fenced until teardown. Events are never dropped: a full event
 channel backpressures; undecodable frames surface as `DecodeFailed`; events are
 missed only on receiver/handle drop or shutdown (abandons ≤1 in-flight).
+Snapshots distinguish nonterminal `connected`, observed `transport_ready`, server-confirmed `authenticated`, and authoritative room membership.
+Decoded game-data receipt counts before suppression; counters are diagnostic boundaries, not cross-peer delivery equality.
 `SignalFishPollingClient` shares the classified/binary sends, queue bound,
 capacity accessors, `stats()`, and coherent `snapshot()`. Its default per-poll
 work budget is 64 frames/64 KiB in each direction, and its default close policy
@@ -432,9 +434,7 @@ strings to match server expectations.
    immediately before spawning the transport loop.
 2. Server responds with `ServerMessage::Authenticated` → `SignalFishEvent::Authenticated`.
 3. Client may then call `join_room`, etc.
-4. Both clients emit a synthetic `SignalFishEvent::Connected` once the transport
-   is ready (`SignalFishClient`: at the start of the transport loop;
-   `SignalFishPollingClient`: once `Transport::is_ready()` returns `true`).
+4. Both clients emit synthetic `SignalFishEvent::Connected` when their driver first observes `Transport::is_ready() == true`.
    `SignalFishEvent::Disconnected` is emitted when the transport closes
    (best-effort; missed only if the receiver is dropped, shutdown times out,
    or the handle is dropped without `shutdown()`).

--- a/.llm/skills/event-lifecycle-timing/SKILL.md
+++ b/.llm/skills/event-lifecycle-timing/SKILL.md
@@ -11,27 +11,26 @@ synthetic events (`Connected`, `Disconnected`) across different client types.
 ## The Problem
 
 Synthetic events like `Connected` are not triggered by server messages — they
-are emitted by the client itself. The timing of these events differs between
-`SignalFishClient` (async) and `SignalFishPollingClient` (synchronous polling),
-which can mislead callers if not documented clearly.
+are emitted by the client itself. Both clients use the same readiness boundary,
+but observe it through different driver mechanics.
 
 ## Client-Specific Timing
 
 ### `SignalFishClient` (async, tokio-based)
 
-- `Connected` is emitted at the **start of the transport loop** (`transport_loop()`
-  in `src/client.rs`), before entering the `tokio::select!` loop.
-- By this point, the transport is already connected — the caller passed an
-  already-connected transport to `start()` (e.g., via
-  `WebSocketTransport::connect(url).await`).
-- `Connected` genuinely reflects a completed handshake.
+- `Connected` is emitted when the transport loop first observes
+  `Transport::is_ready() == true`.
+- Built-in `WebSocketTransport::connect` is already ready. A custom transport
+  may still be handshaking when passed to `start()` and defers the event.
+- A false-to-true readiness transition must wake a waker registered by
+  `poll_send` or `poll_recv` so the async loop can observe it.
 
 ### `SignalFishPollingClient` (synchronous, noop-waker)
 
 - `Connected` is emitted once `Transport::is_ready()` returns `true` during
-  a `poll()` cycle. The check happens after the recv drain loop, so transports
-  that process their open event during recv (e.g., `EmscriptenWebSocketTransport`)
-  will trigger `Connected` in the same poll cycle.
+  a `poll()` cycle. Readiness is checked before I/O and after the recv drain,
+  so already-ready immediate-close ordering and transports that process their
+  open event during recv are both represented correctly.
 - For transports that are already connected at construction time (default
   `is_ready() = true`), `Connected` fires on the first `poll()` call.
 - For `EmscriptenWebSocketTransport`, `Connected` is deferred until the
@@ -42,8 +41,8 @@ which can mislead callers if not documented clearly.
 
 ## Rules
 
-1. **`Connected` is tied to `Transport::is_ready()`** — for the polling
-   client, `Connected` fires only after the transport confirms readiness.
+1. **`Connected` is tied to `Transport::is_ready()`** — both clients fire it
+   only after the transport confirms readiness.
    Document any transport whose `is_ready()` has non-trivial behavior.
 
 2. **Document transport-specific behavior** — if a transport's `connect()`
@@ -51,16 +50,16 @@ which can mislead callers if not documented clearly.
    sent in the interim (e.g., browser buffering).
 
 3. **Keep event ordering invariants documented and tested** — `Connected` must
-   always be the first event returned by the first `poll()` call, before any
-   server-derived events.
+   be the first event in the cycle that observes readiness, before any
+   server-derived events from that cycle.
 
 4. **Use `tracing::info!` for transport lifecycle events** — connection open,
    close, and error events should be logged at `info` level (not `debug`) to
    aid debugging in production.
 
-5. **Cross-reference timing differences in user-facing docs** — `docs/wasm.md`,
-   `docs/events.md`, and the type-level doc comments should all mention the
-   timing difference between async and polling clients.
+5. **Cross-reference driver mechanics in user-facing docs** — `docs/wasm.md`,
+   `docs/events.md`, and type-level doc comments should identify the shared
+   readiness boundary and how each driver observes it.
 
 ## Checklist for New Synthetic Events
 

--- a/.llm/skills/public-api-design/SKILL.md
+++ b/.llm/skills/public-api-design/SKILL.md
@@ -291,6 +291,9 @@ close details come from `Transport::close_info()`.
   clients; keep the common APIs mirrored. Polling-only scheduling telemetry
   such as `PollingQueueAgeStats` stays on the concrete polling client and is
   exported from the crate root.
+- `ClientSnapshot::connected` means nonterminal client ownership;
+  `transport_ready` means the driver observed handshake completion. Preserve
+  pre-ready queueing and keep readiness accessors mirrored across both clients.
 - `GameDataDelivery::Reliable` preserves the v2 wire by omitting class/key;
   `Latest { key }` and `Volatile` require negotiated v3.
 - Adding `SendBufferFull` to the exhaustive `SignalFishError` is breaking

--- a/.llm/skills/shared-core-drivers/SKILL.md
+++ b/.llm/skills/shared-core-drivers/SKILL.md
@@ -79,7 +79,8 @@ frames and events rather than selected fields. Cover:
 - JSON and binary representations;
 - full queues, pending sends, disconnects, and close metadata;
 - all violation policies and authoritative quarantine rebaselines;
-- coherent snapshots and cumulative statistics.
+- coherent snapshots, connecting/readiness phases, and cumulative statistics
+  counted at outbound ownership transfer and inbound logical decode.
 - authoritative session generations, pre-plan send refusal, and stale-signal
   suppression across both drivers.
 

--- a/.llm/skills/testing-async/SKILL.md
+++ b/.llm/skills/testing-async/SKILL.md
@@ -100,8 +100,9 @@ if it returns `Pending`, retain that frame internally until a later `Ready`.
 
 ## Starting a Mock Client
 
-`SignalFishClient::start` always sends `Authenticate` first and emits a
-synthetic `Connected` event before processing server responses:
+`SignalFishClient::start` always queues `Authenticate` first and emits a
+synthetic `Connected` event after `Transport::is_ready()` becomes true, before
+processing server responses. The common mock is ready by default:
 
 ```rust
 #[tokio::test]
@@ -182,6 +183,7 @@ task is aborted), always assert client state accessors are reset even if the
 client.shutdown().await;
 let snapshot = client.snapshot();
 assert!(!snapshot.connected);
+assert!(!snapshot.transport_ready);
 assert!(!snapshot.authenticated);
 assert!(snapshot.player_id.is_none());
 assert!(snapshot.room_id.is_none());

--- a/.llm/skills/transport-abstraction/SKILL.md
+++ b/.llm/skills/transport-abstraction/SKILL.md
@@ -129,8 +129,10 @@ Capture peer close metadata before returning `Ready(None)` from `poll_recv`.
 
 `is_ready()` is cheap and non-blocking. The default `true` fits transports
 whose constructor completes the handshake. Async-handshake transports return
-`false` until ready; the polling client defers its synthetic `Connected` event.
-Once true, readiness should remain true for that physical connection.
+`false` until ready; both clients defer their synthetic `Connected` event.
+Once true, readiness remains true for that physical connection. If readiness
+changes while the async driver is blocked, wake a waker registered by
+`poll_send` or `poll_recv`, because `is_ready()` cannot register one itself.
 
 ## Minimal Channel Transport
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ClientSnapshot::room_role`, matching async/polling/trait accessors, and
   `SignalFishError::{AlreadyInRoom, RoomOperationPending, WrongRoomRole,
   AuthorityRequired}` for synchronous membership-safe command admission.
+- Added `ClientSnapshot::transport_ready` and matching async, polling, and
+  `SignalFishClientApi` accessors so applications can distinguish a client-owned
+  connecting transport from a completed handshake.
 
 ### Changed
 
@@ -76,6 +79,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and `SignalFishError` types gain the membership fields and variants above.
   `ClientSnapshot::player_id` and `current_player_id()` now consistently mean
   the local player-or-spectator participant ID and clear on confirmed exit.
+- **Breaking:** the exhaustive `ClientSnapshot` adds `transport_ready`.
+  `connected` now explicitly means a nonterminal client-owned transport attempt;
+  `Connected` and `transport_ready` identify handshake completion. Commands
+  remain queueable while connecting.
+- Changed `ClientStats` counting boundaries: `game_data_sent` increments when
+  the transport takes frame ownership, including accepted sends that later
+  fail, while `game_data_received` increments after successful protocol decode,
+  including stale or quarantined data suppressed before application delivery.
 
 ### Fixed
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -149,10 +149,10 @@ bounds native WebSocket control-frame work, preserves automatic Pong/Close
 flush ordering, and makes EOF and socket errors terminal for direct Transport
 callers. Session 030 records socket, ownership, wake, and terminal-state evidence.
 
-## Active PR — Client Membership and Operation State
+## Completed Correctness Milestone — Client Membership and Operation State
 
 [Issue #103](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/issues/103)
-is implemented in [PR #114](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/pull/114). It
+shipped in [PR #114](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/pull/114). It
 exposes authoritative player/spectator role state, clears room-scoped identity
 on exit, and enforces one shared operation matrix across async and polling
 drivers. Admission-time room transitions fence later FIFO commands, authority
@@ -161,10 +161,20 @@ queue capacity. The code-bearing head passed all twelve hosted workflow suites;
 Session 031 records the operation/state matrix, pinned-server contract, review
 fixes, and exact verification evidence.
 
-## Next Correctness Milestones — Readiness, Counters, and Transport Deadlines
+## Current Correctness Milestone — Readiness and Traffic Counters
 
-Continue with #104, #106, and #107 before usability, performance, token
-binding, or presentation milestones.
+[Issue #104](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/issues/104)
+defines connection state as nested client-owned, transport-ready,
+server-authenticated, and room-membership phases without preventing FIFO
+queueing during an asynchronous handshake. Traffic statistics count outbound
+transport ownership transfer and inbound decoded receipt, including
+accepted-then-error, stale, and quarantined cases. Session 032 records the
+contract and evidence.
+
+## Next Correctness Milestones — Transport Deadlines and Datagram Scope
+
+Continue with #106 and #107 before usability, performance, token binding, or
+presentation milestones.
 
 ## Following Milestone — Negotiated Token Binding
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ rooms, and receive strongly typed events.
   async driver's bounded Tokio MPSC channel or directly from each polling call
 - **Structured errors** — typed client errors, server error codes, decode failures, and categorized protocol-accountability violations
 - **Typed negotiated-protocol coverage** — typed v2/v3 messages and events, including strict physical MessagePack envelopes
-- **No silent loss while receivers remain active** — event delivery uses backpressure, and the bounded send queue surfaces congestion as `SignalFishError::SendBufferFull` instead of buffering without bound; receiver/handle drop and shutdown remain explicit terminal boundaries, while `stats()` counters make relay-path loss observable
+- **No silent loss while receivers remain active** — event delivery uses backpressure, and the bounded send queue surfaces congestion as `SignalFishError::SendBufferFull` instead of buffering without bound; receiver/handle drop and shutdown remain explicit terminal boundaries, while `stats()` exposes transport-acceptance and decoded-receipt diagnostics
 - **Configurable** — tune event channel capacity, command queue capacity, shutdown timeout, and more via `SignalFishConfig` builder methods
 - **WebAssembly ready** — compiles to `wasm32-unknown-unknown` and `wasm32-unknown-emscripten` with zero unsafe panics
 - **Godot 4.5 native + web adapter** — the lockstep `signal-fish-client-godot` crate wraps Godot's own `WebSocketPeer`, including official no-thread web exports
@@ -230,7 +230,7 @@ Key requirements:
 - Retain accepted outbound frames and partial receives across `Poll::Pending`
 - Register the supplied waker when async progress becomes possible
 - Make `poll_close` idempotent and expose structured peer metadata via `close_info`
-- A transport constructor may begin an asynchronous connection attempt; report readiness through `is_ready()` and retain sends while the handshake is pending
+- A transport constructor may begin an asynchronous connection attempt; both clients defer `Connected` until `is_ready()`, and the transport retains sends and wakes blocked async I/O when the handshake completes
 - The trait has no `Send` bound; only `SignalFishClient::start` requires
   `Send + 'static`, while `SignalFishPollingClient` accepts non-`Send` transports
 

--- a/docs/client.md
+++ b/docs/client.md
@@ -422,23 +422,27 @@ Synchronous diagnostics for the outgoing command queue and game-data traffic:
 | `stats()` | `fn stats(&self) -> ClientStats` | Cumulative game-data traffic counters. |
 
 `ClientStats` (re-exported at the crate root) carries `game_data_sent`
-(`GameData` messages whose frames the transport accepted), `game_data_received`
-(`GameData`/`GameDataBinary` messages read off the transport and accepted by
-the protocol-accountability layer —
-counted at **receipt**, not at delivery to your event loop, so a consumer
-that stops draining events cannot masquerade as relay loss; in steady state
-the two are identical because events are not dropped on overflow), and
+(`GameData` messages counted when the transport takes frame ownership, even if
+backend completion later fails), `game_data_received`
+(`GameData`/`GameDataBinary` messages counted immediately after successful
+protocol decode, before message validation, sequence accountability,
+quarantine, or event suppression), and
 `messages_undecodable` (inbound frames that failed to decode — each also
 surfaces as a [`DecodeFailed`](events.md#decodefailed) event; steady growth
 means protocol drift or a corrupting middlebox). The counters are
 cumulative for the lifetime of the client — they survive room changes and
 disconnects.
 
-During normal operation, event-channel overflow does not drop game data and
-refused sends return `SendBufferFull`. Exchange or log the counters across
-peers to locate a persistent deficit. Also account for receiver drop, handle
-drop without `shutdown()`, shutdown abandoning one blocked event, disconnects,
-and protocol quarantine before attributing a deficit solely to the relay.
+Physical binary frames rejected by lifecycle or negotiated-representation
+policy before logical decoding are outside the counter. Once decoded,
+`game_data_received` includes stale and quarantined messages;
+those explain differences between receipt and application events rather than a
+sent-versus-received deficit. Malformed frames are excluded from it. Cross-peer
+counter equality is not guaranteed: transport acceptance is not server receipt,
+broadcast fanout can increase aggregate receives, and server delivery classes,
+rejection, terminal unread work, or an accepted-then-failed send can reduce it.
+WebRTC data-channel traffic and non-game protocol messages are outside these
+counters. Use them as boundary-specific diagnostics, not delivery receipts.
 
 ```rust,ignore
 let stats = client.stats();
@@ -557,7 +561,8 @@ Useful for keeping the connection alive through proxies or load balancers.
 ### State Accessors
 
 `snapshot()` synchronously returns one coherent `ClientSnapshot`, including
-connection/authentication state, room role/participant ID, room code, the latest
+connection ownership/readiness/authentication state, room role/participant ID,
+room code, the latest
 reconnection token, requested and effective game-data formats, negotiated
 protocol version, current session generation, and whether delivery is
 quarantined. It also carries the latest selected `session_topology` and
@@ -569,7 +574,8 @@ the async room-ID accessors acquire the same internal mutex.
 
 | Method | Signature | Description |
 |---|---|---|
-| `is_connected()` | `fn is_connected(&self) -> bool` | Returns `true` if the transport is believed to be connected. |
+| `is_connected()` | `fn is_connected(&self) -> bool` | Returns `true` while the client owns a nonterminal transport attempt, including its connecting phase. |
+| `is_transport_ready()` | `fn is_transport_ready(&self) -> bool` | Returns `true` after the driver observes a completed transport handshake and before terminal teardown. |
 | `is_authenticated()` | `fn is_authenticated(&self) -> bool` | Returns `true` if the server has confirmed authentication. |
 | `snapshot()` | `fn snapshot(&self) -> ClientSnapshot` | Returns coherent session, reconnect-token, negotiation, and quarantine state. |
 | `room_role()` | `fn room_role(&self) -> Option<RoomRole>` | Server-confirmed `Player` or `Spectator` role; `None` outside a room. |
@@ -582,6 +588,21 @@ the async room-ID accessors acquire the same internal mutex.
 | `current_room_id()` | `async fn current_room_id(&self) -> Option<RoomId>` | Returns the current room ID, if in a room. |
 | `current_player_id()` | `async fn current_player_id(&self) -> Option<PlayerId>` | Legacy name for the local room participant ID (player or spectator). Interpret it with `room_role()`. |
 | `current_room_code()` | `async fn current_room_code(&self) -> Option<String>` | Returns the current room code, if in a room. |
+
+The snapshot fields form these nested connection phases:
+
+| Phase | `connected` | `transport_ready` | `authenticated` | `room_role` |
+|---|---:|---:|---:|---|
+| Connecting / client-owned | `true` | `false` | `false` | `None` |
+| Transport ready | `true` | `true` | `false` | `None` |
+| Authenticated, outside a room | `true` | `true` | `true` | `None` |
+| In a room | `true` | `true` | `true` | player or spectator |
+| Terminal | `false` | `false` | `false` | `None` |
+
+`transport_ready` is the driver's sticky observation for the current physical
+connection, not a fresh call to the backend. `SignalFishEvent::Connected`
+corresponds to that transition. Commands may be queued during the connecting
+phase; a conforming transport leaves their frames caller-owned until ready.
 
 ```rust,ignore
 let state = client.snapshot();
@@ -645,8 +666,8 @@ Shutdown proceeds in four stages:
 3. If the timeout expires, the task is logged as unresponsive and aborted.
    The `Disconnected` event may not be delivered in this case.
 4. Regardless of whether `Disconnected` is delivered, connection/session state
-   is cleared (`is_connected() == false`, `is_authenticated() == false`, and
-   room/player accessors return `None`).
+   is cleared (`is_connected() == false`, `is_transport_ready() == false`,
+   `is_authenticated() == false`, and room/player accessors return `None`).
 
 !!! warning "Drop fallback"
     If `shutdown()` is never called, the `Drop` implementation **aborts** the
@@ -805,7 +826,8 @@ All accessors are **synchronous** (no async, no mutex):
 
 | Method | Returns | Description |
 |---|---|---|
-| `is_connected()` | `bool` | Whether the transport is believed connected. |
+| `is_connected()` | `bool` | Whether the client owns a nonterminal transport attempt, including connecting. |
+| `is_transport_ready()` | `bool` | Whether the driver has observed the transport handshake complete. |
 | `is_authenticated()` | `bool` | Whether the server confirmed authentication. |
 | `room_role()` | `Option<RoomRole>` | Server-confirmed player/spectator role. |
 | `is_closing()` | `bool` | Whether `poll()` must continue driving a close lifecycle. |
@@ -822,7 +844,7 @@ All accessors are **synchronous** (no async, no mutex):
 | `send_capacity()` | `usize` | Messages that can still be queued before `SendBufferFull`. |
 | `max_send_capacity()` | `usize` | Configured command-queue capacity. |
 | `stats()` | `ClientStats` | Cumulative `game_data_sent` / `game_data_received` / `messages_undecodable` counters (see [Send Queue and Traffic Stats](#send-queue-and-traffic-stats)). |
-| `snapshot()` | `ClientSnapshot` | Coherent connection, room, reconnect-token, negotiation, selected-plan, and quarantine state. |
+| `snapshot()` | `ClientSnapshot` | Coherent connection readiness, room, reconnect-token, negotiation, selected-plan, and quarantine state. |
 | `polling_stats()` | `PollingStats` | Client-owned queue depth, budget exhaustion, abandoned-command, and deadline counters. |
 | `queue_age_stats()` | `PollingQueueAgeStats` | Sampled current/peak age of the oldest client-owned outbound item. |
 | `reset_queue_age_peak()` | `()` | Refresh current age and reset its sampled peak; useful after setup. |
@@ -861,8 +883,9 @@ can complete; because session state is already cleared, these late frames are
 not emitted as application events. If
 `SignalFishConfig::shutdown_timeout` expires, remaining work is counted as
 abandoned, the transport is aborted, and `is_closing()` becomes false.
-After calling `close()`, `is_connected()` returns `false` and all command
-methods return `Err(SignalFishError::NotConnected)`.
+After calling `close()`, both `is_connected()` and `is_transport_ready()`
+return `false`, and all command methods return
+`Err(SignalFishError::NotConnected)`.
 
 !!! warning "No Drop fallback"
     Unlike `SignalFishClient`, the polling client does **not** abort a

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -52,8 +52,9 @@ The async client adds `Send + 'static` at `start`; the polling client does not.
 !!! tip "Bring your own transport"
     Connection setup is intentionally **not** part of the trait. Different
     transports have different connection parameters (URLs, host:port, QUIC
-    endpoints, etc.). Construct a connected transport externally, then hand it
-    to `SignalFishClient::start`.
+    endpoints, etc.). Construct a transport externally, then hand it to
+    `SignalFishClient::start`; an asynchronous handshake may still be in
+    progress if its `is_ready()` returns `false`.
 
 The crate ships with a ready-made `WebSocketTransport` (behind the `transport-websocket`
 feature flag), but you can implement the trait for any medium.
@@ -68,18 +69,21 @@ through the same states:
 ```mermaid
 stateDiagram-v2
     [*] --> Disconnected
-    Disconnected --> Connected : Transport opens
+    Disconnected --> Connecting : Client takes transport ownership
+    Connecting --> Connected : Driver observes transport readiness
     Connected --> Authenticated : Server confirms auth
     Authenticated --> InRoom : join_room / join_as_spectator
     InRoom --> Authenticated : leave_room / leave_spectator
     Authenticated --> Disconnected : shutdown / error
     InRoom --> Disconnected : shutdown / error
     Connected --> Disconnected : auth failure / error
+    Connecting --> Disconnected : shutdown / transport terminal
 ```
 
 | Transition | Trigger |
 |------------|---------|
-| **Disconnected → Connected** | The async client emits `Connected` when its loop starts with the already-connected transport. The polling client emits it on the first `poll()` cycle where `Transport::is_ready()` is true. |
+| **Disconnected → Connecting** | Constructing either client transfers ownership of a nonterminal transport attempt; `is_connected()` is true while `is_transport_ready()` remains false. |
+| **Connecting → Connected** | Both drivers emit `Connected` on their first observation that `Transport::is_ready()` is true. For the polling client, observation occurs only while the application calls `poll()`. |
 | **Connected → Authenticated** | The SDK auto-sends an `Authenticate` message. On success the server replies and `SignalFishEvent::Authenticated` is emitted. |
 | **Authenticated → InRoom** | Call `client.join_room(params)` or `client.join_as_spectator(...)`. The server responds with `SignalFishEvent::RoomJoined` (or `SpectatorJoined`). |
 | **InRoom → Authenticated** | Call `client.leave_room()` or `client.leave_spectator()`. The server confirms with `SignalFishEvent::RoomLeft`. |
@@ -87,8 +91,8 @@ stateDiagram-v2
 
 !!! warning "Authentication is automatic"
     You do **not** need to call an authenticate method. `SignalFishClient::start`
-    sends the authentication message immediately using the `SignalFishConfig`
-    you provide.
+    queues the authentication message immediately using the `SignalFishConfig`
+    you provide. The driver transfers it once the transport is ready.
 
 ---
 
@@ -293,12 +297,15 @@ measured capacity envelope — is documented in
 [Delivery Contract & Backpressure](delivery.md).
 
 Because the client applies backpressure instead of dropping events on
-overflow, loss elsewhere becomes observable. `stats()`
-returns [`ClientStats`](client.md) with cumulative `game_data_sent` /
+overflow, boundary-specific loss becomes diagnosable. `stats()` returns
+[`ClientStats`](client.md) with cumulative `game_data_sent` /
 `game_data_received` / `messages_undecodable` counters (they survive
-disconnects): exchange or log them across peers, account for the explicit
-terminal and quarantine boundaries above, and use any remaining persistent
-sent-vs-received deficit to investigate the relay path or a peer. Pace
+disconnects). Sent counts transport ownership transfers, including an accepted
+send that later fails; received counts successfully decoded relay game data,
+including stale or quarantined messages suppressed before application. Fanout,
+delivery-class policy, server rejection, terminal unread work, and WebRTC
+data-channel traffic mean peer counters are diagnostic rather than an equality.
+Pace
 high-rate streams with
 `send_game_data_reliable` instead of guessing at sleep durations — but drain
 events from a separate task while awaiting it: the queue only drains while
@@ -313,6 +320,7 @@ simultaneous send + receive pressure.
 | Accessor | Async? | Returns |
 |----------|--------|---------|
 | `is_connected()` | No | `bool` |
+| `is_transport_ready()` | No | `bool` |
 | `is_authenticated()` | No | `bool` |
 | `snapshot()` | No | `ClientSnapshot` |
 | `room_role()` | No | `Option<RoomRole>` |

--- a/docs/events.md
+++ b/docs/events.md
@@ -43,7 +43,7 @@ Use these to track the raw connection lifecycle.
 
 | Variant | Fields | Description |
 |---------|--------|-------------|
-| `Connected` | — | The transport handshake is complete and the client is ready to communicate. Synthetic — see [Connection timing](wasm.md#connection-timing) for details. |
+| `Connected` | — | The driver first observed `Transport::is_ready() == true` and marked `ClientSnapshot::transport_ready` true; a later terminal transition resets it. Synthetic — see [Connection timing](wasm.md#connection-timing) for details. |
 | `Disconnected` | `reason: Option<String>`, `last_server_error: Option<ServerErrorInfo>` | The transport connection was closed or errored. |
 | `DecodeFailed` | `message_type: Option<String>`, `error: String`, `raw_prefix: String` | An inbound frame could not be decoded into a `ServerMessage`; the connection stays open. |
 | `ProtocolViolation` | `kind: ProtocolViolationKind`, `diagnostic: String` | A decoded message violated lifecycle, version, session-plan, signaling, or delivery-accountability invariants; configured policy decides quarantine, disconnect, or continued observation. Lifecycle/plan/signaling offenders are suppressed. |

--- a/docs/transport.md
+++ b/docs/transport.md
@@ -78,6 +78,10 @@ Never take a frame, forget it on `Pending`, and ask the caller to retry. Never
 repeat a partially completed write: either mistake can lose or duplicate an
 application message.
 
+While `is_ready()` is false, `poll_send` must return `Pending` without taking
+the frame. This lets both clients admit FIFO commands during an asynchronous
+handshake without transferring them prematurely.
+
 `begin_poll_cycle` lets adaptive transports sample once per application tick.
 `diagnostics` distinguishes backend-owned buffering/admission from the client
 queue. `abort` is invoked when the polling close deadline expires; defaulted
@@ -123,7 +127,12 @@ it to attribute `SignalFishEvent::Disconnected`.
 
 `is_ready()` defaults to `true`, which is correct for transports connected by
 their constructor. An asynchronous-handshake transport returns `false` until
-ready; the polling client defers its synthetic `Connected` event accordingly.
+ready; both clients defer their synthetic `Connected` event accordingly. The
+value must be cheap and monotonic for one physical connection. When readiness
+changes while the async client is blocked, the transport must wake a waker
+registered by `poll_send` or `poll_recv`; `is_ready()` itself cannot register
+one. Before readiness, `poll_send` retains caller ownership and `poll_recv`
+must not return a complete protocol frame.
 
 ## Built-in `WebSocketTransport`
 

--- a/docs/wasm.md
+++ b/docs/wasm.md
@@ -258,10 +258,10 @@ bound and does not accept this main-thread transport.
     `poll()` retries the exact same frame, in order. The browser only receives
     the command after its synchronous send API accepts it.
 
-    This aligns with the async `SignalFishClient`, where the transport is
-    passed to `start()` already connected (e.g., via
-    `WebSocketTransport::connect(url).await`), so `Connected` also
-    reflects a completed handshake.
+    The async `SignalFishClient` uses the same readiness boundary. Built-in
+    `WebSocketTransport::connect(url).await` is already ready, while a custom
+    asynchronous-handshake transport defers `Connected` and must wake its
+    registered I/O waker when readiness changes.
 
 ---
 
@@ -426,7 +426,8 @@ environment).
 
 | Method | Signature | Description |
 |--------|-----------|-------------|
-| `is_connected()` | `fn is_connected(&self) -> bool` | Whether the transport is still alive. |
+| `is_connected()` | `fn is_connected(&self) -> bool` | Whether the client owns a nonterminal transport attempt, including connecting. |
+| `is_transport_ready()` | `fn is_transport_ready(&self) -> bool` | Whether the driver observed the transport handshake complete. |
 | `is_closing()` | `fn is_closing(&self) -> bool` | Whether the bounded close lifecycle still needs polling. |
 | `is_authenticated()` | `fn is_authenticated(&self) -> bool` | Whether the server confirmed authentication. |
 | `room_role()` | `fn room_role(&self) -> Option<RoomRole>` | Server-confirmed player/spectator role, or `None` outside a room. |
@@ -446,7 +447,7 @@ environment).
 | `reset_queue_age_peak()` | `fn reset_queue_age_peak(&mut self)` | Refresh current age and reset the sampled peak to it. |
 | `transport_diagnostics()` | `fn transport_diagnostics(&self) -> TransportDiagnostics` | Backend acceptance, buffering, watermark, and capacity diagnostics. |
 | `transport()` | `fn transport(&self) -> &T` | Borrow transport-specific read-only diagnostics; I/O still advances only through `poll()`. |
-| `snapshot()` | `fn snapshot(&self) -> ClientSnapshot` | Return coherent connection, room, token, negotiation, selected plan, generation, and quarantine state. |
+| `snapshot()` | `fn snapshot(&self) -> ClientSnapshot` | Return coherent connection readiness, room, token, negotiation, selected plan, generation, and quarantine state. |
 
 !!! tip "Comparison with `SignalFishClient`"
     `SignalFishPollingClient` mirrors `SignalFishClient`'s common synchronous

--- a/pr-description.md
+++ b/pr-description.md
@@ -1,31 +1,35 @@
 ## Summary
 
-Completes the remaining issue #61 reliability work by hardening browser
-transport ownership, replacing a startup-sensitive soak assertion with a
-phase-aware rollback oracle, strengthening independent CI validation, and
-synchronizing the public documentation with the actual released/unreleased API.
+Clarifies the connection phase and traffic-counter contracts shared by the
+async and polling clients. Applications can now distinguish client ownership
+from transport readiness, and `ClientStats` counts at stable transport/decode
+boundaries instead of backend completion or application delivery.
+
+Closes #104.
 
 ## Changes
 
-- Retain Emscripten outbound frames while the browser socket is connecting and
-  after preparation/FFI send failures.
-- Track early warm-up and steady-state Fortress confirmation lag separately:
-  the first 60 frames remain bounded by the 20-frame prediction window, while
-  steady/final lag remains capped at 8 clean or 13 impaired/soak frames.
-- Independently validate exact load conservation, multi-frame polling, queue
-  ceilings, adaptive buffering, and required schema with negative controls.
-- Compile complete Rust documentation examples containing Unicode ellipses and
-  make broken MkDocs links blocking.
-- Correct stale client, event, protocol, transport, WebAssembly, migration, and
-  installation documentation, including explicit `0.8.0` versus `main` usage.
+- Add `ClientSnapshot::transport_ready` and matching async, polling, and
+  `SignalFishClientApi` accessors; emit `Connected` exactly once on the first
+  driver observation of `Transport::is_ready()`.
+- Preserve FIFO command admission while connecting, require deferred async
+  readiness to wake registered I/O, and reset every connection phase on
+  terminal paths.
+- Count `game_data_sent` at exact frame ownership transfer, including
+  accepted-Pending and accepted-then-error sends without double-counting.
+- Count `game_data_received` immediately after successful text or binary
+  protocol decode, before message validation, sequence accountability, stale,
+  quarantine, or event suppression; preserve physical-binary admission checks
+  that reject a frame before logical decoding.
+- Document the valid phase tuples, counter conservation limits, excluded
+  traffic, and cross-peer diagnostic caveats across the public guides,
+  changelog, roadmap, canonical context, and focused agent skills.
 
 ## Validation
 
-- [x] `cargo fmt`
-- [x] `cargo clippy --all-targets --all-features -- -D warnings`
-- [x] `cargo test --all-features`
-- [x] Nested Godot fixture format, Clippy, and eight unit tests with Godot 4.5
-- [x] Emscripten-target Clippy with warnings denied
-- [x] Documentation snippet extraction, strict MkDocs rendering, Markdown lint,
-  and typos
-- [x] Godot E2E validator negative controls and CI policy tests
+- [x] Focused async and polling readiness tests
+- [x] Focused ownership-transfer and decoded-receipt tests
+- [x] Async/polling frame, snapshot, and statistics parity tests
+- [x] Repository documentation and workflow policy validators
+- [x] `cargo fmt && cargo clippy --workspace --all-targets --all-features -- -D warnings && cargo test --workspace --all-features`
+- [ ] Hosted required checks and review feedback

--- a/progress/session-032-readiness-and-traffic-counters.md
+++ b/progress/session-032-readiness-and-traffic-counters.md
@@ -1,0 +1,77 @@
+# Session 032 — Readiness and Traffic Counter Contracts
+
+## Scope and Priority
+
+Issue #104 was the highest gameplay-impacting open correctness issue after PR
+#114 merged and closed #103. The hosted audit found no open or draft PR and no
+dependency PR to incorporate. This session intentionally excludes #106 and
+#107 so readiness and traffic observability form one reviewable contract.
+
+## Connection Phase Contract
+
+`ClientSnapshot` exposes four nested dimensions without a redundant phase enum:
+
+| Phase | `connected` | `transport_ready` | `authenticated` | `room_role` |
+| --- | ---: | ---: | ---: | --- |
+| Connecting/client-owned | true | false | false | none |
+| Transport ready | true | true | false | none |
+| Authenticated | true | true | true | none |
+| In room | true | true | true | player or spectator |
+| Terminal | false | false | false | none |
+
+`connected` preserves command admission during asynchronous handshakes.
+`transport_ready` is a sticky driver observation of `Transport::is_ready()`
+and drives the one synthetic `Connected` event. Both reset at logical
+termination. A connecting transport retains caller ownership and wakes
+registered async I/O when readiness changes.
+
+## Traffic Counter Contract
+
+- `game_data_sent` increments exactly at `Transport::poll_send` ownership
+  transfer (`Some` to `None`), including accepted-Pending and
+  accepted-then-error outcomes. It is not server or peer delivery.
+- `game_data_received` increments after successful logical game-data decode,
+  before message validation, sequence accountability, stale, quarantine, or
+  event suppression. Physical binary lifecycle/representation checks that
+  reject a frame before logical decoding remain outside this counter.
+- `messages_undecodable` remains disjoint from decoded game data. Non-game
+  protocol frames, WebRTC application traffic, and physical binary frames
+  rejected before logical decode are outside the game-data counters.
+- All counters saturate and survive room and connection teardown. A new client
+  alone starts from zero.
+
+Cross-peer equality is deliberately not promised: broadcast fanout can make
+aggregate receipt larger, while server delivery policy, rejection, terminal
+unread work, or accepted-then-error can make it smaller.
+
+## Invariant to Evidence Matrix
+
+| Invariant | Source | Executable evidence |
+| --- | --- | --- |
+| Both drivers defer `Connected` until readiness and preserve terminal ordering. | `ClientCore::mark_transport_ready`; async `transport_loop`; polling `poll_at`. | Cross-driver phase/terminal parity; async delayed/terminal readiness tests; polling delayed, ready-during-recv, ready-immediate-close, and terminal-before-ready tests. |
+| Outbound ownership is counted once, independent of completion. | Async `poll_pending_send`; polling `drive_outbound`. | Async accepted-Pending success/error and take/no-take error tests; polling accepted-Pending and take/no-take error tests. |
+| Decoded receipt includes suppressed data. | `ClientCore::{process_text,process_binary}`. | Exact async/polling stale/quarantine/lifetime parity, shared-core suppression, and physical binary receipt tests. |
+| State and statistics remain driver-aligned. | `ClientCore` snapshots/counters and default `SignalFishClientApi` readiness accessor. | Full async/polling unit and parity suites plus the mandatory workspace gate. |
+
+## Review and Verification
+
+Three independent audits reviewed readiness semantics, traffic counting points,
+public API/semver impact, documentation obligations, and hidden terminal cases.
+Their findings drove guarded readiness transitions, wake requirements,
+accepted-then-error coverage, stale/quarantine receipt coverage, conservation
+documentation, and the decision not to add a redundant exhaustive phase enum.
+
+Local verification completed with the mandatory workspace command:
+
+```text
+cargo fmt
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo test --workspace --all-features
+```
+
+Clippy completed with zero warnings; all 345 root library tests, 35 Godot
+adapter tests, 470 integration tests, and seven runnable rustdoc tests passed
+(six live-server tests and five example-only rustdoc blocks remained explicitly
+ignored). Repository LLM, workflow-policy, and documentation validators also
+passed. Hosted check and review evidence will be recorded on the PR before
+merge.

--- a/src/client.rs
+++ b/src/client.rs
@@ -571,24 +571,31 @@ impl JoinRoomParams {
 /// polling work remains queued across bounded cycles, and refused sends return
 /// [`SendBufferFull`](crate::SignalFishError::SendBufferFull). Exchange or log
 /// these counters across peers to locate a persistent deficit after accounting
-/// for explicit terminal boundaries (shutdown, handle/receiver drop, or
-/// disconnect) and protocol quarantine.
+/// for explicit terminal boundaries, server delivery policy, and fanout.
 ///
 /// Counters are cumulative for the lifetime of the client (they survive
 /// room changes and disconnection).
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct ClientStats {
     /// `GameData` messages whose frames the transport accepted from the client.
+    ///
+    /// Counted at the ownership-transfer boundary: the first
+    /// [`Transport::poll_send`] call that takes the frame from the client. A
+    /// later backend completion error does not undo that transfer, and this
+    /// counter does not imply peer or server delivery.
     pub game_data_sent: u64,
     /// `GameData`/`GameDataBinary` messages received from the server.
     ///
-    /// Counted at **receipt** (when the message is read off the transport
-    /// and parsed), not at delivery to your event loop. That is the number
-    /// the relay-path deficit diagnostic needs — it measures the wire, so a
-    /// consumer that stops draining events (or a terminal abort racing the
-    /// last deliveries) cannot masquerade as relay loss. In steady state
-    /// normal-operation receipt and delivery remain aligned across async
-    /// backpressure or bounded polling cycles.
+    /// Counted at **receipt** (when the message is read off the transport and
+    /// parsed), before delivery of that message to your event loop. Async
+    /// event-channel backpressure can still stop later transport reads, and a
+    /// terminal boundary can leave buffered frames unread; account for both
+    /// when diagnosing a cross-peer deficit.
+    /// Successfully decoded stale, accountability-invalid, and
+    /// quarantine-suppressed messages are included. Malformed frames are
+    /// excluded and counted by [`messages_undecodable`](Self::messages_undecodable).
+    /// Physical binary frames rejected by lifecycle or representation policy
+    /// before logical decoding are also excluded.
     pub game_data_received: u64,
     /// Inbound frames that failed to decode into a `ServerMessage`.
     ///
@@ -603,7 +610,21 @@ pub struct ClientStats {
 /// Coherent synchronous view of client/session state.
 #[derive(Clone, Default, PartialEq, Eq)]
 pub struct ClientSnapshot {
+    /// Whether the client still owns a nonterminal transport connection.
+    ///
+    /// This becomes `true` when the client is constructed, before a transport
+    /// with an asynchronous handshake is necessarily ready. Read
+    /// [`transport_ready`](Self::transport_ready) to distinguish that
+    /// connecting phase.
     pub connected: bool,
+    /// Whether the transport handshake has completed for this connection.
+    ///
+    /// This becomes `true` immediately before the synthetic
+    /// [`Connected`](SignalFishEvent::Connected) event and returns to `false`
+    /// on terminal disconnect or close. Commands may still be queued while
+    /// this is `false`; transport ownership rules keep their frames pending.
+    pub transport_ready: bool,
+    /// Whether the server has confirmed authentication for this connection.
     pub authenticated: bool,
     pub negotiated_protocol_version: Option<u16>,
     /// Exact game-data preference supplied in [`SignalFishConfig`].
@@ -657,6 +678,7 @@ impl std::fmt::Debug for ClientSnapshot {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ClientSnapshot")
             .field("connected", &self.connected)
+            .field("transport_ready", &self.transport_ready)
             .field("authenticated", &self.authenticated)
             .field(
                 "negotiated_protocol_version",
@@ -739,7 +761,8 @@ impl SignalFishClient {
     ///
     /// # Arguments
     ///
-    /// * `transport` — A connected [`Transport`] implementation.
+    /// * `transport` — A [`Transport`] implementation. Its handshake may still
+    ///   be in progress if [`Transport::is_ready`] returns `false`.
     /// * `config` — Client configuration including the App ID.
     ///
     /// # Returns
@@ -1355,9 +1378,18 @@ impl SignalFishClient {
         lock_core(&self.state).is_p2p_active()
     }
 
-    /// Returns `true` if the transport is believed to be connected.
+    /// Whether the client owns a nonterminal transport attempt.
+    ///
+    /// This is already `true` while the transport handshake is in progress.
+    /// Use [`is_transport_ready`](Self::is_transport_ready) when readiness is
+    /// required.
     pub fn is_connected(&self) -> bool {
         lock_core(&self.state).is_connected()
+    }
+
+    /// Returns `true` once the transport handshake has completed.
+    pub fn is_transport_ready(&self) -> bool {
+        lock_core(&self.state).is_transport_ready()
     }
 
     /// Returns `true` if the server has confirmed authentication.
@@ -1468,6 +1500,7 @@ impl std::fmt::Debug for SignalFishClient {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut dbg = f.debug_struct("SignalFishClient");
         dbg.field("connected", &self.is_connected())
+            .field("transport_ready", &self.is_transport_ready())
             .field("authenticated", &self.is_authenticated());
         #[cfg(feature = "tokio-runtime")]
         dbg.field("has_task", &self.task.is_some());
@@ -1676,20 +1709,12 @@ async fn finish_send_and_close_bounded(
                 pending_send
                     .as_mut()
                     .map_or(std::task::Poll::Ready(Ok(())), |pending| {
-                        transport.poll_send(cx, &mut pending.frame)
+                        poll_pending_send(transport, pending, state, cx)
                     })
             })
             .await;
-            match send_result {
-                Ok(()) => {
-                    if pending_send
-                        .as_ref()
-                        .is_some_and(|pending| pending.is_game_data)
-                    {
-                        lock_core(state).record_game_data_sent();
-                    }
-                }
-                Err(error) => warn!("accepted send failed while closing transport: {error}"),
+            if let Err(error) = send_result {
+                warn!("accepted send failed while closing transport: {error}");
             }
         }
         *pending_send = None;
@@ -1707,12 +1732,30 @@ async fn finish_send_and_close_bounded(
 #[cfg(feature = "tokio-runtime")]
 struct PendingSend {
     frame: Option<TransportFrame>,
+    /// `true` only until the transport first takes ownership of this game-data frame.
     is_game_data: bool,
 }
 
 #[cfg(feature = "tokio-runtime")]
+fn poll_pending_send(
+    transport: &mut impl Transport,
+    pending: &mut PendingSend,
+    state: &Arc<Mutex<ClientCore>>,
+    cx: &mut std::task::Context<'_>,
+) -> std::task::Poll<std::result::Result<(), SignalFishError>> {
+    let was_client_owned = pending.frame.is_some();
+    let result = transport.poll_send(cx, &mut pending.frame);
+    if was_client_owned && pending.frame.is_none() && pending.is_game_data {
+        lock_core(state).record_game_data_sent();
+        pending.is_game_data = false;
+    }
+    result
+}
+
+#[cfg(feature = "tokio-runtime")]
 enum TransportIo {
-    Sent { is_game_data: bool },
+    Ready,
+    Sent,
     SendFailed(SignalFishError),
     Received(Option<std::result::Result<TransportFrame, SignalFishError>>),
 }
@@ -1723,14 +1766,18 @@ enum TransportIo {
 async fn poll_transport_io(
     transport: &mut impl Transport,
     pending_send: &mut Option<PendingSend>,
+    state: &Arc<Mutex<ClientCore>>,
+    waiting_for_ready: bool,
 ) -> TransportIo {
     std::future::poll_fn(|cx| {
+        if waiting_for_ready && transport.is_ready() {
+            return std::task::Poll::Ready(TransportIo::Ready);
+        }
         if let Some(pending) = pending_send.as_mut() {
-            match transport.poll_send(cx, &mut pending.frame) {
+            match poll_pending_send(transport, pending, state, cx) {
                 std::task::Poll::Ready(Ok(())) => {
-                    let is_game_data = pending.is_game_data;
                     *pending_send = None;
-                    return std::task::Poll::Ready(TransportIo::Sent { is_game_data });
+                    return std::task::Poll::Ready(TransportIo::Sent);
                 }
                 std::task::Poll::Ready(Err(error)) => {
                     let peer_closed = transport
@@ -1751,9 +1798,13 @@ async fn poll_transport_io(
             }
         }
 
-        match transport.poll_recv(cx) {
+        let receive = transport.poll_recv(cx);
+        match receive {
             std::task::Poll::Ready(incoming) => {
                 std::task::Poll::Ready(TransportIo::Received(incoming))
+            }
+            std::task::Poll::Pending if waiting_for_ready && transport.is_ready() => {
+                std::task::Poll::Ready(TransportIo::Ready)
             }
             std::task::Poll::Pending => std::task::Poll::Pending,
         }
@@ -1779,24 +1830,27 @@ async fn transport_loop(
     debug!("transport loop started");
 
     let mut pending_send = None;
-
-    if matches!(
-        emit_event_or_shutdown(&event_tx, &mut shutdown_rx, SignalFishEvent::Connected).await,
-        EmitOutcome::ShutdownRequested
-    ) {
-        finish_core_shutdown(
-            &mut transport,
-            &mut pending_send,
-            &event_tx,
-            &state,
-            shutdown_timeout,
-        )
-        .await;
-        debug!("transport loop exited");
-        return;
-    }
+    let mut connected_emitted = false;
 
     loop {
+        if !connected_emitted && transport.is_ready() && lock_core(&state).mark_transport_ready() {
+            connected_emitted = true;
+            if matches!(
+                emit_event_or_shutdown(&event_tx, &mut shutdown_rx, SignalFishEvent::Connected)
+                    .await,
+                EmitOutcome::ShutdownRequested
+            ) {
+                finish_core_shutdown(
+                    &mut transport,
+                    &mut pending_send,
+                    &event_tx,
+                    &state,
+                    shutdown_timeout,
+                )
+                .await;
+                break;
+            }
+        }
         tokio::select! {
             command = cmd_rx.recv(), if pending_send.is_none() => {
                 let Some(command) = command else {
@@ -1843,13 +1897,51 @@ async fn transport_loop(
                 ).await;
                 break;
             }
-            io = poll_transport_io(&mut transport, &mut pending_send) => {
-                match io {
-                    TransportIo::Sent { is_game_data } => {
-                        if is_game_data {
-                            lock_core(&state).record_game_data_sent();
-                        }
+            io = poll_transport_io(
+                &mut transport,
+                &mut pending_send,
+                &state,
+                !connected_emitted,
+            ) => {
+                if !connected_emitted
+                    && transport.is_ready()
+                    && lock_core(&state).mark_transport_ready()
+                {
+                    connected_emitted = true;
+                    if matches!(
+                        emit_event_or_shutdown(
+                            &event_tx,
+                            &mut shutdown_rx,
+                            SignalFishEvent::Connected,
+                        ).await,
+                        EmitOutcome::ShutdownRequested
+                    ) {
+                        finish_core_shutdown(
+                            &mut transport,
+                            &mut pending_send,
+                            &event_tx,
+                            &state,
+                            shutdown_timeout,
+                        ).await;
+                        break;
                     }
+                }
+                if !connected_emitted
+                    && matches!(&io, TransportIo::Received(Some(Ok(_))))
+                {
+                    emit_core_disconnected_or_shutdown(
+                        &mut transport,
+                        &mut pending_send,
+                        &event_tx,
+                        &mut shutdown_rx,
+                        &state,
+                        Some("transport received a protocol frame before readiness".into()),
+                        shutdown_timeout,
+                    ).await;
+                    break;
+                }
+                match io {
+                    TransportIo::Ready | TransportIo::Sent => {}
                     TransportIo::SendFailed(error) => {
                         emit_core_disconnected_or_shutdown(
                             &mut transport,
@@ -2095,6 +2187,254 @@ mod tests {
         }
     }
 
+    #[derive(Clone)]
+    struct DeferredReadyControls {
+        ready: Arc<AtomicBool>,
+        waker: Arc<StdMutex<Option<Waker>>>,
+    }
+
+    impl DeferredReadyControls {
+        fn set_ready(&self, ready: bool) {
+            self.ready.store(ready, Ordering::Release);
+            if ready {
+                if let Some(waker) = self.waker.lock().unwrap().take() {
+                    waker.wake();
+                }
+            }
+        }
+    }
+
+    struct DeferredReadyTransport {
+        controls: DeferredReadyControls,
+        sent: Arc<StdMutex<Vec<TransportFrame>>>,
+    }
+
+    impl DeferredReadyTransport {
+        fn new() -> (
+            Self,
+            DeferredReadyControls,
+            Arc<StdMutex<Vec<TransportFrame>>>,
+        ) {
+            let controls = DeferredReadyControls {
+                ready: Arc::new(AtomicBool::new(false)),
+                waker: Arc::new(StdMutex::new(None)),
+            };
+            let sent = Arc::new(StdMutex::new(Vec::new()));
+            (
+                Self {
+                    controls: controls.clone(),
+                    sent: Arc::clone(&sent),
+                },
+                controls,
+                sent,
+            )
+        }
+    }
+
+    impl Transport for DeferredReadyTransport {
+        fn poll_send(
+            &mut self,
+            cx: &mut Context<'_>,
+            frame: &mut Option<TransportFrame>,
+        ) -> Poll<std::result::Result<(), SignalFishError>> {
+            if !self.is_ready() {
+                *self.controls.waker.lock().unwrap() = Some(cx.waker().clone());
+                return Poll::Pending;
+            }
+            if let Some(frame) = frame.take() {
+                self.sent.lock().unwrap().push(frame);
+            }
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_recv(
+            &mut self,
+            cx: &mut Context<'_>,
+        ) -> Poll<Option<std::result::Result<TransportFrame, SignalFishError>>> {
+            *self.controls.waker.lock().unwrap() = Some(cx.waker().clone());
+            Poll::Pending
+        }
+
+        fn poll_close(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<std::result::Result<(), SignalFishError>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn is_ready(&self) -> bool {
+            self.controls.ready.load(Ordering::Acquire)
+        }
+    }
+
+    struct GameDataErrorTransport {
+        take_before_error: bool,
+    }
+
+    impl Transport for GameDataErrorTransport {
+        fn poll_send(
+            &mut self,
+            _cx: &mut Context<'_>,
+            frame: &mut Option<TransportFrame>,
+        ) -> Poll<std::result::Result<(), SignalFishError>> {
+            let game_data = matches!(
+                frame.as_ref(),
+                Some(TransportFrame::Text(text)) if text.contains("\"type\":\"GameData\"")
+            );
+            if game_data {
+                if self.take_before_error {
+                    let _ = frame.take();
+                }
+                return Poll::Ready(Err(SignalFishError::TransportSend(
+                    "scripted game-data failure".into(),
+                )));
+            }
+            let _ = frame.take();
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_recv(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Option<std::result::Result<TransportFrame, SignalFishError>>> {
+            Poll::Pending
+        }
+
+        fn poll_close(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<std::result::Result<(), SignalFishError>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    #[derive(Clone)]
+    struct PendingGameDataControls {
+        accepted: Arc<AtomicBool>,
+        outcome: Arc<std::sync::atomic::AtomicU8>,
+        waker: Arc<StdMutex<Option<Waker>>>,
+    }
+
+    impl PendingGameDataControls {
+        fn finish(&self, fail: bool) {
+            self.outcome
+                .store(if fail { 2 } else { 1 }, Ordering::Release);
+            if let Some(waker) = self.waker.lock().unwrap().take() {
+                waker.wake();
+            }
+        }
+    }
+
+    struct PendingGameDataTransport {
+        retained: Option<TransportFrame>,
+        controls: PendingGameDataControls,
+    }
+
+    impl PendingGameDataTransport {
+        fn new() -> (Self, PendingGameDataControls) {
+            let controls = PendingGameDataControls {
+                accepted: Arc::new(AtomicBool::new(false)),
+                outcome: Arc::new(std::sync::atomic::AtomicU8::new(0)),
+                waker: Arc::new(StdMutex::new(None)),
+            };
+            (
+                Self {
+                    retained: None,
+                    controls: controls.clone(),
+                },
+                controls,
+            )
+        }
+    }
+
+    impl Transport for PendingGameDataTransport {
+        fn poll_send(
+            &mut self,
+            cx: &mut Context<'_>,
+            frame: &mut Option<TransportFrame>,
+        ) -> Poll<std::result::Result<(), SignalFishError>> {
+            if self.retained.is_none() {
+                let game_data = matches!(
+                    frame.as_ref(),
+                    Some(TransportFrame::Text(text)) if text.contains("\"type\":\"GameData\"")
+                );
+                if !game_data {
+                    let _ = frame.take();
+                    return Poll::Ready(Ok(()));
+                }
+                self.retained = frame.take();
+                self.controls.accepted.store(true, Ordering::Release);
+            }
+            match self.controls.outcome.load(Ordering::Acquire) {
+                1 => {
+                    self.retained = None;
+                    Poll::Ready(Ok(()))
+                }
+                2 => {
+                    self.retained = None;
+                    Poll::Ready(Err(SignalFishError::TransportSend(
+                        "scripted completion failure".into(),
+                    )))
+                }
+                _ => {
+                    *self.controls.waker.lock().unwrap() = Some(cx.waker().clone());
+                    Poll::Pending
+                }
+            }
+        }
+
+        fn poll_recv(
+            &mut self,
+            cx: &mut Context<'_>,
+        ) -> Poll<Option<std::result::Result<TransportFrame, SignalFishError>>> {
+            *self.controls.waker.lock().unwrap() = Some(cx.waker().clone());
+            Poll::Pending
+        }
+
+        fn poll_close(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<std::result::Result<(), SignalFishError>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn abort(&mut self) {
+            self.retained = None;
+        }
+    }
+
+    struct NeverReadyTerminalTransport {
+        frame: Option<TransportFrame>,
+    }
+
+    impl Transport for NeverReadyTerminalTransport {
+        fn poll_send(
+            &mut self,
+            _cx: &mut Context<'_>,
+            _frame: &mut Option<TransportFrame>,
+        ) -> Poll<std::result::Result<(), SignalFishError>> {
+            Poll::Pending
+        }
+
+        fn poll_recv(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Option<std::result::Result<TransportFrame, SignalFishError>>> {
+            Poll::Ready(self.frame.take().map(Ok))
+        }
+
+        fn poll_close(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<std::result::Result<(), SignalFishError>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn is_ready(&self) -> bool {
+            false
+        }
+    }
+
     // ── Helper ──────────────────────────────────────────────────────
 
     async fn wait_for_sent_len(sent: &Arc<StdMutex<Vec<String>>>, expected_len: usize) {
@@ -2225,6 +2565,155 @@ mod tests {
         }
 
         client.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn connected_and_snapshot_wait_for_async_transport_readiness() {
+        let (transport, controls, sent) = DeferredReadyTransport::new();
+        let (mut client, mut events) =
+            SignalFishClient::start(transport, SignalFishConfig::new("app"));
+
+        assert_eq!(
+            (
+                client.is_connected(),
+                client.is_transport_ready(),
+                client.is_authenticated(),
+                client.room_role(),
+            ),
+            (true, false, false, None)
+        );
+        tokio::task::yield_now().await;
+        assert!(matches!(
+            events.try_recv(),
+            Err(tokio::sync::mpsc::error::TryRecvError::Empty)
+        ));
+        assert!(sent.lock().unwrap().is_empty());
+
+        controls.set_ready(true);
+        assert!(matches!(
+            tokio::time::timeout(Duration::from_secs(1), events.recv()).await,
+            Ok(Some(SignalFishEvent::Connected))
+        ));
+        wait_until(|| !sent.lock().unwrap().is_empty()).await;
+        assert!(client.is_transport_ready());
+
+        controls.set_ready(false);
+        tokio::task::yield_now().await;
+        assert!(client.is_transport_ready(), "observed readiness is sticky");
+
+        client.shutdown().await;
+        assert_eq!(
+            (
+                client.is_connected(),
+                client.is_transport_ready(),
+                client.is_authenticated(),
+                client.room_role(),
+            ),
+            (false, false, false, None)
+        );
+    }
+
+    #[tokio::test]
+    async fn send_error_counts_only_frames_the_transport_took() {
+        for (take_before_error, expected_sent) in [(false, 0), (true, 1)] {
+            let transport = GameDataErrorTransport { take_before_error };
+            let (mut client, mut events) =
+                SignalFishClient::start(transport, SignalFishConfig::new("app"));
+            assert!(matches!(
+                events.recv().await,
+                Some(SignalFishEvent::Connected)
+            ));
+            prime_player_room(&client);
+            client
+                .send_game_data(serde_json::json!({"frame": 1}))
+                .expect("primed player may queue game data");
+
+            let terminal = tokio::time::timeout(Duration::from_secs(1), events.recv())
+                .await
+                .expect("send failure should become terminal")
+                .expect("Disconnected event should be delivered");
+
+            assert!(matches!(terminal, SignalFishEvent::Disconnected { .. }));
+            assert_eq!(
+                client.stats().game_data_sent,
+                expected_sent,
+                "take_before_error={take_before_error}"
+            );
+            client.shutdown().await;
+        }
+    }
+
+    #[tokio::test]
+    async fn accepted_pending_game_data_counts_before_completion_without_double_counting() {
+        for fail_completion in [false, true] {
+            let (transport, controls) = PendingGameDataTransport::new();
+            let (mut client, mut events) =
+                SignalFishClient::start(transport, SignalFishConfig::new("app"));
+            assert!(matches!(
+                events.recv().await,
+                Some(SignalFishEvent::Connected)
+            ));
+            prime_player_room(&client);
+            client
+                .send_game_data(serde_json::json!({"frame": 1}))
+                .expect("primed player may queue game data");
+            wait_until(|| controls.accepted.load(Ordering::Acquire)).await;
+            assert_eq!(
+                client.stats().game_data_sent,
+                1,
+                "ownership transfer counts while completion is pending"
+            );
+
+            controls.finish(fail_completion);
+            if fail_completion {
+                let terminal = tokio::time::timeout(Duration::from_secs(1), events.recv())
+                    .await
+                    .expect("failed accepted send should become terminal")
+                    .expect("Disconnected event should be delivered");
+                assert!(matches!(terminal, SignalFishEvent::Disconnected { .. }));
+            } else {
+                tokio::task::yield_now().await;
+            }
+            assert_eq!(client.stats().game_data_sent, 1);
+            client.shutdown().await;
+            assert_eq!(
+                client.stats().game_data_sent,
+                1,
+                "completion and shutdown must not double-count acceptance"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn terminal_before_readiness_never_emits_connected() {
+        for frame in [None, Some(TransportFrame::Text("{}".into()))] {
+            let transport = NeverReadyTerminalTransport { frame };
+            let (mut client, mut events) =
+                SignalFishClient::start(transport, SignalFishConfig::new("app"));
+
+            let event = tokio::time::timeout(Duration::from_secs(1), events.recv())
+                .await
+                .expect("terminal transport should wake the driver")
+                .expect("Disconnected should be delivered");
+
+            assert!(matches!(event, SignalFishEvent::Disconnected { .. }));
+            assert!(matches!(
+                events.try_recv(),
+                Err(tokio::sync::mpsc::error::TryRecvError::Empty)
+                    | Err(tokio::sync::mpsc::error::TryRecvError::Disconnected)
+            ));
+            let snapshot = client.snapshot();
+            assert_eq!(
+                (
+                    snapshot.connected,
+                    snapshot.transport_ready,
+                    snapshot.authenticated,
+                    snapshot.room_role,
+                ),
+                (false, false, false, None)
+            );
+            client.shutdown().await;
+        }
     }
 
     #[tokio::test]

--- a/src/client_api.rs
+++ b/src/client_api.rs
@@ -85,9 +85,14 @@ pub trait SignalFishClientApi {
         self.snapshot().room_role
     }
 
-    /// Whether the physical connection is active.
+    /// Whether the client owns a nonterminal transport connection.
     fn is_connected(&self) -> bool {
         self.snapshot().connected
+    }
+
+    /// Whether the transport handshake has completed.
+    fn is_transport_ready(&self) -> bool {
+        self.snapshot().transport_ready
     }
 
     /// Whether authentication has completed.

--- a/src/client_core.rs
+++ b/src/client_core.rs
@@ -193,6 +193,18 @@ impl ClientCore {
         self.snapshot.connected
     }
 
+    pub(crate) fn is_transport_ready(&self) -> bool {
+        self.snapshot.transport_ready
+    }
+
+    pub(crate) fn mark_transport_ready(&mut self) -> bool {
+        if !self.snapshot.connected || self.snapshot.transport_ready {
+            return false;
+        }
+        self.snapshot.transport_ready = true;
+        true
+    }
+
     pub(crate) fn is_authenticated(&self) -> bool {
         self.snapshot.authenticated
     }
@@ -597,6 +609,7 @@ impl ClientCore {
     pub(crate) fn disconnect(&mut self, reason: Option<String>) -> SignalFishEvent {
         self.accountability.observe_terminal();
         self.snapshot.connected = false;
+        self.snapshot.transport_ready = false;
         self.clear_session();
         SignalFishEvent::Disconnected {
             reason,
@@ -629,6 +642,13 @@ impl ClientCore {
                 return outcome;
             }
         };
+
+        if matches!(
+            &server_msg,
+            ServerMessage::GameData { .. } | ServerMessage::GameDataBinary { .. }
+        ) {
+            self.stats.game_data_received = self.stats.game_data_received.saturating_add(1);
+        }
 
         if let Err(diagnostic) = self.validate_inbound_message(&server_msg) {
             self.reject_inbound(&mut outcome, diagnostic);
@@ -793,6 +813,8 @@ impl ClientCore {
                 return outcome;
             }
         };
+
+        self.stats.game_data_received = self.stats.game_data_received.saturating_add(1);
 
         if let Err(diagnostic) = self.validate_inbound_message(&server_msg) {
             self.reject_inbound(&mut outcome, diagnostic);
@@ -1491,9 +1513,6 @@ impl ClientCore {
             ServerMessage::GameStarting { .. } => {
                 self.room_finalized = true;
             }
-            ServerMessage::GameData { .. } | ServerMessage::GameDataBinary { .. } => {
-                self.stats.game_data_received = self.stats.game_data_received.saturating_add(1);
-            }
             _ => {}
         }
     }
@@ -1734,7 +1753,7 @@ mod tests {
     use crate::protocol::{
         DirectEndpoint, IceServer, LobbyState, MessageTransport, PlayerInfo, ProtocolInfoPayload,
         RateLimitInfo, ReconnectedPayload, ReplayStatus, RoomJoinedPayload, SenderWatermark,
-        SessionPeer, SpectatorJoinedPayload,
+        SessionPeer, SpectatorJoinedPayload, V2BinaryGameDataFrame,
     };
 
     const LOCAL: u128 = 1;
@@ -1876,6 +1895,109 @@ mod tests {
         let _ = process(&mut core, protocol_info(Some(3)));
         let _ = process(&mut core, spectator_joined());
         core
+    }
+
+    #[test]
+    fn decoded_game_data_count_includes_stale_and_quarantined_receipts() {
+        let game_data = |seq| ServerMessage::GameData {
+            from_player: PlayerId::from_u128(PEER),
+            data: serde_json::json!({"seq": seq}),
+            seq: Some(seq),
+            epoch: Some(1),
+            class: Some(DeliveryClass::Reliable),
+            key: None,
+        };
+        let mut core = v3_room(ProtocolViolationPolicy::Quarantine);
+
+        let applied = process(&mut core, game_data(1));
+        assert!(matches!(
+            applied.events.as_slice(),
+            [SignalFishEvent::GameData { .. }]
+        ));
+
+        let _ = process(
+            &mut core,
+            ServerMessage::PlayerLeft {
+                player_id: PlayerId::from_u128(PEER),
+                epoch: Some(1),
+                final_seq: Some(2),
+            },
+        );
+        let _ = process(
+            &mut core,
+            ServerMessage::PlayerReconnected {
+                player_id: PlayerId::from_u128(PEER),
+                epoch: Some(2),
+            },
+        );
+        let stale = process(&mut core, game_data(2));
+        assert!(stale.events.is_empty());
+
+        core.snapshot.quarantined = true;
+        let quarantined = process(
+            &mut core,
+            ServerMessage::GameData {
+                from_player: PlayerId::from_u128(PEER),
+                data: serde_json::json!({"seq": 1}),
+                seq: Some(1),
+                epoch: Some(2),
+                class: Some(DeliveryClass::Reliable),
+                key: None,
+            },
+        );
+        assert!(quarantined.events.is_empty());
+        assert_eq!(core.stats().game_data_received, 3);
+
+        let _ = process(&mut core, ServerMessage::RoomLeft);
+        let _ = core.disconnect(None);
+        assert_eq!(
+            core.stats().game_data_received,
+            3,
+            "lifetime counters survive room and connection teardown"
+        );
+        assert_eq!(
+            ClientCore::new(None, ProtocolViolationPolicy::Quarantine, false).stats(),
+            ClientStats::default(),
+            "a new client starts with fresh counters"
+        );
+
+        let binary = V2BinaryGameDataFrame {
+            from_player: PlayerId::from_u128(PEER),
+            encoding: GameDataEncoding::MessagePack,
+            payload: vec![1, 2, 3],
+        };
+        let mut binary_core = ClientCore::new(
+            Some(GameDataEncoding::MessagePack),
+            ProtocolViolationPolicy::Quarantine,
+            false,
+        );
+        let _ = process(&mut binary_core, authenticated());
+        let ServerMessage::ProtocolInfo(mut binary_protocol) = protocol_info(None) else {
+            unreachable!("protocol_info helper always returns ProtocolInfo")
+        };
+        binary_protocol.game_data_formats =
+            vec![GameDataEncoding::Json, GameDataEncoding::MessagePack];
+        let _ = process(
+            &mut binary_core,
+            ServerMessage::ProtocolInfo(binary_protocol),
+        );
+        let _ = process(&mut binary_core, room_joined_v2());
+        binary_core.snapshot.quarantined = true;
+        let rejected = binary_core.process_frame(TransportFrame::Binary(
+            rmp_serde::to_vec_named(&binary).expect("binary receipt should serialize"),
+        ));
+        assert!(rejected
+            .events
+            .iter()
+            .all(|event| !matches!(event, SignalFishEvent::GameDataBinary { .. })));
+        assert_eq!(
+            binary_core.stats(),
+            ClientStats {
+                game_data_received: 1,
+                ..ClientStats::default()
+            },
+            "successful binary decode counts before quarantine suppression"
+        );
     }
 
     fn spectator_joined() -> ServerMessage {

--- a/src/event.rs
+++ b/src/event.rs
@@ -49,20 +49,16 @@ use crate::protocol::{
 #[derive(Clone)]
 pub enum SignalFishEvent {
     // ── Synthetic events ────────────────────────────────────────────
-    /// The client has started and will begin communicating with the server.
+    /// The transport handshake has completed.
     ///
     /// This is a **synthetic event** — it is not triggered by a server message.
     ///
-    /// - **`SignalFishClient`** (async): emitted at the start of the transport
-    ///   loop, after the transport has already been connected via
-    ///   `.connect().await`.
-    /// - **`SignalFishPollingClient`**: emitted once
-    ///   [`Transport::is_ready()`](crate::Transport::is_ready) returns `true`
-    ///   during a [`poll()`](crate::SignalFishPollingClient::poll) cycle. For
-    ///   transports that are already connected at construction time, this is
-    ///   the first `poll()` call. For transports with asynchronous handshakes
-    ///   (e.g., `EmscriptenWebSocketTransport`), `Connected` is deferred
-    ///   until the handshake completes.
+    /// Both clients emit this once they first observe
+    /// [`Transport::is_ready()`](crate::Transport::is_ready) returning `true`.
+    /// For the polling client that observation happens during
+    /// [`poll()`](crate::SignalFishPollingClient::poll); for the async client it
+    /// happens in the transport loop. Transports ready at construction emit it
+    /// on the first driven cycle, while asynchronous handshakes defer it.
     Connected,
 
     /// The transport connection was closed.

--- a/src/polling_client.rs
+++ b/src/polling_client.rs
@@ -199,14 +199,12 @@ pub struct SignalFishPollingClient<T: Transport> {
     polling_stats: PollingStats,
     queue_age_stats: PollingQueueAgeStats,
     shutdown_timeout: Duration,
-    started: bool,
     pending_frame: Option<TransportFrame>,
     pending_frame_enqueued_at: Option<Instant>,
     /// The transport accepted the current frame and is still completing it.
     /// While true, poll with `None` and do not dequeue a replacement frame.
     send_in_flight: bool,
     pending_frame_is_game_data: bool,
-    in_flight_is_game_data: bool,
     pending_inbound: Option<TransportFrame>,
     close_phase: ClosePhase,
 }
@@ -259,12 +257,10 @@ impl<T: Transport> SignalFishPollingClient<T> {
             },
             queue_age_stats: PollingQueueAgeStats::default(),
             shutdown_timeout,
-            started: false,
             pending_frame: None,
             pending_frame_enqueued_at: None,
             send_in_flight: false,
             pending_frame_is_game_data: false,
-            in_flight_is_game_data: false,
             pending_inbound: None,
             close_phase: ClosePhase::Open,
         };
@@ -324,6 +320,14 @@ impl<T: Transport> SignalFishPollingClient<T> {
             return events;
         }
 
+        // Observe transports that completed their handshake before this poll
+        // before driving any terminal or inbound I/O. This preserves
+        // Connected -> Disconnected ordering for an already-ready transport
+        // that closes immediately.
+        if self.transport.is_ready() && self.core.mark_transport_ready() {
+            events.push(SignalFishEvent::Connected);
+        }
+
         if let Err(error) = self.drive_outbound(&mut cx, now) {
             error!(%error, "transport send failed");
             self.handle_disconnect_at(
@@ -342,7 +346,11 @@ impl<T: Transport> SignalFishPollingClient<T> {
             let frame = if let Some(frame) = self.pending_inbound.take() {
                 frame
             } else {
-                match self.transport.poll_recv(&mut cx) {
+                let incoming = self.transport.poll_recv(&mut cx);
+                if self.transport.is_ready() && self.core.mark_transport_ready() {
+                    events.insert(0, SignalFishEvent::Connected);
+                }
+                match incoming {
                     std::task::Poll::Ready(Some(Ok(frame))) => frame,
                     std::task::Poll::Ready(Some(Err(e))) => {
                         error!("transport receive error: {e}");
@@ -387,6 +395,19 @@ impl<T: Transport> SignalFishPollingClient<T> {
 
             received_frames = received_frames.saturating_add(1);
             received_bytes = next_bytes.unwrap_or(usize::MAX);
+            if !self.core.is_transport_ready() {
+                if self.transport.is_ready() && self.core.mark_transport_ready() {
+                    events.insert(0, SignalFishEvent::Connected);
+                } else {
+                    self.handle_disconnect_at(
+                        &mut events,
+                        Some("transport received a protocol frame before readiness".into()),
+                        &mut cx,
+                        now,
+                    );
+                    return events;
+                }
+            }
             let outcome = self.core.process_frame(frame);
             events.extend(outcome.events);
             if outcome.disconnect {
@@ -406,8 +427,7 @@ impl<T: Transport> SignalFishPollingClient<T> {
         // have a chance to process their connection-open event before
         // we check is_ready(). Connected is inserted at position 0 to
         // guarantee it is always the first event in the batch.
-        if !self.started && self.transport.is_ready() {
-            self.started = true;
+        if self.transport.is_ready() && self.core.mark_transport_ready() {
             events.insert(0, SignalFishEvent::Connected);
         }
 
@@ -786,9 +806,14 @@ impl<T: Transport> SignalFishPollingClient<T> {
         self.core.is_p2p_active()
     }
 
-    /// Whether the transport connection is still alive.
+    /// Whether the client owns a nonterminal transport connection.
     pub fn is_connected(&self) -> bool {
         self.core.is_connected()
+    }
+
+    /// Whether the transport handshake has completed.
+    pub fn is_transport_ready(&self) -> bool {
+        self.core.is_transport_ready()
     }
 
     /// Whether a transport close handshake still needs to be driven by
@@ -968,15 +993,10 @@ impl<T: Transport> SignalFishPollingClient<T> {
             let mut no_frame = None;
             match self.transport.poll_send(cx, &mut no_frame) {
                 std::task::Poll::Ready(Ok(())) => {
-                    if self.in_flight_is_game_data {
-                        self.core.record_game_data_sent();
-                    }
                     self.send_in_flight = false;
-                    self.in_flight_is_game_data = false;
                 }
                 std::task::Poll::Ready(Err(error)) => {
                     self.send_in_flight = false;
-                    self.in_flight_is_game_data = false;
                     return Err(error);
                 }
                 std::task::Poll::Pending => return Ok(()),
@@ -1028,6 +1048,10 @@ impl<T: Transport> SignalFishPollingClient<T> {
             let result = self.transport.poll_send(cx, &mut self.pending_frame);
             let transferred = self.pending_frame.is_none();
             if transferred {
+                if self.pending_frame_is_game_data {
+                    self.core.record_game_data_sent();
+                }
+                self.pending_frame_is_game_data = false;
                 self.pending_frame_enqueued_at = None;
                 sent_frames = sent_frames.saturating_add(1);
                 sent_bytes = next_bytes.unwrap_or(usize::MAX);
@@ -1038,22 +1062,11 @@ impl<T: Transport> SignalFishPollingClient<T> {
                     if !transferred {
                         break;
                     }
-                    if self.pending_frame_is_game_data {
-                        self.core.record_game_data_sent();
-                    }
-                    self.pending_frame_is_game_data = false;
                 }
-                std::task::Poll::Ready(Err(error)) => {
-                    if transferred {
-                        self.pending_frame_is_game_data = false;
-                    }
-                    return Err(error);
-                }
+                std::task::Poll::Ready(Err(error)) => return Err(error),
                 std::task::Poll::Pending => {
                     if transferred {
                         self.send_in_flight = true;
-                        self.in_flight_is_game_data = self.pending_frame_is_game_data;
-                        self.pending_frame_is_game_data = false;
                     }
                     break;
                 }
@@ -1182,7 +1195,6 @@ impl<T: Transport> SignalFishPollingClient<T> {
         if include_in_flight {
             abandoned = abandoned.saturating_add(usize::from(self.send_in_flight));
             self.send_in_flight = false;
-            self.in_flight_is_game_data = false;
         }
         self.cmd_queue.clear();
         self.pending_frame = None;
@@ -1258,8 +1270,8 @@ impl<T: Transport> std::fmt::Debug for SignalFishPollingClient<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SignalFishPollingClient")
             .field("connected", &self.core.is_connected())
+            .field("transport_ready", &self.core.is_transport_ready())
             .field("authenticated", &self.core.is_authenticated())
-            .field("started", &self.started)
             .field("queued_commands", &self.cmd_queue.len())
             .finish()
     }
@@ -1537,6 +1549,9 @@ mod tests {
             _cx: &mut std::task::Context<'_>,
             frame: &mut Option<TransportFrame>,
         ) -> std::task::Poll<std::result::Result<(), SignalFishError>> {
+            if !self.ready {
+                return std::task::Poll::Pending;
+            }
             if let Some(frame) = frame.take() {
                 match frame {
                     TransportFrame::Text(text) => self.sent.push(text),
@@ -1963,6 +1978,7 @@ mod tests {
                 ..
             } if *from_player == from
         )));
+        assert_eq!(client.stats().game_data_received, 1);
     }
 
     #[test]
@@ -2861,6 +2877,15 @@ mod tests {
         // defer the Connected event until is_ready() returns true.
         let transport = NotReadyTransport::new();
         let mut client = SignalFishPollingClient::new(transport, default_config());
+        assert_eq!(
+            (
+                client.is_connected(),
+                client.is_transport_ready(),
+                client.is_authenticated(),
+                client.room_role(),
+            ),
+            (true, false, false, None)
+        );
 
         // First poll: transport is not ready, so no Connected.
         let events = client.poll();
@@ -2870,6 +2895,8 @@ mod tests {
                 .any(|e| matches!(e, SignalFishEvent::Connected)),
             "Connected should not be emitted when transport is not ready, got: {events:?}"
         );
+        assert!(!client.is_transport_ready());
+        assert!(client.transport.sent.is_empty());
 
         // Mark transport as ready.
         client.transport.ready = true;
@@ -2880,8 +2907,16 @@ mod tests {
             matches!(events.first(), Some(SignalFishEvent::Connected)),
             "Connected should be emitted once transport becomes ready, got: {events:?}"
         );
+        assert!(client.is_transport_ready());
+        assert_eq!(
+            client.transport.sent.len(),
+            1,
+            "Authenticate should transfer"
+        );
 
-        // Subsequent poll: no duplicate Connected.
+        // A buggy readiness regression cannot roll the observed phase back or
+        // produce another Connected event.
+        client.transport.ready = false;
         let events = client.poll();
         assert!(
             !events
@@ -2889,6 +2924,33 @@ mod tests {
                 .any(|e| matches!(e, SignalFishEvent::Connected)),
             "Connected should not be re-emitted, got: {events:?}"
         );
+        assert!(client.is_transport_ready());
+    }
+
+    #[test]
+    fn terminal_before_readiness_never_emits_connected() {
+        for incoming in [None, Some(Ok("{}".into()))] {
+            let mut transport = NotReadyTransport::new();
+            transport.incoming.push_back(incoming);
+            let mut client = SignalFishPollingClient::new(transport, default_config());
+
+            let events = client.poll();
+
+            assert!(matches!(
+                events.as_slice(),
+                [SignalFishEvent::Disconnected { .. }]
+            ));
+            let snapshot = client.snapshot();
+            assert_eq!(
+                (
+                    snapshot.connected,
+                    snapshot.transport_ready,
+                    snapshot.authenticated,
+                    snapshot.room_role,
+                ),
+                (false, false, false, None)
+            );
+        }
     }
 
     #[test]
@@ -2919,6 +2981,38 @@ mod tests {
             "Authenticated should follow Connected, got: {:?}",
             events[1]
         );
+    }
+
+    #[test]
+    fn readiness_observed_during_terminal_recv_precedes_disconnected() {
+        for incoming in [
+            None,
+            Some(Err(SignalFishError::TransportReceive(
+                "scripted terminal error".into(),
+            ))),
+        ] {
+            let transport = NotReadyTransport::with_incoming_and_ready_after_recv(vec![incoming]);
+            let mut client = SignalFishPollingClient::new(transport, default_config());
+
+            let events = client.poll();
+
+            assert!(matches!(
+                events.as_slice(),
+                [
+                    SignalFishEvent::Connected,
+                    SignalFishEvent::Disconnected { .. }
+                ]
+            ));
+            assert_eq!(
+                (
+                    client.is_connected(),
+                    client.is_transport_ready(),
+                    client.is_authenticated(),
+                    client.room_role(),
+                ),
+                (false, false, false, None)
+            );
+        }
     }
 
     #[test]
@@ -3143,6 +3237,48 @@ mod tests {
         sent: Vec<TransportFrame>,
         replacement_seen: bool,
         peer_closes_on_recv: bool,
+        fail_game_data_completion: bool,
+    }
+
+    struct GameDataErrorTransport {
+        take_before_error: bool,
+    }
+
+    impl Transport for GameDataErrorTransport {
+        fn poll_send(
+            &mut self,
+            _cx: &mut std::task::Context<'_>,
+            frame: &mut Option<TransportFrame>,
+        ) -> std::task::Poll<std::result::Result<(), SignalFishError>> {
+            let game_data = matches!(
+                frame.as_ref(),
+                Some(TransportFrame::Text(text)) if text.contains("\"type\":\"GameData\"")
+            );
+            if game_data {
+                if self.take_before_error {
+                    let _ = frame.take();
+                }
+                return std::task::Poll::Ready(Err(SignalFishError::TransportSend(
+                    "scripted game-data failure".into(),
+                )));
+            }
+            let _ = frame.take();
+            std::task::Poll::Ready(Ok(()))
+        }
+
+        fn poll_recv(
+            &mut self,
+            _cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<Option<std::result::Result<TransportFrame, SignalFishError>>> {
+            std::task::Poll::Pending
+        }
+
+        fn poll_close(
+            &mut self,
+            _cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<std::result::Result<(), SignalFishError>> {
+            std::task::Poll::Ready(Ok(()))
+        }
     }
 
     /// Accepts an initial FIFO burst, then permanently refuses caller-owned
@@ -3198,6 +3334,16 @@ mod tests {
         ) -> std::task::Poll<std::result::Result<(), SignalFishError>> {
             if let Some(retained) = self.retained.take() {
                 self.replacement_seen |= frame.is_some();
+                if self.fail_game_data_completion
+                    && matches!(
+                        &retained,
+                        TransportFrame::Text(text) if text.contains("\"type\":\"GameData\"")
+                    )
+                {
+                    return std::task::Poll::Ready(Err(SignalFishError::TransportSend(
+                        "scripted accepted game-data failure".into(),
+                    )));
+                }
                 self.sent.push(retained);
                 return std::task::Poll::Ready(Ok(()));
             }
@@ -3799,6 +3945,7 @@ mod tests {
             assert_eq!(*seq, Some(1));
             assert_eq!(*epoch, Some(1));
         }
+        assert_eq!(client.stats().game_data_received, 1);
     }
 
     #[test]
@@ -4471,6 +4618,7 @@ mod tests {
             sent: Vec::new(),
             replacement_seen: false,
             peer_closes_on_recv: false,
+            fail_game_data_completion: false,
         };
         let mut client = SignalFishPollingClient::new(transport, default_config());
         let base = Instant::now();
@@ -4502,6 +4650,7 @@ mod tests {
             sent: Vec::new(),
             replacement_seen: false,
             peer_closes_on_recv: false,
+            fail_game_data_completion: false,
         };
         let mut client = SignalFishPollingClient::new(
             transport,
@@ -4517,6 +4666,11 @@ mod tests {
 
         let _ = client.poll();
         assert!(client.send_in_flight, "game data should now be in flight");
+        assert_eq!(
+            client.stats().game_data_sent,
+            1,
+            "ownership transfer counts before backend completion"
+        );
         let _ = client.poll();
 
         assert!(!client.transport.replacement_seen);
@@ -4529,6 +4683,57 @@ mod tests {
             client.transport.sent.get(1),
             Some(TransportFrame::Text(text)) if text.contains("GameData")
         ));
+        assert_eq!(client.stats().game_data_sent, 1);
+    }
+
+    #[test]
+    fn send_error_counts_only_frames_the_transport_took() {
+        for (take_before_error, expected_sent) in [(false, 0), (true, 1)] {
+            let transport = GameDataErrorTransport { take_before_error };
+            let mut client = SignalFishPollingClient::new(transport, default_config());
+            prime_room(&mut client);
+            let _ = client.poll();
+            client
+                .send_game_data(serde_json::json!({"frame": 1}))
+                .expect("primed player may queue game data");
+
+            let events = client.poll();
+
+            assert!(events
+                .iter()
+                .any(|event| matches!(event, SignalFishEvent::Disconnected { .. })));
+            assert_eq!(
+                client.stats().game_data_sent,
+                expected_sent,
+                "take_before_error={take_before_error}"
+            );
+        }
+    }
+
+    #[test]
+    fn accepted_pending_game_data_error_counts_once_at_transfer() {
+        let transport = AcceptedPendingSendTransport {
+            retained: None,
+            sent: Vec::new(),
+            replacement_seen: false,
+            peer_closes_on_recv: false,
+            fail_game_data_completion: true,
+        };
+        let mut client = SignalFishPollingClient::new(transport, default_config());
+        prime_room(&mut client);
+        let _ = client.poll();
+        client
+            .send_game_data(serde_json::json!({"frame": 1}))
+            .expect("primed player may queue game data");
+
+        let accepted = client.poll();
+        assert!(accepted.is_empty());
+        assert_eq!(client.stats().game_data_sent, 1);
+
+        let terminal = client.poll();
+        assert!(terminal
+            .iter()
+            .any(|event| matches!(event, SignalFishEvent::Disconnected { .. })));
         assert_eq!(client.stats().game_data_sent, 1);
     }
 
@@ -4917,6 +5122,7 @@ mod tests {
                 sent: Vec::new(),
                 replacement_seen: false,
                 peer_closes_on_recv: false,
+                fail_game_data_completion: false,
             };
             let options = PollingClientOptions {
                 close_policy,
@@ -5021,6 +5227,7 @@ mod tests {
             sent: Vec::new(),
             replacement_seen: false,
             peer_closes_on_recv: true,
+            fail_game_data_completion: false,
         };
         let mut client = SignalFishPollingClient::new(transport, default_config());
 
@@ -6156,7 +6363,11 @@ mod tests {
                             budget.receive_bytes,
                         ));
                     }
-                    SchedulerOperation::SetReady(ready) => client.transport.ready = ready,
+                    SchedulerOperation::SetReady(ready) => {
+                        // This reference model exercises conforming transports,
+                        // whose readiness is monotonic for one connection.
+                        client.transport.ready |= ready;
+                    }
                     SchedulerOperation::RefuseBeforeAcceptance => client.transport.accept = false,
                     SchedulerOperation::PendingAfterAcceptance(pending) => {
                         client.transport.pending_after_acceptance = pending;
@@ -6173,13 +6384,18 @@ mod tests {
                     }
                     operation @ (SchedulerOperation::ReceiveText
                     | SchedulerOperation::ReceiveBinary) => {
-                        let inbound = scheduler_inbound(
-                            next_receive_id,
-                            matches!(operation, SchedulerOperation::ReceiveBinary),
-                        );
-                        next_receive_id = next_receive_id.saturating_add(1);
-                        client.transport.incoming.push_back(inbound.frame.clone());
-                        model.incoming.push_back(inbound);
+                        // The scheduler property models conforming transports.
+                        // Pre-ready protocol frames are covered separately as
+                        // a terminal transport-contract violation.
+                        if client.transport.ready || model.connected_emitted {
+                            let inbound = scheduler_inbound(
+                                next_receive_id,
+                                matches!(operation, SchedulerOperation::ReceiveBinary),
+                            );
+                            next_receive_id = next_receive_id.saturating_add(1);
+                            client.transport.incoming.push_back(inbound.frame.clone());
+                            model.incoming.push_back(inbound);
+                        }
                     }
                     SchedulerOperation::AdvanceClock(milliseconds) => {
                         now += Duration::from_millis(u64::from(milliseconds));

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -126,6 +126,15 @@ pub trait Transport {
     fn abort(&mut self) {}
 
     /// Whether the connection handshake has completed.
+    ///
+    /// This must be cheap and monotonic for one physical connection. A
+    /// transport that changes from `false` to `true` while the async client is
+    /// blocked must wake a waker previously registered by `poll_send` or
+    /// `poll_recv`, because this accessor does not receive a waker itself.
+    /// While this returns `false`, `poll_send` must return `Pending` without
+    /// taking a caller-owned frame.
+    /// Complete protocol frames must not be returned by `poll_recv` before
+    /// readiness.
     fn is_ready(&self) -> bool {
         true
     }

--- a/tests/polling_parity_tests.rs
+++ b/tests/polling_parity_tests.rs
@@ -17,6 +17,7 @@
 )]
 
 use std::collections::VecDeque;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 use signal_fish_client::client::{SignalFishClient, SignalFishConfig};
@@ -30,7 +31,7 @@ use signal_fish_client::protocol::{
     Topology, TransportKind, V2BinaryGameDataFrame, V3BinaryGameDataFrame,
 };
 use signal_fish_client::transport::TransportFrame;
-use signal_fish_client::{ErrorCode, ProtocolViolationPolicy, RoomRole};
+use signal_fish_client::{ClientStats, ErrorCode, ProtocolViolationPolicy, RoomRole};
 use signal_fish_client::{
     GameDataDelivery, JoinRoomParams, PeerSignal, SignalFishClientApi, SignalFishEvent, Transport,
 };
@@ -547,6 +548,94 @@ impl Transport for SharedMock {
     }
 }
 
+#[derive(Clone)]
+struct ReadinessControls {
+    ready: Arc<AtomicBool>,
+    terminal: Arc<AtomicBool>,
+    waker: Arc<Mutex<Option<std::task::Waker>>>,
+}
+
+impl ReadinessControls {
+    fn set_ready(&self) {
+        self.ready.store(true, Ordering::Release);
+        self.wake();
+    }
+
+    fn terminate(&self) {
+        self.terminal.store(true, Ordering::Release);
+        self.wake();
+    }
+
+    fn wake(&self) {
+        if let Some(waker) = self.waker.lock().unwrap().take() {
+            waker.wake();
+        }
+    }
+}
+
+struct ReadinessMock {
+    controls: ReadinessControls,
+}
+
+impl ReadinessMock {
+    fn new() -> (Self, ReadinessControls) {
+        let controls = ReadinessControls {
+            ready: Arc::new(AtomicBool::new(false)),
+            terminal: Arc::new(AtomicBool::new(false)),
+            waker: Arc::new(Mutex::new(None)),
+        };
+        (
+            Self {
+                controls: controls.clone(),
+            },
+            controls,
+        )
+    }
+}
+
+impl Transport for ReadinessMock {
+    fn poll_send(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+        frame: &mut Option<TransportFrame>,
+    ) -> std::task::Poll<Result<(), SignalFishError>> {
+        if !self.is_ready() {
+            *self.controls.waker.lock().unwrap() = Some(cx.waker().clone());
+            if !self.is_ready() {
+                return std::task::Poll::Pending;
+            }
+        }
+        let _ = frame.take();
+        std::task::Poll::Ready(Ok(()))
+    }
+
+    fn poll_recv(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Result<TransportFrame, SignalFishError>>> {
+        if self.controls.terminal.swap(false, Ordering::AcqRel) {
+            return std::task::Poll::Ready(None);
+        }
+        *self.controls.waker.lock().unwrap() = Some(cx.waker().clone());
+        if self.controls.terminal.swap(false, Ordering::AcqRel) {
+            std::task::Poll::Ready(None)
+        } else {
+            std::task::Poll::Pending
+        }
+    }
+
+    fn poll_close(
+        &mut self,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), SignalFishError>> {
+        std::task::Poll::Ready(Ok(()))
+    }
+
+    fn is_ready(&self) -> bool {
+        self.controls.ready.load(Ordering::Acquire)
+    }
+}
+
 fn pi_v3_payload() -> ProtocolInfoPayload {
     ProtocolInfoPayload {
         platform: None,
@@ -953,13 +1042,22 @@ async fn assert_frame_trace_parity(
     frames: Vec<TransportFrame>,
     config: SignalFishConfig,
 ) -> Vec<String> {
-    assert_frame_trace_parity_with_reconnect(frames, config, false).await
+    assert_frame_trace_parity_with_stats(frames, config, false, None).await
 }
 
 async fn assert_frame_trace_parity_with_reconnect(
     frames: Vec<TransportFrame>,
     config: SignalFishConfig,
     admit_reconnect: bool,
+) -> Vec<String> {
+    assert_frame_trace_parity_with_stats(frames, config, admit_reconnect, None).await
+}
+
+async fn assert_frame_trace_parity_with_stats(
+    frames: Vec<TransportFrame>,
+    config: SignalFishConfig,
+    admit_reconnect: bool,
+    expected_stats: Option<ClientStats>,
 ) -> Vec<String> {
     let make_mock = || TraceMock::new(frames.clone());
 
@@ -1008,7 +1106,11 @@ async fn assert_frame_trace_parity_with_reconnect(
         .collect::<Vec<_>>();
     assert_eq!(async_events, polling_events);
     assert_eq!(async_client.snapshot(), polling_client.snapshot());
-    assert_eq!(async_client.stats(), polling_client.stats());
+    let async_stats = async_client.stats();
+    assert_eq!(async_stats, polling_client.stats());
+    if let Some(expected) = expected_stats {
+        assert_eq!(async_stats, expected);
+    }
     async_events
 }
 
@@ -1019,6 +1121,77 @@ async fn assert_server_trace_parity(lines: &str, config: SignalFishConfig) {
         .map(|line| TransportFrame::Text(line.to_owned()))
         .collect();
     let _ = assert_frame_trace_parity(frames, config).await;
+}
+
+#[tokio::test]
+async fn readiness_phase_and_terminal_order_have_complete_driver_parity() {
+    let (async_transport, async_controls) = ReadinessMock::new();
+    let (mut async_client, mut async_events) =
+        SignalFishClient::start(async_transport, SignalFishConfig::new("app"));
+    let (polling_transport, polling_controls) = ReadinessMock::new();
+    let mut polling_client =
+        SignalFishPollingClient::new(polling_transport, SignalFishConfig::new("app"));
+
+    assert_eq!(async_client.snapshot(), polling_client.snapshot());
+    assert_eq!(
+        (
+            async_client.is_connected(),
+            async_client.is_transport_ready(),
+            async_client.is_authenticated(),
+            async_client.room_role(),
+        ),
+        (true, false, false, None)
+    );
+    tokio::task::yield_now().await;
+    assert!(matches!(
+        async_events.try_recv(),
+        Err(tokio::sync::mpsc::error::TryRecvError::Empty)
+    ));
+    assert!(polling_client.poll().is_empty());
+
+    async_controls.set_ready();
+    polling_controls.set_ready();
+    let async_connected =
+        tokio::time::timeout(std::time::Duration::from_secs(1), async_events.recv())
+            .await
+            .expect("async readiness transition should wake")
+            .expect("Connected should be delivered");
+    let polling_connected = polling_client.poll();
+    assert!(matches!(async_connected, SignalFishEvent::Connected));
+    assert!(matches!(
+        polling_connected.as_slice(),
+        [SignalFishEvent::Connected]
+    ));
+    assert_eq!(async_client.snapshot(), polling_client.snapshot());
+
+    async_controls.terminate();
+    polling_controls.terminate();
+    let async_terminal =
+        tokio::time::timeout(std::time::Duration::from_secs(1), async_events.recv())
+            .await
+            .expect("async terminal transition should wake")
+            .expect("Disconnected should be delivered");
+    let polling_terminal = polling_client.poll();
+    assert!(matches!(
+        async_terminal,
+        SignalFishEvent::Disconnected { .. }
+    ));
+    assert!(matches!(
+        polling_terminal.as_slice(),
+        [SignalFishEvent::Disconnected { .. }]
+    ));
+    assert_eq!(async_client.snapshot(), polling_client.snapshot());
+    assert_eq!(
+        (
+            async_client.is_connected(),
+            async_client.is_transport_ready(),
+            async_client.is_authenticated(),
+            async_client.room_role(),
+        ),
+        (false, false, false, None)
+    );
+
+    async_client.shutdown().await;
 }
 
 async fn assert_open_text_trace_parity(
@@ -2057,6 +2230,59 @@ async fn inbound_binary_events_decode_failures_and_accountability_have_complete_
         config.game_data_format = Some(GameDataEncoding::MessagePack);
         let _ = assert_frame_trace_parity(frames, config).await;
     }
+}
+
+#[tokio::test]
+async fn suppressed_receipts_and_lifetime_stats_have_exact_driver_parity() {
+    let sender = uuid::Uuid::from_u128(98);
+    let game_data = |seq, epoch| {
+        text_server_frame(ServerMessage::GameData {
+            from_player: sender,
+            data: serde_json::json!({"seq": seq, "epoch": epoch}),
+            seq: Some(seq),
+            epoch: Some(epoch),
+            class: Some(DeliveryClass::Reliable),
+            key: None,
+        })
+    };
+    let mut frames = binary_accountability_prefix(sender);
+    frames.extend([
+        game_data(1, 1),
+        text_server_frame(ServerMessage::PlayerLeft {
+            player_id: sender,
+            epoch: Some(1),
+            final_seq: Some(2),
+        }),
+        text_server_frame(ServerMessage::PlayerReconnected {
+            player_id: sender,
+            epoch: Some(2),
+        }),
+        game_data(2, 1),
+        game_data(3, 2),
+        game_data(1, 2),
+    ]);
+
+    let events = assert_frame_trace_parity_with_stats(
+        frames,
+        SignalFishConfig::new("app")
+            .enable_v3()
+            .with_protocol_violation_policy(ProtocolViolationPolicy::Quarantine),
+        false,
+        Some(ClientStats {
+            game_data_received: 4,
+            ..ClientStats::default()
+        }),
+    )
+    .await;
+
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| event.starts_with("GameData|"))
+            .count(),
+        1,
+        "one applied receipt plus three stale/quarantined receipts"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Clarifies the connection phase and traffic-counter contracts shared by the
async and polling clients. Applications can now distinguish client ownership
from transport readiness, and `ClientStats` counts at stable transport/decode
boundaries instead of backend completion or application delivery.

Closes #104.

## Changes

- Add `ClientSnapshot::transport_ready` and matching async, polling, and
  `SignalFishClientApi` accessors; emit `Connected` exactly once on the first
  driver observation of `Transport::is_ready()`.
- Preserve FIFO command admission while connecting, require deferred async
  readiness to wake registered I/O, and reset every connection phase on
  terminal paths.
- Count `game_data_sent` at exact frame ownership transfer, including
  accepted-Pending and accepted-then-error sends without double-counting.
- Count `game_data_received` immediately after successful text or binary
  protocol decode, before message validation, sequence accountability, stale,
  quarantine, or event suppression; preserve physical-binary admission checks
  that reject a frame before logical decoding.
- Document the valid phase tuples, counter conservation limits, excluded
  traffic, and cross-peer diagnostic caveats across the public guides,
  changelog, roadmap, canonical context, and focused agent skills.

## Validation

- [x] Focused async and polling readiness tests
- [x] Focused ownership-transfer and decoded-receipt tests
- [x] Async/polling frame, snapshot, and statistics parity tests
- [x] Repository documentation and workflow policy validators
- [x] `cargo fmt && cargo clippy --workspace --all-targets --all-features -- -D warnings && cargo test --workspace --all-features`
- [x] Hosted required checks and review feedback

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking public snapshot/API change that retimes connection events and diagnostic counters across both drivers. Semantics are well-tested, but callers matching ClientSnapshot or treating Connected as loop-start will need updates.
> 
> **Overview**
> Splits **client-owned connecting** from **handshake-complete** so both drivers share one readiness boundary. `ClientSnapshot` gains `transport_ready`; `connected` now means a nonterminal owned attempt (commands still queue). Synthetic `Connected` fires once on the first `Transport::is_ready()` observation, including deferred async handshakes that must wake I/O. Pre-ready protocol frames and terminal-before-ready paths never emit `Connected`.
> 
> **Traffic counters** move to stable boundaries: `game_data_sent` at `poll_send` ownership transfer (accepted-Pending and accepted-then-error, no double-count); `game_data_received` immediately after successful decode, including stale/quarantined data, excluding malformed and pre-decode binary rejects. Docs, changelog, and skills describe the nested phase tuples and that counters are diagnostics, not peer delivery equality.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4003239305e2e6a6813d41f45808634bd1194272. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->