### PR TITLE
fix!: enforce transport abort contract

### DIFF
--- a/.llm/context.md
+++ b/.llm/context.md
@@ -152,20 +152,20 @@ pub trait Transport {
     fn poll_close(&mut self, cx: &mut Context<'_>)
         -> Poll<Result<(), SignalFishError>>;
     fn begin_poll_cycle(&mut self) {}
-    fn abort(&mut self) {}
+    fn abort(&mut self);
     fn diagnostics(&self) -> TransportDiagnostics { TransportDiagnostics::default() }
     fn is_ready(&self) -> bool { true }
     fn close_info(&self) -> Option<TransportCloseInfo> { None }
 }
 ```
 
-The trait has no `Send` bound; `SignalFishClient::start` separately requires
-`Transport + Send + 'static`. `poll_send` may take a frame only at backend
-ownership transfer; that increments `game_data_sent` even if completion later
-fails, but never proves peer delivery. `Pending` before acceptance leaves the
-frame intact. Async readiness changes wake registered I/O; both drivers map the
-first `is_ready()` observation to `transport_ready` and `Connected`. Close is
-idempotent. See `skills/transport-abstraction/SKILL.md`.
+The trait has no `Send` bound; `SignalFishClient::start` separately requires `Transport + Send + 'static`.
+`poll_send` may take a frame only at backend ownership transfer; that increments
+`game_data_sent` even if completion later fails, but never proves peer delivery.
+`Pending` before acceptance leaves the frame intact. Async readiness changes wake registered I/O; both drivers map the first `is_ready()` observation to `transport_ready` and `Connected`. Close is
+idempotent; on error, logical I/O terminates and fallible cleanup remains safe for the abort fallback. `abort` is a required,
+prompt, nonblocking, non-panicking, idempotent fallback that releases or safely detaches backend resources,
+discards retained sends, and ends driver polling; completed cleanup is not repeated, while failed cleanup may retry safely. See `skills/transport-abstraction/SKILL.md`.
 
 The async driver retains an in-flight send in its main select loop and polls
 send and receive with the same runtime waker, so outbound backpressure cannot

--- a/.llm/skills/async-rust-patterns/SKILL.md
+++ b/.llm/skills/async-rust-patterns/SKILL.md
@@ -44,6 +44,8 @@ pub trait Transport {
         &mut self,
         cx: &mut Context<'_>,
     ) -> Poll<Result<(), SignalFishError>>;
+
+    fn abort(&mut self);
 }
 ```
 
@@ -180,7 +182,10 @@ if tokio::time::timeout(Duration::from_secs(1), &mut task)
 
 Graceful transport shutdown is itself multi-poll. Internal code adapts
 `poll_close` with `poll_fn` and awaits it until ready; the client timeout may
-still abort a transport whose close never makes progress.
+still abort a transport whose close never makes progress. The async task owns
+its transport through an abort-on-drop guard so task cancellation, panic, or
+client-handle drop also invokes the required synchronous `Transport::abort`
+fallback unless graceful close already completed.
 
 ## Synchronization
 

--- a/.llm/skills/doc-accuracy-guarantees/SKILL.md
+++ b/.llm/skills/doc-accuracy-guarantees/SKILL.md
@@ -73,11 +73,12 @@ request preempt a blocked delivery, so the guarantee is scoped precisely:
 /// draining) lets shutdown win, abandoning that one in-flight event.
 ```
 
-### `shutdown_timeout` — Documenting abort consequences
+### `shutdown_timeout` — Documenting abandonment consequences
 
 ```rust
-/// If the timeout expires the task is aborted and the `Disconnected` event
-/// may not be delivered.
+/// If the close deadline expires, the transport's required `abort` fallback
+/// runs and the loop normally returns. A later watchdog cancels only a task
+/// that still does not stop. `Disconnected` delivery remains best-effort.
 ```
 
 ## When to Apply This Skill

--- a/.llm/skills/error-handling/SKILL.md
+++ b/.llm/skills/error-handling/SKILL.md
@@ -116,12 +116,12 @@ Io(#[from] std::io::Error),
 ## The ? Operator
 
 ```rust
-async fn do_thing(&mut self) -> Result<(), SignalFishError> {
+fn do_thing(&mut self) -> Result<(), SignalFishError> {
     // serde_json::Error auto-converts via #[from] Serialization variant
     let json = serde_json::to_string(&msg)?;
 
-    // String errors need manual mapping
-    self.transport.send(json).await
+    // This example backend is not the SDK's poll-based Transport trait.
+    self.backend.try_send(json)
         .map_err(|e| SignalFishError::TransportSend(e.to_string()))?;
 
     Ok(())
@@ -205,13 +205,20 @@ stream.next().await
 ### Returning early on error
 
 ```rust
-async fn process(&mut self) -> Result<(), SignalFishError> {
-    match self.transport.recv().await {
-        Some(Ok(s)) => { /* use s */ }
-        Some(Err(e)) => return Err(e),
-        None => return Err(SignalFishError::TransportClosed),
+fn poll_process(
+    &mut self,
+    cx: &mut Context<'_>,
+) -> Poll<Result<(), SignalFishError>> {
+    match self.transport.poll_recv(cx) {
+        Poll::Pending => Poll::Pending,
+        Poll::Ready(Some(Ok(frame))) => {
+            // Process the complete text or binary frame.
+            let _ = frame;
+            Poll::Ready(Ok(()))
+        }
+        Poll::Ready(Some(Err(error))) => Poll::Ready(Err(error)),
+        Poll::Ready(None) => Poll::Ready(Err(SignalFishError::TransportClosed)),
     }
-    Ok(())
 }
 ```
 

--- a/.llm/skills/event-lifecycle-timing/SKILL.md
+++ b/.llm/skills/event-lifecycle-timing/SKILL.md
@@ -36,7 +36,7 @@ but observe it through different driver mechanics.
 - For `EmscriptenWebSocketTransport`, `Connected` is deferred until the
   browser's `onopen` callback fires, which sets `opened = true` and makes
   `is_ready()` return `true`.
-- `IncomingEvent::Open` from the Emscripten transport is consumed by `recv()`
+- `IncomingEvent::Open` from the Emscripten transport is consumed by `poll_recv`
   and sets the `opened` flag rather than being surfaced to the caller.
 
 ## Rules

--- a/.llm/skills/ffi-safety/SKILL.md
+++ b/.llm/skills/ffi-safety/SKILL.md
@@ -81,25 +81,46 @@ corrupts the layout by widening a one-byte field to four bytes.
 C functions communicate failure through return values. Ignoring them leads to silent failures that manifest as crashes later.
 
 ```rust
-let result = emscripten_websocket_set_onopen_callback_on_thread(
-    socket, user_data, Some(on_open_callback), thread_id,
-);
+// SAFETY: `socket` is owned by this transport and `user_data` points to the
+// live callback state allocated for it.
+let result = unsafe {
+    emscripten_websocket_set_onopen_callback_on_thread(
+        socket, user_data, Some(on_open_callback), thread_id,
+    )
+};
 if result != EMSCRIPTEN_RESULT_SUCCESS {
-    emscripten_websocket_close(socket, 1000, ptr::null());
-    drop(Box::from_raw(user_data as *mut State));
-    return Err(format!("onopen registration failed: {result}"));
+    // SAFETY: the socket remains owned here; close is attempted before delete.
+    let close_result = unsafe { emscripten_websocket_close(socket, 1000, ptr::null()) };
+    // SAFETY: this is the sole cleanup path for the still-owned socket handle.
+    let delete_result = unsafe { emscripten_websocket_delete(socket) };
+    if delete_result == EMSCRIPTEN_RESULT_SUCCESS {
+        // SAFETY: successful deletion unregisters callbacks, so the foreign
+        // runtime can no longer access the uniquely owned callback state.
+        unsafe { drop(Box::from_raw(user_data as *mut State)) };
+    }
+    // If deletion failed, preserve (and ultimately leak) callback state: the
+    // foreign runtime may still invoke a callback with `user_data`.
+    return Err(format!(
+        "onopen registration failed: {result}; close: {close_result}; delete: {delete_result}"
+    ));
 }
 ```
 
 ### Pattern: Register-and-Rollback
 
-When registering multiple callbacks, iterate over results and roll back (close socket, free state via `Box::from_raw`) on first failure. See the codebase for concrete examples.
+When registering multiple callbacks, iterate over results and roll back on the
+first failure: attempt close, then delete/unregister, and reclaim state with
+`Box::from_raw` only after deletion succeeds. If deletion fails, preserve the
+callback state so a later foreign callback cannot access freed memory. See the
+codebase for the complete retry-and-safe-leak state machine.
 
 ## Raw Pointer Lifecycle
 
 ### `Box::into_raw` and `Box::from_raw`
 
-`Box::into_raw` leaks memory intentionally — ownership transfers to the raw pointer. You must reclaim it with `Box::from_raw` exactly once.
+`Box::into_raw` transfers ownership to a raw pointer. Reclaim it with
+`Box::from_raw` exactly once, but only after the foreign API proves that no
+callback can use it again.
 
 ```rust
 // Allocate and leak
@@ -109,19 +130,24 @@ let raw: *mut CallbackState = Box::into_raw(state);
 // Pass raw pointer as user_data to C callbacks
 register_callback(raw as *mut c_void);
 
-// Later, reclaim exactly once (usually in Drop or a close handler)
-unsafe {
-    let _state = Box::from_raw(raw);
-    // _state is dropped here, freeing the memory
+// Later, after callback deletion succeeds, reclaim exactly once.
+if callbacks_were_deleted {
+    unsafe {
+        let _state = Box::from_raw(raw);
+        // _state is dropped here, freeing the memory
+    }
 }
 ```
 
 ### Rules
 
-- Every `Box::into_raw` must have exactly one matching `Box::from_raw`
-- Zero calls: memory leak
+- Every successfully unregistered `Box::into_raw` allocation must have exactly
+  one matching `Box::from_raw`
+- Zero calls after confirmed unregistration: memory leak
 - Two calls: double-free (undefined behavior)
 - Reclaim AFTER all callbacks that reference the pointer have been unregistered
+- If unregistration fails, intentionally retain/leak the allocation rather
+  than risk use-after-free
 
 ### Cleanup Order
 
@@ -129,66 +155,63 @@ Clean up resources in an order that prevents use-after-free:
 
 1. **Close** the handle (may trigger synchronous callbacks — state pointer must still be valid)
 2. **Delete/unregister** callbacks (prevents any further callback access to state)
-3. **Reclaim** the state pointer via `Box::from_raw` (safe — no callbacks can fire)
+3. **Reclaim** the state pointer via `Box::from_raw` only after confirmed
+   deletion (safe — no callbacks can fire)
 
-### `close()` Must Also Unregister Callbacks
+### `poll_close`, `abort`, and `Drop` Must Attempt Callback Unregistration
 
-A `close()` method that only closes the handle but does **not** unregister callbacks creates a window where callbacks can still fire between `close()` returning and `Drop` running. On the single-threaded Emscripten model this only matters if a JavaScript event loop tick occurs in that window, but the safe pattern is to **always unregister callbacks in `close()`**.
+A `poll_close` method that only closes the handle but does **not** unregister
+callbacks creates a window where callbacks can still fire before `Drop`. The
+safe pattern is to attempt callback deletion during `poll_close`, `abort`, and
+`Drop`, using shared state that makes successful steps one-shot and failed
+steps retryable.
 
-Use a `deleted: bool` flag to prevent double-unregistration in `Drop`:
+Use an ownership state machine to authorize reclamation only after a close
+attempt and successful deletion:
 
 ```rust,ignore
-async fn close(&mut self) -> Result<(), Error> {
-    if self.closed { return Ok(()); }
-    self.closed = true;
-    emscripten_websocket_close(self.socket, 1000, ptr::null());
-    emscripten_websocket_delete(self.socket); // unregister callbacks NOW
-    self.deleted = true;
-    Ok(())
+fn cleanup(&mut self) -> Result<(), Error> {
+    self.try_close();
+    match self.try_delete_callbacks() {
+        Ok(reclaim_authorization) => {
+            self.callback_state.reclaim(reclaim_authorization);
+            Ok(())
+        }
+        Err(error) => Err(error), // state remains live and retryable
+    }
 }
 
 impl Drop for Transport {
     fn drop(&mut self) {
-        if !self.closed {
-            emscripten_websocket_close(self.socket, 1000, ptr::null());
+        if self.cleanup().is_err() {
+            // The foreign runtime may still invoke callbacks. Intentionally
+            // retain the backing allocation to prevent use-after-free.
         }
-        if !self.deleted {
-            emscripten_websocket_delete(self.socket);
-        }
-        drop(Box::from_raw(self.state_ptr)); // always reclaim
     }
 }
 ```
 
-### Error Path Cleanup Must Match `close()` + `Drop`
+### Error Path Cleanup Must Match `poll_close` + `abort` + `Drop`
 
-Every error path that cleans up FFI resources **must** follow the same sequence as `close()` + `Drop`. A common bug: `Drop` does close -> delete -> free correctly, but an error path or `close()` skips `delete`, leaving callbacks registered.
+Every error path that cleans up FFI resources **must** follow the same sequence
+as `poll_close` + `abort` + `Drop`. A common bug is reclaiming callback state
+after deletion failed, leaving the foreign runtime with a dangling pointer.
 
 **Checklist for FFI cleanup paths:**
 
-- [ ] Does `close()` both close the handle AND unregister callbacks?
-- [ ] Does `Drop` skip steps already performed by `close()` (using boolean flags)?
-- [ ] Does `Drop` always reclaim heap-allocated state (`Box::from_raw`) as the final step?
-- [ ] Does every constructor error path follow the same close -> delete -> free sequence?
+- [ ] Do `poll_close`, `abort`, and `Drop` attempt close before callback deletion?
+- [ ] Does cleanup skip successful steps and safely retry failed ones?
+- [ ] Is heap state reclaimed only after confirmed callback deletion?
+- [ ] Does terminal deletion failure intentionally preserve callback state?
+- [ ] Does every constructor error path follow close -> delete -> conditional reclaim?
 
 ## Single-Threaded Safety
 
-### `unsafe impl Send` on wasm32-unknown-emscripten
-
-The `wasm32-unknown-emscripten` target is single-threaded. Types that hold raw pointers or other `!Send` fields can safely implement `Send` on this target because no concurrent access is possible.
-
-```rust
-// SAFETY: wasm32-unknown-emscripten is single-threaded. The Send bound is
-// required by the Transport trait but is vacuously satisfied since there
-// are no other threads.
-unsafe impl Send for EmscriptenWebSocketTransport {}
-```
-
-### Rules
-
-- Always include a `// SAFETY:` comment explaining the single-threaded assumption
-- If the containing module is already feature-gated to emscripten-only, the module-level gate is sufficient. Otherwise, gate the impl directly with `#[cfg(target_os = "emscripten")]`
-- Never add `unsafe impl Sync` unless the type is genuinely safe for shared references (rare for FFI wrappers)
+The `Transport` trait has no `Send` bound. Keep an Emscripten transport
+explicitly `!Send` when it owns main-thread callback state, and use it with
+`SignalFishPollingClient`. Do not add `unsafe impl Send` merely because the
+current runtime configuration is single-threaded; the async client applies
+`Send + 'static` separately at its Tokio task-spawn boundary.
 
 ## Callback SAFETY Comment Convention
 
@@ -279,12 +302,13 @@ Use this checklist when adding or reviewing any FFI binding:
 - [ ] All `#[repr(C)]` struct fields match the C header exactly (WebSocket C `bool` fields use one-byte `C_BOOL`; callback returns use `EM_BOOL = c_int`)
 - [ ] Field order matches the C header exactly
 - [ ] All return values from FFI functions are checked
-- [ ] Error paths follow the **same cleanup sequence** as `close()` + `Drop`
+- [ ] Error paths follow the **same cleanup sequence** as `poll_close` + `abort` + `Drop`
 - [ ] Raw pointer lifetimes are documented with `// SAFETY:` comments
 - [ ] Callback `user_data` lifetime outlives all possible callback invocations
-- [ ] `close()` both closes the handle AND unregisters callbacks (no window for late callbacks)
-- [ ] `Drop` skips steps already done by `close()` using boolean flags (`closed`, `deleted`)
-- [ ] `Drop` always reclaims heap state (`Box::from_raw`) as the final step
+- [ ] `poll_close`, `abort`, and `Drop` attempt close before callback deletion
+- [ ] Successful cleanup is one-shot and failed cleanup remains retryable
+- [ ] Heap state is reclaimed only after confirmed callback deletion
+- [ ] Terminal deletion failure preserves callback backing state
 - [ ] Target-restricted FFI modules have a `compile_error!()` guard at the file top
 - [ ] Every `extern "C" fn` in files with a shared SAFETY block has a per-function `// SAFETY:` comment
 - [ ] All std library API calls in `#[cfg(...)]` blocks use correct argument types (especially reference vs. owned)
@@ -298,8 +322,8 @@ Use this checklist when adding or reviewing any FFI binding:
 | Missing return value check | Silent callback registration failure | Check every FFI return value |
 | Double `Box::from_raw` | Double-free crash or UB | Track ownership, reclaim exactly once |
 | Wrong cleanup order | Use-after-free in callbacks | Close socket before reclaiming state |
-| Error path skips cleanup step | Resource leak (e.g., missing `delete` between `close` and `free`) | Mirror `close()` + `Drop` sequence exactly |
-| `close()` skips callback unregistration | Late callbacks fire between `close()` and `Drop` | Call `delete`/unregister in `close()`, use `deleted` flag to prevent double-delete in `Drop` |
-| `unsafe impl Send` without safety justification | Unsound on multi-threaded targets | Document single-threaded assumption; gate at module or impl level |
+| Error path skips cleanup step | Resource leak (e.g., missing `delete` between close and free) | Mirror the shared close/delete state machine |
+| Deletion failure still frees callback state | Callback use-after-free | Preserve state and allow retry; safety-leak on final failure |
+| `unsafe impl Send` added for Emscripten | Main-thread callback state crosses the async spawn boundary | Keep the transport `!Send` and use the polling client |
 | Missing per-function SAFETY comment on callback | Inconsistent safety documentation, harder to audit | Add `// SAFETY:` referencing the block comment before every `extern "C" fn` |
 | `.will_wake(&waker)` with explicit `&` | Nightly clippy `needless_borrow` warning | Omit the `&` — write `.will_wake(waker)`; the compiler auto-refs. Caught by emscripten CI clippy job |

--- a/.llm/skills/godot-websocket/SKILL.md
+++ b/.llm/skills/godot-websocket/SKILL.md
@@ -118,6 +118,11 @@ connection, then wrap the peer.
 | Godot-accepted packets | Call `WebSocketPeer::close` without waiting for zero; WebSocket ordering puts accepted messages before Close. |
 | Peer already closing/closed | Preserve peer attribution and drain available inbound packets. |
 | Client deadline expires | Count remaining work, invoke `Transport::abort`, and stop reporting closing. |
+| Polling client dropped before close completes | Invoke required `Transport::abort` synchronously; Godot force-close runs at most once. |
+
+Godot abort must be immediate and idempotent: call the backend force-close at
+most once, clear current buffering diagnostics, and let no later client poll
+re-enter the backend.
 
 For web pages served over HTTPS, use a `wss://` server URL to avoid browser
 mixed-content rejection.

--- a/.llm/skills/shared-core-drivers/SKILL.md
+++ b/.llm/skills/shared-core-drivers/SKILL.md
@@ -29,6 +29,9 @@ abandons client-owned queued work; flush-on-close is an explicit option. Never
 wait indefinitely for polling close, and never interpret backend acceptance as
 peer delivery. Queue age belongs only to polling-driver client ownership and
 stops at backend acceptance; backend buffering remains transport diagnostics.
+Both drivers invoke required `Transport::abort` after a close deadline or
+error and when their owner is dropped before graceful close completes; no
+transport polling occurs afterward.
 
 Never add protocol interpretation or state mutation directly to a driver. Add
 it to `ClientCore`, then exercise it through both drivers in the parity matrix.

--- a/.llm/skills/testing-async/SKILL.md
+++ b/.llm/skills/testing-async/SKILL.md
@@ -91,12 +91,21 @@ impl Transport for MockTransport {
         self.closed.store(true, Ordering::Relaxed);
         Poll::Ready(Ok(()))
     }
+
+    fn abort(&mut self) {
+        self.closed.store(true, Ordering::Relaxed);
+        self.incoming.clear();
+    }
 }
 ```
 
 For binary-path tests, script and record `TransportFrame` values directly.
 A `poll_send` implementation may take the frame only after accepting it;
 if it returns `Pending`, retain that frame internally until a later `Ready`.
+Every mock must implement the required `abort` decision. Clear retained work
+and resource registrations; an explicit no-op is suitable only for a genuinely
+stateless/resource-free mock. Client drivers do not poll a transport after
+abort.
 
 ## Starting a Mock Client
 
@@ -175,9 +184,11 @@ let (transport, _, _) = MockTransport::new(vec![
 
 ## Shutdown Timeout State Invariants
 
-When testing shutdown timeout paths (e.g., `transport.close()` hangs and the
-task is aborted), always assert client state accessors are reset even if the
-`Disconnected` event is not observed:
+When testing shutdown deadline paths (e.g., `Transport::poll_close` remains
+pending and the loop invokes `Transport::abort`), always assert client state
+accessors are reset even if the `Disconnected` event is not observed. Task
+cancellation is a later watchdog/owner-drop fallback, not the configured
+deadline's primary mechanism:
 
 ```rust
 client.shutdown().await;

--- a/.llm/skills/transport-abstraction/SKILL.md
+++ b/.llm/skills/transport-abstraction/SKILL.md
@@ -35,7 +35,7 @@ pub trait Transport {
     ) -> Poll<Result<(), SignalFishError>>;
 
     fn begin_poll_cycle(&mut self) {}
-    fn abort(&mut self) {}
+    fn abort(&mut self);
     fn diagnostics(&self) -> TransportDiagnostics { TransportDiagnostics::default() }
     fn is_ready(&self) -> bool { true }
     fn close_info(&self) -> Option<TransportCloseInfo> { None }
@@ -110,7 +110,8 @@ idempotent:
 - Retain close progress across polls.
 - After `Ready(Ok(()))`, every later call returns `Ready(Ok(()))` without
   emitting another close.
-- Release local resources even when the handshake fails.
+- On handshake failure, terminate logical I/O and leave any fallible backend
+  cleanup safe for the required abort fallback.
 
 `close_info()` returns structured terminal metadata when available:
 
@@ -124,6 +125,31 @@ pub struct TransportCloseInfo {
 ```
 
 Capture peer close metadata before returning `Ready(None)` from `poll_recv`.
+
+### Required abort fallback
+
+`abort` is required because both clients use it to enforce their configured
+close deadline. It must return promptly without blocking or panicking. The
+call releases or safely detaches backend-owned work and discards any retained
+accepted send. It must be idempotent. After it returns:
+
+- the client driver makes no further `begin_poll_cycle`, `poll_send`,
+  `poll_recv`, or `poll_close` calls;
+- only repeated `abort`, `is_ready`, `close_info`, `diagnostics`, and drop are
+  allowed;
+- repeated `abort` must not repeat completed cleanup; failed cleanup may be
+  retried safely.
+
+An implementation may satisfy resource release by closing owned handles or by
+dropping/detaching them into a backend mechanism whose ownership and lifetime
+are explicit. A no-op is valid only for a transport that owns no live resource
+or retained operation. Implementations may fuse post-abort polling to terminal
+results as a stronger convenience, as the built-in transports do, but custom
+callers must not depend on polling after abort.
+
+If an external callback-unregistration API fails, retain the callback backing
+allocation rather than risk use-after-free. That safety leak counts as a
+logical detach; a later `abort` or `Drop` may retry the failed cleanup.
 
 ## Readiness
 
@@ -143,8 +169,9 @@ use signal_fish_client::transport::{Transport, TransportFrame};
 use tokio::sync::mpsc;
 
 struct LoopbackTransport {
-    tx: mpsc::UnboundedSender<TransportFrame>,
+    tx: Option<mpsc::UnboundedSender<TransportFrame>>,
     rx: mpsc::UnboundedReceiver<TransportFrame>,
+    closed: bool,
 }
 
 impl Transport for LoopbackTransport {
@@ -153,8 +180,11 @@ impl Transport for LoopbackTransport {
         _cx: &mut Context<'_>,
         frame: &mut Option<TransportFrame>,
     ) -> Poll<Result<(), SignalFishError>> {
+        let Some(tx) = self.tx.as_ref() else {
+            return Poll::Ready(Err(SignalFishError::TransportClosed));
+        };
         let result = match frame.take() {
-            Some(frame) => self.tx.send(frame).map_err(|error| {
+            Some(frame) => tx.send(frame).map_err(|error| {
                 SignalFishError::TransportSend(error.to_string())
             }),
             None => Ok(()),
@@ -166,6 +196,9 @@ impl Transport for LoopbackTransport {
         &mut self,
         cx: &mut Context<'_>,
     ) -> Poll<Option<Result<TransportFrame, SignalFishError>>> {
+        if self.closed {
+            return Poll::Ready(None);
+        }
         self.rx.poll_recv(cx).map(|frame| frame.map(Ok))
     }
 
@@ -173,7 +206,16 @@ impl Transport for LoopbackTransport {
         &mut self,
         _cx: &mut Context<'_>,
     ) -> Poll<Result<(), SignalFishError>> {
+        self.closed = true;
+        self.tx = None;
+        self.rx.close();
         Poll::Ready(Ok(()))
+    }
+
+    fn abort(&mut self) {
+        self.closed = true;
+        self.tx = None;
+        self.rx.close();
     }
 }
 ```
@@ -245,6 +287,8 @@ in integration testing. The `websocket-client` skill has the concrete
 - [ ] `poll_recv` retains partial input across `Pending`.
 - [ ] Peer close returns `None` and preserves structured metadata.
 - [ ] `poll_close` is multi-poll and idempotent.
+- [ ] `abort` is required, immediate, idempotent, releases or safely detaches
+      backend resources, and discards accepted sends; drivers never poll afterward.
 - [ ] `is_ready` matches handshake state.
 - [ ] Non-`Send` transports compile with the polling client.
 - [ ] `Send + 'static` is imposed only by async-client construction.

--- a/.llm/skills/websocket-client/SKILL.md
+++ b/.llm/skills/websocket-client/SKILL.md
@@ -117,6 +117,11 @@ does not supply a separate clean-handshake boolean here, so `clean` remains
 marks the transport closed on either terminal success or error. Once closed,
 later calls return `Ready(Ok(()))` without another close frame.
 
+Required `Transport::abort` drops the stream and retained send/control state
+immediately and is idempotent. Async task cancellation is protected by an
+owner guard that invokes abort unless graceful close completed; client drivers
+perform no later transport polls.
+
 EOF and terminal receive/send failures drop the stream, clear retained send and
 control state, and fuse the transport. Report the first receive failure as
 `TransportReceive`; later receives return `None`, sends return

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Breaking:** `Transport::abort` is now required. Custom transport
+  implementors must provide a prompt, nonblocking, non-panicking, idempotent
+  backend-abandonment path that releases or safely detaches resources and
+  discards retained sends; completed cleanup is one-shot and failed external
+  cleanup may be retried safely. Both clients
+  invoke it when the configured close deadline expires, after a graceful-close
+  error, and when their owner is dropped without completing graceful close;
+  drivers perform no later transport polling.
 - **Breaking:** the new fields and variants listed above change exhaustive
   struct literals and matches. `SignalFishClientApi` implementors must add the
   two generation-bound send methods. These APIs require the forthcoming 0.11

--- a/PLAN.md
+++ b/PLAN.md
@@ -77,7 +77,7 @@ were delivered by PR #91 and closed when it merged as `963a9fc`.
   deletion failures remain retryable, and terminal cleanup deliberately leaks
   the small allocation instead of risking a late-callback use-after-free. The
   host-tested state machine and required FFI checker enforce this condition
-  with 43 checker self-tests.
+  with 50 checker self-tests.
 - Dependabot's first default-branch Cargo run after PR #91 failed because its
   temporary file set omitted `crates/signal-fish-client-godot/Cargo.toml`, then
   opened zero-file PR #92. The three-directory attempt also failed in run
@@ -161,20 +161,31 @@ queue capacity. The code-bearing head passed all twelve hosted workflow suites;
 Session 031 records the operation/state matrix, pinned-server contract, review
 fixes, and exact verification evidence.
 
-## Current Correctness Milestone — Readiness and Traffic Counters
+## Completed Correctness Milestone — Readiness and Traffic Counters
 
 [Issue #104](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/issues/104)
-defines connection state as nested client-owned, transport-ready,
+shipped in [PR #115](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/pull/115). It defines connection state as nested client-owned, transport-ready,
 server-authenticated, and room-membership phases without preventing FIFO
 queueing during an asynchronous handshake. Traffic statistics count outbound
 transport ownership transfer and inbound decoded receipt, including
 accepted-then-error, stale, and quarantined cases. Session 032 records the
-contract and evidence.
+contract, review, and green hosted evidence.
 
-## Next Correctness Milestones — Transport Deadlines and Datagram Scope
+## Current Correctness Milestone — Enforceable Transport Abandonment
 
-Continue with #106 and #107 before usability, performance, token binding, or
-presentation milestones.
+[Issue #106](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/issues/106)
+makes `Transport::abort` a required backend-lifetime decision and invokes it
+after close deadlines/errors and owner cancellation/drop. Async and polling
+drivers must preserve accepted-send-before-close ordering while proving
+deadline abandonment, resource release, and no later transport polling.
+Session 033 records the contract and evidence.
+
+## Next Correctness Milestone — Datagram Scope
+
+Resolve [issue #107](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/issues/107)
+before usability, performance, token binding, or presentation milestones. Do
+not claim UDP resilience without an explicit framing, trust, ownership, and
+delivery decision.
 
 ## Following Milestone — Negotiated Token Binding
 
@@ -200,6 +211,16 @@ Track [issue #82](https://github.com/Ambiguous-Interactive/signal-fish-client-ru
   stable enough for CI.
 - Preserve frame ownership, backpressure, exact accountability, and event
   delivery invariants in every optimization.
+
+The stale `agent/fortress-rollback-throughput-e2e` branch is retained only as
+research input for #82. Its pre-session-018 standalone fixture was superseded
+by the merged two-browser Godot Fortress suite and is not an active PR.
+
+## Later Milestone — Simplified Documentation
+
+Track [issue #110](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/issues/110)
+and its completed server-side prerequisite to define a smaller onboarding path
+without duplicating or weakening the strict reference documentation.
 
 ## Later Milestone — Documentation Design System
 

--- a/README.md
+++ b/README.md
@@ -221,6 +221,12 @@ impl Transport for MyTransport {
         // Drive one idempotent close handshake across as many polls as needed.
         todo!()
     }
+
+    fn abort(&mut self) {
+        // Promptly abandon retained work and release or safely detach resources.
+        // This method must be non-blocking, non-panicking, and idempotent.
+        todo!()
+    }
 }
 ```
 
@@ -230,6 +236,8 @@ Key requirements:
 - Retain accepted outbound frames and partial receives across `Poll::Pending`
 - Register the supplied waker when async progress becomes possible
 - Make `poll_close` idempotent and expose structured peer metadata via `close_info`
+- Make `abort` prompt, non-blocking, non-panicking, and idempotent; it must
+  release or safely detach owned resources and discard retained sends
 - A transport constructor may begin an asynchronous connection attempt; both clients defer `Connected` until `is_ready()`, and the transport retains sends and wakes blocked async I/O when the handshake completes
 - The trait has no `Send` bound; only `SignalFishClient::start` requires
   `Send + 'static`, while `SignalFishPollingClient` accepts non-`Send` transports

--- a/crates/signal-fish-client-godot/src/lib.rs
+++ b/crates/signal-fish-client-godot/src/lib.rs
@@ -1366,9 +1366,21 @@ mod tests {
         transport.begin_poll_cycle();
 
         transport.abort();
+        transport.abort();
 
         assert_eq!(abort_calls.get(), 1);
         assert_eq!(transport.diagnostics().current_buffered_bytes, 0);
+        let expected = TransportFrame::Text("caller still owns this".into());
+        let mut offered = Some(expected.clone());
+        assert!(matches!(
+            transport.poll_send(&mut context(), &mut offered),
+            Poll::Ready(Err(SignalFishError::TransportClosed))
+        ));
+        assert_eq!(offered, Some(expected));
+        assert!(matches!(
+            transport.poll_recv(&mut context()),
+            Poll::Ready(None)
+        ));
         assert!(matches!(
             transport.poll_close(&mut context()),
             Poll::Ready(Ok(()))

--- a/docs/client.md
+++ b/docs/client.md
@@ -661,18 +661,22 @@ client.shutdown().await;
 Shutdown proceeds in four stages:
 
 1. Sends a oneshot signal to the background transport loop.
-2. Awaits the loop task with a configurable timeout (default **1 second**,
-   set via [`SignalFishConfig::shutdown_timeout`](#signalfishconfig)).
-3. If the timeout expires, the task is logged as unresponsive and aborted.
-   The `Disconnected` event may not be delivered in this case.
+2. The loop finishes a backend-owned send and drives `Transport::poll_close`
+   within the configurable deadline (default **1 second**, set via
+   [`SignalFishConfig::shutdown_timeout`](#signalfishconfig)).
+3. If the deadline expires, the transport's required `abort` fallback releases
+   or safely detaches backend resources and the loop normally returns. A later
+   watchdog cancels the task only if it still does not stop. The `Disconnected`
+   event may not be delivered in this case.
 4. Regardless of whether `Disconnected` is delivered, connection/session state
    is cleared (`is_connected() == false`, `is_transport_ready() == false`,
    `is_authenticated() == false`, and room/player accessors return `None`).
 
 !!! warning "Drop fallback"
     If `shutdown()` is never called, the `Drop` implementation **aborts** the
-    background task immediately. Always prefer an explicit `shutdown().await` for
-    a clean disconnect.
+    background task immediately; the task's ownership guard invokes
+    `Transport::abort` as it is cancelled. Always prefer an explicit
+    `shutdown().await` for a clean disconnect.
 
 ---
 
@@ -887,9 +891,8 @@ After calling `close()`, both `is_connected()` and `is_transport_ready()`
 return `false`, and all command methods return
 `Err(SignalFishError::NotConnected)`.
 
-!!! warning "No Drop fallback"
-    Unlike `SignalFishClient`, the polling client does **not** abort a
-    background task on drop (there is no background task). However, the
-    underlying transport's `Drop` implementation will still clean up
-    resources. Call `close()` and continue polling while `is_closing()` for a
-    graceful WebSocket close handshake.
+!!! warning "Drop fallback"
+    The polling client has no background task. If it is dropped before
+    graceful close completes, it synchronously calls the transport's required
+    `abort` method. Call `close()` and continue polling while `is_closing()` for
+    a graceful WebSocket close handshake.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -30,7 +30,7 @@ pub trait Transport {
         -> Poll<Option<Result<TransportFrame, SignalFishError>>>;
     fn poll_close(&mut self, cx: &mut Context<'_>)
         -> Poll<Result<(), SignalFishError>>;
-    fn abort(&mut self) {}
+    fn abort(&mut self);
     fn is_ready(&self) -> bool { true }
     fn close_info(&self) -> Option<TransportCloseInfo> { None }
     fn diagnostics(&self) -> TransportDiagnostics { TransportDiagnostics::default() }
@@ -42,9 +42,14 @@ pub trait Transport {
 | `poll_send` | Accept and progress one `TransportFrame`; preserve ownership correctly across `Pending`. |
 | `poll_recv` | Poll the next text/binary frame; `Ready(None)` is a clean close. |
 | `poll_close` | Progress idempotent graceful shutdown across calls. |
+| `abort` | Immediately abandon backend work and end driver polling after a deadline, close error, or owner drop. |
 
-The defaulted hooks mark a polling cycle, abort after a close deadline, report
-handshake readiness and close metadata, and expose backend-owned diagnostics.
+The required `abort` method enforces deadline abandonment. It releases or
+safely detaches backend resources, discards accepted sends, and makes later
+polling invalid; only repeated `abort`, `is_ready`, `close_info`, `diagnostics`,
+and drop remain allowed. The
+remaining defaulted hooks mark a polling cycle, report handshake readiness and
+close metadata, and expose backend-owned diagnostics.
 
 The trait has no `Send` bound, allowing engine-owned main-thread transports.
 The async client adds `Send + 'static` at `start`; the polling client does not.
@@ -419,11 +424,12 @@ client.shutdown().await;
 Under the hood this:
 
 1. Sends a signal to the background transport loop via a `oneshot` channel.
-2. The loop drives `transport.poll_close()` and attempts to emit
-   `SignalFishEvent::Disconnected`.
-3. `shutdown()` awaits the background task with a configurable timeout (default
-   **1 second**, set via `SignalFishConfig::shutdown_timeout`). If the task does
-   not finish in time, it is aborted to prevent detached background work.
+2. The loop attempts `SignalFishEvent::Disconnected`, finishes any
+   backend-owned send, and drives `Transport::poll_close` within the configured
+   close deadline (default **1 second**).
+3. Deadline expiry invokes `Transport::abort`, after which the loop normally
+   returns. `shutdown()` uses a later deadline-plus-grace watchdog to cancel
+   the task only if it still does not stop.
 4. On completion, client session state is reset even if the `Disconnected`
    event was not delivered due to timeout/abort.
 
@@ -437,8 +443,9 @@ capacity and the shutdown deadline permit.
 
 !!! warning
     `Drop` cannot run async code. It calls `task.abort()`, which cancels the
-    future without executing `transport.close()`. The server may see an
-    unclean disconnection.
+    future without driving `Transport::poll_close`; the task's ownership guard
+    then invokes the required `Transport::abort` fallback. The server may see
+    an unclean disconnection.
 
 ---
 

--- a/docs/delivery.md
+++ b/docs/delivery.md
@@ -154,9 +154,10 @@ blocks delivering the next event, stops reading the socket, and the server
 eventually evicts you (`SLOW_CONSUMER`) — but the wedged client cannot
 observe the eviction (it is not reading), so from the inside the session
 just goes quiet. As of 0.7.0, [`shutdown()`](client.md#shutdown) preempts
-the wedge: it abandons at most the one in-flight event delivery, closes
-the transport cleanly, and completes without waiting for the timeout
-abort. If draining ever resumes instead, the buffered events (often
+the wedge: it abandons at most the one in-flight event delivery and progresses
+graceful transport close without waiting for event-channel capacity. A close
+error or the configured close deadline invokes `Transport::abort` before the
+driver stops. If draining ever resumes instead, the buffered events (often
 including the eviction farewell) arrive, followed by `Disconnected`.
 
 ## Sizing the channels

--- a/docs/events.md
+++ b/docs/events.md
@@ -25,11 +25,11 @@ descriptions and usage examples.
     consumer that falls behind pauses the transport loop until the channel
     has room — backpressure propagates to the server instead of losing
     events. Inbound frames that fail to decode surface as
-    [`DecodeFailed`](#decodefailed) events rather than being skipped. There
-    Delivery can still stop or be preempted: the event receiver can be dropped,
+    [`DecodeFailed`](#decodefailed) events rather than being skipped. Delivery
+    can still stop or be preempted: the event receiver can be dropped,
     the client handle can be dropped without calling
-    [`shutdown()`](client.md#shutdown) (which aborts the loop immediately),
-    or `shutdown()` can abandon the one delivery currently blocked on channel
+    [`shutdown()`](client.md#shutdown), which aborts the loop immediately, or
+    `shutdown()` can abandon the one delivery currently blocked on channel
     capacity. Shutdown attempts a graceful close and delivers the terminal
     `Disconnected` best-effort; its configured deadline may abort that work.
     The event channel closing is the authoritative end-of-stream signal.
@@ -64,7 +64,8 @@ Use these to track the raw connection lifecycle.
     loop lets shutdown preempt a delivery blocked on channel capacity, and the
     shutdown path attempts the terminal event with non-blocking admission. If
     the channel is full, the event **may be omitted**. The configured shutdown
-    deadline may also abort the task before it reaches that attempt. The event
+    deadline may invoke the transport's abort path and stop the task before it
+    reaches that attempt. The event
     channel closing (`recv()`
     returns `None`) is the guaranteed end-of-stream signal — rely on it, not
     on always observing a final `Disconnected`.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -194,8 +194,9 @@ client.shutdown().await;
 ```
 
 `shutdown()` asks the transport loop to close gracefully and waits up to
-`SignalFishConfig::shutdown_timeout`; if that deadline expires, it aborts the
-task and the terminal `Disconnected` event may be omitted.
+`SignalFishConfig::shutdown_timeout`; if that deadline expires, it invokes the
+transport's abort path, stops the task, and may omit the terminal
+`Disconnected` event.
 
 ### Running it
 
@@ -241,8 +242,9 @@ use signal_fish_client::{
 use tokio::sync::mpsc;
 
 pub struct LoopbackTransport {
-    tx: mpsc::UnboundedSender<String>,
+    tx: Option<mpsc::UnboundedSender<String>>,
     rx: mpsc::UnboundedReceiver<String>,
+    closed: bool,
 }
 
 pub struct LoopbackServer {
@@ -253,7 +255,11 @@ pub struct LoopbackServer {
 fn loopback_pair() -> (LoopbackTransport, LoopbackServer) {
     let (client_tx, server_rx) = mpsc::unbounded_channel();
     let (server_tx, client_rx) = mpsc::unbounded_channel();
-    let transport = LoopbackTransport { tx: client_tx, rx: client_rx };
+    let transport = LoopbackTransport {
+        tx: Some(client_tx),
+        rx: client_rx,
+        closed: false,
+    };
     let server = LoopbackServer { rx: server_rx, tx: server_tx };
     (transport, server)
 }
@@ -264,8 +270,11 @@ impl Transport for LoopbackTransport {
         _cx: &mut std::task::Context<'_>,
         frame: &mut Option<TransportFrame>,
     ) -> std::task::Poll<Result<(), SignalFishError>> {
+        let Some(tx) = self.tx.as_ref() else {
+            return std::task::Poll::Ready(Err(SignalFishError::TransportClosed));
+        };
         let result = match frame.take() {
-            Some(TransportFrame::Text(message)) => self.tx.send(message)
+            Some(TransportFrame::Text(message)) => tx.send(message)
                 .map_err(|e| SignalFishError::TransportSend(e.to_string())),
             Some(TransportFrame::Binary(_)) => Err(SignalFishError::TransportSend(
                 "text-only loopback does not accept binary frames".into(),
@@ -278,6 +287,9 @@ impl Transport for LoopbackTransport {
         &mut self,
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Option<Result<TransportFrame, SignalFishError>>> {
+        if self.closed {
+            return std::task::Poll::Ready(None);
+        }
         self.rx.poll_recv(cx)
             .map(|message| message.map(|text| Ok(TransportFrame::Text(text))))
     }
@@ -285,7 +297,16 @@ impl Transport for LoopbackTransport {
         &mut self,
         _cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Result<(), SignalFishError>> {
+        self.closed = true;
+        self.tx = None;
+        self.rx.close();
         std::task::Poll::Ready(Ok(()))
+    }
+
+    fn abort(&mut self) {
+        self.closed = true;
+        self.tx = None;
+        self.rx.close();
     }
 }
 
@@ -337,8 +358,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 ```rust,ignore
 pub struct LoopbackTransport {
-    tx: mpsc::UnboundedSender<String>,
+    tx: Option<mpsc::UnboundedSender<String>>,
     rx: mpsc::UnboundedReceiver<String>,
+    closed: bool,
 }
 ```
 
@@ -357,8 +379,11 @@ impl Transport for LoopbackTransport {
         _cx: &mut std::task::Context<'_>,
         frame: &mut Option<TransportFrame>,
     ) -> std::task::Poll<Result<(), SignalFishError>> {
+        let Some(tx) = self.tx.as_ref() else {
+            return std::task::Poll::Ready(Err(SignalFishError::TransportClosed));
+        };
         let result = match frame.take() {
-            Some(TransportFrame::Text(message)) => self.tx.send(message)
+            Some(TransportFrame::Text(message)) => tx.send(message)
                 .map_err(|e| SignalFishError::TransportSend(e.to_string())),
             Some(TransportFrame::Binary(_)) => Err(SignalFishError::TransportSend(
                 "text-only loopback does not accept binary frames".into(),
@@ -371,6 +396,9 @@ impl Transport for LoopbackTransport {
         &mut self,
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Option<Result<TransportFrame, SignalFishError>>> {
+        if self.closed {
+            return std::task::Poll::Ready(None);
+        }
         self.rx.poll_recv(cx)
             .map(|message| message.map(|text| Ok(TransportFrame::Text(text))))
     }
@@ -378,18 +406,28 @@ impl Transport for LoopbackTransport {
         &mut self,
         _cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Result<(), SignalFishError>> {
+        self.closed = true;
+        self.tx = None;
+        self.rx.close();
         std::task::Poll::Ready(Ok(()))
+    }
+
+    fn abort(&mut self) {
+        self.closed = true;
+        self.tx = None;
+        self.rx.close();
     }
 }
 ```
 
-Only three polling methods are required:
+Four lifecycle methods are required:
 
 | Method | Purpose |
 |---|---|
 | `poll_send` | Accept and progress a text or binary frame. |
 | `poll_recv` | Poll the next frame (returns `Ready(None)` on close). |
 | `poll_close` | Progress cleanup idempotently (immediately ready here). |
+| `abort` | Immediately abandon work and release owned resources. |
 
 #### 3. Create a fake server that injects responses
 

--- a/docs/transport.md
+++ b/docs/transport.md
@@ -27,7 +27,7 @@ pub trait Transport {
     ) -> Poll<Result<(), SignalFishError>>;
 
     fn begin_poll_cycle(&mut self) {}
-    fn abort(&mut self) {}
+    fn abort(&mut self);
     fn diagnostics(&self) -> TransportDiagnostics { TransportDiagnostics::default() }
     fn is_ready(&self) -> bool { true }
     fn close_info(&self) -> Option<TransportCloseInfo> { None }
@@ -84,10 +84,48 @@ handshake without transferring them prematurely.
 
 `begin_poll_cycle` lets adaptive transports sample once per application tick.
 `diagnostics` distinguishes backend-owned buffering/admission from the client
-queue. `abort` is invoked when the polling close deadline expires; defaulted
-hooks preserve existing custom transport implementations. The built-in
-WebSocket transports override `abort` to release their socket immediately;
-custom transports with owned resources should do the same.
+queue. `abort` is required and is invoked when graceful close errors, either
+client's close deadline expires, or an owner is dropped before close completes.
+It must promptly release or safely detach backend-owned work, discard retained
+accepted sends, return without blocking or panicking, and be idempotent.
+Completed cleanup is not repeated, while failed cleanup may be retried safely.
+Afterwards, client drivers make no further polling calls: only repeated
+`abort`, `is_ready`, `close_info`, `diagnostics`, and drop are allowed. The
+built-in WebSocket transports and Godot adapter also fuse later polls to
+terminal results as a stronger convenience.
+
+### Migrating custom transports for 0.11
+
+`abort` no longer has a default implementation. Every custom transport must
+make an explicit resource-lifetime decision:
+
+```rust,ignore
+fn abort(&mut self) {
+    if self.aborted {
+        return;
+    }
+    self.aborted = true;
+    self.retained_send = None;
+    self.shared_backend.unregister(self.connection_id);
+    self.socket = None;
+    self.waker = None;
+}
+```
+
+The exact fields vary by backend. Clear retained frames and wakers, revoke this
+transport's participation in any shared backend, and release owned handles
+without blocking. If the implementation owns no live resource, retained work,
+callback, or shared registration, an explicit no-op is valid:
+
+```rust,ignore
+fn abort(&mut self) {}
+```
+
+Do not wait for a peer handshake in `abort`; that belongs to `poll_close`.
+Because `abort` can run from `Drop` during unwinding, it must never panic. If an
+external cleanup API fails, keep callback backing storage alive rather than
+risk use-after-free, and make later `abort` or `Drop` retries safe.
+`examples/custom_transport.rs` shows a complete channel-backed implementation.
 
 ## Receiving
 
@@ -109,7 +147,9 @@ and polls again on the next application tick.
 
 `poll_close` may need multiple calls. It is idempotent: it starts at most one
 close handshake, retains progress across `Pending`, and returns
-`Ready(Ok(()))` on every call after successful completion.
+`Ready(Ok(()))` on every call after successful completion. On error, logical
+I/O terminates and both clients immediately call `abort`; fallible backend
+cleanup may remain safely retryable.
 
 After a peer close, `close_info()` may return:
 
@@ -193,8 +233,9 @@ use signal_fish_client::transport::{Transport, TransportFrame};
 use tokio::sync::mpsc;
 
 pub struct LoopbackTransport {
-    tx: mpsc::UnboundedSender<TransportFrame>,
+    tx: Option<mpsc::UnboundedSender<TransportFrame>>,
     rx: mpsc::UnboundedReceiver<TransportFrame>,
+    closed: bool,
 }
 
 impl Transport for LoopbackTransport {
@@ -203,8 +244,11 @@ impl Transport for LoopbackTransport {
         _cx: &mut Context<'_>,
         frame: &mut Option<TransportFrame>,
     ) -> Poll<Result<(), SignalFishError>> {
+        let Some(tx) = self.tx.as_ref() else {
+            return Poll::Ready(Err(SignalFishError::TransportClosed));
+        };
         let result = match frame.take() {
-            Some(frame) => self.tx.send(frame).map_err(|error| {
+            Some(frame) => tx.send(frame).map_err(|error| {
                 SignalFishError::TransportSend(error.to_string())
             }),
             None => Ok(()),
@@ -216,6 +260,9 @@ impl Transport for LoopbackTransport {
         &mut self,
         cx: &mut Context<'_>,
     ) -> Poll<Option<Result<TransportFrame, SignalFishError>>> {
+        if self.closed {
+            return Poll::Ready(None);
+        }
         self.rx.poll_recv(cx).map(|frame| frame.map(Ok))
     }
 
@@ -223,7 +270,16 @@ impl Transport for LoopbackTransport {
         &mut self,
         _cx: &mut Context<'_>,
     ) -> Poll<Result<(), SignalFishError>> {
+        self.closed = true;
+        self.tx = None;
+        self.rx.close();
         Poll::Ready(Ok(()))
+    }
+
+    fn abort(&mut self) {
+        self.closed = true;
+        self.tx = None;
+        self.rx.close();
     }
 }
 ```
@@ -266,7 +322,8 @@ backend-accepted, backend-buffered, and peer-delivered are distinct stages.
 `wasm32-unknown-emscripten`. Its browser callbacks buffer readiness, text,
 binary, error, and close events; `SignalFishPollingClient::poll` drains them on
 the main thread. It exposes structured close metadata and drives idempotent
-cleanup through `poll_close`.
+cleanup through `poll_close`; `abort` applies the same close-before-release
+ordering when close errors, times out, or the polling owner is dropped.
 
 It is intended for the polling client, not the Tokio-spawned async client. See
 the [WebAssembly guide](wasm.md) for target and linker requirements.
@@ -279,6 +336,8 @@ the [WebAssembly guide](wasm.md) for target and linker requirements.
   a socket-wide buffered byte count to reach zero as per-frame completion.
 - Register the supplied waker when async progress depends on readiness.
 - Make close multi-poll and idempotent.
+- Implement prompt, non-blocking, non-panicking, idempotent `abort` cleanup;
+  clear retained work and make failed backend cleanup safe to retry.
 - Record close code/reason/initiator before returning `None`.
 - Keep `is_ready` cheap and monotonic for one physical connection.
 - Put connection-specific construction outside the trait.

--- a/docs/wasm.md
+++ b/docs/wasm.md
@@ -71,9 +71,10 @@ cargo build --target wasm32-unknown-unknown --no-default-features
 ### Bring your own transport
 
 Implement the `Transport` trait using a browser-compatible WebSocket binding
-(e.g., `web-sys`, `gloo-net`, or `wasm-bindgen`). The trait requires three
-object-safe polling methods — `poll_send`, `poll_recv`, and `poll_close` — as documented on the
-[Transport](transport.md) page.
+(e.g., `web-sys`, `gloo-net`, or `wasm-bindgen`). The trait requires the three
+object-safe polling methods `poll_send`, `poll_recv`, and `poll_close`, plus a
+prompt, idempotent `abort` path, as documented on the [Transport](transport.md)
+page.
 
 ### Compatibility
 
@@ -367,6 +368,9 @@ The fixed defaults are 64 frames/64 KiB for sends and the same for receives.
 Zero limits clamp to one; an individually oversized frame can consume one poll
 by itself. `PollingClientOptions` also selects `Abandon` (default) or `Flush`
 close behavior. Both are bounded by `SignalFishConfig::shutdown_timeout`.
+Deadline expiry, a graceful-close error, or dropping the polling client before
+close completes invokes the transport's required synchronous `abort` fallback;
+the driver performs no later transport polling.
 Use `polling_stats()` for client-owned queue depth, budget exhaustion, and
 deadline counters; use `transport_diagnostics()` for backend buffering,
 watermark, acceptance, and capacity counters. Backend acceptance is not peer
@@ -831,10 +835,11 @@ channel:
    channel is empty, it returns `Poll::Pending`, which the polling client
    handles by breaking out of the receive loop.
 
-4. **Cleanup** — on `Drop`, the transport calls `emscripten_websocket_close()`
-   and `emscripten_websocket_delete()` (which unregisters all callbacks), then
-   reclaims the `CallbackState` via `Box::from_raw`. The ordering ensures no
-   callback can fire after the state is freed.
+4. **Cleanup** — `poll_close`, `abort`, and `Drop` all attempt native close
+   before socket deletion. A successful deletion unregisters every callback
+   and authorizes reclaiming `CallbackState` via `Box::from_raw`. If deletion
+   fails, the state intentionally remains live for a safe retry (or final
+   safety leak), so no callback can dereference freed memory.
 
 ```mermaid
 sequenceDiagram

--- a/examples/custom_transport.rs
+++ b/examples/custom_transport.rs
@@ -31,9 +31,11 @@ use tokio::sync::mpsc;
 ///   what the client sent — perfect for testing.
 pub struct LoopbackTransport {
     /// Messages the client sends go here (server reads from the other end).
-    tx: mpsc::UnboundedSender<String>,
+    tx: Option<mpsc::UnboundedSender<String>>,
     /// Messages the server sends arrive here (client reads them).
     rx: mpsc::UnboundedReceiver<String>,
+    /// Terminal flag established by graceful close or abort.
+    closed: bool,
 }
 
 /// The "server side" of the loopback — use this to drive the conversation.
@@ -52,8 +54,9 @@ fn loopback_pair() -> (LoopbackTransport, LoopbackServer) {
     let (server_tx, client_rx) = mpsc::unbounded_channel();
 
     let transport = LoopbackTransport {
-        tx: client_tx,
+        tx: Some(client_tx),
         rx: client_rx,
+        closed: false,
     };
     let server = LoopbackServer {
         rx: server_rx,
@@ -74,9 +77,11 @@ impl Transport for LoopbackTransport {
         _cx: &mut std::task::Context<'_>,
         frame: &mut Option<TransportFrame>,
     ) -> std::task::Poll<Result<(), SignalFishError>> {
+        let Some(tx) = self.tx.as_ref() else {
+            return std::task::Poll::Ready(Err(SignalFishError::TransportClosed));
+        };
         let result = match frame.take() {
-            Some(TransportFrame::Text(message)) => self
-                .tx
+            Some(TransportFrame::Text(message)) => tx
                 .send(message)
                 .map_err(|e| SignalFishError::TransportSend(e.to_string())),
             Some(TransportFrame::Binary(_)) => Err(SignalFishError::TransportSend(
@@ -96,6 +101,9 @@ impl Transport for LoopbackTransport {
         &mut self,
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Option<Result<TransportFrame, SignalFishError>>> {
+        if self.closed {
+            return std::task::Poll::Ready(None);
+        }
         self.rx
             .poll_recv(cx)
             .map(|message| message.map(|message| Ok(TransportFrame::Text(message))))
@@ -106,7 +114,17 @@ impl Transport for LoopbackTransport {
         &mut self,
         _cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Result<(), SignalFishError>> {
+        self.closed = true;
+        self.tx = None;
+        self.rx.close();
         std::task::Poll::Ready(Ok(()))
+    }
+
+    /// Abandon both channel halves immediately and make later polls terminal.
+    fn abort(&mut self) {
+        self.closed = true;
+        self.tx = None;
+        self.rx.close();
     }
 }
 

--- a/examples/mesh_session.rs
+++ b/examples/mesh_session.rs
@@ -112,6 +112,7 @@ struct ScriptedServer {
     incoming: VecDeque<String>,
     peer: PlayerId,
     started: bool,
+    aborted: bool,
 }
 
 impl Transport for ScriptedServer {
@@ -120,6 +121,9 @@ impl Transport for ScriptedServer {
         _cx: &mut std::task::Context<'_>,
         frame: &mut Option<TransportFrame>,
     ) -> std::task::Poll<Result<(), SignalFishError>> {
+        if self.aborted {
+            return std::task::Poll::Ready(Err(SignalFishError::TransportClosed));
+        }
         let Some(frame) = frame.take() else {
             return std::task::Poll::Ready(Ok(()));
         };
@@ -143,6 +147,9 @@ impl Transport for ScriptedServer {
         &mut self,
         _cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Option<Result<TransportFrame, SignalFishError>>> {
+        if self.aborted {
+            return std::task::Poll::Ready(None);
+        }
         if let Some(msg) = self.incoming.pop_front() {
             std::task::Poll::Ready(Some(Ok(TransportFrame::Text(msg))))
         } else {
@@ -154,7 +161,14 @@ impl Transport for ScriptedServer {
         &mut self,
         _cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Result<(), SignalFishError>> {
+        self.aborted = true;
+        self.incoming.clear();
         std::task::Poll::Ready(Ok(()))
+    }
+
+    fn abort(&mut self) {
+        self.aborted = true;
+        self.incoming.clear();
     }
 }
 
@@ -184,6 +198,7 @@ async fn main() -> Result<(), SignalFishError> {
         ]),
         peer,
         started: false,
+        aborted: false,
     };
 
     // `MeshController::start` preserves compatible explicit choices and adds

--- a/pr-description.md
+++ b/pr-description.md
@@ -1,35 +1,32 @@
 ## Summary
 
-Clarifies the connection phase and traffic-counter contracts shared by the
-async and polling clients. Applications can now distinguish client ownership
-from transport readiness, and `ClientStats` counts at stable transport/decode
-boundaries instead of backend completion or application delivery.
+Gives every custom transport an explicit close-deadline abandonment hook.
+`Transport::abort` is now required; both client drivers invoke it for deadline
+expiry, close errors, or owner drop before graceful close completes, while the
+async ownership guard also covers task cancellation and panic unwinding.
 
-Closes #104.
+Closes #106.
 
 ## Changes
 
-- Add `ClientSnapshot::transport_ready` and matching async, polling, and
-  `SignalFishClientApi` accessors; emit `Connected` exactly once on the first
-  driver observation of `Transport::is_ready()`.
-- Preserve FIFO command admission while connecting, require deferred async
-  readiness to wake registered I/O, and reset every connection phase on
-  terminal paths.
-- Count `game_data_sent` at exact frame ownership transfer, including
-  accepted-Pending and accepted-then-error sends without double-counting.
-- Count `game_data_received` immediately after successful text or binary
-  protocol decode, before message validation, sequence accountability, stale,
-  quarantine, or event suppression; preserve physical-binary admission checks
-  that reject a frame before logical decoding.
-- Document the valid phase tuples, counter conservation limits, excluded
-  traffic, and cross-peer diagnostic caveats across the public guides,
-  changelog, roadmap, canonical context, and focused agent skills.
+- Require every `Transport` implementation to provide a synchronous,
+  idempotent abort path that releases or safely detaches backend resources and
+  discards retained accepted sends.
+- Add an async transport ownership guard plus polling-client drop fallback so
+  cancellation and drop cannot bypass backend abandonment.
+- Preserve backend-owned send completion before graceful close under the one
+  configured deadline; abort on expiry or close failure and never poll the
+  transport afterward.
+- Prove accepted-send hangs, close hangs/errors, resource release, repeated
+  shutdown/drop, event termination, and zero post-abort transport activity in
+  both drivers; strengthen native WebSocket and Godot abort tests.
+- Add third-party migration guidance and update custom transport examples,
+  lifecycle docs, changelog, roadmap, canonical context, and focused skills.
 
 ## Validation
 
-- [x] Focused async and polling readiness tests
-- [x] Focused ownership-transfer and decoded-receipt tests
-- [x] Async/polling frame, snapshot, and statistics parity tests
-- [x] Repository documentation and workflow policy validators
+- [x] Focused async/polling deadline, close-error, and drop tests
+- [x] Built-in native WebSocket and Godot abort contract tests
+- [x] Repository documentation and policy validators
 - [x] `cargo fmt && cargo clippy --workspace --all-targets --all-features -- -D warnings && cargo test --workspace --all-features`
 - [ ] Hosted required checks and review feedback

--- a/pr-description.md
+++ b/pr-description.md
@@ -29,4 +29,4 @@ Closes #106.
 - [x] Built-in native WebSocket and Godot abort contract tests
 - [x] Repository documentation and policy validators
 - [x] `cargo fmt && cargo clippy --workspace --all-targets --all-features -- -D warnings && cargo test --workspace --all-features`
-- [ ] Hosted required checks and review feedback
+- [x] Hosted required checks and review feedback

--- a/progress/session-032-readiness-and-traffic-counters.md
+++ b/progress/session-032-readiness-and-traffic-counters.md
@@ -73,5 +73,5 @@ Clippy completed with zero warnings; all 345 root library tests, 35 Godot
 adapter tests, 470 integration tests, and seven runnable rustdoc tests passed
 (six live-server tests and five example-only rustdoc blocks remained explicitly
 ignored). Repository LLM, workflow-policy, and documentation validators also
-passed. Hosted check and review evidence will be recorded on the PR before
-merge.
+passed. PR #115 passed all eleven required workflow suites with zero review
+threads and merged as `423d821`.

--- a/progress/session-033-transport-abort-contract.md
+++ b/progress/session-033-transport-abort-contract.md
@@ -67,4 +67,9 @@ configured inner deadline calls abort before the async guard is dropped, so the
 outer task watchdog cannot mask a regression. The mandatory workspace workflow,
 quick all-configuration check, documentation/policy validators, strict MkDocs
 build, and three independent adversarial review tracks pass locally. Hosted
-checks and review feedback are recorded after the pull request is opened.
+PR #116's first run reached ten green aggregates, then exposed one
+configuration-specific documentation defect: the new WebSocket example was
+compiled without its feature in the no-default-feature doctest lane. The
+example now has an item-level `transport-websocket` gate, and both exact
+no-default workspace tests and all-feature doctests pass locally. Final hosted
+checks and review feedback are recorded after the corrected head completes.

--- a/progress/session-033-transport-abort-contract.md
+++ b/progress/session-033-transport-abort-contract.md
@@ -72,4 +72,10 @@ configuration-specific documentation defect: the new WebSocket example was
 compiled without its feature in the no-default-feature doctest lane. The
 example now has an item-level `transport-websocket` gate, and both exact
 no-default workspace tests and all-feature doctests pass locally. Final hosted
-checks and review feedback are recorded after the corrected head completes.
+checks on corrected head `4559905` are all green: CI `32426236185`, Coverage
+`32426236161`, Docs Validation `32426236202`, Examples Validation
+`32426236163`, Godot Web `32426236239`, No Panics `32426236208`, Security
+`32426236191`, Semver Checks `32426236192`, Unused Deps `32426236171`, WASM
+`32426236198`, and Workflow Lint `32426236233`. PR #116 has zero inline review
+threads or actionable reviewer findings. Copilot's quota-exhausted comment is
+the known repository-administration blocker tracked in issue #90.

--- a/progress/session-033-transport-abort-contract.md
+++ b/progress/session-033-transport-abort-contract.md
@@ -1,0 +1,70 @@
+# Session 033 — Enforceable Transport Abandonment
+
+## Scope and Priority
+
+Issue #106 was the highest gameplay-impacting actionable issue after PR #115
+merged issue #104. The hosted audit found no open/draft/dependency PR. The only
+other agent branch is a five-commit, 30-commit-behind standalone Fortress
+experiment superseded by the merged session-018 Godot browser suite; issue #82
+retains it as later performance research input. Issue #90 remains an
+administrator-owned governance blocker.
+
+## Contract Decision
+
+`Transport::abort` is required for the forthcoming breaking 0.11 release. It
+must promptly, without blocking or panicking, release or safely detach backend
+work, discard retained accepted sends and wakers, revoke shared-backend
+registrations, and be idempotent. Completed cleanup is not repeated; failed
+external cleanup can retry safely, and callback storage must remain live if
+freeing it would risk use-after-free. After abort, client drivers perform no
+more poll-cycle/send/receive/close calls. Only repeated abort, `is_ready`,
+`close_info`, `diagnostics`, and destruction remain valid. Resource-free
+stateless transports may implement an explicit no-op; built-in transports
+additionally fuse later polling to terminal results.
+
+Graceful termination still finishes a backend-owned send before close under
+one configured deadline. Deadline expiry or a close error invokes abort and
+does not imply send completion or peer delivery.
+
+## Ownership Enforcement
+
+- The async transport task wraps its backend in an armed ownership guard.
+  Graceful close success disarms it; explicit abort disarms before delegating,
+  while task cancellation, panic, watchdog cancellation, or handle drop invokes
+  backend abort from the guard. The guard is armed synchronously before spawn,
+  so cancellation before the task's first poll is also covered.
+- The polling client aborts on deadline expiry and close error, aborts from
+  `Drop` unless graceful close completed, and returns from a closed poll before
+  even `begin_poll_cycle` can touch the backend.
+- Native WebSocket, Emscripten, and Godot implementations already own explicit
+  abort paths. Native and Godot tests now prove idempotency and their stronger
+  fused post-abort behavior.
+
+## Invariant-to-Evidence Matrix
+
+| Invariant | Source | Executable evidence |
+| --- | --- | --- |
+| Every implementor makes an explicit abort decision. | Required `Transport::abort`; all repository implementations and examples migrated. | Workspace all-target/all-feature compilation and Clippy. |
+| Accepted backend work precedes graceful close but is abandoned at the deadline. | Async `finish_send_and_close_bounded`; polling `ClosePhase::Flushing`. | Custom hanging-resource transport in accepted-send and close modes for both drivers; existing deterministic polling close models. |
+| Cancellation/drop cannot bypass backend abandonment. | Async `AbortOnDropTransport`; polling `Drop`. | Async before-first-poll and active handle-drop plus polling owner-drop tests with shared resource evidence. |
+| Close failure immediately invokes abort and terminates logical I/O. | Both drivers abort on `poll_close` error. | Async/polling `CloseError` cases assert one abort and zero deadline count for polling. |
+| No work resumes after abort. | Async guard disarm; polling closed early return. | Probe counts every post-abort transport poll; repeated shutdown/poll stays at zero activity and the async producer channel is disconnected. |
+| Built-in transports remain compliant. | Native stream drop/fused state; Godot one-shot force-close; Emscripten authorized cleanup/safe-leak policy. | Native peer disconnect plus repeated abort/fused polls; Godot fake backend abort-once/fused polls; Emscripten source policy proves abort closes before guarded deletion and preserves state on failure. |
+
+## Documentation and Migration
+
+The public trait docs, transport/client/concepts/WASM guides, changelog,
+canonical context, focused skills, and channel/mesh examples describe the
+breaking requirement and allowed calls. The migration guide distinguishes
+resource-owning cleanup from a valid explicit no-op and warns that abort must
+not wait for a peer handshake.
+
+## Verification
+
+The focused contract suite passes for async and polling accepted send, close
+hang, close error, and owner-drop paths. A direct unit test proves the
+configured inner deadline calls abort before the async guard is dropped, so the
+outer task watchdog cannot mask a regression. The mandatory workspace workflow,
+quick all-configuration check, documentation/policy validators, strict MkDocs
+build, and three independent adversarial review tracks pass locally. Hosted
+checks and review feedback are recorded after the pull request is opened.

--- a/src/client.rs
+++ b/src/client.rs
@@ -235,15 +235,15 @@ pub struct SignalFishConfig {
     /// Deadline for graceful async shutdown and polling-client close.
     ///
     /// When [`SignalFishClient::shutdown`] is called, the background transport
-    /// loop is given this much time to close the transport and emit a final
-    /// `Disconnected` event. If the timeout expires the task is aborted and
-    /// the `Disconnected` event may not be delivered. The polling client uses
-    /// the same duration to bound queued-work flushing and its transport close
-    /// handshake; expiry invokes [`Transport::abort`].
+    /// loop is given this much time to finish a backend-owned send and drive
+    /// [`Transport::poll_close`]. Expiry invokes [`Transport::abort`], after
+    /// which the loop normally returns; a later watchdog cancels the task only
+    /// if it still does not stop. The polling client uses the same duration to
+    /// bound queued-work flushing and its transport close handshake.
     ///
-    /// Defaults to **1 second**. A zero timeout aborts the transport loop
-    /// immediately without waiting for graceful shutdown, meaning the
-    /// `Disconnected` event will likely not be emitted.
+    /// Defaults to **1 second**. A zero timeout invokes the transport abort
+    /// fallback without waiting for graceful close. Terminal `Disconnected`
+    /// delivery remains best-effort during shutdown.
     pub shutdown_timeout: Duration,
     /// Response to a protocol-v3 delivery-accountability violation.
     pub protocol_violation_policy: ProtocolViolationPolicy,
@@ -290,8 +290,8 @@ impl SignalFishConfig {
 
     /// Set the deadline for graceful async shutdown and polling-client close.
     ///
-    /// Defaults to **1 second**. A zero timeout aborts the transport loop
-    /// immediately without waiting for graceful shutdown.
+    /// Defaults to **1 second**. A zero timeout invokes `Transport::abort`
+    /// without waiting for graceful close; the loop then normally returns.
     #[must_use]
     pub fn with_shutdown_timeout(mut self, timeout: Duration) -> Self {
         self.shutdown_timeout = timeout;
@@ -796,8 +796,11 @@ impl SignalFishClient {
         // capacity is clamped to at least 1.
         let _ = cmd_tx.try_send(auth_msg);
 
+        // Arm backend abandonment before constructing/spawning the future so
+        // cancellation before its first poll cannot bypass `Transport::abort`.
+        let guarded_transport = AbortOnDropTransport::new(transport);
         let task = tokio::spawn(transport_loop(
-            transport,
+            guarded_transport,
             cmd_rx,
             event_tx,
             loop_state,
@@ -824,8 +827,11 @@ impl SignalFishClient {
     /// gracefully, and delivers a terminal
     /// [`Disconnected`](SignalFishEvent::Disconnected) best-effort. The loop
     /// is given [`shutdown_timeout`](SignalFishConfig::shutdown_timeout) to
-    /// finish; if the timeout expires (e.g. a transport whose `close()`
-    /// hangs), the task is aborted. After shutdown completes, the event
+    /// finish; if the timeout expires (e.g. a transport whose `poll_close`
+    /// remains pending), the transport is aborted and the loop normally
+    /// returns. A later watchdog cancels the task if it still does not stop.
+    /// Task cancellation and handle drop also invoke the transport's required
+    /// abort fallback. After shutdown completes, the event
     /// receiver yields the remaining buffered events and then `None` — treat
     /// the channel closing as the authoritative end-of-stream signal.
     pub async fn shutdown(&mut self) {
@@ -836,8 +842,9 @@ impl SignalFishClient {
             let _ = tx.send(());
         }
 
-        // Await the transport loop with a timeout. If it doesn't exit in time,
-        // abort it so the task cannot detach and run indefinitely.
+        // The loop owns the configured graceful-close deadline. This outer
+        // watchdog adds scheduling grace, then cancels only if the loop still
+        // does not exit after invoking the transport abort fallback.
         if let Some(mut task) = self.task.take() {
             let task_timeout = self.shutdown_timeout.saturating_add(SHUTDOWN_TASK_GRACE);
             match tokio::time::timeout(task_timeout, &mut task).await {
@@ -1634,8 +1641,10 @@ impl Drop for SignalFishClient {
         // The only safe action is to abort the spawned task, which causes
         // the transport loop future to be dropped immediately.  The
         // `shutdown_tx` oneshot is intentionally *not* sent here: sending
-        // it would trigger a graceful path that calls async `transport.close()`,
-        // but there is no executor context to drive it inside `Drop`.
+        // it would trigger a graceful path that awaits `poll_close`, but there
+        // is no executor context to drive it inside `Drop`. Aborting
+        // the task drops its transport guard, which synchronously invokes the
+        // required backend `Transport::abort` fallback.
         if let Some(task) = self.task.take() {
             task.abort();
         }
@@ -1649,6 +1658,77 @@ fn lock_core(state: &Arc<Mutex<ClientCore>>) -> std::sync::MutexGuard<'_, Client
     match state.lock() {
         Ok(core) => core,
         Err(poisoned) => poisoned.into_inner(),
+    }
+}
+
+/// Owns the async task's transport and enforces backend abandonment whenever
+/// task cancellation skips the ordinary graceful-close path.
+#[cfg(feature = "tokio-runtime")]
+struct AbortOnDropTransport<T: Transport> {
+    inner: T,
+    armed: bool,
+}
+
+#[cfg(feature = "tokio-runtime")]
+impl<T: Transport> AbortOnDropTransport<T> {
+    const fn new(inner: T) -> Self {
+        Self { inner, armed: true }
+    }
+}
+
+#[cfg(feature = "tokio-runtime")]
+impl<T: Transport> Transport for AbortOnDropTransport<T> {
+    fn begin_poll_cycle(&mut self) {
+        self.inner.begin_poll_cycle();
+    }
+
+    fn poll_send(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+        frame: &mut Option<TransportFrame>,
+    ) -> std::task::Poll<Result<()>> {
+        self.inner.poll_send(cx, frame)
+    }
+
+    fn poll_recv(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Result<TransportFrame>>> {
+        self.inner.poll_recv(cx)
+    }
+
+    fn poll_close(&mut self, cx: &mut std::task::Context<'_>) -> std::task::Poll<Result<()>> {
+        let result = self.inner.poll_close(cx);
+        if matches!(result, std::task::Poll::Ready(Ok(()))) {
+            self.armed = false;
+        }
+        result
+    }
+
+    fn abort(&mut self) {
+        if self.armed {
+            self.armed = false;
+            self.inner.abort();
+        }
+    }
+
+    fn is_ready(&self) -> bool {
+        self.inner.is_ready()
+    }
+
+    fn close_info(&self) -> Option<crate::transport::TransportCloseInfo> {
+        self.inner.close_info()
+    }
+
+    fn diagnostics(&self) -> crate::transport::TransportDiagnostics {
+        self.inner.diagnostics()
+    }
+}
+
+#[cfg(feature = "tokio-runtime")]
+impl<T: Transport> Drop for AbortOnDropTransport<T> {
+    fn drop(&mut self) {
+        self.abort();
     }
 }
 
@@ -1718,7 +1798,10 @@ async fn finish_send_and_close_bounded(
             }
         }
         *pending_send = None;
-        let _ = close_transport(transport).await;
+        if let Err(error) = close_transport(transport).await {
+            warn!("transport close failed; aborting transport: {error}");
+            transport.abort();
+        }
     })
     .await;
 
@@ -2100,11 +2183,11 @@ mod tests {
 
     /// A mock transport that records sent messages and replays scripted responses.
     struct MockTransport {
-        /// Messages that `recv()` will yield in order.
+        /// Messages that `poll_recv` will yield in order.
         incoming: VecDeque<Option<std::result::Result<String, SignalFishError>>>,
         /// Recorded outgoing messages.
         sent: Arc<StdMutex<Vec<String>>>,
-        /// Whether `close()` was called.
+        /// Whether `poll_close` was called.
         closed: Arc<AtomicBool>,
     }
 
@@ -2124,6 +2207,8 @@ mod tests {
     }
 
     impl Transport for MockTransport {
+        fn abort(&mut self) {}
+
         fn poll_send(
             &mut self,
             _cx: &mut Context<'_>,
@@ -2232,6 +2317,10 @@ mod tests {
     }
 
     impl Transport for DeferredReadyTransport {
+        fn abort(&mut self) {
+            let _ = self.controls.waker.lock().unwrap().take();
+        }
+
         fn poll_send(
             &mut self,
             cx: &mut Context<'_>,
@@ -2272,6 +2361,8 @@ mod tests {
     }
 
     impl Transport for GameDataErrorTransport {
+        fn abort(&mut self) {}
+
         fn poll_send(
             &mut self,
             _cx: &mut Context<'_>,
@@ -2400,6 +2491,7 @@ mod tests {
 
         fn abort(&mut self) {
             self.retained = None;
+            let _ = self.controls.waker.lock().unwrap().take();
         }
     }
 
@@ -2408,6 +2500,10 @@ mod tests {
     }
 
     impl Transport for NeverReadyTerminalTransport {
+        fn abort(&mut self) {
+            self.frame = None;
+        }
+
         fn poll_send(
             &mut self,
             _cx: &mut Context<'_>,
@@ -3253,7 +3349,7 @@ mod tests {
 
     // ── Send-side backpressure (issue #47, item 2) ──────────────────
 
-    /// Transport whose `send()` requires a semaphore permit per message, so
+    /// Transport whose `poll_send` requires a semaphore permit per message, so
     /// tests can stall the outgoing path deterministically.
     type PermitWait = Pin<
         Box<
@@ -3303,6 +3399,11 @@ mod tests {
     }
 
     impl Transport for GatedSendTransport {
+        fn abort(&mut self) {
+            self.pending_frame = None;
+            self.permit_wait = None;
+        }
+
         fn poll_send(
             &mut self,
             cx: &mut Context<'_>,
@@ -3461,6 +3562,8 @@ mod tests {
 
         fn abort(&mut self) {
             self.retained_frame = None;
+            let _ = self.controls.send_waker.lock().unwrap().take();
+            let _ = self.controls.recv_waker.lock().unwrap().take();
             self.controls.abort_called.store(true, Ordering::Release);
         }
     }
@@ -3489,6 +3592,11 @@ mod tests {
     }
 
     impl Transport for PeerCloseDuringSendTransport {
+        fn abort(&mut self) {
+            self.send_accepted = false;
+            self.peer_close_observed = true;
+        }
+
         fn poll_send(
             &mut self,
             _cx: &mut Context<'_>,
@@ -4339,7 +4447,7 @@ mod tests {
         assert!(!client.is_connected());
     }
 
-    /// Transport that hangs forever in `close()` so shutdown timeout/abort can be tested.
+    /// Transport whose `poll_close` remains pending so deadline abort can be tested.
     struct HangingCloseTransport {
         incoming: VecDeque<Option<std::result::Result<String, SignalFishError>>>,
         close_called: Arc<AtomicBool>,
@@ -4396,7 +4504,7 @@ mod tests {
                 Poll::Ready(item.map(|result| result.map(TransportFrame::Text)))
             } else {
                 // No scripted messages and no registered waker: preserve the
-                // old never-completing recv until shutdown aborts the task.
+                // pending receive until shutdown preempts it and closes.
                 Poll::Pending
             }
         }
@@ -4416,8 +4524,94 @@ mod tests {
         }
     }
 
+    struct DirectDeadlineTransport {
+        hang_accepted_send: bool,
+        close_called: Arc<AtomicBool>,
+        abort_called: Arc<AtomicBool>,
+    }
+
+    impl Transport for DirectDeadlineTransport {
+        fn poll_send(
+            &mut self,
+            _cx: &mut Context<'_>,
+            frame: &mut Option<TransportFrame>,
+        ) -> Poll<std::result::Result<(), SignalFishError>> {
+            assert!(frame.is_none(), "the send must already be backend-owned");
+            if self.hang_accepted_send {
+                Poll::Pending
+            } else {
+                Poll::Ready(Ok(()))
+            }
+        }
+
+        fn poll_recv(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Option<std::result::Result<TransportFrame, SignalFishError>>> {
+            Poll::Pending
+        }
+
+        fn poll_close(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<std::result::Result<(), SignalFishError>> {
+            self.close_called.store(true, Ordering::Release);
+            Poll::Pending
+        }
+
+        fn abort(&mut self) {
+            self.abort_called.store(true, Ordering::Release);
+        }
+    }
+
     #[tokio::test]
-    async fn shutdown_timeout_aborts_stuck_transport_task() {
+    async fn configured_deadline_aborts_before_transport_guard_drop() {
+        for hang_accepted_send in [true, false] {
+            let close_called = Arc::new(AtomicBool::new(false));
+            let abort_called = Arc::new(AtomicBool::new(false));
+            let mut transport = AbortOnDropTransport::new(DirectDeadlineTransport {
+                hang_accepted_send,
+                close_called: Arc::clone(&close_called),
+                abort_called: Arc::clone(&abort_called),
+            });
+            let mut pending_send = hang_accepted_send.then_some(PendingSend {
+                frame: None,
+                is_game_data: false,
+            });
+            let state = Arc::new(Mutex::new(ClientCore::new(
+                None,
+                ProtocolViolationPolicy::Quarantine,
+                false,
+            )));
+
+            tokio::time::timeout(
+                Duration::from_millis(100),
+                finish_send_and_close_bounded(
+                    &mut transport,
+                    &mut pending_send,
+                    &state,
+                    Duration::from_millis(5),
+                ),
+            )
+            .await
+            .expect("the configured inner deadline must finish before the test watchdog");
+
+            assert!(
+                abort_called.load(Ordering::Acquire),
+                "the helper itself must abort before its owning guard is dropped"
+            );
+            assert_eq!(
+                close_called.load(Ordering::Acquire),
+                !hang_accepted_send,
+                "close starts only after a backend-owned send completes"
+            );
+            assert!(pending_send.is_none());
+            assert!(!transport.armed);
+        }
+    }
+
+    #[tokio::test]
+    async fn shutdown_timeout_aborts_stuck_transport() {
         let (transport, close_called, abort_called, dropped) = HangingCloseTransport::new();
         let config = SignalFishConfig::new("mb_test")
             .with_shutdown_timeout(std::time::Duration::from_millis(20));
@@ -4431,7 +4625,7 @@ mod tests {
 
         assert!(
             close_called.load(Ordering::Acquire),
-            "transport.close() should have been attempted during graceful shutdown"
+            "transport.poll_close should have been attempted during graceful shutdown"
         );
         assert!(
             abort_called.load(Ordering::Acquire),
@@ -4439,7 +4633,7 @@ mod tests {
         );
         assert!(
             dropped.load(Ordering::Acquire),
-            "timed-out shutdown should abort and drop the transport loop task"
+            "deadline-aborted shutdown must drop the transport when its loop returns"
         );
         assert!(!client.is_connected());
     }
@@ -4981,12 +5175,10 @@ mod tests {
         client.shutdown().await;
     }
 
-    /// Validates the documented best-effort delivery guarantee: when `shutdown()`
-    /// times out and aborts the transport task, the `Disconnected` event may NOT
-    /// be delivered because the transport loop is forcibly cancelled before it can
-    /// emit the event. Both outcomes (event received or not) are acceptable.
+    /// Validates the documented best-effort delivery guarantee: deadline
+    /// abandonment does not make the terminal `Disconnected` event mandatory.
     #[tokio::test]
-    async fn shutdown_abort_may_skip_disconnected_event() {
+    async fn shutdown_deadline_may_skip_disconnected_event() {
         let (transport, _close_called, _abort_called, _dropped) = HangingCloseTransport::new();
         let config = SignalFishConfig::new("mb_test")
             .with_shutdown_timeout(std::time::Duration::from_millis(1));
@@ -4996,17 +5188,16 @@ mod tests {
         let event = events.recv().await.unwrap();
         assert!(matches!(event, SignalFishEvent::Connected));
 
-        // Shutdown will timeout (close() hangs) and abort the transport task.
+        // The configured deadline expires because poll_close remains pending.
         client.shutdown().await;
 
-        // The transport loop was aborted, so `emit_disconnected` may never have
-        // executed. Try to receive with a short timeout — either outcome is valid.
+        // Terminal event delivery is best-effort on the deadline path.
         let result =
             tokio::time::timeout(std::time::Duration::from_millis(50), events.recv()).await;
 
         match result {
             Ok(Some(SignalFishEvent::Disconnected { .. })) => {
-                // Disconnected was delivered before the abort took effect — acceptable.
+                // Disconnected was delivered before deadline abandonment.
             }
             Ok(None) => {
                 // Channel closed without a Disconnected event — acceptable.
@@ -5015,7 +5206,7 @@ mod tests {
                 // Timed out waiting; no Disconnected event was delivered — acceptable.
             }
             Ok(Some(other)) => {
-                panic!("unexpected event after shutdown abort: {other:?}");
+                panic!("unexpected event after shutdown deadline: {other:?}");
             }
         }
 

--- a/src/polling_client.rs
+++ b/src/polling_client.rs
@@ -147,7 +147,8 @@ enum ClosePhase {
 /// Unlike [`SignalFishClient`](crate::SignalFishClient), this client does **not**
 /// spawn a background task or require a tokio runtime. Instead, the caller drives
 /// the client by calling [`poll()`](Self::poll) on each frame (e.g., from Godot's
-/// `_process(delta)` method).
+/// `_process(delta)` method). Dropping a client that has not completed graceful
+/// close invokes [`Transport::abort`] synchronously.
 ///
 /// # Example (Godot via gdext)
 ///
@@ -304,6 +305,9 @@ impl<T: Transport> SignalFishPollingClient<T> {
 
     fn poll_at(&mut self, now: Instant) -> Vec<SignalFishEvent> {
         let mut events = Vec::new();
+        if matches!(self.close_phase, ClosePhase::Closed) {
+            return events;
+        }
         self.refresh_queue_diagnostics_at(now);
 
         // Create a noop waker to poll transport futures synchronously.
@@ -1123,6 +1127,7 @@ impl<T: Transport> SignalFishPollingClient<T> {
                 }
                 std::task::Poll::Ready(Err(error)) => {
                     error!(%error, "polling client transport close failed");
+                    self.transport.abort();
                     self.close_phase = ClosePhase::Closed;
                 }
                 std::task::Poll::Pending => {}
@@ -1274,6 +1279,15 @@ impl<T: Transport> std::fmt::Debug for SignalFishPollingClient<T> {
             .field("authenticated", &self.core.is_authenticated())
             .field("queued_commands", &self.cmd_queue.len())
             .finish()
+    }
+}
+
+impl<T: Transport> Drop for SignalFishPollingClient<T> {
+    fn drop(&mut self) {
+        if !matches!(self.close_phase, ClosePhase::Closed) {
+            self.transport.abort();
+            self.close_phase = ClosePhase::Closed;
+        }
     }
 }
 
@@ -1452,6 +1466,8 @@ mod tests {
     }
 
     impl Transport for MockTransport {
+        fn abort(&mut self) {}
+
         fn poll_send(
             &mut self,
             _cx: &mut std::task::Context<'_>,
@@ -1514,7 +1530,7 @@ mod tests {
         incoming: VecDeque<Option<std::result::Result<String, SignalFishError>>>,
         sent: Vec<String>,
         _sent_binary: Vec<Vec<u8>>,
-        /// When true, `recv()` sets `ready = true` before returning,
+        /// When true, `poll_recv` sets `ready = true` before returning,
         /// simulating a transport that becomes ready during the recv drain.
         ready_after_recv: bool,
     }
@@ -1544,6 +1560,8 @@ mod tests {
     }
 
     impl Transport for NotReadyTransport {
+        fn abort(&mut self) {}
+
         fn poll_send(
             &mut self,
             _cx: &mut std::task::Context<'_>,
@@ -3193,10 +3211,12 @@ mod tests {
 
     // ── Additional mock transports ─────────────────────────────────
 
-    /// A transport whose `send()` always returns an error.
+    /// A transport whose `poll_send` always returns an error.
     struct ErrorOnSendTransport;
 
     impl Transport for ErrorOnSendTransport {
+        fn abort(&mut self) {}
+
         fn poll_send(
             &mut self,
             _cx: &mut std::task::Context<'_>,
@@ -3221,7 +3241,7 @@ mod tests {
         }
     }
 
-    /// A transport whose `send()` always returns `Pending`.
+    /// A transport whose `poll_send` always returns `Pending`.
     struct PendingOnSendTransport;
 
     impl PendingOnSendTransport {
@@ -3238,6 +3258,7 @@ mod tests {
         replacement_seen: bool,
         peer_closes_on_recv: bool,
         fail_game_data_completion: bool,
+        close_calls: usize,
     }
 
     struct GameDataErrorTransport {
@@ -3245,6 +3266,8 @@ mod tests {
     }
 
     impl Transport for GameDataErrorTransport {
+        fn abort(&mut self) {}
+
         fn poll_send(
             &mut self,
             _cx: &mut std::task::Context<'_>,
@@ -3327,6 +3350,10 @@ mod tests {
     }
 
     impl Transport for AcceptedPendingSendTransport {
+        fn abort(&mut self) {
+            self.retained = None;
+        }
+
         fn poll_send(
             &mut self,
             _cx: &mut std::task::Context<'_>,
@@ -3370,11 +3397,18 @@ mod tests {
             &mut self,
             _cx: &mut std::task::Context<'_>,
         ) -> std::task::Poll<std::result::Result<(), SignalFishError>> {
+            assert!(
+                self.retained.is_none(),
+                "backend-owned send must complete before close"
+            );
+            self.close_calls = self.close_calls.saturating_add(1);
             std::task::Poll::Ready(Ok(()))
         }
     }
 
     impl Transport for PendingOnSendTransport {
+        fn abort(&mut self) {}
+
         fn poll_send(
             &mut self,
             _cx: &mut std::task::Context<'_>,
@@ -3398,11 +3432,13 @@ mod tests {
         }
     }
 
-    /// A transport whose `close()` always returns `Pending` (never completes).
-    /// `send()` and `recv()` behave normally (Ready).
+    /// A transport whose `poll_close` always returns `Pending`.
+    /// `poll_send` and `poll_recv` otherwise return `Ready`.
     struct PendingCloseTransport;
 
     impl Transport for PendingCloseTransport {
+        fn abort(&mut self) {}
+
         fn poll_send(
             &mut self,
             _cx: &mut std::task::Context<'_>,
@@ -4353,7 +4389,7 @@ mod tests {
         assert!(!client.is_connected());
     }
 
-    /// Transport whose `send()` stays `Pending` until `allow` is set, so tests
+    /// Transport whose `poll_send` stays `Pending` until `allow` is set, so tests
     /// can saturate and then drain the bounded command queue deterministically.
     struct TogglePendingSendTransport {
         allow: std::sync::Arc<std::sync::atomic::AtomicBool>,
@@ -4362,6 +4398,8 @@ mod tests {
     }
 
     impl Transport for TogglePendingSendTransport {
+        fn abort(&mut self) {}
+
         fn poll_send(
             &mut self,
             _cx: &mut std::task::Context<'_>,
@@ -4619,6 +4657,7 @@ mod tests {
             replacement_seen: false,
             peer_closes_on_recv: false,
             fail_game_data_completion: false,
+            close_calls: 0,
         };
         let mut client = SignalFishPollingClient::new(transport, default_config());
         let base = Instant::now();
@@ -4651,6 +4690,7 @@ mod tests {
             replacement_seen: false,
             peer_closes_on_recv: false,
             fail_game_data_completion: false,
+            close_calls: 0,
         };
         let mut client = SignalFishPollingClient::new(
             transport,
@@ -4718,6 +4758,7 @@ mod tests {
             replacement_seen: false,
             peer_closes_on_recv: false,
             fail_game_data_completion: true,
+            close_calls: 0,
         };
         let mut client = SignalFishPollingClient::new(transport, default_config());
         prime_room(&mut client);
@@ -5123,6 +5164,7 @@ mod tests {
                 replacement_seen: false,
                 peer_closes_on_recv: false,
                 fail_game_data_completion: false,
+                close_calls: 0,
             };
             let options = PollingClientOptions {
                 close_policy,
@@ -5142,6 +5184,7 @@ mod tests {
                 client.transport.sent.first(),
                 Some(TransportFrame::Text(text)) if text.contains("Authenticate")
             ));
+            assert_eq!(client.transport.close_calls, 1, "policy {close_policy:?}");
         }
     }
 
@@ -5228,6 +5271,7 @@ mod tests {
             replacement_seen: false,
             peer_closes_on_recv: true,
             fail_game_data_completion: false,
+            close_calls: 0,
         };
         let mut client = SignalFishPollingClient::new(transport, default_config());
 
@@ -5657,14 +5701,14 @@ mod tests {
         // Sanity: client starts connected.
         assert!(client.is_connected(), "client should start connected");
 
-        // Close the client. The transport's close() returns Pending,
+        // Close the client. The transport's poll_close returns Pending,
         // but the client should still mark itself as disconnected.
         client.close();
 
-        // 1. Client must be disconnected even though transport.close() was Pending.
+        // 1. Client must be disconnected even though poll_close was Pending.
         assert!(
             !client.is_connected(),
-            "client should be disconnected after close(), even when transport returns Pending"
+            "client should be disconnected after close(), even when poll_close returns Pending"
         );
 
         // 2. Command methods must return NotConnected.

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -98,6 +98,17 @@ pub struct TransportDiagnostics {
 ///
 /// `poll_close` is idempotent and may require multiple polls. Once it returns
 /// `Ready(Ok(()))`, later calls must also succeed without sending another close.
+/// If it returns an error, logical I/O must terminate and the client immediately
+/// calls `abort`; fallible backend cleanup may remain safely retryable.
+///
+/// `abort` is the fallback when graceful close fails, its deadline expires, or
+/// the transport owner is cancelled or dropped. It is required so every
+/// backend has an explicit abandonment path: a call must promptly release or
+/// safely detach backend-owned work and discard any retained send. It must be
+/// idempotent: completed cleanup is not repeated, while failed cleanup may be
+/// retried safely. After it returns, drivers make no further polling calls;
+/// only repeated `abort`, `is_ready`, `close_info`, `diagnostics`, and drop are
+/// allowed.
 pub trait Transport {
     /// Mark the start of one caller-driven polling cycle.
     ///
@@ -120,10 +131,19 @@ pub trait Transport {
     /// Advance an idempotent graceful close.
     fn poll_close(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), SignalFishError>>;
 
-    /// Immediately abandon transport work after a client-side close deadline.
+    /// Immediately abandon transport work after failed or preempted close.
     ///
-    /// The default preserves source compatibility for existing implementors.
-    fn abort(&mut self) {}
+    /// This operation must return promptly without blocking or panicking,
+    /// release or safely detach backend resources, discard any retained send,
+    /// and be idempotent. Completed cleanup must not be repeated, but a failed
+    /// cleanup attempt may be retried safely; when an external API cannot
+    /// unregister callbacks, preserving their backing allocation is required
+    /// to avoid use-after-free. After it returns, the client will not
+    /// call `begin_poll_cycle`, `poll_send`, `poll_recv`, or `poll_close` again.
+    /// Only repeated `abort`, `is_ready`, `close_info`, `diagnostics`, and drop
+    /// are allowed. This method can run from `Drop`, including during
+    /// unwinding, so it must never panic.
+    fn abort(&mut self);
 
     /// Whether the connection handshake has completed.
     ///

--- a/src/transports/mod.rs
+++ b/src/transports/mod.rs
@@ -11,18 +11,18 @@
 //!
 //! # Example
 //!
-//! ```rust,ignore
+//! ```rust,no_run
 //! # async fn example() -> Result<(), signal_fish_client::SignalFishError> {
-//! use signal_fish_client::{WebSocketTransport, Transport};
+//! use signal_fish_client::{SignalFishClient, SignalFishConfig, WebSocketTransport};
 //!
-//! let mut ws = WebSocketTransport::connect("ws://localhost:3536/ws").await?;
-//! ws.send(r#"{"type":"ping"}"#.to_string()).await?;
+//! let transport = WebSocketTransport::connect("ws://localhost:3536/ws").await?;
+//! let config = SignalFishConfig::new("mb_app_example");
+//! let (mut client, mut events) = SignalFishClient::start(transport, config);
 //!
-//! if let Some(Ok(msg)) = ws.recv().await {
-//!     println!("server said: {msg}");
-//! }
-//!
-//! ws.close().await?;
+//! // Observe the initial readiness or terminal event, then choose when to stop.
+//! let _first_event = events.recv().await;
+//! client.shutdown().await;
+//! while events.recv().await.is_some() {}
 //! # Ok(())
 //! # }
 //! ```

--- a/src/transports/mod.rs
+++ b/src/transports/mod.rs
@@ -12,6 +12,7 @@
 //! # Example
 //!
 //! ```rust,no_run
+//! # #[cfg(feature = "transport-websocket")]
 //! # async fn example() -> Result<(), signal_fish_client::SignalFishError> {
 //! use signal_fish_client::{SignalFishClient, SignalFishConfig, WebSocketTransport};
 //!

--- a/src/transports/websocket.rs
+++ b/src/transports/websocket.rs
@@ -1509,9 +1509,21 @@ mod tests {
             .await
             .expect("WebSocket connect must succeed");
         transport.abort();
+        transport.abort();
 
         assert!(transport.state.closed);
         assert!(transport.state.stream.is_none());
+        let expected = TransportFrame::Text("caller still owns this".into());
+        let mut offered = Some(expected.clone());
+        let waker = std::task::Waker::noop();
+        let mut cx = Context::from_waker(waker);
+        assert!(matches!(
+            transport.poll_send(&mut cx, &mut offered),
+            Poll::Ready(Err(SignalFishError::TransportClosed))
+        ));
+        assert_eq!(offered, Some(expected));
+        assert!(matches!(transport.poll_recv(&mut cx), Poll::Ready(None)));
+        assert!(matches!(transport.poll_close(&mut cx), Poll::Ready(Ok(()))));
         assert!(
             disconnected_rx
                 .await

--- a/src/webrtc.rs
+++ b/src/webrtc.rs
@@ -1109,6 +1109,8 @@ mod tests {
     }
 
     impl Transport for MockTransport {
+        fn abort(&mut self) {}
+
         fn poll_send(
             &mut self,
             _cx: &mut std::task::Context<'_>,
@@ -1543,6 +1545,10 @@ mod tests {
     }
 
     impl Transport for GatedTransport {
+        fn abort(&mut self) {
+            self.pending_acquire = None;
+        }
+
         fn poll_send(
             &mut self,
             cx: &mut std::task::Context<'_>,

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -6650,9 +6650,15 @@ mod ffi_safety_documentation {
 
         // Drop must close before the guarded deletion helper and explicitly
         // retain the allocation if its final retry fails.
-        let drop_block = contents
+        let mut in_block_comment = false;
+        let code_only = contents
+            .lines()
+            .map(|line| strip_non_code_stateful(line, &mut in_block_comment))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let drop_block = code_only
             .find("impl Drop for EmscriptenWebSocketTransport")
-            .map(|start| &contents[start..])
+            .map(|start| &code_only[start..])
             .expect("EmscriptenWebSocketTransport must implement Drop");
 
         let drop_close = drop_block
@@ -6663,8 +6669,37 @@ mod ffi_safety_documentation {
             .expect("Drop must use the guarded callback cleanup helper");
         assert!(drop_close < drop_delete, "Drop must close BEFORE delete");
         assert!(
-            drop_block.contains("intentionally leaking callback state to prevent use-after-free"),
-            "Drop must preserve callback state when final deletion fails"
+            !drop_block.contains("callback_state.reclaim"),
+            "Drop must not reclaim callback state without guarded deletion authorization"
+        );
+
+        // Abort follows the same close-before-delete ownership proof. Failed
+        // deletion remains retryable and keeps callback state live rather than
+        // freeing memory that Emscripten may still reference.
+        let abort_block = code_only
+            .find("    fn abort(&mut self) {")
+            .and_then(|start| {
+                code_only[start..]
+                    .find("\n    }\n}")
+                    .map(|end| &code_only[start..start + end])
+            })
+            .expect("EmscriptenWebSocketTransport must implement abort");
+        let abort_terminal = abort_block
+            .find("self.closed = true")
+            .expect("abort must make Emscripten polling terminal");
+        let abort_close = abort_block
+            .find("close_native_socket")
+            .expect("abort must close the native socket");
+        let abort_delete = abort_block
+            .find("delete_after_close_attempt")
+            .expect("abort must use the guarded callback cleanup helper");
+        assert!(
+            abort_terminal < abort_close && abort_close < abort_delete,
+            "abort must become terminal, then close, then use guarded deletion"
+        );
+        assert!(
+            !abort_block.contains("callback_state.reclaim"),
+            "abort must not reclaim callback state without guarded deletion authorization"
         );
     }
 }

--- a/tests/client_tests.rs
+++ b/tests/client_tests.rs
@@ -185,6 +185,8 @@ impl HangingCloseTransport {
 }
 
 impl Transport for HangingCloseTransport {
+    fn abort(&mut self) {}
+
     fn poll_send(
         &mut self,
         _cx: &mut std::task::Context<'_>,

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -79,6 +79,11 @@ impl MockTransport {
 }
 
 impl Transport for MockTransport {
+    fn abort(&mut self) {
+        self.closed.store(true, Ordering::Relaxed);
+        self.incoming.clear();
+    }
+
     fn poll_send(
         &mut self,
         _cx: &mut std::task::Context<'_>,

--- a/tests/negotiation_robustness_tests.rs
+++ b/tests/negotiation_robustness_tests.rs
@@ -325,6 +325,8 @@ impl SendErrorTransport {
 }
 
 impl Transport for SendErrorTransport {
+    fn abort(&mut self) {}
+
     fn poll_send(
         &mut self,
         _cx: &mut std::task::Context<'_>,

--- a/tests/polling_parity_tests.rs
+++ b/tests/polling_parity_tests.rs
@@ -79,6 +79,10 @@ impl NeverSendMock {
 }
 
 impl Transport for NeverSendMock {
+    fn abort(&mut self) {
+        let _ = self.waker.lock().unwrap().take();
+    }
+
     fn poll_send(
         &mut self,
         cx: &mut std::task::Context<'_>,
@@ -212,6 +216,8 @@ impl FrameMock {
 }
 
 impl Transport for FrameMock {
+    fn abort(&mut self) {}
+
     fn poll_send(
         &mut self,
         _cx: &mut std::task::Context<'_>,
@@ -515,6 +521,8 @@ impl SharedMock {
 }
 
 impl Transport for SharedMock {
+    fn abort(&mut self) {}
+
     fn poll_send(
         &mut self,
         _cx: &mut std::task::Context<'_>,
@@ -594,6 +602,11 @@ impl ReadinessMock {
 }
 
 impl Transport for ReadinessMock {
+    fn abort(&mut self) {
+        self.controls.terminal.store(true, Ordering::Release);
+        let _ = self.controls.waker.lock().unwrap().take();
+    }
+
     fn poll_send(
         &mut self,
         cx: &mut std::task::Context<'_>,
@@ -738,6 +751,8 @@ impl TraceMock {
 }
 
 impl Transport for TraceMock {
+    fn abort(&mut self) {}
+
     fn poll_send(
         &mut self,
         _cx: &mut std::task::Context<'_>,

--- a/tests/transport_abort_contract_tests.rs
+++ b/tests/transport_abort_contract_tests.rs
@@ -1,0 +1,326 @@
+#![cfg(all(feature = "tokio-runtime", feature = "polling-client"))]
+
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use signal_fish_client::{
+    SignalFishClient, SignalFishConfig, SignalFishError, SignalFishEvent, SignalFishPollingClient,
+    Transport, TransportFrame,
+};
+use tokio::sync::mpsc::error::TryRecvError;
+
+#[derive(Clone, Copy, Debug)]
+enum HangPoint {
+    AcceptedSend,
+    Close,
+    CloseError,
+}
+
+#[derive(Default)]
+struct AbortEvidence {
+    accepted_sends: AtomicUsize,
+    completed_sends: AtomicUsize,
+    close_polls: AtomicUsize,
+    abort_calls: AtomicUsize,
+    backend_activity: AtomicUsize,
+    post_abort_polls: AtomicUsize,
+    resource_live: AtomicBool,
+    dropped: AtomicBool,
+}
+
+struct HangingResourceTransport {
+    hang_point: HangPoint,
+    retained: Option<TransportFrame>,
+    aborted: bool,
+    evidence: Arc<AbortEvidence>,
+}
+
+impl HangingResourceTransport {
+    fn new(hang_point: HangPoint) -> (Self, Arc<AbortEvidence>) {
+        let evidence = Arc::new(AbortEvidence {
+            resource_live: AtomicBool::new(true),
+            ..AbortEvidence::default()
+        });
+        (
+            Self {
+                hang_point,
+                retained: None,
+                aborted: false,
+                evidence: Arc::clone(&evidence),
+            },
+            evidence,
+        )
+    }
+}
+
+impl Drop for HangingResourceTransport {
+    fn drop(&mut self) {
+        self.evidence.dropped.store(true, Ordering::Release);
+    }
+}
+
+impl Transport for HangingResourceTransport {
+    fn begin_poll_cycle(&mut self) {
+        if self.aborted {
+            self.evidence
+                .post_abort_polls
+                .fetch_add(1, Ordering::AcqRel);
+        }
+    }
+
+    fn poll_send(
+        &mut self,
+        _cx: &mut Context<'_>,
+        frame: &mut Option<TransportFrame>,
+    ) -> Poll<Result<(), SignalFishError>> {
+        if self.aborted {
+            self.evidence
+                .post_abort_polls
+                .fetch_add(1, Ordering::AcqRel);
+            return Poll::Ready(Err(SignalFishError::TransportClosed));
+        }
+        if self.retained.is_some() {
+            return Poll::Pending;
+        }
+        let Some(accepted) = frame.take() else {
+            return Poll::Ready(Ok(()));
+        };
+        self.evidence.accepted_sends.fetch_add(1, Ordering::AcqRel);
+        self.evidence
+            .backend_activity
+            .fetch_add(1, Ordering::AcqRel);
+        if matches!(self.hang_point, HangPoint::AcceptedSend) {
+            self.retained = Some(accepted);
+            Poll::Pending
+        } else {
+            self.evidence.completed_sends.fetch_add(1, Ordering::AcqRel);
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    fn poll_recv(
+        &mut self,
+        _cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<TransportFrame, SignalFishError>>> {
+        if self.aborted {
+            self.evidence
+                .post_abort_polls
+                .fetch_add(1, Ordering::AcqRel);
+            Poll::Ready(None)
+        } else {
+            Poll::Pending
+        }
+    }
+
+    fn poll_close(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), SignalFishError>> {
+        if self.aborted {
+            self.evidence
+                .post_abort_polls
+                .fetch_add(1, Ordering::AcqRel);
+            return Poll::Ready(Ok(()));
+        }
+        self.evidence.close_polls.fetch_add(1, Ordering::AcqRel);
+        self.evidence
+            .backend_activity
+            .fetch_add(1, Ordering::AcqRel);
+        if matches!(self.hang_point, HangPoint::CloseError) {
+            Poll::Ready(Err(SignalFishError::TransportSend(
+                "scripted close failure".into(),
+            )))
+        } else {
+            Poll::Pending
+        }
+    }
+
+    fn abort(&mut self) {
+        if self.aborted {
+            return;
+        }
+        self.aborted = true;
+        self.retained = None;
+        self.evidence.abort_calls.fetch_add(1, Ordering::AcqRel);
+        self.evidence.resource_live.store(false, Ordering::Release);
+    }
+}
+
+fn assert_abandoned(
+    evidence: &AbortEvidence,
+    hang_point: HangPoint,
+    expected_accepted_sends: usize,
+) {
+    assert_eq!(
+        evidence.abort_calls.load(Ordering::Acquire),
+        1,
+        "abort must run exactly once for {hang_point:?}"
+    );
+    assert!(
+        !evidence.resource_live.load(Ordering::Acquire),
+        "abort must release the backend resource for {hang_point:?}"
+    );
+    assert_eq!(
+        evidence.accepted_sends.load(Ordering::Acquire),
+        expected_accepted_sends,
+        "the expected outbound frame must reach the transport for {hang_point:?}"
+    );
+    assert_eq!(
+        evidence.completed_sends.load(Ordering::Acquire),
+        usize::from(matches!(
+            hang_point,
+            HangPoint::Close | HangPoint::CloseError
+        )),
+        "an accepted hanging send must not complete during abandonment"
+    );
+    assert_eq!(
+        evidence.close_polls.load(Ordering::Acquire) > 0,
+        matches!(hang_point, HangPoint::Close | HangPoint::CloseError),
+        "graceful close is reached only after backend-owned sends complete"
+    );
+    assert_eq!(
+        evidence.post_abort_polls.load(Ordering::Acquire),
+        0,
+        "the client driver must never poll after abort"
+    );
+}
+
+#[tokio::test]
+async fn async_deadline_abandons_accepted_send_and_hanging_close() {
+    for hang_point in [
+        HangPoint::AcceptedSend,
+        HangPoint::Close,
+        HangPoint::CloseError,
+    ] {
+        let (transport, evidence) = HangingResourceTransport::new(hang_point);
+        let config = SignalFishConfig::new("abort-contract")
+            .with_shutdown_timeout(Duration::from_millis(10));
+        let (mut client, mut events) = SignalFishClient::start(transport, config);
+
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Connected)
+        ));
+        for _ in 0..100 {
+            if evidence.accepted_sends.load(Ordering::Acquire) == 1 {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(evidence.accepted_sends.load(Ordering::Acquire), 1);
+        client.shutdown().await;
+
+        assert_abandoned(&evidence, hang_point, 1);
+        assert!(
+            evidence.dropped.load(Ordering::Acquire),
+            "the async task must drop the abandoned transport"
+        );
+        let activity_after_shutdown = evidence.backend_activity.load(Ordering::Acquire);
+        client.shutdown().await;
+        tokio::task::yield_now().await;
+        assert_eq!(
+            evidence.backend_activity.load(Ordering::Acquire),
+            activity_after_shutdown,
+            "no backend activity may resume after async abandonment"
+        );
+        assert_eq!(evidence.post_abort_polls.load(Ordering::Acquire), 0);
+
+        let remaining: Vec<_> = std::iter::from_fn(|| events.try_recv().ok()).collect();
+        assert!(remaining.len() <= 1, "only the terminal event may remain");
+        assert!(remaining
+            .iter()
+            .all(|event| matches!(event, SignalFishEvent::Disconnected { .. })));
+        assert!(
+            matches!(events.try_recv(), Err(TryRecvError::Disconnected)),
+            "the event producer must terminate after abandonment"
+        );
+    }
+}
+
+#[test]
+fn polling_deadline_abandons_accepted_send_and_hanging_close() {
+    for hang_point in [
+        HangPoint::AcceptedSend,
+        HangPoint::Close,
+        HangPoint::CloseError,
+    ] {
+        let (transport, evidence) = HangingResourceTransport::new(hang_point);
+        let config =
+            SignalFishConfig::new("abort-contract").with_shutdown_timeout(Duration::from_millis(5));
+        let mut client = SignalFishPollingClient::new(transport, config);
+
+        let events = client.poll();
+        assert!(events
+            .iter()
+            .any(|event| matches!(event, SignalFishEvent::Connected)));
+        client.close();
+        if matches!(hang_point, HangPoint::CloseError) {
+            assert!(!client.is_closing());
+        } else {
+            assert!(client.is_closing());
+            std::thread::sleep(Duration::from_millis(10));
+            assert!(client.poll().is_empty());
+        }
+
+        assert_abandoned(&evidence, hang_point, 1);
+        assert_eq!(
+            client.polling_stats().close_deadline_expirations,
+            u64::from(!matches!(hang_point, HangPoint::CloseError))
+        );
+        let activity_after_deadline = evidence.backend_activity.load(Ordering::Acquire);
+        assert!(client.poll().is_empty());
+        assert_eq!(
+            evidence.backend_activity.load(Ordering::Acquire),
+            activity_after_deadline,
+            "no backend activity may resume after polling abandonment"
+        );
+        assert_eq!(evidence.post_abort_polls.load(Ordering::Acquire), 0);
+        assert!(!client.is_closing());
+    }
+}
+
+#[tokio::test]
+async fn dropping_either_client_aborts_its_owned_transport() {
+    let (unpolled_transport, unpolled_evidence) =
+        HangingResourceTransport::new(HangPoint::AcceptedSend);
+    let (unpolled_client, _events) = SignalFishClient::start(
+        unpolled_transport,
+        SignalFishConfig::new("unpolled-async-drop-contract"),
+    );
+    drop(unpolled_client);
+    tokio::task::yield_now().await;
+    assert_abandoned(&unpolled_evidence, HangPoint::AcceptedSend, 0);
+    assert!(unpolled_evidence.dropped.load(Ordering::Acquire));
+
+    let (async_transport, async_evidence) = HangingResourceTransport::new(HangPoint::AcceptedSend);
+    let (async_client, mut events) = SignalFishClient::start(
+        async_transport,
+        SignalFishConfig::new("async-drop-contract"),
+    );
+    assert!(matches!(
+        events.recv().await,
+        Some(SignalFishEvent::Connected)
+    ));
+    drop(async_client);
+    let dropped = tokio::time::timeout(Duration::from_secs(1), async {
+        while !async_evidence.dropped.load(Ordering::Acquire) {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await;
+    assert!(
+        dropped.is_ok(),
+        "aborted async task must promptly drop its transport guard"
+    );
+    assert_abandoned(&async_evidence, HangPoint::AcceptedSend, 1);
+
+    let (polling_transport, polling_evidence) =
+        HangingResourceTransport::new(HangPoint::AcceptedSend);
+    let mut polling_client = SignalFishPollingClient::new(
+        polling_transport,
+        SignalFishConfig::new("polling-drop-contract"),
+    );
+    let _ = polling_client.poll();
+    drop(polling_client);
+    assert_abandoned(&polling_evidence, HangPoint::AcceptedSend, 1);
+    assert!(polling_evidence.dropped.load(Ordering::Acquire));
+}


### PR DESCRIPTION
## Summary

Gives every custom transport an explicit close-deadline abandonment hook.
`Transport::abort` is now required; both client drivers invoke it for deadline
expiry, close errors, or owner drop before graceful close completes, while the
async ownership guard also covers task cancellation and panic unwinding.

Closes #106.

## Changes

- Require every `Transport` implementation to provide a synchronous,
  idempotent abort path that releases or safely detaches backend resources and
  discards retained accepted sends.
- Add an async transport ownership guard plus polling-client drop fallback so
  cancellation and drop cannot bypass backend abandonment.
- Preserve backend-owned send completion before graceful close under the one
  configured deadline; abort on expiry or close failure and never poll the
  transport afterward.
- Prove accepted-send hangs, close hangs/errors, resource release, repeated
  shutdown/drop, event termination, and zero post-abort transport activity in
  both drivers; strengthen native WebSocket and Godot abort tests.
- Add third-party migration guidance and update custom transport examples,
  lifecycle docs, changelog, roadmap, canonical context, and focused skills.

## Validation

- [x] Focused async/polling deadline, close-error, and drop tests
- [x] Built-in native WebSocket and Godot abort contract tests
- [x] Repository documentation and policy validators
- [x] `cargo fmt && cargo clippy --workspace --all-targets --all-features -- -D warnings && cargo test --workspace --all-features`
- [x] Hosted required checks and review feedback

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking public trait change that rewires async and polling shutdown, drop, and cancellation so custom transports must implement a non-panicking abort path. Incorrect implementations can leak sockets or skip cleanup.
> 
> **Overview**
> **Breaking:** `Transport::abort` is no longer defaulted. Every implementor must provide a prompt, non-blocking, non-panicking, idempotent path that releases or safely detaches backend resources and discards retained sends. Drivers never poll after abort.
> 
> Both clients now *enforce* that contract: close-deadline expiry and `poll_close` errors call `abort`; the async task wraps the backend in `AbortOnDropTransport` (armed before spawn) so cancellation, panic, watchdog abort, and handle drop cannot skip it; the polling client aborts from `Drop` unless graceful close already completed and skips further polls once closed.
> 
> Graceful shutdown still finishes a backend-owned send, then `poll_close`, under the one configured deadline. Task abort is only a later watchdog. Docs, examples, changelog, and mocks are updated for 0.11 migration; new contract tests cover hang/error/drop paths and fused post-abort behavior on native WebSocket and Godot.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9fe1d90d4ed6603f4d3019d78e4cb362c3b0ea4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->