### PR TITLE
feat!: support negotiated WebSocket token binding v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,8 @@ jobs:
             flags: ""
           - name: all-features
             flags: "--all-features"
+          - name: token-binding-no-tls
+            flags: "--no-default-features --features token-binding"
           - name: no-default-features
             flags: "--no-default-features"
     steps:
@@ -110,6 +112,8 @@ jobs:
             flags: ""
           - name: all-features
             flags: "--all-features"
+          - name: token-binding-no-tls
+            flags: "--no-default-features --features token-binding"
           - name: no-default-features
             flags: "--no-default-features"
     steps:
@@ -123,11 +127,11 @@ jobs:
         run: cargo test --workspace ${{ matrix.flags }}
 
   # ──────────────────────────────────────────────────────────────
-  # Pinned server mesh wire smokes — generation-less 0.4 compatibility plus
-  # generation-aware signaling and retained-pair replan on 0.7.
+  # Pinned server compatibility E2E — generation-less 0.4, Server 0.7 mesh and
+  # reconnect behavior, and required token-binding security cases.
   # ──────────────────────────────────────────────────────────────
   server-mesh-e2e:
-    name: Server mesh E2E (${{ matrix.server_version }})
+    name: Server compatibility E2E (${{ matrix.server_version }})
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     needs: fmt
@@ -144,6 +148,12 @@ jobs:
           - server_version: "0.7.0"
             server_sha256: "70c6d12ac77843038c96d374a91225825c685cbf65fd7bedfd26b08d4003af7e"
             test_name: e2e_reconnect_after_disconnect_uses_server_token
+          - server_version: "0.7.0"
+            server_sha256: "70c6d12ac77843038c96d374a91225825c685cbf65fd7bedfd26b08d4003af7e"
+            test_name: e2e_server_070_required_token_binding_wss
+          - server_version: "0.7.0"
+            server_sha256: "70c6d12ac77843038c96d374a91225825c685cbf65fd7bedfd26b08d4003af7e"
+            test_name: e2e_server_070_rejects_invalid_token_binding_proofs
           - server_version: "0.4.0"
             server_sha256: "971410b9503dd2f0c9f69c8a0a97e043e3979c79bf3d305e2ad03e21da8584e9"
             test_name: e2e_server_040_generationless_mesh_signal
@@ -167,7 +177,7 @@ jobs:
           printf '%s  %s\n' "${SERVER_SHA256}" "${asset}" | sha256sum --check
           mkdir -p .signal-fish-server
           tar -xzf "${asset}" -C .signal-fish-server
-      - name: Run pinned mesh compatibility smoke
+      - name: Run pinned server compatibility E2E
         run: |
           set -euo pipefail
           server_bin="$(find .signal-fish-server -type f -name signal-fish-server -print -quit)"

--- a/.github/workflows/deep-safety.yml
+++ b/.github/workflows/deep-safety.yml
@@ -32,6 +32,11 @@ on:
       - src/protocol.rs
       - src/protocol/**
       - src/signal.rs
+      - src/token_binding.rs
+      - src/transports/websocket.rs
+      - tests/real_server_e2e.rs
+      - tests/token-binding/**
+      - tests/token_binding_conformance_tests.rs
       - tests/protocol_tests.rs
   schedule:
     # Weekdays at 04:00 UTC — staggered from unused-deps at 05:00 and security at 06:00

--- a/.llm/context.md
+++ b/.llm/context.md
@@ -3,16 +3,13 @@
 ## Identity
 
 - **Company:** Ambiguous Interactive
-- **Product:** Signal Fish Client SDK
 - **Crates:** `signal-fish-client` (core) and `signal-fish-client-godot` (adapter)
 - **Version:** 0.10.0 lockstep across both crates
 - **Edition:** 2021
 - **MSRV:** Rust 1.87.0 for core; Rust 1.94.0 for the Godot adapter
 - **License:** MIT
 - **Repository:** <https://github.com/Ambiguous-Interactive/signal-fish-client-rust>
-- **Guide (GitHub Pages):** <https://Ambiguous-Interactive.github.io/signal-fish-client-rust/>
-- **API Docs (docs.rs):** <https://docs.rs/signal-fish-client> and
-  <https://docs.rs/signal-fish-client-godot>
+- **Guide/API:** <https://Ambiguous-Interactive.github.io/signal-fish-client-rust/> · <https://docs.rs/signal-fish-client>
 
 ## Purpose
 
@@ -24,7 +21,7 @@ Framed-transport-agnostic client over one complete, ordered text/binary frame st
 cargo fmt && cargo clippy --workspace --all-targets --all-features -- -D warnings && cargo test --workspace --all-features
 ```
 
-Run this before every commit. All three steps must pass with zero warnings.
+Run this before every commit.
 
 ## Release Automation
 
@@ -79,46 +76,24 @@ Only add `CHANGELOG.md` entries for user-visible changes.
 
 Production Rust is safe by default. The core manifest denies `unsafe_code`, the
 Godot adapter forbids it, and the target-gated Emscripten WebSocket module is
-the sole documented exception because it binds the platform C API. The
-required WASM workflow runs the Emscripten FFI policy checker and its negative
-self-test before compiling and linting the actual target. Registered browser
-callback state is reclaimed only by its owning wrapper after it consumes a
-non-forgeable authorization emitted when native close was attempted or observed and
-`emscripten_websocket_delete` reports success. Cleanup retries deletion where
-possible and intentionally leaks the small state allocation after a terminal
-failure rather than allowing a late callback to access freed memory; logical
-receive errors do not skip the native close attempt. The host-tested ownership
-state machine and source checker with its 50-case self-test enforce that guard.
+sole documented exception for the platform C API. Required WASM policy and 50
+checker self-tests enforce close-before-delete callback-state ownership;
+terminal deletion failure intentionally leaks the small allocation instead of
+risking late-callback use-after-free.
 
-The change-scoped PR, scheduled, and manual Deep Safety workflow provides
-fail-closed evidence from Miri protocol tests, all three protocol fuzz targets,
-and a narrow mutation scope. Fuzzing selects the nightly host explicitly and
-writes discoveries only to temporary corpora; committed seeds are read-only
-inputs. The binary target exercises raw, valid, and perturbed protocol-v2 and
-protocol-v3 MessagePack envelopes. Deep Safety is intentionally not a required
-PR workflow because of nightly/runtime variability; required Clippy and WASM
-aggregates enforce the compiler safety and warning policies on every PR.
+Change-scoped, scheduled, and manual Deep Safety runs Miri protocol tests, three
+raw-byte JSON/MessagePack fuzz targets with temporary corpora, and focused
+mutation testing. It is not required because of nightly/runtime variability;
+required Clippy and WASM gates enforce compiler safety on every PR.
 
-Native ASan is deferred because the only owned unsafe implementation is
-Emscripten-only, so a native sanitizer lane would not execute it. The fuzz
-lane's sanitizer instrumentation instead covers the owned protocol parsers it
-actually drives. Blanket Clippy pedantic/nursery/cargo groups are also deferred:
-the inventory produced more than 170 mostly stylistic/documentation findings,
-and its only suspicious correctness warning was verified as a false positive.
-Add either class only when it demonstrates a stable, actionable defect.
+Native ASan is deferred because owned unsafe is Emscripten-only; fuzz sanitizer
+instrumentation covers the parsers it drives. Blanket Clippy
+pedantic/nursery/cargo groups remain deferred after a noisy inventory; add them
+only for stable, actionable defects.
 
-Dependabot monitors the root Cargo workspace from one root updater; Cargo
-discovers the Godot adapter as a real workspace member. Hosted run 31964370221
-proved that a multi-directory Cargo updater does not combine directory file
-sets: adapter processing lost the workspace root, fixture processing lost its
-sibling path dependency, and Dependabot opened the second zero-file PR #96.
-The minimum and latest Godot fixtures therefore remain deliberately standalone
-and are updated only with their locked compatibility/browser E2E evidence;
-putting them in the root workspace would unify incompatible Godot types and
-expand ordinary `--workspace --all-features` builds into engine-dependent
-fixtures. Default-branch updater run 31969079956 subsequently completed
-successfully on the root workspace, discovered the adapter dependencies,
-reported no resolution errors, and opened no Cargo PR.
+Dependabot uses one root-workspace updater; minimum/latest Godot fixtures remain
+standalone because combining incompatible godot-rust versions would break the
+workspace. Hosted run 31969079956 proved clean root discovery.
 
 ## Architecture — Core Modules
 
@@ -139,6 +114,7 @@ reported no resolution errors, and opened no Cargo PR.
 | `src/mesh.rs` | `MeshSession` v3 state tracker (feature: `mesh`) |
 | `src/webrtc.rs` | `WebRtcDriver` seam + `MeshController` (feature: `mesh`) |
 | `src/transports/websocket.rs` | WebSocket transport (feature: `transport-websocket`) |
+| `src/token_binding.rs` | Native WebSocket token-binding-v2 types, validation, canonicalization, and proof state (feature: `token-binding`) |
 | `crates/signal-fish-client-godot/src/lib.rs` | Godot 4.5 native/web `WebSocketPeer` adapter and its 35 fake-backend tests |
 
 ### Transport Trait
@@ -186,6 +162,25 @@ The Emscripten transport reports `Pending` while its browser WebSocket is still
 connecting and must not call `emscripten_websocket_send_*` or consume the
 caller's frame until `onopen`. Preparation or FFI send errors likewise leave
 the exact frame available to its caller.
+
+Native token binding belongs exclusively to `WebSocketTransport`. Disabled is
+the byte/dependency-compatible default; optional retries without the offer only
+after tungstenite's exact successful-upgrade/no-selection result; required
+fails closed. A selected connection consumes and validates the first challenge
+before either client sees a ready transport, derives HKDF-SHA-256 from the exact
+RFC 6455 key plus server nonce, zeroizes retained key material, and protects all
+outbound JSON/binary frames with one sequence. Sequence commits only at backend
+ownership transfer. Browser, Emscripten, and Godot APIs cannot expose the
+handshake key; `from_stream` is likewise post-handshake and cannot opt in.
+Required Server 0.7 profiles require WSS. Custom roots/mTLS use
+`connect_with_tls_config`, but `require_client_fingerprint=true` profiles remain
+unsupported: the SDK does not calculate, transmit, or authenticate the leaf
+certificate fingerprint, and presenting an mTLS certificate alone is
+insufficient.
+The v2 proof is client-to-server only and binds content/order to one physical
+handshake; it is not confidentiality or server authentication. On `ws://`, an
+on-path observer sees the key and nonce and can forge it. Every reconnect gets a
+fresh nonce, derived key, and sequence space; replay/reordering/tamper fails.
 
 The lockstep `signal-fish-client-godot` adapter defaults to adaptive outbound admission: a 50 ms latency target with a
 4 KiB floor, 32 KiB ceiling, and a further native-capacity clamp. A successful Godot send
@@ -330,6 +325,7 @@ accounted `one_frame_escape_bytes()` empty-buffer exception.
 | Flag | Default | Description |
 |------|---------|-------------|
 | `transport-websocket` | on | Built-in WebSocket via `tokio-tungstenite` |
+| `token-binding` | off | Native `signalfish.tokenbinding.v2` negotiation and outbound proofs; enables `transport-websocket` |
 | `tls` | off | `wss://` TLS for the built-in WebSocket transport (rustls + ring provider + webpki roots) |
 | `transport-websocket-emscripten` | off | Emscripten WebSocket transport; enables `polling-client` |
 | `polling-client` | off | `SignalFishPollingClient` — sync, polling-based client for any `Transport` |
@@ -348,6 +344,7 @@ accounted `one_frame_escape_bytes()` empty-buffer exception.
 | `tracing` | Structured logging and diagnostics |
 | `tokio-tungstenite` | WebSocket transport (optional) |
 | `futures-util` | Stream/sink utilities for WebSocket (optional) |
+| `base64` + `hkdf` + `hmac` + `sha2` + `zeroize` | Opt-in token-binding-v2 derivation, proofs, and secret lifetime |
 
 The core manifest must never depend on `godot` or expose godot-rust types.
 `signal-fish-client-godot` depends exactly on the same core version with
@@ -430,11 +427,14 @@ strings to match server expectations.
 
 ### Connection / Auth Flow
 
-1. `SignalFishClient::start(transport, config)` queues `ClientMessage::Authenticate`
+1. A token-binding-selected native WebSocket consumes its challenge and
+   establishes proof state inside `connect_with_options`; disabled transports
+   keep the old path.
+2. `SignalFishClient::start(transport, config)` queues `ClientMessage::Authenticate`
    immediately before spawning the transport loop.
-2. Server responds with `ServerMessage::Authenticated` → `SignalFishEvent::Authenticated`.
-3. Client may then call `join_room`, etc.
-4. Both clients emit synthetic `SignalFishEvent::Connected` when their driver first observes `Transport::is_ready() == true`.
+3. Server responds with `ServerMessage::Authenticated` → `SignalFishEvent::Authenticated`.
+4. Client may then call `join_room`, etc.
+5. Both clients emit synthetic `SignalFishEvent::Connected` when their driver first observes `Transport::is_ready() == true`.
    `SignalFishEvent::Disconnected` is emitted when the transport closes
    (best-effort; missed only if the receiver is dropped, shutdown times out,
    or the handle is dropped without `shutdown()`).

--- a/.llm/skills/crate-publishing/SKILL.md
+++ b/.llm/skills/crate-publishing/SKILL.md
@@ -277,6 +277,8 @@ mind on future bumps:
 
 - `tests/wire-samples/PROVENANCE.toml` — its `synced` date is human-maintained
   (refresh at release; see [protocol-wire-conformance](../protocol-wire-conformance/SKILL.md)).
+- `tests/token-binding/PROVENANCE.toml` — release preparation refreshes its
+  `synced` date with the other pinned Server 0.7 corpora.
 - New skills: `protocol-versioning-and-negotiation.md`, `webrtc-mesh-signaling.md`,
   `../protocol-wire-conformance/SKILL.md` (auto-indexed; no version literal).
 - New feature `mesh` (pure-std, zero deps). Concrete WebRTC backends (str0m,

--- a/.llm/skills/error-handling/SKILL.md
+++ b/.llm/skills/error-handling/SKILL.md
@@ -190,6 +190,13 @@ Call `error_code.description()` for a human-readable explanation.
 
 ## Mapping External Errors
 
+`SignalFishError::TokenBinding(TokenBindingFailure)` carries only static,
+typed, non-secret reasons. Never attach a handshake/derived key, nonce, proof,
+signature, fingerprint, URL credential, protected frame, or TLS client config
+to `Debug`, `Display`, tracing, or an error source. Challenge fields remain
+explicitly inspectable through the transport accessor, while its `Debug`
+redacts the nonce.
+
 ```rust
 // WebSocket transport errors → TransportSend / TransportReceive
 stream.send(msg).await

--- a/.llm/skills/protocol-versioning-and-negotiation/SKILL.md
+++ b/.llm/skills/protocol-versioning-and-negotiation/SKILL.md
@@ -24,6 +24,11 @@ flow is unchanged.
 **Never regress the relay floor.** Any new optional field on an existing message
 MUST be `Option` + `skip_serializing_if` (or `Vec` + `default` + `skip_if-empty`).
 
+WebSocket token binding is a separate physical-transport negotiation completed
+before client construction. Its disabled mode must preserve both the handshake
+and these `Authenticate` bytes. Do not add its mode/challenge to
+`SignalFishConfig`, `ClientMessage`, `ServerMessage`, or `SignalFishEvent`.
+
 ## Capability Negotiation Flow
 
 1. The client advertises what it can fulfill in `Authenticate`:

--- a/.llm/skills/transport-abstraction/SKILL.md
+++ b/.llm/skills/transport-abstraction/SKILL.md
@@ -284,9 +284,18 @@ dropping it each call.
 - bounds skipped control frames per receive poll and self-wakes to resume;
 - fuses EOF and terminal socket errors while clearing retained poll state;
 - disables Nagle's algorithm (`TCP_NODELAY`) by default on the socket it owns.
+- when opt-in token binding is active, owns subprotocol/challenge/key/proof
+  state and advances the shared JSON/binary sequence only after `start_send`
+  accepts the protected frame.
 
 Do not treat Ping/Pong as application frames. Do not skip binary application
 frames.
+
+Browser/Godot/Emscripten WebSocket APIs and post-handshake `from_stream` do not
+expose the RFC 6455 client key, so they cannot claim required token binding. A
+custom capable transport owns negotiation, proof wrapping, and key lifetime;
+none of those details belong in `SignalFishConfig`, `ClientCore`, or protocol
+events.
 
 ### Low-latency socket options (class-level rule)
 

--- a/.llm/skills/websocket-client/SKILL.md
+++ b/.llm/skills/websocket-client/SKILL.md
@@ -24,6 +24,15 @@ let transport = WebSocketTransport::connect_with_timeout(url, timeout).await?;
 or cookies. Connection failures map to `SignalFishError::Io`, preserving an
 underlying I/O error kind when possible.
 
+The opt-in `token-binding` feature adds `TokenBindingMode` to
+`WebSocketConnectOptions`. Keep disabled mode on the exact old connect path.
+Optional mode may reconnect without an offer only for tungstenite's exact
+`NoSubProtocol` result; never downgrade HTTP/TLS/network rejection, unexpected
+selection, or a malformed/missing challenge. Required mode maps missing
+selection to a typed failure. Consume the first challenge inside connect before
+returning the transport, so `Authenticate` cannot race it. `from_stream` cannot
+opt in after losing the exact generated handshake key.
+
 ## Low-Latency Socket Defaults
 
 `connect` and `connect_with_timeout` disable Nagle's algorithm (`TCP_NODELAY`)
@@ -64,14 +73,18 @@ Raw `Message::Frame` is not expected from the read half and is ignored.
 
 1. If no send is active and the caller slot is empty, return `Ready(Ok(()))`.
 2. Otherwise call `poll_ready`; on `Pending`, leave the caller slot untouched.
-3. On readiness, take exactly one `TransportFrame` and translate it to
-   `Message::Text` or `Message::Binary`.
-4. Call `start_send` once and, on success, record that a send is active.
+3. On readiness, prepare an active token-binding wrapper from `frame.as_ref()`;
+   do not take the original yet. Disabled mode translates it directly.
+4. Call `start_send` once and, on success, take the original, commit the shared
+   JSON/binary sequence, and record that a send is active.
 5. Poll `poll_flush` until ready; do not take another frame while pending.
 
 This preserves an accepted frame across `Pending` and prevents duplicate
 `start_send` calls. If a custom stream rejects the message with
-`WriteBufferFull`, restore the exact Text/Binary frame to the caller slot.
+`WriteBufferFull`, restore the exact Text/Binary frame to the caller slot in
+disabled mode. In active token-binding mode the original never left the slot;
+discard the rejected protected message and do not advance the sequence. Never
+restore a protected envelope, which would be wrapped twice on retry.
 
 ```rust,ignore
 match frame {
@@ -145,6 +158,9 @@ which panics when both `ring` and `aws_lc_rs` are in the dependency graph.
 Without the `tls` feature, a `wss://` connect fails cleanly with
 `SignalFishError::Io` (never a panic). Keep TLS features aligned with
 `Cargo.toml` rather than duplicating an alternative stack in the transport.
+`connect_with_tls_config` accepts caller-controlled roots or mTLS without
+retaining or formatting the configuration. Server 0.7 refuses required token
+binding without built-in TLS, so its positive E2E must use WSS.
 
 ## Reconnection
 
@@ -167,6 +183,13 @@ closed WebSocket object.
 - A real waker is notified when socket readiness changes.
 - The connected TCP socket has `TCP_NODELAY` set by default; `connect_with_options`
   can turn it off.
+- Disabled token binding offers no subprotocol and keeps application bytes exact.
+- Optional fallback occurs only for `NoSubProtocol`; HTTP rejection is not retried.
+- Required negotiation consumes a strict first-message challenge under timeout.
+- Preparation, `Pending`, and `WriteBufferFull` preserve the original frame and
+  sequence; JSON/binary goldens share one sequence.
+- Debug/tracing/errors omit keys, nonces, proofs, signatures, URL credentials,
+  and protected payloads.
 
 ## Common Errors
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added opt-in native `signalfish.tokenbinding.v2` support through the
+  `token-binding` feature. New public types are `TokenBindingMode`,
+  `TokenBindingStatus`, `TokenBindingScheme`, `TokenBindingChallenge`, and
+  `TokenBindingFailure`. `WebSocketConnectOptions` gains public
+  `token_binding` / `token_binding_challenge_timeout` fields and matching
+  `with_token_binding` / `with_token_binding_challenge_timeout` builders.
+  `WebSocketTransport` gains `connect_with_tls_config`,
+  `token_binding_status`, and `token_binding_challenge`. Strict challenge
+  validation, shared JSON/binary proof sequencing, canonical Server 0.7
+  goldens, and pinned positive/negative required-WSS smokes back the surface.
+  The default connection path and dependency graph remain unchanged.
 - Added Signal Fish Server 0.7.0 protocol conformance, including
   `SessionGeneration`, `DirectEndpoint::{host, port}`,
   `SessionPlanPayload::generation`, `SessionPlanPayload::direct_endpoint`,
@@ -47,6 +58,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Breaking:** `WebSocketConnectOptions` gains token-binding mode and challenge
+  timeout fields, and exhaustive `SignalFishError` matches must handle
+  `TokenBinding(TokenBindingFailure)`. Browser, Emscripten, Godot, and
+  post-handshake `from_stream` transports remain incapable of required mode
+  because their APIs do not expose the RFC 6455 handshake key.
 - Clarified that `Transport` requires a complete, ordered text/binary frame
   stream for the intended signaling server and that `RelayTransport::Udp` is
   ignored legacy `JoinRoom` metadata under Server 0.7, not a built-in UDP

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,16 @@ transport-websocket = [
     "dep:futures-util",
     "tokio-runtime",
 ]
+# Native WebSocket token-binding-v2 support. Kept opt-in so ordinary/default
+# connections retain both their handshake and lightweight dependency graph.
+token-binding = [
+    "transport-websocket",
+    "dep:base64",
+    "dep:hkdf",
+    "dep:hmac",
+    "dep:sha2",
+    "dep:zeroize",
+]
 # Optional TLS (wss://) for the built-in WebSocket transport: rustls with the
 # ring crypto provider and bundled Mozilla webpki roots. Opt-in so the default
 # build stays free of the heavier TLS/crypto dependency tree.
@@ -71,6 +81,13 @@ thiserror = "2.0"
 
 # Logging
 tracing = "0.1"
+
+# Optional Signal Fish token-binding-v2 primitives.
+base64 = { version = "0.22", optional = true }
+hkdf = { version = "0.13", optional = true }
+hmac = { version = "0.13", optional = true }
+sha2 = { version = "0.11", optional = true }
+zeroize = { version = "1.8", optional = true }
 
 # Optional: WebSocket transport
 tokio-tungstenite = { version = "0.30", optional = true }

--- a/PLAN.md
+++ b/PLAN.md
@@ -42,6 +42,9 @@ zero-file merge commit. The checked-in `GITHUB_TOKEN` Dependabot auto-merge path
 is now removed; repository policy rejects Dependabot-specific workflows,
 automated-merge primitives, and non-allowlisted workflow write permissions.
 PR #94 then merged despite its explicit do-not-merge gates and zero approvals.
+PR #118 likewise merged into current `main` with zero approvals after all
+code-tree workflows succeeded; its only review was the quota-exhausted Copilot
+comment. The latest scheduled Repository Policy run remains red.
 Ordinary reviewed merges remain policy but are not enforced until issue #90 is
 fixed. Restoring the live ruleset, disabling or funding the quota-broken
 Copilot review gate, adding an eligible independent reviewer (the repository
@@ -68,6 +71,11 @@ were delivered by PR #91 and closed when it merged as `963a9fc`.
 - PR #91 passed all eleven project aggregates plus Deep Safety and Protocol
   Sync, but merged without the approval and quota-green state it explicitly
   required. That governance failure remains tracked in issue #90.
+- Issue #117's later umbrella request for fuzzing, mutation, and formal methods
+  was closed as completed after confirming this existing fail-closed program.
+  TLA+/Z3 remains applicability-driven: add a formal model only for a concrete
+  invariant with a useful counterexample oracle, not as an unscoped tool-count
+  target.
 
 ## Completed Correctness Follow-up — FFI and Dependency Automation
 
@@ -181,10 +189,11 @@ drivers must preserve accepted-send-before-close ordering while proving
 deadline abandonment, resource release, and no later transport polling.
 Session 033 records the contract and evidence.
 
-## Current Correctness Decision — Datagram Scope
+## Completed Correctness Decision — Datagram Scope
 
 [Issue #107](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/issues/107)
-is being resolved as out of scope for this SDK's current transport abstraction.
+shipped in [PR #118](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/pull/118)
+as an out-of-scope decision for this SDK's current transport abstraction.
 
 - `Transport` begins at one complete, ordered text/binary frame stream bound to
   the intended server. A raw stream/datagram backend owns framing,
@@ -204,7 +213,7 @@ is being resolved as out of scope for this SDK's current transport abstraction.
 
 Session 034 records the source-to-decision matrix and verification evidence.
 
-## Next Correctness Milestone — Negotiated Token Binding
+## Current Correctness Milestone — Negotiated Token Binding
 
 Track [issue #88](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/issues/88).
 
@@ -215,6 +224,12 @@ Track [issue #88](https://github.com/Ambiguous-Interactive/signal-fish-client-ru
 - Make handshake-material capability differences explicit for native, browser,
   Godot, polling, and custom transports, with typed required-mode failures.
 - Keep keys, proofs, and handshake secrets out of `Debug`, tracing, and errors.
+- The implementation keeps this state in native `WebSocketTransport`, gates the
+  crypto dependency graph behind `token-binding`, consumes the challenge before
+  client construction, and advances one JSON/binary sequence only at backend
+  ownership transfer. Exact Server 0.7 goldens and a required-WSS pinned-server
+  smoke provide interoperability evidence; browser/Godot/Emscripten and
+  post-handshake `from_stream` paths remain explicitly incapable.
 
 ## Later Milestone — Allocation and Performance Evidence
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -217,6 +217,16 @@ Session 034 records the source-to-decision matrix and verification evidence.
 
 Track [issue #88](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/issues/88).
 
+[PR #119](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/pull/119)
+implements the milestone and is open, non-draft, mergeable, and fully green on
+code-bearing head `3bf73fdd1eebadf9aa3821b224492575fe8da312`. All twelve hosted workflows
+passed, including required-WSS positive and adversarial Server 0.7 E2E, Deep
+Safety, and the full Godot Web matrix. Two independent adversarial review
+passes found no remaining concrete issue, and hosted review has zero threads.
+It remains intentionally unmerged because the repository has no eligible
+independent collaborator, Copilot review is quota-exhausted, and issue #90's
+approval/ruleset administration is still incomplete.
+
 - Preserve byte-for-byte default connections while adding explicit disabled,
   optional, and required token-binding-v2 modes.
 - Bind the native proof algorithm and negative cases to one exact server

--- a/README.md
+++ b/README.md
@@ -50,8 +50,9 @@ and receive strongly typed events.
   signaling-server trust/source binding, and packet recovery remain backend
   responsibilities
 - **Wire-compatible** — protocol types are conformance-tested against the server's published wire samples and error-code registry; undecodable frames surface as a typed `DecodeFailed` event
-- **Protocol support: v2 relay + server 0.7.0 v3** — opt-in v3 adds classified delivery, accountability, binary frames, reconnect tokens, graceful drain, and generation-fenced WebRTC mesh signaling; the default remains byte-identical to v2. Generation-less server 0.4 plans remain supported. Use `enable_v3()` for relay-only support or `enable_mesh()` with a WebRTC driver. Server 0.7 compatibility currently targets the default token-binding-disabled deployment profile.
+- **Protocol support: v2 relay + server 0.7.0 v3** — opt-in v3 adds classified delivery, accountability, binary frames, reconnect tokens, graceful drain, and generation-fenced WebRTC mesh signaling; the default remains byte-identical to v2. Generation-less server 0.4 plans remain supported. Use `enable_v3()` for relay-only support or `enable_mesh()` with a WebRTC driver.
 - **Feature-gated WebSocket transport** — the default `transport-websocket` feature provides a ready-to-use `WebSocketTransport`
+- **Native token binding** — the opt-in `token-binding` feature negotiates Server 0.7's `signalfish.tokenbinding.v2` extension with disabled, optional, and required policies while preserving the default handshake
 - **Typed events for both drivers** — receive `SignalFishEvent`s through the
   async driver's bounded Tokio MPSC channel or directly from each polling call
 - **Structured errors** — typed client errors, server error codes, decode failures, and categorized protocol-accountability violations
@@ -88,10 +89,11 @@ for 0.11. Until the next release, test those APIs and fixes with:
 signal-fish-client = { git = "https://github.com/Ambiguous-Interactive/signal-fish-client-rust" }
 ```
 
-> Server deployments that require the optional
-> `signalfish.tokenbinding.v2` WebSocket extension are not supported yet and
-> will reject this client. That negotiated transport feature is tracked in
-> [issue #88](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/issues/88).
+Server deployments that require `signalfish.tokenbinding.v2` need the native
+`token-binding` and `tls` features plus required-mode WebSocket options. See
+[WebSocket Token Binding](docs/token-binding.md). Browser, Emscripten, and Godot
+WebSocket APIs cannot expose the handshake key and therefore cannot use a
+required token-binding server profile.
 
 ## Quick Start
 
@@ -141,6 +143,8 @@ async fn main() -> Result<(), signal_fish_client::SignalFishError> {
 | --------------------- | ------- | ----------------------------------------------------------------------- |
 | `transport-websocket` | **yes** | Built-in WebSocket transport via `tokio-tungstenite` and `futures-util` |
 | `transport-websocket-emscripten` | no | Emscripten WebSocket transport via raw FFI to `<emscripten/websocket.h>` |
+| `token-binding` | no | Native `WebSocketTransport` support for `signalfish.tokenbinding.v2`; preserves the crypto-free default build |
+| `tls` | no | Native `wss://` support with rustls and bundled webpki roots |
 | `polling-client` | no | Synchronous protocol pump for frame-driven and single-threaded hosts |
 | `mesh` | no | v3 mesh state, signaling orchestration, and WebRTC driver seam |
 | `tokio-runtime` | **yes** (via `transport-websocket`) | Tokio runtime integration (`rt`, `time`); disable for pure WASM targets |

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -19,14 +19,15 @@ All fallible client methods return `Result<T>`, which is an alias for
 pub type Result<T> = std::result::Result<T, SignalFishError>;
 ```
 
-`SignalFishError` derives `Debug` and `Error` (via `thiserror`). It has **18
-variants**:
+`SignalFishError` derives `Debug` and `Error` (via `thiserror`). It is an
+exhaustive public enum:
 
 | Variant | Fields | When it occurs |
 |---------|--------|----------------|
 | `TransportSend` | `String` | Failed to send a message through the transport. |
 | `TransportReceive` | `String` | Failed to receive a message from the transport. |
 | `TransportClosed` | — | The transport connection was closed unexpectedly. |
+| `TokenBinding` | `TokenBindingFailure` | Native WebSocket token-binding negotiation, challenge validation, key derivation, canonicalization, encoding, or sequence handling failed. Reasons are typed and contain no key, nonce, proof, signature, fingerprint, URL credential, or payload material. See [WebSocket Token Binding](token-binding.md). |
 | `Serialization` | `serde_json::Error` | Failed to serialize or deserialize a protocol message. Implements `From<serde_json::Error>`. |
 | `NotConnected` | — | Attempted an operation requiring an active connection but the client is not connected. |
 | `SendBufferFull` | `capacity: usize` | The bounded outgoing command queue is full — the caller is producing messages faster than the transport can drain them. The message was refused, **not** queued; nothing is silently dropped. See [Handling `SendBufferFull`](#handling-sendbufferfull). |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -43,6 +43,8 @@ cannot use the SDK's transitive Tokio dependency directly.
 |------------------------|---------|--------------------------------------------------|
 | `transport-websocket`  | Yes     | WebSocket transport via `tokio-tungstenite`       |
 | `transport-websocket-emscripten` | No | Emscripten WebSocket transport for `wasm32-unknown-emscripten` |
+| `token-binding` | No | Native `WebSocketTransport` support for Server 0.7 token binding |
+| `tls` | No | Native `wss://` via rustls; required by token-binding-required Server 0.7 profiles |
 | `polling-client` | No | Synchronous, caller-driven `SignalFishPollingClient` |
 | `tokio-runtime` | No (enabled by default `transport-websocket`) | Tokio task/time integration used by the async client |
 | `mesh` | No | Protocol-v3 `MeshSession`, `WebRtcDriver`, and `MeshController` helpers |

--- a/docs/protocol-versioning.md
+++ b/docs/protocol-versioning.md
@@ -6,12 +6,12 @@ and backward-compatible** — a client that opts into nothing sends the same v2
 authentication bytes and remains on the relay floor. Version 0.8 separately
 made protocol-v2 game start explicit. This page explains both changes.
 
-!!! warning "Optional Server 0.7 token binding"
-    Compatibility currently covers the default token-binding-disabled Server
-    0.7 deployment profile. This SDK does not yet negotiate or answer
-    `signalfish.tokenbinding.v2` / `TokenBindingChallenge`; a deployment that
-    requires that extension will reject the connection. Implementation is
-    tracked in [issue #88](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/issues/88).
+!!! info "Server 0.7 token binding is a transport negotiation"
+    The opt-in native `token-binding` feature supports disabled, optional, and
+    required `signalfish.tokenbinding.v2` modes. It is negotiated and completed
+    before either protocol driver sends `Authenticate`, so it is separate from
+    v2/v3 application capability negotiation. See
+    [WebSocket Token Binding](token-binding.md).
 
 !!! tip "Just want peer-to-peer?"
     If you have a WebRTC stack and want full mesh, jump to the

--- a/docs/token-binding.md
+++ b/docs/token-binding.md
@@ -26,7 +26,6 @@ use signal_fish_client::{
     WebSocketTransport,
 };
 
-# async fn connect() -> Result<(), signal_fish_client::SignalFishError> {
 let options = WebSocketConnectOptions::new()
     .with_token_binding(TokenBindingMode::Required);
 let transport = WebSocketTransport::connect_with_options(
@@ -34,8 +33,6 @@ let transport = WebSocketTransport::connect_with_options(
     options,
 ).await?;
 assert_eq!(transport.token_binding_status(), TokenBindingStatus::Active);
-# Ok(())
-# }
 ```
 
 | Mode | Behavior |

--- a/docs/token-binding.md
+++ b/docs/token-binding.md
@@ -1,0 +1,118 @@
+# WebSocket Token Binding
+
+Signal Fish Server 0.7 can require the negotiated
+`signalfish.tokenbinding.v2` WebSocket extension. The built-in native
+`WebSocketTransport` supports it behind the opt-in `token-binding` Cargo
+feature.
+
+```toml
+[dependencies]
+signal-fish-client = { git = "https://github.com/Ambiguous-Interactive/signal-fish-client-rust", features = ["token-binding", "tls"] }
+```
+
+`token-binding` is not a default feature. Ordinary builds therefore keep the
+previous dependency graph, WebSocket handshake, and `Authenticate` bytes.
+Server deployments that require token binding also require TLS; enable `tls`
+and use `wss://` for that profile.
+
+## Connecting
+
+Choose the negotiation policy on the transport, before constructing either
+client driver:
+
+```rust,no_run
+use signal_fish_client::{
+    TokenBindingMode, TokenBindingStatus, WebSocketConnectOptions,
+    WebSocketTransport,
+};
+
+# async fn connect() -> Result<(), signal_fish_client::SignalFishError> {
+let options = WebSocketConnectOptions::new()
+    .with_token_binding(TokenBindingMode::Required);
+let transport = WebSocketTransport::connect_with_options(
+    "wss://signal.example/v2/ws",
+    options,
+).await?;
+assert_eq!(transport.token_binding_status(), TokenBindingStatus::Active);
+# Ok(())
+# }
+```
+
+| Mode | Behavior |
+|---|---|
+| `Disabled` | Default. Does not offer a subprotocol and preserves the old connection path exactly. |
+| `Optional` | Offers v2. If the server completes the upgrade without selecting a subprotocol, reconnects once without the offer and reports `NotNegotiated`. It never retries an HTTP rejection, malformed challenge, unexpected selection, network error, or TLS failure. |
+| `Required` | Fails with a typed `SignalFishError::TokenBinding` unless the server selects v2 and sends a valid first-message challenge before the configured deadline. |
+
+Optional mode permits an explicit downgrade when the server accepts an
+unsigned upgrade. TLS authenticates the handshake and prevents an on-path
+party from stripping the server's selection. Use `Required` when downgrade is
+not acceptable.
+
+## Threat model and lifetime
+
+Token binding authenticates the order and contents of client-to-server
+application frames to the one physical WebSocket handshake. It does not protect
+server-to-client frames and is not a substitute for TLS server authentication
+or confidentiality. On plain `ws://`, an on-path observer can read both
+`Sec-WebSocket-Key` and the server nonce, derive the same session key, and forge
+proofs. Use `wss://`; Server 0.7 enforces TLS when token binding is required.
+
+The server nonce, derived key, and sequence space are fresh for every physical
+connection and are never reused across reconnects. Replayed or reordered
+sequence numbers, payload/signature tampering, proofs made with another
+connection's key, and malformed JSON/MessagePack proof envelopes fail closed.
+The encoded and decoded client handshake key live only through challenge
+validation and derivation. The derived key and validated challenge remain only
+while the physical transport is live; terminal close/error/abort clears them
+immediately, and their zeroizing storage is also a final drop guard.
+
+`token_binding_status()` safely reports the result. The validated challenge is
+available through `token_binding_challenge()` when an application has a
+specific reason to inspect it; its `Debug` output redacts the nonce.
+
+For private roots or mutual TLS, enable `tls` and call
+`WebSocketTransport::connect_with_tls_config` with an
+`Arc<rustls::ClientConfig>`. The transport uses that configuration only during
+connection setup and does not retain or format it. Server profiles that set
+`require_client_fingerprint=true` are not supported: this implementation does
+not calculate the leaf-certificate fingerprint, add it to the proof, or include
+its bytes in the HMAC. Supplying an mTLS certificate alone does not satisfy that
+profile.
+
+## Wire and failure contract
+
+The transport consumes the challenge before it can be passed to
+`SignalFishClient` or `SignalFishPollingClient`, preventing `Authenticate` from
+racing the handshake. It derives the per-connection key from the exact RFC 6455
+`Sec-WebSocket-Key` and the server nonce, then protects every outbound JSON and
+binary application frame. Text and binary frames share one strictly increasing
+sequence. A frame consumes its sequence only when the WebSocket backend accepts
+ownership; preparation failures, `Pending`, and `WriteBufferFull` leave both
+the original caller frame and sequence unchanged.
+
+The implementation follows Signal Fish Server 0.7.0 commit
+`3f7f43d4cd4b3cc7f8fb893220dc35c9b1fad333`. Checked-in provenance and exact
+JSON/MessagePack goldens live under `tests/token-binding/`. Unsupported JSON
+forms—duplicate object members, floats/exponents/negative zero, and integers
+outside JavaScript's safe range—fail closed with a typed, non-secret reason.
+
+Handshake keys, derived keys, proofs, signatures, URL credentials, and wrapped
+payloads are never included in token-binding `Debug`, tracing, or error text.
+
+## Transport and platform capability
+
+Token binding belongs to the physical WebSocket connection, not the Signal
+Fish protocol core:
+
+- Both the Tokio background client and `SignalFishPollingClient` work when
+  given a connected native `WebSocketTransport`.
+- `WebSocketTransport::from_stream` cannot enable token binding because the
+  completed handshake no longer exposes the exact client key. A custom
+  transport must own subprotocol negotiation, challenge consumption, proof
+  wrapping, shared sequence state, and key zeroization itself.
+- Browser WebSocket APIs do not expose `Sec-WebSocket-Key`. Consequently the
+  browser, Emscripten, and Godot `WebSocketPeer` transports cannot support
+  required token binding. Use a server profile where the extension is not
+  required, or terminate the connection through a capable trusted native
+  component.

--- a/docs/transport.md
+++ b/docs/transport.md
@@ -245,7 +245,18 @@ let transport = WebSocketTransport::connect_with_timeout(
 ```
 
 `from_stream` wraps an already-established `WsStream` for custom TLS, proxy,
-headers, or cookie setup.
+headers, or cookie setup. It cannot turn on token binding after the handshake;
+a custom constructor/transport must retain the exact handshake key and own the
+complete extension state machine.
+
+The opt-in native `token-binding` feature adds disabled, optional, and required
+`signalfish.tokenbinding.v2` policies to `WebSocketConnectOptions`. Negotiation,
+challenge validation, and outbound frame protection stay inside this physical
+transport, so the same connected transport works with both async and polling
+clients. Required Server 0.7 deployments use WSS; private trust roots or mTLS
+can be supplied through `connect_with_tls_config`. See
+[WebSocket Token Binding](token-binding.md) for downgrade behavior, platform
+limits, and the exact wire contract.
 
 The WebSocket mapping is direct:
 

--- a/docs/wasm.md
+++ b/docs/wasm.md
@@ -645,6 +645,7 @@ for the full workflow. Key steps:
 |---------|---------|-------------|:------------------------:|:---------------------------:|
 | `transport-websocket` | Yes | WebSocket transport via `tokio-tungstenite` (TCP sockets) | No | No |
 | `transport-websocket-emscripten` | No | `EmscriptenWebSocketTransport`; enables `polling-client` | No | Yes |
+| `token-binding` | No | Native `WebSocketTransport` support for `signalfish.tokenbinding.v2` | No | No |
 | `polling-client` | No | `SignalFishPollingClient` — sync, polling-based client for any `Transport` | Yes | Yes |
 | `tokio-runtime` | Yes (via `transport-websocket`) | Enables `tokio/rt` and `tokio/time` for background task spawning | No | No |
 
@@ -661,6 +662,13 @@ for the full workflow. Key steps:
     Do not enable `transport-websocket` or `tokio-runtime` when targeting any
     WASM target. They depend on `tokio::net::TcpStream` and Tokio's
     multi-threaded runtime, which do not compile to WebAssembly.
+
+!!! warning "Required token-binding deployments are native-only"
+    Browser WebSocket APIs—including Emscripten and Godot's browser-backed
+    `WebSocketPeer`—do not expose the generated `Sec-WebSocket-Key`. Those
+    transports therefore cannot derive `signalfish.tokenbinding.v2` proofs.
+    Use a server profile where token binding is not required, or connect
+    through a trusted native component that owns the handshake and proof state.
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -135,6 +135,7 @@ nav:
       - Installation & Quick Start: getting-started.md
       - Core Concepts: concepts.md
       - Protocol Versioning: protocol-versioning.md
+      - WebSocket Token Binding: token-binding.md
       - Migrating 0.7 to 0.8: migration-0.8.md
       - Migrating 0.8 to 0.9: migration-0.9.md
   - API Reference:

--- a/progress/session-035-token-binding-v2.md
+++ b/progress/session-035-token-binding-v2.md
@@ -164,3 +164,8 @@ required `feat!:` major marker; the next head event re-evaluates that policy.
 The automated review inventory contains one quota-exhausted Copilot comment,
 no approval, and no review threads. An eligible human approval and the separate
 #90 branch-protection administration therefore remain external merge blockers.
+
+The fresh major-classified head passed Semver Checks. Deep Safety then exposed
+one missed mutation that replaced `TokenBindingFailure::fmt` with an empty
+success; an exhaustive actionable-display regression test now kills that
+mutant for every static failure reason.

--- a/progress/session-035-token-binding-v2.md
+++ b/progress/session-035-token-binding-v2.md
@@ -113,6 +113,7 @@ cargo +1.87.0 check -p signal-fish-client --all-features --lib
 cargo test --all-features --test ci_config_tests
 python3 -m unittest scripts.test_release
 MKDOCS=/tmp/signal-fish-docs-venv/bin/mkdocs bash scripts/check-docs-rendering.sh
+bash scripts/extract-rust-snippets.sh
 SIGNAL_FISH_SERVER_BIN=/tmp/signal-fish-server-pinned/target/release/signal-fish-server \
   cargo test --all-features --test real_server_e2e \
   e2e_server_070_required_token_binding_wss -- --ignored --exact --test-threads=1

--- a/progress/session-035-token-binding-v2.md
+++ b/progress/session-035-token-binding-v2.md
@@ -1,0 +1,150 @@
+# Session 035 — Native WebSocket Token Binding v2
+
+## Scope and Priority
+
+The hosted audit found current `main` clean at `2a18bbc`, no open/draft PRs or
+dependency updates, and open issues #117, #110, #90, #88, #80, and #82. Issue
+#117 was an unscoped safety umbrella and was triaged against the already-shipped
+Deep Safety program; it is now closed completed with the concrete Miri, fuzz,
+mutation, and unsafe/FFI evidence. Issue #88 was therefore the highest-impact
+implementation-ready correctness/interoperability item.
+
+Issue #90 remains a separate maintainer-administration blocker. PR #118 merged
+into current main with no approval and a quota-exhausted Copilot comment despite
+green code-tree workflows, while the latest observable Repository Policy run is
+red. This client change cannot repair or prove the live ruleset, approval,
+reviewer, or quota state.
+
+## Pinned Contract
+
+All token-binding behavior is pinned to Signal Fish Server 0.7.0 commit
+`3f7f43d4cd4b3cc7f8fb893220dc35c9b1fad333`. The server already contains merged
+replay-resistant token binding and has no open token-binding dependency.
+
+- WebSocket subprotocol: `signalfish.tokenbinding.v2`.
+- The first application frame is a strict `TokenBindingChallenge`.
+- HKDF-SHA-256 uses the decoded 16-byte `Sec-WebSocket-Key` as IKM, the decoded
+  32-byte server nonce as salt, and
+  `signalfish.tokenbinding.v2/session-key` as info.
+- HMAC-SHA-256 covers the JSON/binary domain, one shared u64 big-endian
+  sequence, and canonical JSON or the exact raw binary payload.
+- JSON is duplicate-free, safe-integer-only, RFC8785-subset canonical JSON with
+  UTF-16 object-key ordering. Binary uses the named-field MessagePack envelope.
+- Required mode is valid only on a TLS-enabled Server 0.7 deployment.
+
+`tests/token-binding/PROVENANCE.toml` records exact upstream source hashes and
+binds the checked-in JSON/binary vectors to a checksum.
+
+## Architecture and Public Surface
+
+Token binding stays in native `WebSocketTransport`; it is not a protocol event,
+`SignalFishConfig` capability, or `ClientCore` concern. The opt-in
+`token-binding` Cargo feature keeps the default dependency graph crypto-free.
+
+`WebSocketConnectOptions` exposes disabled, optional, and required modes plus a
+challenge deadline. Disabled takes the exact old connection path. Optional
+retries once without the offer only after tungstenite reports the precise
+successful-upgrade/no-subprotocol condition; HTTP, TLS, network, unexpected
+selection, and malformed challenge failures never downgrade. Required fails
+with typed static `TokenBindingFailure` reasons.
+
+The selected challenge is consumed before a ready transport can reach either
+client driver, preventing `Authenticate` from racing setup. A safe status and
+explicit challenge accessor are available; ambient `Debug`, tracing, and
+errors exclude keys, nonces, proofs, signatures, fingerprints, URL credentials,
+wrapped frames, and TLS client configuration. Handshake key material lives only
+through derivation; terminal close/error/abort immediately drops the challenge
+and zeroizes the derived key, with drop as the final guard.
+
+`connect_with_tls_config` supports private roots and mTLS, but server profiles
+with `require_client_fingerprint=true` remain unsupported because the SDK does
+not add the leaf fingerprint to the proof/HMAC. Browser, Emscripten, Godot `WebSocketPeer`,
+and post-handshake `from_stream` paths cannot expose the exact client handshake
+key and therefore cannot support required mode. Both async and polling clients
+can use a connected native `WebSocketTransport`.
+
+## Ownership and Sequence Invariant
+
+For an active session, `poll_send` waits for backend readiness, prepares a
+protected frame from `frame.as_ref()`, and calls `start_send` before taking the
+caller's original or committing the sequence. Preparation failure, `Pending`,
+and `WriteBufferFull` leave the byte-exact original and sequence unchanged. A
+rejected protected envelope is never restored into the caller slot, preventing
+double wrapping. JSON and binary frames share the same sequence; exhaustion
+fails closed.
+
+## Evidence
+
+- Exact default handshake test proves no subprotocol offer and unchanged raw
+  application bytes.
+- Mock handshakes cover selected/challenge-first ordering, optional fallback,
+  required absence/malformed challenge, challenge timeout, and no HTTP retry.
+- Ownership tests cover unsupported JSON and backend buffer refusal without
+  frame mutation or sequence consumption.
+- Server-derived goldens cover canonical JSON, full named-field MessagePack,
+  shared JSON/binary sequence, forbidden numeric/duplicate inputs, challenge
+  shape, and static redaction canaries.
+- A required-WSS ignored E2E against a native build of the exact pinned Server
+  0.7 commit passes authentication, room join, JSON relay, physical binary
+  relay, and a final Pong. The CI matrix runs the same test against the
+  checksummed published x86_64 Server 0.7 artifact.
+- A second pinned raw-WSS E2E proves replay, payload/signature tamper,
+  cross-connection wrong-key reuse, and malformed JSON and binary envelopes are
+  rejected. Required downgrade and optional fallback boundaries remain covered
+  by deterministic mock handshakes.
+- Feature-off checks compile the core and native WebSocket transport without
+  `base64`, `hkdf`, `hmac`, `sha2`, or `zeroize` in the normal dependency tree.
+
+Local verification completed across the implementation and adversarial review
+loop:
+
+```text
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo test --all-features token_binding
+cargo test --all-features optional_mode
+cargo test --all-features selected_mode
+cargo test --all-features --test token_binding_conformance_tests
+cargo doc --workspace --all-features --no-deps
+cargo check --no-default-features
+cargo check --no-default-features --features transport-websocket
+cargo clippy --no-default-features --features token-binding --all-targets -- -D warnings
+cargo test --no-default-features --features token-binding
+cargo +1.87.0 check -p signal-fish-client --all-features --lib
+cargo test --all-features --test ci_config_tests
+python3 -m unittest scripts.test_release
+MKDOCS=/tmp/signal-fish-docs-venv/bin/mkdocs bash scripts/check-docs-rendering.sh
+SIGNAL_FISH_SERVER_BIN=/tmp/signal-fish-server-pinned/target/release/signal-fish-server \
+  cargo test --all-features --test real_server_e2e \
+  e2e_server_070_required_token_binding_wss -- --ignored --exact --test-threads=1
+SIGNAL_FISH_SERVER_BIN=/tmp/signal-fish-server-pinned/target/release/signal-fish-server \
+  cargo test --all-features --test real_server_e2e \
+  e2e_server_070_rejects_invalid_token_binding_proofs -- --ignored --exact --test-threads=1
+cargo fmt && cargo clippy --workspace --all-targets --all-features -- -D warnings && \
+  cargo test --workspace --all-features
+```
+
+The exact mandatory repository gate passes with zero warnings on the final
+local diff. Hosted PR checks/reviews and issue closure remain pending until the
+branch head is published.
+
+## Adversarial Review
+
+Two independent read-only reviewers audited the implementation and acceptance
+matrix. Pass 1 found and drove fixes for:
+
+- feature-combination imports and missing token-binding-without-TLS CI rows;
+- missing pinned replay/tamper/wrong-key/malformed-envelope negative evidence;
+- a false mTLS fingerprint capability claim plus incomplete threat, replay, and
+  key-lifetime documentation;
+- derived key/challenge retention after terminal close/error/abort;
+- structurally weak provenance checks and partially unused golden fields;
+- incomplete public API changelog and Rustdoc error contracts;
+- omitted release-preflight provenance participation;
+- stale CI matrix policy tests/wording and an inaccurate custom-TLS secure log;
+- canonical context line/URL policy regressions.
+
+Every finding was fixed with executable coverage. Terminalization now drops the
+challenge and zeroizes the active session while preserving historical `Active`
+status, and the test pins that behavior. The exact provenance paths/hashes and
+every golden field are consumed by tests. Pass 2 reached zero remaining concrete
+findings.

--- a/progress/session-035-token-binding-v2.md
+++ b/progress/session-035-token-binding-v2.md
@@ -169,3 +169,22 @@ The fresh major-classified head passed Semver Checks. Deep Safety then exposed
 one missed mutation that replaced `TokenBindingFailure::fmt` with an empty
 success; an exhaustive actionable-display regression test now kills that
 mutant for every static failure reason.
+
+The resulting code-bearing head,
+`3bf73fdd1eebadf9aa3821b224492575fe8da312`, passed every hosted workflow:
+
+- CI 32444513502, including both pinned Server 0.7 token-binding E2Es;
+- Deep Safety 32444513103, including the corrected mutation lane, Miri, and all
+  protocol fuzz smokes;
+- Godot Web 32444513087, including build/export and clean, impaired, and soak
+  browser scenarios;
+- Semver Checks 32444513016 under the `feat!:` major-change policy; and
+- WASM, Docs Validation, Workflow Lint, Security, Coverage, Unused Deps,
+  Examples Validation, and No Panics.
+
+PR #119 is open, non-draft, mergeable, and has zero review threads. Three
+Copilot attempts ended before analysis because the requesting account has no
+remaining quota, and the only repository collaborator is also the PR author.
+The implementation and hosted verification are complete; an eligible external
+approval plus issue #90's live ruleset and Repository Policy administration are
+the remaining merge/issue-closure dependencies.

--- a/progress/session-035-token-binding-v2.md
+++ b/progress/session-035-token-binding-v2.md
@@ -149,3 +149,18 @@ challenge and zeroizes the active session while preserving historical `Active`
 status, and the test pins that behavior. The exact provenance paths/hashes and
 every golden field are consumed by tests. Pass 2 reached zero remaining concrete
 findings.
+
+## Hosted Checkpoint
+
+PR #119 (`feat!: support negotiated WebSocket token binding v2`) links and
+closes #88 when merged. The first published head, `7751e32`, reached ten green
+hosted workflows while Godot Web and Deep Safety were still running. Semver
+Checks correctly identified the two documented breaking surfaces—new public
+fields on exhaustively constructible `WebSocketConnectOptions` and the new
+exhaustive `SignalFishError::TokenBinding` variant—but its original event had
+the pre-classification `feat:` title. The PR title now carries the repository's
+required `feat!:` major marker; the next head event re-evaluates that policy.
+
+The automated review inventory contains one quota-exhausted Copilot comment,
+no approval, and no review threads. An eligible human approval and the separate
+#90 branch-protection administration therefore remain external merge blockers.

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -37,6 +37,7 @@ VERSION_FILES = (
 PROVENANCE_FILES = (
     "tests/compatibility.toml",
     "tests/server-spec/PROVENANCE.toml",
+    "tests/token-binding/PROVENANCE.toml",
     "tests/wire-samples/PROVENANCE.toml",
 )
 CHANGELOG_CATEGORIES = (

--- a/scripts/test_release.py
+++ b/scripts/test_release.py
@@ -657,7 +657,7 @@ class WorkflowPolicyTests(unittest.TestCase):
             "registry-plan",
             "SHA256SUMS",
             "cargo cyclonedx",
-            "actions/attest@v4.2.0",
+            "actions/attest@v4.2.2",
             "cargo publish --dry-run",
             "cargo publish",
             "gh release create",

--- a/src/error.rs
+++ b/src/error.rs
@@ -230,6 +230,39 @@ mod tests {
     use super::*;
 
     #[test]
+    fn token_binding_failure_display_is_actionable_for_every_reason() {
+        let cases = [
+            (TokenBindingFailure::FeatureDisabled, "feature"),
+            (TokenBindingFailure::NegotiationRejected, "rejected"),
+            (
+                TokenBindingFailure::SubprotocolNotNegotiated,
+                "did not select",
+            ),
+            (TokenBindingFailure::UnexpectedSubprotocol, "unexpected"),
+            (TokenBindingFailure::MissingChallenge, "closed"),
+            (TokenBindingFailure::ChallengeTimeout, "timed out"),
+            (TokenBindingFailure::MalformedChallenge, "malformed"),
+            (TokenBindingFailure::UnsupportedVersion, "version"),
+            (TokenBindingFailure::UnsupportedScheme, "scheme"),
+            (TokenBindingFailure::InvalidNonce, "nonce"),
+            (TokenBindingFailure::InvalidFirstSequence, "sequence"),
+            (TokenBindingFailure::InvalidHandshakeKey, "handshake key"),
+            (TokenBindingFailure::KeyDerivation, "derived"),
+            (TokenBindingFailure::UnsupportedJson, "JSON"),
+            (TokenBindingFailure::MessageEncoding, "encoded"),
+            (TokenBindingFailure::SequenceExhausted, "exhausted"),
+        ];
+
+        for (failure, expected) in cases {
+            let message = failure.to_string();
+            assert!(
+                message.contains(expected),
+                "{failure:?} must retain an actionable display message: {message}"
+            );
+        }
+    }
+
+    #[test]
     fn server_error_uses_typed_error_code() {
         let err = SignalFishError::ServerError {
             message: "room full".into(),

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,6 +5,72 @@ use crate::protocol::SessionGeneration;
 use crate::RoomRole;
 use thiserror::Error;
 
+/// A non-secret reason that token-binding-v2 setup or message protection failed.
+///
+/// The variants deliberately contain no handshake key, derived key, nonce,
+/// proof, signature, certificate fingerprint, or application payload, so the
+/// exhaustive public error remains safe to format in ambient logs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TokenBindingFailure {
+    /// The crate was built without the opt-in `token-binding` feature.
+    FeatureDisabled,
+    /// The server rejected the WebSocket upgrade while token binding was offered.
+    NegotiationRejected,
+    /// Required mode completed an upgrade without selecting token-binding-v2.
+    SubprotocolNotNegotiated,
+    /// The server selected a WebSocket subprotocol other than the one offered.
+    UnexpectedSubprotocol,
+    /// The selected connection closed before sending its challenge.
+    MissingChallenge,
+    /// The selected connection did not send its challenge before the deadline.
+    ChallengeTimeout,
+    /// The first application frame was not a valid token-binding challenge.
+    MalformedChallenge,
+    /// The challenge declared an unsupported protocol version.
+    UnsupportedVersion,
+    /// The challenge declared an unsupported proof scheme.
+    UnsupportedScheme,
+    /// The challenge nonce was not canonical base64 for exactly 32 bytes.
+    InvalidNonce,
+    /// The challenge did not start at the pinned protocol's first sequence.
+    InvalidFirstSequence,
+    /// The WebSocket handshake key was missing, malformed, or not 16 bytes.
+    InvalidHandshakeKey,
+    /// The per-connection HKDF key could not be derived.
+    KeyDerivation,
+    /// An outbound JSON frame cannot be represented by the pinned canonical form.
+    UnsupportedJson,
+    /// An outbound binary proof envelope could not be encoded.
+    MessageEncoding,
+    /// The shared text/binary sequence space has been exhausted.
+    SequenceExhausted,
+}
+
+impl std::fmt::Display for TokenBindingFailure {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::FeatureDisabled => "crate feature `token-binding` is disabled",
+            Self::NegotiationRejected => "the server rejected token-binding negotiation",
+            Self::SubprotocolNotNegotiated => {
+                "the server did not select signalfish.tokenbinding.v2"
+            }
+            Self::UnexpectedSubprotocol => "the server selected an unexpected subprotocol",
+            Self::MissingChallenge => "the server closed before the token-binding challenge",
+            Self::ChallengeTimeout => "the server token-binding challenge timed out",
+            Self::MalformedChallenge => "the server sent a malformed token-binding challenge",
+            Self::UnsupportedVersion => "the server selected an unsupported token-binding version",
+            Self::UnsupportedScheme => "the server selected an unsupported token-binding scheme",
+            Self::InvalidNonce => "the server challenge nonce is invalid",
+            Self::InvalidFirstSequence => "the server challenge sequence is invalid",
+            Self::InvalidHandshakeKey => "the WebSocket handshake key is unavailable or invalid",
+            Self::KeyDerivation => "the token-binding session key could not be derived",
+            Self::UnsupportedJson => "the outbound JSON frame is not token-binding compatible",
+            Self::MessageEncoding => "the token-bound frame could not be encoded",
+            Self::SequenceExhausted => "the token-binding sequence space is exhausted",
+        })
+    }
+}
+
 /// Errors that can occur when using the Signal Fish client.
 #[derive(Debug, Error)]
 pub enum SignalFishError {
@@ -131,6 +197,13 @@ pub enum SignalFishError {
         "binary game data requires an effectively negotiated MessagePack format; this connection uses JSON"
     )]
     BinaryFormatNotNegotiated,
+
+    /// Native WebSocket token-binding-v2 setup or outbound protection failed.
+    ///
+    /// The reason is intentionally structured and contains no secret or proof
+    /// material. Required mode never silently falls back after this error.
+    #[error("token binding error: {0}")]
+    TokenBinding(TokenBindingFailure),
 
     /// An operation timed out.
     #[error("operation timed out")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,6 +123,8 @@ pub mod error_codes;
 pub mod event;
 pub mod protocol;
 pub mod signal;
+#[cfg(feature = "transport-websocket")]
+pub mod token_binding;
 pub mod transport;
 pub mod transports;
 
@@ -141,7 +143,7 @@ pub use client::{
     RoomRole, SignalFishClient, SignalFishConfig,
 };
 pub use client_api::SignalFishClientApi;
-pub use error::SignalFishError;
+pub use error::{SignalFishError, TokenBindingFailure};
 pub use error_codes::ErrorCode;
 pub use event::{
     ProtocolViolationKind, ServerErrorInfo, SignalFishEvent, DECODE_FAILED_RAW_PREFIX_MAX,
@@ -154,6 +156,10 @@ pub use protocol::{
     V3BinaryGameDataFrame, VolatileDeliveryCounters,
 };
 pub use signal::PeerSignal;
+#[cfg(feature = "transport-websocket")]
+pub use token_binding::{
+    TokenBindingChallenge, TokenBindingMode, TokenBindingScheme, TokenBindingStatus,
+};
 pub use transport::{Transport, TransportCloseInfo, TransportDiagnostics, TransportFrame};
 
 #[cfg(feature = "transport-websocket")]

--- a/src/token_binding.rs
+++ b/src/token_binding.rs
@@ -1,0 +1,745 @@
+//! Signal Fish token-binding-v2 negotiation and challenge types.
+//!
+//! The built-in native WebSocket transport implements the extension when the
+//! `token-binding` feature is enabled. The default remains disabled.
+
+use serde::{Deserialize, Serialize};
+
+#[cfg(feature = "token-binding")]
+use crate::error::{SignalFishError, TokenBindingFailure};
+#[cfg(feature = "token-binding")]
+use crate::transport::TransportFrame;
+
+/// Exact RFC 6455 subprotocol token for the pinned v2 extension.
+pub const TOKEN_BINDING_SUBPROTOCOL: &str = "signalfish.tokenbinding.v2";
+
+/// Whether a native WebSocket connection offers and requires token binding.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum TokenBindingMode {
+    /// Do not offer token binding. This is the byte-compatible default.
+    #[default]
+    Disabled,
+    /// Offer v2 and protect frames only when the server selects it.
+    Optional,
+    /// Offer v2 and reject the connection unless the server selects it.
+    Required,
+}
+
+/// Observable token-binding state of an established native WebSocket.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TokenBindingStatus {
+    /// The connection did not offer token binding.
+    Disabled,
+    /// Optional mode was offered and the server permitted an unsigned fallback.
+    NotNegotiated,
+    /// The server selected v2 and outbound frames are protected.
+    Active,
+}
+
+/// Token-binding proof scheme defined by Signal Fish Server 0.7.0.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TokenBindingScheme {
+    /// HKDF-SHA-256 over the RFC 6455 key and a fresh server nonce.
+    ServerNonceHkdfSha256,
+}
+
+/// First application message on a token-bound WebSocket.
+///
+/// The nonce is public server-fresh input, not a credential, but `Debug`
+/// deliberately reports only its length so transitive transport diagnostics do
+/// not accumulate handshake material. Explicit field access is unchanged.
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TokenBindingChallenge {
+    /// Wire-contract version. Server 0.7.0 emits `2`.
+    pub version: u8,
+    /// Selected key-derivation and proof scheme.
+    pub scheme: TokenBindingScheme,
+    /// Standard-base64 server nonce, which decodes to exactly 32 bytes.
+    pub nonce: String,
+    /// First shared JSON/binary sequence number. Server 0.7.0 emits `1`.
+    pub first_sequence: u64,
+}
+
+impl std::fmt::Debug for TokenBindingChallenge {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TokenBindingChallenge")
+            .field("version", &self.version)
+            .field("scheme", &self.scheme)
+            .field("nonce_len", &self.nonce.len())
+            .field("first_sequence", &self.first_sequence)
+            .finish()
+    }
+}
+
+#[cfg(feature = "token-binding")]
+const VERSION: u8 = 2;
+#[cfg(feature = "token-binding")]
+const MAX_SAFE_INTEGER: u64 = 9_007_199_254_740_991;
+#[cfg(feature = "token-binding")]
+const JSON_DOMAIN: &[u8] = b"signalfish.tokenbinding.v2\0json\0";
+#[cfg(feature = "token-binding")]
+const BINARY_DOMAIN: &[u8] = b"signalfish.tokenbinding.v2\0binary\0";
+#[cfg(feature = "token-binding")]
+const HKDF_INFO: &[u8] = b"signalfish.tokenbinding.v2/session-key";
+
+#[cfg(feature = "token-binding")]
+#[derive(Serialize)]
+struct TokenBindingProof {
+    version: u8,
+    scheme: TokenBindingScheme,
+    sequence: u64,
+    signature: String,
+    fingerprint: Option<String>,
+}
+
+#[cfg(feature = "token-binding")]
+#[derive(Serialize)]
+struct TokenBoundBinaryFrame<'a> {
+    token_binding: TokenBindingProof,
+    #[serde(with = "serde_bytes")]
+    payload: &'a [u8],
+}
+
+/// Secret-bearing per-connection signer. Its custom `Debug` exposes only state.
+#[cfg(feature = "token-binding")]
+pub(crate) struct TokenBindingSession {
+    secret: zeroize::Zeroizing<[u8; 32]>,
+    next_sequence: u64,
+    challenge: TokenBindingChallenge,
+}
+
+#[cfg(feature = "token-binding")]
+impl std::fmt::Debug for TokenBindingSession {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TokenBindingSession")
+            .field("next_sequence", &self.next_sequence)
+            .field("challenge", &self.challenge)
+            .finish_non_exhaustive()
+    }
+}
+
+#[cfg(feature = "token-binding")]
+impl TokenBindingSession {
+    pub(crate) fn from_challenge(
+        handshake_key: &str,
+        challenge: TokenBindingChallenge,
+    ) -> Result<Self, SignalFishError> {
+        use base64::{engine::general_purpose::STANDARD, Engine as _};
+
+        if challenge.version != VERSION {
+            return Err(SignalFishError::TokenBinding(
+                TokenBindingFailure::UnsupportedVersion,
+            ));
+        }
+        if challenge.scheme != TokenBindingScheme::ServerNonceHkdfSha256 {
+            return Err(SignalFishError::TokenBinding(
+                TokenBindingFailure::UnsupportedScheme,
+            ));
+        }
+        if challenge.first_sequence != 1 {
+            return Err(SignalFishError::TokenBinding(
+                TokenBindingFailure::InvalidFirstSequence,
+            ));
+        }
+
+        let client_key =
+            zeroize::Zeroizing::new(STANDARD.decode(handshake_key.as_bytes()).map_err(|_| {
+                SignalFishError::TokenBinding(TokenBindingFailure::InvalidHandshakeKey)
+            })?);
+        if client_key.len() != 16 {
+            return Err(SignalFishError::TokenBinding(
+                TokenBindingFailure::InvalidHandshakeKey,
+            ));
+        }
+        let nonce = zeroize::Zeroizing::new(
+            STANDARD
+                .decode(challenge.nonce.as_bytes())
+                .map_err(|_| SignalFishError::TokenBinding(TokenBindingFailure::InvalidNonce))?,
+        );
+        if nonce.len() != 32 {
+            return Err(SignalFishError::TokenBinding(
+                TokenBindingFailure::InvalidNonce,
+            ));
+        }
+
+        let hkdf = hkdf::Hkdf::<sha2::Sha256>::new(Some(nonce.as_slice()), client_key.as_slice());
+        let mut secret = zeroize::Zeroizing::new([0_u8; 32]);
+        hkdf.expand(HKDF_INFO, secret.as_mut())
+            .map_err(|_| SignalFishError::TokenBinding(TokenBindingFailure::KeyDerivation))?;
+
+        Ok(Self {
+            secret,
+            next_sequence: challenge.first_sequence,
+            challenge,
+        })
+    }
+
+    pub(crate) fn challenge(&self) -> &TokenBindingChallenge {
+        &self.challenge
+    }
+
+    pub(crate) fn prepare(
+        &self,
+        frame: &TransportFrame,
+    ) -> Result<TransportFrame, SignalFishError> {
+        if self.next_sequence > MAX_SAFE_INTEGER {
+            return Err(SignalFishError::TokenBinding(
+                TokenBindingFailure::SequenceExhausted,
+            ));
+        }
+        match frame {
+            TransportFrame::Text(text) => self.prepare_text(text),
+            TransportFrame::Binary(payload) => self.prepare_binary(payload),
+        }
+    }
+
+    pub(crate) fn commit(&mut self) -> Result<(), SignalFishError> {
+        self.next_sequence =
+            self.next_sequence
+                .checked_add(1)
+                .ok_or(SignalFishError::TokenBinding(
+                    TokenBindingFailure::SequenceExhausted,
+                ))?;
+        Ok(())
+    }
+
+    fn proof(&self, domain: &[u8], payload: &[u8]) -> Result<TokenBindingProof, SignalFishError> {
+        use base64::{engine::general_purpose::STANDARD, Engine as _};
+        use hmac::Mac as _;
+
+        type HmacSha256 = hmac::Hmac<sha2::Sha256>;
+        let mut mac = <HmacSha256 as hmac::KeyInit>::new_from_slice(self.secret.as_ref())
+            .map_err(|_| SignalFishError::TokenBinding(TokenBindingFailure::KeyDerivation))?;
+        mac.update(domain);
+        mac.update(&self.next_sequence.to_be_bytes());
+        mac.update(payload);
+        Ok(TokenBindingProof {
+            version: VERSION,
+            scheme: TokenBindingScheme::ServerNonceHkdfSha256,
+            sequence: self.next_sequence,
+            signature: STANDARD.encode(mac.finalize().into_bytes()),
+            fingerprint: None,
+        })
+    }
+
+    fn prepare_text(&self, text: &str) -> Result<TransportFrame, SignalFishError> {
+        let UniqueJsonValue(mut value) = serde_json::from_str(text)
+            .map_err(|_| SignalFishError::TokenBinding(TokenBindingFailure::UnsupportedJson))?;
+        if value
+            .as_object()
+            .is_some_and(|object| object.contains_key("token_binding"))
+        {
+            return Err(SignalFishError::TokenBinding(
+                TokenBindingFailure::UnsupportedJson,
+            ));
+        }
+        let canonical = canonical_json(&value)?;
+        let proof = serde_json::to_value(self.proof(JSON_DOMAIN, &canonical)?)
+            .map_err(|_| SignalFishError::TokenBinding(TokenBindingFailure::MessageEncoding))?;
+        value
+            .as_object_mut()
+            .ok_or(SignalFishError::TokenBinding(
+                TokenBindingFailure::UnsupportedJson,
+            ))?
+            .insert("token_binding".to_string(), proof);
+        serde_json::to_string(&value)
+            .map(TransportFrame::Text)
+            .map_err(|_| SignalFishError::TokenBinding(TokenBindingFailure::MessageEncoding))
+    }
+
+    fn prepare_binary(&self, payload: &[u8]) -> Result<TransportFrame, SignalFishError> {
+        let envelope = TokenBoundBinaryFrame {
+            token_binding: self.proof(BINARY_DOMAIN, payload)?,
+            payload,
+        };
+        rmp_serde::to_vec_named(&envelope)
+            .map(TransportFrame::Binary)
+            .map_err(|_| SignalFishError::TokenBinding(TokenBindingFailure::MessageEncoding))
+    }
+}
+
+#[cfg(feature = "token-binding")]
+pub(crate) fn parse_challenge(text: &str) -> Result<TokenBindingChallenge, SignalFishError> {
+    let UniqueJsonValue(value) = serde_json::from_str(text)
+        .map_err(|_| SignalFishError::TokenBinding(TokenBindingFailure::MalformedChallenge))?;
+    let envelope = value.as_object().ok_or(SignalFishError::TokenBinding(
+        TokenBindingFailure::MalformedChallenge,
+    ))?;
+    if envelope.len() != 2 || !envelope.contains_key("type") || !envelope.contains_key("data") {
+        return Err(SignalFishError::TokenBinding(
+            TokenBindingFailure::MalformedChallenge,
+        ));
+    }
+    if envelope.get("type").and_then(serde_json::Value::as_str) != Some("TokenBindingChallenge") {
+        return Err(SignalFishError::TokenBinding(
+            TokenBindingFailure::MalformedChallenge,
+        ));
+    }
+    let data = envelope
+        .get("data")
+        .and_then(serde_json::Value::as_object)
+        .ok_or(SignalFishError::TokenBinding(
+            TokenBindingFailure::MalformedChallenge,
+        ))?;
+    if data.len() != 4
+        || !["version", "scheme", "nonce", "first_sequence"]
+            .iter()
+            .all(|field| data.contains_key(*field))
+    {
+        return Err(SignalFishError::TokenBinding(
+            TokenBindingFailure::MalformedChallenge,
+        ));
+    }
+    let version = data
+        .get("version")
+        .and_then(serde_json::Value::as_u64)
+        .and_then(|version| u8::try_from(version).ok())
+        .ok_or(SignalFishError::TokenBinding(
+            TokenBindingFailure::MalformedChallenge,
+        ))?;
+    if version != VERSION {
+        return Err(SignalFishError::TokenBinding(
+            TokenBindingFailure::UnsupportedVersion,
+        ));
+    }
+    let scheme = match data.get("scheme").and_then(serde_json::Value::as_str) {
+        Some("server_nonce_hkdf_sha256") => TokenBindingScheme::ServerNonceHkdfSha256,
+        Some(_) => {
+            return Err(SignalFishError::TokenBinding(
+                TokenBindingFailure::UnsupportedScheme,
+            ))
+        }
+        None => {
+            return Err(SignalFishError::TokenBinding(
+                TokenBindingFailure::MalformedChallenge,
+            ))
+        }
+    };
+    let nonce = data
+        .get("nonce")
+        .and_then(serde_json::Value::as_str)
+        .ok_or(SignalFishError::TokenBinding(
+            TokenBindingFailure::MalformedChallenge,
+        ))?
+        .to_owned();
+    let first_sequence = data
+        .get("first_sequence")
+        .and_then(serde_json::Value::as_u64)
+        .ok_or(SignalFishError::TokenBinding(
+            TokenBindingFailure::MalformedChallenge,
+        ))?;
+    if first_sequence != 1 {
+        return Err(SignalFishError::TokenBinding(
+            TokenBindingFailure::InvalidFirstSequence,
+        ));
+    }
+    Ok(TokenBindingChallenge {
+        version,
+        scheme,
+        nonce,
+        first_sequence,
+    })
+}
+
+#[cfg(feature = "token-binding")]
+fn canonical_json(value: &serde_json::Value) -> Result<Vec<u8>, SignalFishError> {
+    fn write(value: &serde_json::Value, output: &mut Vec<u8>) -> serde_json::Result<()> {
+        use serde::ser::Error as _;
+        use serde_json::Value;
+
+        match value {
+            Value::Null => output.extend_from_slice(b"null"),
+            Value::Bool(true) => output.extend_from_slice(b"true"),
+            Value::Bool(false) => output.extend_from_slice(b"false"),
+            Value::Number(number) => {
+                let rendered = number
+                    .as_i64()
+                    .filter(|value| value.unsigned_abs() <= MAX_SAFE_INTEGER)
+                    .map(|value| value.to_string())
+                    .or_else(|| {
+                        number
+                            .as_u64()
+                            .filter(|value| *value <= MAX_SAFE_INTEGER)
+                            .map(|value| value.to_string())
+                    })
+                    .ok_or_else(|| serde_json::Error::custom("unsupported JSON number"))?;
+                output.extend_from_slice(rendered.as_bytes());
+            }
+            Value::String(string) => serde_json::to_writer(output, string)?,
+            Value::Array(values) => {
+                output.push(b'[');
+                for (index, item) in values.iter().enumerate() {
+                    if index > 0 {
+                        output.push(b',');
+                    }
+                    write(item, output)?;
+                }
+                output.push(b']');
+            }
+            Value::Object(values) => {
+                let mut properties: Vec<_> = values.iter().collect();
+                properties.sort_by_cached_key(|(key, _)| key.encode_utf16().collect::<Vec<_>>());
+                output.push(b'{');
+                for (index, (key, item)) in properties.into_iter().enumerate() {
+                    if index > 0 {
+                        output.push(b',');
+                    }
+                    serde_json::to_writer(&mut *output, key)?;
+                    output.push(b':');
+                    write(item, output)?;
+                }
+                output.push(b'}');
+            }
+        }
+        Ok(())
+    }
+
+    let mut output = Vec::with_capacity(128);
+    write(value, &mut output)
+        .map_err(|_| SignalFishError::TokenBinding(TokenBindingFailure::UnsupportedJson))?;
+    Ok(output)
+}
+
+#[cfg(feature = "token-binding")]
+struct UniqueJsonValue(serde_json::Value);
+
+#[cfg(feature = "token-binding")]
+impl<'de> Deserialize<'de> for UniqueJsonValue {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(UniqueJsonVisitor)
+    }
+}
+
+#[cfg(feature = "token-binding")]
+struct UniqueJsonVisitor;
+
+#[cfg(feature = "token-binding")]
+impl<'de> serde::de::Visitor<'de> for UniqueJsonVisitor {
+    type Value = UniqueJsonValue;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("a JSON value without duplicate object members")
+    }
+
+    fn visit_bool<E>(self, value: bool) -> Result<Self::Value, E> {
+        Ok(UniqueJsonValue(serde_json::Value::Bool(value)))
+    }
+
+    fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        if value.unsigned_abs() > MAX_SAFE_INTEGER {
+            return Err(E::custom(
+                "JSON integer exceeds the interoperable safe range",
+            ));
+        }
+        Ok(UniqueJsonValue(serde_json::Value::Number(value.into())))
+    }
+
+    fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        if value > MAX_SAFE_INTEGER {
+            return Err(E::custom(
+                "JSON integer exceeds the interoperable safe range",
+            ));
+        }
+        Ok(UniqueJsonValue(serde_json::Value::Number(value.into())))
+    }
+
+    fn visit_f64<E>(self, _value: f64) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        Err(E::custom("floating-point JSON numbers are unsupported"))
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        self.visit_string(value.to_owned())
+    }
+
+    fn visit_string<E>(self, value: String) -> Result<Self::Value, E> {
+        Ok(UniqueJsonValue(serde_json::Value::String(value)))
+    }
+
+    fn visit_none<E>(self) -> Result<Self::Value, E> {
+        Ok(UniqueJsonValue(serde_json::Value::Null))
+    }
+
+    fn visit_unit<E>(self) -> Result<Self::Value, E> {
+        Ok(UniqueJsonValue(serde_json::Value::Null))
+    }
+
+    fn visit_seq<A>(self, mut sequence: A) -> Result<Self::Value, A::Error>
+    where
+        A: serde::de::SeqAccess<'de>,
+    {
+        let mut values = Vec::with_capacity(sequence.size_hint().unwrap_or(0));
+        while let Some(UniqueJsonValue(value)) = sequence.next_element()? {
+            values.push(value);
+        }
+        Ok(UniqueJsonValue(serde_json::Value::Array(values)))
+    }
+
+    fn visit_map<A>(self, mut entries: A) -> Result<Self::Value, A::Error>
+    where
+        A: serde::de::MapAccess<'de>,
+    {
+        let mut values = serde_json::Map::new();
+        while let Some((key, UniqueJsonValue(value))) = entries.next_entry::<String, _>()? {
+            if values.contains_key(&key) {
+                return Err(serde::de::Error::custom(format!(
+                    "duplicate JSON object member: {key}"
+                )));
+            }
+            values.insert(key, value);
+        }
+        Ok(UniqueJsonValue(serde_json::Value::Object(values)))
+    }
+}
+
+#[cfg(all(test, feature = "token-binding"))]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::todo,
+    clippy::unimplemented,
+    clippy::indexing_slicing
+)]
+mod tests {
+    use super::*;
+
+    const HANDSHAKE_KEY: &str = "MDEyMzQ1Njc4OWFiY2RlZg==";
+    const NONCE: &str = "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8=";
+
+    #[derive(Deserialize)]
+    struct GoldenVectors {
+        handshake_key_base64: String,
+        nonce_base64: String,
+        derived_key_hex: String,
+        hkdf_info: String,
+        json_domain_hex: String,
+        json_input: String,
+        json_canonical: String,
+        json_sequence: u64,
+        json_signature_base64: String,
+        binary_domain_hex: String,
+        binary_payload_hex: String,
+        binary_sequence: u64,
+        binary_signature_base64: String,
+        binary_envelope_hex: String,
+    }
+
+    fn golden_vectors() -> GoldenVectors {
+        toml::from_str(include_str!("../tests/token-binding/vectors.toml"))
+            .expect("pinned token-binding vectors must parse")
+    }
+
+    fn challenge() -> TokenBindingChallenge {
+        TokenBindingChallenge {
+            version: 2,
+            scheme: TokenBindingScheme::ServerNonceHkdfSha256,
+            nonce: NONCE.to_string(),
+            first_sequence: 1,
+        }
+    }
+
+    fn decode_hex(raw: &str) -> Vec<u8> {
+        raw.as_bytes()
+            .chunks_exact(2)
+            .map(|pair| {
+                let digit = |byte: u8| match byte {
+                    b'0'..=b'9' => byte - b'0',
+                    b'a'..=b'f' => byte - b'a' + 10,
+                    _ => 0xff,
+                };
+                let high = digit(pair[0]);
+                let low = digit(pair[1]);
+                assert!(high < 16 && low < 16, "golden hex must be valid");
+                high * 16 + low
+            })
+            .collect()
+    }
+
+    fn encode_hex(bytes: &[u8]) -> String {
+        bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+    }
+
+    #[test]
+    fn server_070_json_and_binary_goldens_match_exactly() {
+        let vectors = golden_vectors();
+        let mut challenge = challenge();
+        challenge.nonce.clone_from(&vectors.nonce_base64);
+        let mut session =
+            TokenBindingSession::from_challenge(&vectors.handshake_key_base64, challenge)
+                .expect("pinned Server 0.7 challenge must derive a session");
+        assert_eq!(encode_hex(session.secret.as_ref()), vectors.derived_key_hex);
+        assert_eq!(HKDF_INFO, vectors.hkdf_info.as_bytes());
+        assert_eq!(encode_hex(JSON_DOMAIN), vectors.json_domain_hex);
+        assert_eq!(encode_hex(BINARY_DOMAIN), vectors.binary_domain_hex);
+        let UniqueJsonValue(unsigned_json) = serde_json::from_str(&vectors.json_input)
+            .expect("golden JSON must be unique and strict");
+        assert_eq!(
+            canonical_json(&unsigned_json).expect("golden JSON must canonicalize"),
+            vectors.json_canonical.as_bytes()
+        );
+
+        let input = TransportFrame::Text(vectors.json_input.clone());
+        let TransportFrame::Text(signed) = session
+            .prepare(&input)
+            .expect("golden JSON must be token-binding compatible")
+        else {
+            panic!("text input must produce text output");
+        };
+        let signed: serde_json::Value =
+            serde_json::from_str(&signed).expect("signed JSON must parse");
+        assert_eq!(
+            signed["token_binding"]["signature"],
+            vectors.json_signature_base64
+        );
+        assert_eq!(signed["token_binding"]["sequence"], vectors.json_sequence);
+        session
+            .commit()
+            .expect("accepting the JSON golden must advance sequence");
+
+        let payload = decode_hex(&vectors.binary_payload_hex);
+        let TransportFrame::Binary(signed) = session
+            .prepare(&TransportFrame::Binary(payload))
+            .expect("golden binary must be token-binding compatible")
+        else {
+            panic!("binary input must produce binary output");
+        };
+        assert_eq!(vectors.binary_sequence, vectors.json_sequence + 1);
+        assert!(
+            signed
+                .windows(vectors.binary_signature_base64.len())
+                .any(|window| window == vectors.binary_signature_base64.as_bytes()),
+            "binary envelope must contain the independently pinned signature"
+        );
+        assert_eq!(signed, decode_hex(&vectors.binary_envelope_hex));
+    }
+
+    #[test]
+    fn canonical_json_rejects_the_server_forbidden_input_class() {
+        let session = TokenBindingSession::from_challenge(HANDSHAKE_KEY, challenge())
+            .expect("test challenge must derive a session");
+        for raw in [
+            r#"{"type":"Ping","n":1.0}"#,
+            r#"{"type":"Ping","n":1e0}"#,
+            r#"{"type":"Ping","n":-0}"#,
+            r#"{"type":"Ping","n":9007199254740992}"#,
+            r#"{"type":"Ping","type":"Pong"}"#,
+            r#"{"type":"Ping","token_binding":{}}"#,
+            r#"["Ping"]"#,
+        ] {
+            assert!(matches!(
+                session.prepare(&TransportFrame::Text(raw.to_string())),
+                Err(SignalFishError::TokenBinding(
+                    TokenBindingFailure::UnsupportedJson
+                ))
+            ));
+        }
+    }
+
+    #[test]
+    fn malformed_challenges_fail_with_specific_non_secret_reasons() {
+        let cases = [
+            (
+                r#"{"type":"Other","data":{}}"#,
+                TokenBindingFailure::MalformedChallenge,
+            ),
+            (
+                r#"{"type":"TokenBindingChallenge","data":{"version":3,"scheme":"server_nonce_hkdf_sha256","nonce":"AA==","first_sequence":1}}"#,
+                TokenBindingFailure::UnsupportedVersion,
+            ),
+            (
+                r#"{"type":"TokenBindingChallenge","data":{"version":2,"scheme":"future","nonce":"AA==","first_sequence":1}}"#,
+                TokenBindingFailure::UnsupportedScheme,
+            ),
+            (
+                r#"{"type":"TokenBindingChallenge","data":{"version":2,"scheme":"server_nonce_hkdf_sha256","nonce":"AA==","first_sequence":2}}"#,
+                TokenBindingFailure::InvalidFirstSequence,
+            ),
+            (
+                r#"{"type":"TokenBindingChallenge","type":"TokenBindingChallenge","data":{}}"#,
+                TokenBindingFailure::MalformedChallenge,
+            ),
+        ];
+        for (raw, expected) in cases {
+            assert!(matches!(
+                parse_challenge(raw).expect_err("malformed challenge must fail"),
+                SignalFishError::TokenBinding(actual) if actual == expected
+            ));
+        }
+    }
+
+    #[test]
+    fn debug_and_errors_omit_handshake_and_proof_material() {
+        let challenge = challenge();
+        let session = TokenBindingSession::from_challenge(HANDSHAKE_KEY, challenge.clone())
+            .expect("test challenge must derive a session");
+        let signed = session
+            .prepare(&TransportFrame::Text(r#"{"type":"Ping"}"#.to_string()))
+            .expect("Ping must be signable");
+        let TransportFrame::Text(signed) = signed else {
+            panic!("Ping must stay a text frame");
+        };
+        let proof: serde_json::Value =
+            serde_json::from_str(&signed).expect("signed Ping must parse");
+        let signature = proof["token_binding"]["signature"]
+            .as_str()
+            .expect("proof must contain a signature");
+        for output in [
+            format!("{challenge:?}"),
+            format!("{session:?}"),
+            format!(
+                "{:?}",
+                SignalFishError::TokenBinding(TokenBindingFailure::InvalidHandshakeKey)
+            ),
+            SignalFishError::TokenBinding(TokenBindingFailure::InvalidHandshakeKey).to_string(),
+        ] {
+            assert!(
+                !output.contains(HANDSHAKE_KEY),
+                "handshake key leaked: {output}"
+            );
+            assert!(!output.contains(NONCE), "challenge nonce leaked: {output}");
+            assert!(
+                !output.contains(signature),
+                "proof signature leaked: {output}"
+            );
+            assert!(
+                !output.contains("Ping"),
+                "application payload leaked: {output}"
+            );
+        }
+    }
+
+    #[test]
+    fn sequence_exhaustion_is_fail_closed() {
+        let mut session = TokenBindingSession::from_challenge(HANDSHAKE_KEY, challenge())
+            .expect("test challenge must derive a session");
+        session.next_sequence = MAX_SAFE_INTEGER;
+        assert!(session
+            .prepare(&TransportFrame::Text(r#"{"type":"Ping"}"#.to_string()))
+            .is_ok());
+        session
+            .commit()
+            .expect("the final safe sequence may be accepted");
+        assert!(matches!(
+            session.prepare(&TransportFrame::Text(r#"{"type":"Ping"}"#.to_string())),
+            Err(SignalFishError::TokenBinding(
+                TokenBindingFailure::SequenceExhausted
+            ))
+        ));
+    }
+}

--- a/src/transports/websocket.rs
+++ b/src/transports/websocket.rs
@@ -30,9 +30,12 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use futures_util::{Sink, Stream};
+#[cfg(feature = "token-binding")]
+use futures_util::{SinkExt as _, StreamExt as _};
 use tokio_tungstenite::tungstenite::{protocol::Message, Error as WebSocketError};
 
 use crate::error::SignalFishError;
+use crate::token_binding::{TokenBindingChallenge, TokenBindingMode, TokenBindingStatus};
 use crate::transport::{Transport, TransportCloseInfo, TransportFrame};
 
 /// Type alias for the underlying WebSocket stream.
@@ -43,6 +46,162 @@ pub type WsStream =
     tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>;
 
 const MAX_SKIPPED_CONTROL_FRAMES_PER_POLL: usize = 64;
+
+fn map_connect_error(error: WebSocketError) -> SignalFishError {
+    let kind = match &error {
+        WebSocketError::Io(io) => io.kind(),
+        _ => std::io::ErrorKind::Other,
+    };
+    SignalFishError::Io(std::io::Error::new(kind, error))
+}
+
+#[cfg(feature = "tls")]
+fn install_tls_provider() {
+    use std::sync::Once;
+    static INSTALL: Once = Once::new();
+    INSTALL.call_once(|| {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+    });
+}
+
+#[cfg(feature = "token-binding")]
+async fn connect_with_token_binding(
+    url: &str,
+    options: WebSocketConnectOptions,
+    #[cfg(feature = "tls")] connector: Option<tokio_tungstenite::Connector>,
+) -> Result<(WsStream, WebSocketTokenBinding), SignalFishError> {
+    use tokio_tungstenite::tungstenite::client::IntoClientRequest as _;
+    use tokio_tungstenite::tungstenite::error::{ProtocolError, SubProtocolError};
+    use tokio_tungstenite::tungstenite::http::header::{SEC_WEBSOCKET_KEY, SEC_WEBSOCKET_PROTOCOL};
+
+    let mut request = url.into_client_request().map_err(map_connect_error)?;
+    let handshake_key = zeroize::Zeroizing::new(
+        request
+            .headers()
+            .get(SEC_WEBSOCKET_KEY)
+            .and_then(|value| value.to_str().ok())
+            .ok_or(SignalFishError::TokenBinding(
+                crate::TokenBindingFailure::InvalidHandshakeKey,
+            ))?
+            .to_owned(),
+    );
+    request.headers_mut().insert(
+        SEC_WEBSOCKET_PROTOCOL,
+        tokio_tungstenite::tungstenite::http::HeaderValue::from_static(
+            crate::token_binding::TOKEN_BINDING_SUBPROTOCOL,
+        ),
+    );
+
+    #[cfg(feature = "tls")]
+    let connected = tokio_tungstenite::connect_async_tls_with_config(
+        request,
+        None,
+        options.disable_nagle,
+        connector.clone(),
+    )
+    .await;
+    #[cfg(not(feature = "tls"))]
+    let connected =
+        tokio_tungstenite::connect_async_with_config(request, None, options.disable_nagle).await;
+    let (mut stream, _response) = match connected {
+        Ok(connected) => connected,
+        Err(WebSocketError::Protocol(ProtocolError::SecWebSocketSubProtocolError(
+            SubProtocolError::NoSubProtocol,
+        ))) if options.token_binding == TokenBindingMode::Optional => {
+            // Tungstenite rejects an otherwise successful 101 when an offered
+            // subprotocol is omitted. That exact response proves the server
+            // permits an unsigned connection; reconnect without the offer.
+            #[cfg(feature = "tls")]
+            let fallback = tokio_tungstenite::connect_async_tls_with_config(
+                url,
+                None,
+                options.disable_nagle,
+                connector,
+            )
+            .await;
+            #[cfg(not(feature = "tls"))]
+            let fallback =
+                tokio_tungstenite::connect_async_with_config(url, None, options.disable_nagle)
+                    .await;
+            let (stream, _response) = fallback.map_err(|error| match error {
+                WebSocketError::Http(_) => {
+                    SignalFishError::TokenBinding(crate::TokenBindingFailure::NegotiationRejected)
+                }
+                error => map_connect_error(error),
+            })?;
+            return Ok((stream, WebSocketTokenBinding::NotNegotiated));
+        }
+        Err(WebSocketError::Protocol(ProtocolError::SecWebSocketSubProtocolError(
+            SubProtocolError::NoSubProtocol,
+        ))) => {
+            return Err(SignalFishError::TokenBinding(
+                crate::TokenBindingFailure::SubprotocolNotNegotiated,
+            ))
+        }
+        Err(WebSocketError::Protocol(ProtocolError::SecWebSocketSubProtocolError(
+            SubProtocolError::InvalidSubProtocol
+            | SubProtocolError::ServerSentSubProtocolNoneRequested,
+        ))) => {
+            return Err(SignalFishError::TokenBinding(
+                crate::TokenBindingFailure::UnexpectedSubprotocol,
+            ))
+        }
+        Err(WebSocketError::Http(_)) => {
+            return Err(SignalFishError::TokenBinding(
+                crate::TokenBindingFailure::NegotiationRejected,
+            ))
+        }
+        Err(error) => return Err(map_connect_error(error)),
+    };
+
+    let challenge = tokio::time::timeout(
+        options.token_binding_challenge_timeout,
+        receive_token_binding_challenge(&mut stream),
+    )
+    .await
+    .map_err(|_| SignalFishError::TokenBinding(crate::TokenBindingFailure::ChallengeTimeout))??;
+    let session = crate::token_binding::TokenBindingSession::from_challenge(
+        handshake_key.as_str(),
+        challenge,
+    )?;
+    Ok((stream, WebSocketTokenBinding::Active(Some(session))))
+}
+
+#[cfg(feature = "token-binding")]
+async fn receive_token_binding_challenge(
+    stream: &mut WsStream,
+) -> Result<TokenBindingChallenge, SignalFishError> {
+    for _ in 0..MAX_SKIPPED_CONTROL_FRAMES_PER_POLL {
+        let message = stream
+            .next()
+            .await
+            .ok_or(SignalFishError::TokenBinding(
+                crate::TokenBindingFailure::MissingChallenge,
+            ))?
+            .map_err(|error| SignalFishError::TransportReceive(error.to_string()))?;
+        match message {
+            Message::Text(text) => return crate::token_binding::parse_challenge(&text),
+            Message::Ping(_) => stream
+                .flush()
+                .await
+                .map_err(|error| SignalFishError::TransportSend(error.to_string()))?,
+            Message::Pong(_) | Message::Frame(_) => {}
+            Message::Close(_) => {
+                return Err(SignalFishError::TokenBinding(
+                    crate::TokenBindingFailure::MissingChallenge,
+                ))
+            }
+            Message::Binary(_) => {
+                return Err(SignalFishError::TokenBinding(
+                    crate::TokenBindingFailure::MalformedChallenge,
+                ))
+            }
+        }
+    }
+    Err(SignalFishError::TokenBinding(
+        crate::TokenBindingFailure::MalformedChallenge,
+    ))
+}
 
 /// Options controlling how a [`WebSocketTransport`] connection is established.
 ///
@@ -74,6 +233,16 @@ pub struct WebSocketConnectOptions {
     /// Applied to the raw socket before any TLS handshake, so it covers both
     /// `ws://` and `wss://`.
     pub disable_nagle: bool,
+    /// Token-binding-v2 negotiation policy.
+    ///
+    /// Defaults to [`TokenBindingMode::Disabled`]. Optional or required mode
+    /// needs the crate's `token-binding` feature; otherwise connection fails
+    /// with a typed [`SignalFishError::TokenBinding`] error.
+    pub token_binding: TokenBindingMode,
+    /// Maximum wait for the first token-binding challenge after negotiation.
+    ///
+    /// Defaults to 10 seconds and is ignored when token binding is not selected.
+    pub token_binding_challenge_timeout: std::time::Duration,
 }
 
 impl Default for WebSocketConnectOptions {
@@ -81,6 +250,8 @@ impl Default for WebSocketConnectOptions {
         // NB: a *derived* `Default` would yield `false`; the low-latency default is `true`.
         Self {
             disable_nagle: true,
+            token_binding: TokenBindingMode::Disabled,
+            token_binding_challenge_timeout: std::time::Duration::from_secs(10),
         }
     }
 }
@@ -98,6 +269,20 @@ impl WebSocketConnectOptions {
     #[must_use]
     pub fn with_disable_nagle(mut self, disable_nagle: bool) -> Self {
         self.disable_nagle = disable_nagle;
+        self
+    }
+
+    /// Set whether token-binding-v2 is disabled, optional, or required.
+    #[must_use]
+    pub fn with_token_binding(mut self, mode: TokenBindingMode) -> Self {
+        self.token_binding = mode;
+        self
+    }
+
+    /// Set the deadline for receiving the negotiated server challenge.
+    #[must_use]
+    pub fn with_token_binding_challenge_timeout(mut self, timeout: std::time::Duration) -> Self {
+        self.token_binding_challenge_timeout = timeout;
         self
     }
 }
@@ -121,7 +306,8 @@ impl WebSocketConnectOptions {
 /// ```
 ///
 /// For advanced use-cases (custom TLS, proxy, headers) construct the stream
-/// yourself and use [`WebSocketTransport::from_stream`].
+/// yourself and use [`WebSocketTransport::from_stream`]. Because that receives
+/// an already-completed handshake, it cannot enable token binding.
 ///
 /// # Polling Safety
 ///
@@ -140,6 +326,67 @@ struct WebSocketState<S> {
     send_started: bool,
     control_flush_pending: bool,
     peer_close_pending: bool,
+    token_binding: WebSocketTokenBinding,
+}
+
+enum WebSocketTokenBinding {
+    Disabled,
+    #[cfg(feature = "token-binding")]
+    NotNegotiated,
+    #[cfg(feature = "token-binding")]
+    Active(Option<crate::token_binding::TokenBindingSession>),
+}
+
+impl WebSocketTokenBinding {
+    fn status(&self) -> TokenBindingStatus {
+        match self {
+            Self::Disabled => TokenBindingStatus::Disabled,
+            #[cfg(feature = "token-binding")]
+            Self::NotNegotiated => TokenBindingStatus::NotNegotiated,
+            #[cfg(feature = "token-binding")]
+            Self::Active(_) => TokenBindingStatus::Active,
+        }
+    }
+
+    fn challenge(&self) -> Option<&TokenBindingChallenge> {
+        match self {
+            #[cfg(feature = "token-binding")]
+            Self::Active(Some(session)) => Some(session.challenge()),
+            #[cfg(feature = "token-binding")]
+            Self::Active(None) => None,
+            Self::Disabled => None,
+            #[cfg(feature = "token-binding")]
+            Self::NotNegotiated => None,
+        }
+    }
+
+    fn is_active(&self) -> bool {
+        matches!(self.status(), TokenBindingStatus::Active)
+    }
+
+    fn prepare(&self, frame: &TransportFrame) -> Result<TransportFrame, SignalFishError> {
+        match self {
+            #[cfg(feature = "token-binding")]
+            Self::Active(Some(session)) => session.prepare(frame),
+            #[cfg(feature = "token-binding")]
+            Self::Active(None) => Err(SignalFishError::TransportClosed),
+            Self::Disabled => Ok(frame.clone()),
+            #[cfg(feature = "token-binding")]
+            Self::NotNegotiated => Ok(frame.clone()),
+        }
+    }
+
+    fn commit(&mut self) -> Result<(), SignalFishError> {
+        match self {
+            #[cfg(feature = "token-binding")]
+            Self::Active(Some(session)) => session.commit(),
+            #[cfg(feature = "token-binding")]
+            Self::Active(None) => Err(SignalFishError::TransportClosed),
+            Self::Disabled => Ok(()),
+            #[cfg(feature = "token-binding")]
+            Self::NotNegotiated => Ok(()),
+        }
+    }
 }
 
 impl std::fmt::Debug for WebSocketTransport {
@@ -153,12 +400,17 @@ impl std::fmt::Debug for WebSocketTransport {
             .field("send_started", &self.state.send_started)
             .field("control_flush_pending", &self.state.control_flush_pending)
             .field("peer_close_pending", &self.state.peer_close_pending)
+            .field("token_binding", &self.state.token_binding.status())
             .finish()
     }
 }
 
 impl<S> WebSocketState<S> {
     fn new(stream: S) -> Self {
+        Self::new_with_token_binding(stream, WebSocketTokenBinding::Disabled)
+    }
+
+    fn new_with_token_binding(stream: S, token_binding: WebSocketTokenBinding) -> Self {
         Self {
             stream: Some(stream),
             closed: false,
@@ -166,6 +418,7 @@ impl<S> WebSocketState<S> {
             send_started: false,
             control_flush_pending: false,
             peer_close_pending: false,
+            token_binding,
         }
     }
 
@@ -175,6 +428,12 @@ impl<S> WebSocketState<S> {
         self.send_started = false;
         self.control_flush_pending = false;
         self.peer_close_pending = false;
+        #[cfg(feature = "token-binding")]
+        if let WebSocketTokenBinding::Active(session) = &mut self.token_binding {
+            // Drop and zeroize the derived key/challenge as soon as the
+            // physical connection becomes terminal while preserving status.
+            *session = None;
+        }
     }
 
     fn close_info(&self) -> Option<TransportCloseInfo> {
@@ -210,50 +469,64 @@ impl WebSocketTransport {
     /// [`WebSocketConnectOptions`].
     ///
     /// Behaves like [`connect`](Self::connect) but lets the caller control
-    /// socket tuning — currently whether Nagle's algorithm is disabled
-    /// (`TCP_NODELAY`). The option is applied to the raw socket before any TLS
-    /// handshake, so it covers both `ws://` and `wss://`.
+    /// socket tuning and token-binding negotiation policy. Socket options are
+    /// applied before any TLS handshake, so they cover both `ws://` and
+    /// `wss://`. A selected token-binding challenge is consumed before this
+    /// method returns.
     ///
     /// # Errors
     ///
     /// Returns [`SignalFishError::Io`] if the URL is invalid or the connection
     /// cannot be established. When the underlying error is an I/O error its
     /// [`ErrorKind`](std::io::ErrorKind) is preserved; all other errors are
-    /// mapped to [`ErrorKind::Other`](std::io::ErrorKind::Other).
+    /// mapped to [`ErrorKind::Other`](std::io::ErrorKind::Other). Optional or
+    /// required mode returns [`SignalFishError::TokenBinding`] when the feature
+    /// is disabled or negotiation, challenge validation, or key derivation
+    /// fails.
     pub async fn connect_with_options(
         url: &str,
         options: WebSocketConnectOptions,
     ) -> Result<Self, SignalFishError> {
-        #[cfg(feature = "tls")]
-        {
-            // Ensure a rustls crypto provider is installed process-wide so the
-            // wss:// path below cannot panic when the dependency graph enables
-            // both `ring` and `aws_lc_rs` (rustls' auto-detection panics on that
-            // ambiguity). Idempotent and first-wins: yields to any provider the
-            // application already installed.
-            use std::sync::Once;
-            static INSTALL: Once = Once::new();
-            INSTALL.call_once(|| {
-                let _ = rustls::crypto::ring::default_provider().install_default();
-            });
+        #[cfg(not(feature = "token-binding"))]
+        if options.token_binding != TokenBindingMode::Disabled {
+            return Err(SignalFishError::TokenBinding(
+                crate::TokenBindingFailure::FeatureDisabled,
+            ));
         }
+
+        #[cfg(feature = "tls")]
+        install_tls_provider();
 
         tracing::debug!(
             secure = url.starts_with("wss://"),
             disable_nagle = options.disable_nagle,
+            token_binding = ?options.token_binding,
             "connecting to WebSocket server"
         );
 
-        let (stream, _response) =
-            tokio_tungstenite::connect_async_with_config(url, None, options.disable_nagle)
-                .await
-                .map_err(|e| {
-                    let kind = match &e {
-                        tokio_tungstenite::tungstenite::Error::Io(io) => io.kind(),
-                        _ => std::io::ErrorKind::Other,
-                    };
-                    SignalFishError::Io(std::io::Error::new(kind, e))
-                })?;
+        #[cfg(feature = "token-binding")]
+        let (stream, token_binding) = if options.token_binding == TokenBindingMode::Disabled {
+            let (stream, _response) =
+                tokio_tungstenite::connect_async_with_config(url, None, options.disable_nagle)
+                    .await
+                    .map_err(map_connect_error)?;
+            (stream, WebSocketTokenBinding::Disabled)
+        } else {
+            #[cfg(feature = "tls")]
+            let connected = connect_with_token_binding(url, options, None).await?;
+            #[cfg(not(feature = "tls"))]
+            let connected = connect_with_token_binding(url, options).await?;
+            connected
+        };
+
+        #[cfg(not(feature = "token-binding"))]
+        let (stream, token_binding) = {
+            let (stream, _response) =
+                tokio_tungstenite::connect_async_with_config(url, None, options.disable_nagle)
+                    .await
+                    .map_err(map_connect_error)?;
+            (stream, WebSocketTokenBinding::Disabled)
+        };
 
         tracing::info!(
             secure = url.starts_with("wss://"),
@@ -261,7 +534,78 @@ impl WebSocketTransport {
         );
 
         Ok(Self {
-            state: WebSocketState::new(stream),
+            state: WebSocketState::new_with_token_binding(stream, token_binding),
+        })
+    }
+
+    /// Establish a native WebSocket with an explicit rustls client configuration.
+    ///
+    /// This is the token-binding-capable path for private roots, custom trust
+    /// stores, and mTLS. The configuration is used only during connection setup
+    /// and is not retained or formatted by the transport.
+    ///
+    /// # Errors
+    ///
+    /// Returns the same connection and token-binding errors as
+    /// [`connect_with_options`](Self::connect_with_options).
+    #[cfg(feature = "tls")]
+    pub async fn connect_with_tls_config(
+        url: &str,
+        options: WebSocketConnectOptions,
+        tls_config: std::sync::Arc<rustls::ClientConfig>,
+    ) -> Result<Self, SignalFishError> {
+        #[cfg(not(feature = "token-binding"))]
+        if options.token_binding != TokenBindingMode::Disabled {
+            return Err(SignalFishError::TokenBinding(
+                crate::TokenBindingFailure::FeatureDisabled,
+            ));
+        }
+
+        install_tls_provider();
+        let connector = tokio_tungstenite::Connector::Rustls(tls_config);
+        tracing::debug!(
+            secure = url.starts_with("wss://"),
+            disable_nagle = options.disable_nagle,
+            token_binding = ?options.token_binding,
+            custom_tls = true,
+            "connecting to WebSocket server"
+        );
+
+        #[cfg(feature = "token-binding")]
+        let (stream, token_binding) = if options.token_binding == TokenBindingMode::Disabled {
+            let (stream, _response) = tokio_tungstenite::connect_async_tls_with_config(
+                url,
+                None,
+                options.disable_nagle,
+                Some(connector),
+            )
+            .await
+            .map_err(map_connect_error)?;
+            (stream, WebSocketTokenBinding::Disabled)
+        } else {
+            connect_with_token_binding(url, options, Some(connector)).await?
+        };
+
+        #[cfg(not(feature = "token-binding"))]
+        let (stream, token_binding) = {
+            let (stream, _response) = tokio_tungstenite::connect_async_tls_with_config(
+                url,
+                None,
+                options.disable_nagle,
+                Some(connector),
+            )
+            .await
+            .map_err(map_connect_error)?;
+            (stream, WebSocketTokenBinding::Disabled)
+        };
+
+        tracing::info!(
+            secure = url.starts_with("wss://"),
+            custom_tls = true,
+            "WebSocket connection established"
+        );
+        Ok(Self {
+            state: WebSocketState::new_with_token_binding(stream, token_binding),
         })
     }
 
@@ -273,10 +617,28 @@ impl WebSocketTransport {
     /// Unlike [`connect`](Self::connect), this does **not** touch socket options:
     /// the caller owns the stream and is responsible for `TCP_NODELAY` (Nagle) or
     /// any other tuning on the underlying socket before wrapping it here.
+    /// It also cannot enable token binding: an established stream no longer
+    /// exposes the exact generated `Sec-WebSocket-Key`, so callers needing that
+    /// extension must own the full handshake/proof wrapper or use a connect API.
     pub fn from_stream(stream: WsStream) -> Self {
         Self {
             state: WebSocketState::new(stream),
         }
+    }
+
+    /// Return the negotiated token-binding state for this physical connection.
+    #[must_use]
+    pub fn token_binding_status(&self) -> TokenBindingStatus {
+        self.state.token_binding.status()
+    }
+
+    /// Return the validated server challenge when token binding is active.
+    ///
+    /// The transport consumes this challenge internally before it can sign any
+    /// application frame. Callers normally need only [`token_binding_status`](Self::token_binding_status).
+    #[must_use]
+    pub fn token_binding_challenge(&self) -> Option<&TokenBindingChallenge> {
+        self.state.token_binding.challenge()
     }
 
     /// Establish a new WebSocket connection with a timeout.
@@ -340,8 +702,20 @@ where
                 }
                 Poll::Ready(Ok(())) => {}
             }
-            let Some(accepted_frame) = frame.take() else {
+            let token_binding_active = self.token_binding.is_active();
+            let Some(original_frame) = frame.as_ref() else {
                 return Poll::Ready(Ok(()));
+            };
+            let accepted_frame = if token_binding_active {
+                match self.token_binding.prepare(original_frame) {
+                    Ok(prepared) => prepared,
+                    Err(error) => return Poll::Ready(Err(error)),
+                }
+            } else {
+                let Some(frame) = frame.take() else {
+                    return Poll::Ready(Ok(()));
+                };
+                frame
             };
             let message = match accepted_frame {
                 TransportFrame::Text(text) => Message::Text(text.into()),
@@ -357,38 +731,44 @@ where
             if let Err(error) = send_result {
                 let detail = error.to_string();
                 if let WebSocketError::WriteBufferFull(message) = error {
-                    let restored = match *message {
-                        Message::Text(text) => {
-                            *frame = Some(TransportFrame::Text(text.to_string()));
-                            true
-                        }
-                        Message::Binary(bytes) => {
-                            *frame = Some(TransportFrame::Binary(bytes.to_vec()));
-                            true
-                        }
-                        Message::Frame(frame_data) => {
-                            use tokio_tungstenite::tungstenite::protocol::frame::coding::{
-                                Data, OpCode,
-                            };
+                    let restored = if token_binding_active {
+                        // The exact original remains in the caller slot. Never
+                        // restore the protected envelope or a retry would wrap it twice.
+                        true
+                    } else {
+                        match *message {
+                            Message::Text(text) => {
+                                *frame = Some(TransportFrame::Text(text.to_string()));
+                                true
+                            }
+                            Message::Binary(bytes) => {
+                                *frame = Some(TransportFrame::Binary(bytes.to_vec()));
+                                true
+                            }
+                            Message::Frame(frame_data) => {
+                                use tokio_tungstenite::tungstenite::protocol::frame::coding::{
+                                    Data, OpCode,
+                                };
 
-                            match frame_data.header().opcode {
-                                OpCode::Data(Data::Text) => match frame_data.into_text() {
-                                    Ok(text) => {
-                                        *frame = Some(TransportFrame::Text(text.to_string()));
+                                match frame_data.header().opcode {
+                                    OpCode::Data(Data::Text) => match frame_data.into_text() {
+                                        Ok(text) => {
+                                            *frame = Some(TransportFrame::Text(text.to_string()));
+                                            true
+                                        }
+                                        Err(_) => false,
+                                    },
+                                    OpCode::Data(Data::Binary) => {
+                                        *frame = Some(TransportFrame::Binary(
+                                            frame_data.into_payload().to_vec(),
+                                        ));
                                         true
                                     }
-                                    Err(_) => false,
-                                },
-                                OpCode::Data(Data::Binary) => {
-                                    *frame = Some(TransportFrame::Binary(
-                                        frame_data.into_payload().to_vec(),
-                                    ));
-                                    true
+                                    _ => false,
                                 }
-                                _ => false,
                             }
+                            _ => false,
                         }
-                        _ => false,
                     };
                     if !restored {
                         self.mark_terminal();
@@ -397,6 +777,13 @@ where
                     self.mark_terminal();
                 }
                 return Poll::Ready(Err(SignalFishError::TransportSend(detail)));
+            }
+            if token_binding_active {
+                let _accepted_original = frame.take();
+                if let Err(error) = self.token_binding.commit() {
+                    self.mark_terminal();
+                    return Poll::Ready(Err(error));
+                }
             }
             self.send_started = true;
         }
@@ -632,7 +1019,8 @@ impl Transport for WebSocketTransport {
     clippy::panic,
     clippy::todo,
     clippy::unimplemented,
-    clippy::indexing_slicing
+    clippy::indexing_slicing,
+    clippy::result_large_err
 )]
 mod tests {
     use super::*;
@@ -666,6 +1054,22 @@ mod tests {
         let result = WebSocketTransport::connect("ws://127.0.0.1:1").await;
         let err = result.unwrap_err();
         assert!(matches!(err, SignalFishError::Io(_)));
+    }
+
+    #[cfg(not(feature = "token-binding"))]
+    #[tokio::test]
+    async fn non_disabled_mode_requires_the_token_binding_feature() {
+        let result = WebSocketTransport::connect_with_options(
+            "ws://127.0.0.1:1",
+            WebSocketConnectOptions::new().with_token_binding(TokenBindingMode::Required),
+        )
+        .await;
+        assert!(matches!(
+            result,
+            Err(SignalFishError::TokenBinding(
+                crate::TokenBindingFailure::FeatureDisabled
+            ))
+        ));
     }
 
     // ── Mock-stream helpers ──────────────────────────────────────────────
@@ -707,6 +1111,328 @@ mod tests {
             .await
             .expect("mock WebSocket server must finish promptly")
             .expect("mock WebSocket server must not panic");
+    }
+
+    #[cfg(feature = "token-binding")]
+    fn required_token_binding_options() -> WebSocketConnectOptions {
+        WebSocketConnectOptions::new().with_token_binding(TokenBindingMode::Required)
+    }
+
+    #[cfg(feature = "token-binding")]
+    fn challenge_json() -> &'static str {
+        r#"{"type":"TokenBindingChallenge","data":{"version":2,"scheme":"server_nonce_hkdf_sha256","nonce":"AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8=","first_sequence":1}}"#
+    }
+
+    #[tokio::test]
+    async fn default_connect_does_not_offer_a_subprotocol() {
+        use tokio_tungstenite::tungstenite::http::header::SEC_WEBSOCKET_PROTOCOL;
+
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("default-handshake listener must bind");
+        let addr = listener
+            .local_addr()
+            .expect("default-handshake listener must have an address");
+        let server_task = tokio::spawn(async move {
+            let (tcp, _) = listener.accept().await.expect("server must accept client");
+            let mut ws = tokio_tungstenite::accept_hdr_async(
+                tcp,
+                |request: &tokio_tungstenite::tungstenite::handshake::server::Request, response| {
+                    assert!(
+                        request.headers().get(SEC_WEBSOCKET_PROTOCOL).is_none(),
+                        "disabled/default mode must not change the WebSocket handshake"
+                    );
+                    Ok(response)
+                },
+            )
+            .await
+            .expect("default handshake must succeed");
+            assert_eq!(
+                ws.next()
+                    .await
+                    .expect("client must send one frame")
+                    .expect("client frame must be valid"),
+                Message::Text(r#"{"type":"Ping"}"#.into())
+            );
+        });
+
+        let mut transport = WebSocketTransport::connect(&format!("ws://{addr}"))
+            .await
+            .expect("default connect must succeed");
+        assert_eq!(
+            transport.token_binding_status(),
+            TokenBindingStatus::Disabled
+        );
+        let mut frame = Some(TransportFrame::Text(r#"{"type":"Ping"}"#.to_string()));
+        std::future::poll_fn(|cx| transport.poll_send(cx, &mut frame))
+            .await
+            .expect("default frame must send");
+        assert!(frame.is_none());
+        finish_mock_server(server_task).await;
+    }
+
+    #[cfg(feature = "token-binding")]
+    #[tokio::test]
+    async fn required_mode_selects_and_consumes_challenge_before_sending() {
+        use tokio_tungstenite::tungstenite::http::header::SEC_WEBSOCKET_PROTOCOL;
+
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("required-handshake listener must bind");
+        let addr = listener
+            .local_addr()
+            .expect("required-handshake listener must have an address");
+        let server_task = tokio::spawn(async move {
+            let (tcp, _) = listener.accept().await.expect("server must accept client");
+            let mut ws = tokio_tungstenite::accept_hdr_async(
+                tcp,
+                |request: &tokio_tungstenite::tungstenite::handshake::server::Request, mut response: tokio_tungstenite::tungstenite::handshake::server::Response| {
+                    assert_eq!(
+                        request
+                            .headers()
+                            .get(SEC_WEBSOCKET_PROTOCOL)
+                            .and_then(|value| value.to_str().ok()),
+                        Some(crate::token_binding::TOKEN_BINDING_SUBPROTOCOL)
+                    );
+                    response.headers_mut().insert(
+                        SEC_WEBSOCKET_PROTOCOL,
+                        tokio_tungstenite::tungstenite::http::HeaderValue::from_static(
+                            crate::token_binding::TOKEN_BINDING_SUBPROTOCOL,
+                        ),
+                    );
+                    Ok(response)
+                },
+            )
+            .await
+            .expect("required handshake must succeed");
+            ws.send(Message::Text(challenge_json().into()))
+                .await
+                .expect("server must send challenge");
+            let signed = ws
+                .next()
+                .await
+                .expect("client must send after challenge")
+                .expect("signed client frame must be valid")
+                .into_text()
+                .expect("Ping must remain text");
+            let signed: serde_json::Value =
+                serde_json::from_str(&signed).expect("signed Ping must parse");
+            assert_eq!(signed["type"], "Ping");
+            assert_eq!(signed["token_binding"]["sequence"], 1);
+            assert!(signed["token_binding"]["signature"].is_string());
+        });
+
+        let mut transport = WebSocketTransport::connect_with_options(
+            &format!("ws://{addr}"),
+            required_token_binding_options(),
+        )
+        .await
+        .expect("required token binding must connect");
+        assert_eq!(transport.token_binding_status(), TokenBindingStatus::Active);
+        assert!(transport.token_binding_challenge().is_some());
+        let mut frame = Some(TransportFrame::Text(r#"{"type":"Ping"}"#.to_string()));
+        std::future::poll_fn(|cx| transport.poll_send(cx, &mut frame))
+            .await
+            .expect("signed Ping must send");
+        assert!(frame.is_none());
+        finish_mock_server(server_task).await;
+    }
+
+    #[cfg(feature = "token-binding")]
+    #[tokio::test]
+    async fn optional_mode_retries_only_after_unsigned_upgrade_is_permitted() {
+        use tokio_tungstenite::tungstenite::http::header::SEC_WEBSOCKET_PROTOCOL;
+
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("optional-handshake listener must bind");
+        let addr = listener
+            .local_addr()
+            .expect("optional-handshake listener must have an address");
+        let server_task = tokio::spawn(async move {
+            let (first, _) = listener.accept().await.expect("server must accept offer");
+            let mut first = tokio_tungstenite::accept_hdr_async(
+                first,
+                |request: &tokio_tungstenite::tungstenite::handshake::server::Request, response| {
+                    assert!(request.headers().get(SEC_WEBSOCKET_PROTOCOL).is_some());
+                    Ok(response)
+                },
+            )
+            .await
+            .expect("server permits unsigned first upgrade");
+            let _closed_first_attempt = first.next().await;
+
+            let (second, _) = listener
+                .accept()
+                .await
+                .expect("server must accept fallback");
+            let mut second = tokio_tungstenite::accept_hdr_async(
+                second,
+                |request: &tokio_tungstenite::tungstenite::handshake::server::Request, response| {
+                    assert!(request.headers().get(SEC_WEBSOCKET_PROTOCOL).is_none());
+                    Ok(response)
+                },
+            )
+            .await
+            .expect("unsigned fallback handshake must succeed");
+            while second.next().await.is_some() {}
+        });
+
+        let transport = WebSocketTransport::connect_with_options(
+            &format!("ws://{addr}"),
+            WebSocketConnectOptions::new().with_token_binding(TokenBindingMode::Optional),
+        )
+        .await
+        .expect("optional mode must accept server-permitted fallback");
+        assert_eq!(
+            transport.token_binding_status(),
+            TokenBindingStatus::NotNegotiated
+        );
+        drop(transport);
+        finish_mock_server(server_task).await;
+    }
+
+    #[cfg(feature = "token-binding")]
+    #[tokio::test]
+    async fn optional_mode_does_not_retry_an_http_rejection() {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("rejection listener must bind");
+        let addr = listener
+            .local_addr()
+            .expect("rejection listener must have an address");
+        let server_task = tokio::spawn(async move {
+            let (mut tcp, _) = listener.accept().await.expect("server must accept offer");
+            tcp.write_all(
+                b"HTTP/1.1 403 Forbidden\r\nConnection: close\r\nContent-Length: 0\r\n\r\n",
+            )
+            .await
+            .expect("server must reject the offered handshake");
+            drop(tcp);
+
+            assert!(
+                tokio::time::timeout(std::time::Duration::from_millis(100), listener.accept())
+                    .await
+                    .is_err(),
+                "HTTP rejection must not trigger an unsigned fallback"
+            );
+        });
+
+        let error = WebSocketTransport::connect_with_options(
+            &format!("ws://{addr}"),
+            WebSocketConnectOptions::new().with_token_binding(TokenBindingMode::Optional),
+        )
+        .await
+        .expect_err("optional mode must preserve an HTTP rejection");
+        assert!(matches!(
+            error,
+            SignalFishError::TokenBinding(crate::TokenBindingFailure::NegotiationRejected)
+        ));
+        finish_mock_server(server_task).await;
+    }
+
+    #[cfg(feature = "token-binding")]
+    #[tokio::test]
+    async fn selected_mode_times_out_waiting_for_the_first_challenge() {
+        use tokio_tungstenite::tungstenite::http::header::SEC_WEBSOCKET_PROTOCOL;
+
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("challenge-timeout listener must bind");
+        let addr = listener
+            .local_addr()
+            .expect("challenge-timeout listener must have an address");
+        let server_task = tokio::spawn(async move {
+            let (tcp, _) = listener.accept().await.expect("server must accept client");
+            let _ws = tokio_tungstenite::accept_hdr_async(
+                tcp,
+                |_request: &tokio_tungstenite::tungstenite::handshake::server::Request,
+                 mut response: tokio_tungstenite::tungstenite::handshake::server::Response| {
+                    response.headers_mut().insert(
+                        SEC_WEBSOCKET_PROTOCOL,
+                        tokio_tungstenite::tungstenite::http::HeaderValue::from_static(
+                            crate::token_binding::TOKEN_BINDING_SUBPROTOCOL,
+                        ),
+                    );
+                    Ok(response)
+                },
+            )
+            .await
+            .expect("selected handshake must succeed");
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        });
+
+        let options = required_token_binding_options()
+            .with_token_binding_challenge_timeout(std::time::Duration::from_millis(20));
+        let error = WebSocketTransport::connect_with_options(&format!("ws://{addr}"), options)
+            .await
+            .expect_err("selected connection must not wait forever for its challenge");
+        assert!(matches!(
+            error,
+            SignalFishError::TokenBinding(crate::TokenBindingFailure::ChallengeTimeout)
+        ));
+        finish_mock_server(server_task).await;
+    }
+
+    #[cfg(feature = "token-binding")]
+    #[tokio::test]
+    async fn required_mode_rejects_missing_selection_and_malformed_challenge() {
+        use tokio_tungstenite::tungstenite::http::header::SEC_WEBSOCKET_PROTOCOL;
+
+        for (send_selection, challenge, expected) in [
+            (
+                false,
+                None,
+                crate::TokenBindingFailure::SubprotocolNotNegotiated,
+            ),
+            (
+                true,
+                Some(r#"{"type":"Authenticated","data":{}}"#),
+                crate::TokenBindingFailure::MalformedChallenge,
+            ),
+        ] {
+            let listener = TcpListener::bind("127.0.0.1:0")
+                .await
+                .expect("negative-handshake listener must bind");
+            let addr = listener
+                .local_addr()
+                .expect("negative-handshake listener must have an address");
+            let server_task = tokio::spawn(async move {
+                let (tcp, _) = listener.accept().await.expect("server must accept client");
+                let mut ws = tokio_tungstenite::accept_hdr_async(
+                    tcp,
+                    move |_request: &tokio_tungstenite::tungstenite::handshake::server::Request, mut response: tokio_tungstenite::tungstenite::handshake::server::Response| {
+                        if send_selection {
+                            response.headers_mut().insert(
+                                SEC_WEBSOCKET_PROTOCOL,
+                                tokio_tungstenite::tungstenite::http::HeaderValue::from_static(
+                                    crate::token_binding::TOKEN_BINDING_SUBPROTOCOL,
+                                ),
+                            );
+                        }
+                        Ok(response)
+                    },
+                )
+                .await
+                .expect("server-side negative handshake must complete");
+                if let Some(challenge) = challenge {
+                    ws.send(Message::Text(challenge.into()))
+                        .await
+                        .expect("server must send malformed challenge");
+                }
+            });
+            let error = WebSocketTransport::connect_with_options(
+                &format!("ws://{addr}"),
+                required_token_binding_options(),
+            )
+            .await
+            .expect_err("required mode must fail closed");
+            assert!(matches!(
+                error,
+                SignalFishError::TokenBinding(actual) if actual == expected
+            ));
+            finish_mock_server(server_task).await;
+        }
     }
 
     type MemoryWebSocket = tokio_tungstenite::WebSocketStream<tokio::io::DuplexStream>;
@@ -875,6 +1601,7 @@ mod tests {
                 send_started: false,
                 control_flush_pending: false,
                 peer_close_pending: false,
+                token_binding: WebSocketTokenBinding::Disabled,
             },
         };
 
@@ -883,7 +1610,8 @@ mod tests {
         assert_eq!(
             output,
             "WebSocketTransport { has_stream: false, closed: true, has_close_info: true, \
-             send_started: false, control_flush_pending: false, peer_close_pending: false }"
+             send_started: false, control_flush_pending: false, peer_close_pending: false, \
+             token_binding: Disabled }"
         );
     }
 
@@ -1209,6 +1937,78 @@ mod tests {
             );
             assert!(!state.send_started);
         }
+    }
+
+    #[cfg(feature = "token-binding")]
+    #[tokio::test]
+    async fn token_binding_failures_preserve_original_frame_and_sequence() {
+        use tokio_tungstenite::tungstenite::protocol::{Role, WebSocketConfig};
+
+        let (client_io, _server_io) = tokio::io::duplex(64);
+        let config = WebSocketConfig::default()
+            .write_buffer_size(0)
+            .max_write_buffer_size(16);
+        let client = tokio_tungstenite::WebSocketStream::from_raw_socket(
+            client_io,
+            Role::Client,
+            Some(config),
+        )
+        .await;
+        let challenge = crate::token_binding::parse_challenge(challenge_json())
+            .expect("fixture challenge must parse");
+        let session = crate::token_binding::TokenBindingSession::from_challenge(
+            "MDEyMzQ1Njc4OWFiY2RlZg==",
+            challenge,
+        )
+        .expect("fixture handshake key must derive a session");
+        let mut state = WebSocketState::new(client);
+        state.token_binding = WebSocketTokenBinding::Active(Some(session));
+        let (_wake_counter, waker) = counting_waker();
+        let mut cx = Context::from_waker(&waker);
+
+        let unsupported = TransportFrame::Text(r#"{"type":"Ping","bad":9007199254740992}"#.into());
+        let mut offered = Some(unsupported.clone());
+        assert!(matches!(
+            state.poll_send(&mut cx, &mut offered),
+            Poll::Ready(Err(SignalFishError::TokenBinding(
+                crate::TokenBindingFailure::UnsupportedJson
+            )))
+        ));
+        assert_eq!(offered, Some(unsupported));
+
+        let original = TransportFrame::Text(format!(
+            r#"{{"type":"Ping","padding":"{}"}}"#,
+            "x".repeat(64)
+        ));
+        let mut offered = Some(original.clone());
+        assert!(matches!(
+            state.poll_send(&mut cx, &mut offered),
+            Poll::Ready(Err(SignalFishError::TransportSend(_)))
+        ));
+        assert_eq!(offered, Some(original.clone()));
+        assert!(!state.closed, "buffer refusal must remain retryable");
+
+        let TransportFrame::Text(retry) = state
+            .token_binding
+            .prepare(&original)
+            .expect("retry preparation must succeed")
+        else {
+            panic!("text input must produce a text proof");
+        };
+        let retry: serde_json::Value =
+            serde_json::from_str(&retry).expect("retry proof must parse");
+        assert_eq!(
+            retry["token_binding"]["sequence"], 1,
+            "preparation and backend refusal must not consume a sequence"
+        );
+
+        state.mark_terminal();
+        assert_eq!(state.token_binding.status(), TokenBindingStatus::Active);
+        assert!(
+            state.token_binding.challenge().is_none(),
+            "terminalization must drop challenge and zeroize the active session"
+        );
+        assert!(state.stream.is_none());
     }
 
     #[tokio::test]

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -1474,6 +1474,16 @@ mod ci_workflow_policy {
                 "e2e_reconnect_after_disconnect_uses_server_token",
             ),
             (
+                "signal-fish-server-v0.7.0-x86_64-unknown-linux-gnu.tar.gz",
+                "0.7.0",
+                "e2e_server_070_required_token_binding_wss",
+            ),
+            (
+                "signal-fish-server-v0.7.0-x86_64-unknown-linux-gnu.tar.gz",
+                "0.7.0",
+                "e2e_server_070_rejects_invalid_token_binding_proofs",
+            ),
+            (
                 "signal-fish-server-v0.4.0-x86_64-unknown-linux-gnu.tar.gz",
                 "0.4.0",
                 "e2e_server_040_generationless_mesh_signal",
@@ -1679,21 +1689,27 @@ mod ci_workflow_policy {
         }
     }
 
-    /// Verify that the CI clippy job tests all feature combinations:
-    /// default, `--all-features`, and `--no-default-features`.
+    /// Verify that both ordinary Rust jobs cover the pure minimal build and the
+    /// token-binding implementation without TLS.
     ///
     /// Regression: Without `--no-default-features`, dead_code warnings from
     /// items only used behind feature gates go undetected until a user builds
     /// the crate with a minimal feature set.
     #[test]
-    fn ci_clippy_covers_no_default_features() {
+    fn ci_covers_minimal_and_token_binding_without_tls() {
         let contents = ci_contents();
-        assert!(
-            contents.contains("--no-default-features"),
-            "ci.yml clippy job must include a '--no-default-features' matrix entry. \
-             Without this check, dead_code and other warnings that only appear \
-             when optional features are disabled will not be caught in CI."
-        );
+        for job_name in ["clippy", "test"] {
+            let job = extract_job_block(&contents, job_name)
+                .unwrap_or_else(|| panic!("ci.yml must define the {job_name} job"));
+            assert!(
+                job.contains("flags: \"--no-default-features\""),
+                "ci.yml {job_name} matrix must retain the pure no-default-features row"
+            );
+            assert!(
+                job.contains("flags: \"--no-default-features --features token-binding\""),
+                "ci.yml {job_name} matrix must compile token binding without TLS"
+            );
+        }
     }
 
     #[test]

--- a/tests/real_server_e2e.rs
+++ b/tests/real_server_e2e.rs
@@ -27,16 +27,210 @@
 use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
 
+#[cfg(all(feature = "tls", feature = "token-binding"))]
+use futures_util::{SinkExt as _, StreamExt as _};
+#[cfg(all(feature = "tls", feature = "token-binding"))]
+use rustls::pki_types::pem::PemObject as _;
 use signal_fish_client::protocol::GameDataEncoding;
 use signal_fish_client::{
     ErrorCode, JoinRoomParams, SignalFishClient, SignalFishConfig, SignalFishError,
     SignalFishEvent, WebSocketTransport,
 };
+#[cfg(all(feature = "tls", feature = "token-binding"))]
+use signal_fish_client::{TokenBindingMode, TokenBindingStatus, WebSocketConnectOptions};
 
 // ── Harness ─────────────────────────────────────────────────────────
 
 struct ServerGuard {
     child: Child,
+}
+
+#[cfg(all(feature = "tls", feature = "token-binding"))]
+struct TlsFixture {
+    directory: std::path::PathBuf,
+    certificate: std::path::PathBuf,
+    private_key: std::path::PathBuf,
+}
+
+#[cfg(all(feature = "tls", feature = "token-binding"))]
+impl TlsFixture {
+    fn generate() -> Self {
+        let directory = std::env::temp_dir().join(format!(
+            "signal-fish-token-binding-{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir(&directory).expect("create token-binding TLS fixture directory");
+        let certificate = directory.join("server-cert.pem");
+        let private_key = directory.join("server-key.pem");
+        let status = Command::new("openssl")
+            .args([
+                "req", "-x509", "-newkey", "rsa:2048", "-sha256", "-nodes", "-keyout",
+            ])
+            .arg(&private_key)
+            .arg("-out")
+            .arg(&certificate)
+            .args([
+                "-days",
+                "1",
+                "-subj",
+                "/CN=localhost",
+                "-addext",
+                "subjectAltName=DNS:localhost,IP:127.0.0.1",
+                "-addext",
+                "basicConstraints=critical,CA:FALSE",
+                "-addext",
+                "keyUsage=critical,digitalSignature,keyEncipherment",
+                "-addext",
+                "extendedKeyUsage=serverAuth",
+            ])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .expect("run openssl for token-binding TLS fixture");
+        assert!(status.success(), "openssl must generate the TLS fixture");
+        Self {
+            directory,
+            certificate,
+            private_key,
+        }
+    }
+
+    fn client_config(&self) -> std::sync::Arc<rustls::ClientConfig> {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let certificate = rustls::pki_types::CertificateDer::from_pem_file(&self.certificate)
+            .expect("parse generated server certificate");
+        let mut roots = rustls::RootCertStore::empty();
+        roots
+            .add(certificate)
+            .expect("trust generated token-binding server certificate");
+        std::sync::Arc::new(
+            rustls::ClientConfig::builder()
+                .with_root_certificates(roots)
+                .with_no_client_auth(),
+        )
+    }
+}
+
+#[cfg(all(feature = "tls", feature = "token-binding"))]
+impl Drop for TlsFixture {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.directory);
+    }
+}
+
+#[cfg(all(feature = "tls", feature = "token-binding"))]
+type RawTlsWebSocket =
+    tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>;
+
+#[cfg(all(feature = "tls", feature = "token-binding"))]
+async fn raw_token_binding_connect(
+    url: &str,
+    tls_config: std::sync::Arc<rustls::ClientConfig>,
+) -> (RawTlsWebSocket, zeroize::Zeroizing<[u8; 32]>) {
+    use base64::{engine::general_purpose::STANDARD, Engine as _};
+    use tokio_tungstenite::tungstenite::client::IntoClientRequest as _;
+    use tokio_tungstenite::tungstenite::http::header::{SEC_WEBSOCKET_KEY, SEC_WEBSOCKET_PROTOCOL};
+
+    let mut request = url
+        .into_client_request()
+        .expect("raw negative client URL must be valid");
+    let handshake_key = request
+        .headers()
+        .get(SEC_WEBSOCKET_KEY)
+        .and_then(|value| value.to_str().ok())
+        .expect("tungstenite must generate a handshake key");
+    let handshake_key = zeroize::Zeroizing::new(
+        STANDARD
+            .decode(handshake_key)
+            .expect("generated handshake key must be base64"),
+    );
+    request.headers_mut().insert(
+        SEC_WEBSOCKET_PROTOCOL,
+        tokio_tungstenite::tungstenite::http::HeaderValue::from_static(
+            "signalfish.tokenbinding.v2",
+        ),
+    );
+    let (mut stream, response) = tokio_tungstenite::connect_async_tls_with_config(
+        request,
+        None,
+        true,
+        Some(tokio_tungstenite::Connector::Rustls(tls_config)),
+    )
+    .await
+    .expect("raw token-binding handshake must succeed");
+    assert_eq!(
+        response
+            .headers()
+            .get(SEC_WEBSOCKET_PROTOCOL)
+            .and_then(|value| value.to_str().ok()),
+        Some("signalfish.tokenbinding.v2")
+    );
+    let challenge = stream
+        .next()
+        .await
+        .expect("server must send a challenge")
+        .expect("challenge frame must be valid")
+        .into_text()
+        .expect("challenge must be text");
+    let challenge: serde_json::Value =
+        serde_json::from_str(&challenge).expect("challenge must parse");
+    let nonce = challenge["data"]["nonce"]
+        .as_str()
+        .expect("challenge nonce must be a string");
+    let nonce = zeroize::Zeroizing::new(STANDARD.decode(nonce).expect("nonce must be base64"));
+    let hkdf = hkdf::Hkdf::<sha2::Sha256>::new(Some(nonce.as_slice()), handshake_key.as_slice());
+    let mut secret = zeroize::Zeroizing::new([0_u8; 32]);
+    hkdf.expand(b"signalfish.tokenbinding.v2/session-key", secret.as_mut())
+        .expect("raw negative client must derive the session key");
+    (stream, secret)
+}
+
+#[cfg(all(feature = "tls", feature = "token-binding"))]
+fn raw_signed_json(secret: &[u8], sequence: u64, signed_payload: &str, sent_type: &str) -> String {
+    use base64::{engine::general_purpose::STANDARD, Engine as _};
+    use hmac::Mac as _;
+
+    type HmacSha256 = hmac::Hmac<sha2::Sha256>;
+    let mut mac = <HmacSha256 as hmac::KeyInit>::new_from_slice(secret)
+        .expect("SHA-256 accepts the derived key");
+    mac.update(b"signalfish.tokenbinding.v2\0json\0");
+    mac.update(&sequence.to_be_bytes());
+    mac.update(signed_payload.as_bytes());
+    serde_json::json!({
+        "type": sent_type,
+        "token_binding": {
+            "version": 2,
+            "scheme": "server_nonce_hkdf_sha256",
+            "sequence": sequence,
+            "signature": STANDARD.encode(mac.finalize().into_bytes()),
+            "fingerprint": null
+        }
+    })
+    .to_string()
+}
+
+#[cfg(all(feature = "tls", feature = "token-binding"))]
+async fn expect_token_binding_rejection(stream: &mut RawTlsWebSocket) {
+    let rejected = tokio::time::timeout(Duration::from_secs(2), async {
+        while let Some(message) = stream.next().await {
+            match message {
+                Ok(tokio_tungstenite::tungstenite::Message::Text(text)) => {
+                    let value: serde_json::Value =
+                        serde_json::from_str(&text).expect("server response must parse");
+                    assert_ne!(value["type"], "Pong", "invalid proof must not reach Ping");
+                    if value["type"] == "Error" {
+                        return true;
+                    }
+                }
+                Ok(tokio_tungstenite::tungstenite::Message::Close(_)) | Err(_) => return true,
+                Ok(_) => {}
+            }
+        }
+        true
+    })
+    .await
+    .expect("server must reject an invalid proof promptly");
+    assert!(rejected);
 }
 
 impl Drop for ServerGuard {
@@ -166,6 +360,190 @@ async fn recv_next_event(
 }
 
 // ── Tests ───────────────────────────────────────────────────────────
+
+/// Native token-binding-v2 interoperability against required WSS on the pinned
+/// Server 0.7 release. A Pong after mixed JSON/binary traffic proves the server
+/// accepted the shared proof sequence instead of disconnecting the client.
+#[cfg(all(feature = "tls", feature = "token-binding"))]
+#[tokio::test]
+#[ignore = "requires pinned Signal Fish Server 0.7 and openssl; set SIGNAL_FISH_SERVER_BIN"]
+async fn e2e_server_070_required_token_binding_wss() {
+    let tls = TlsFixture::generate();
+    let certificate = tls.certificate.to_string_lossy().into_owned();
+    let private_key = tls.private_key.to_string_lossy().into_owned();
+    let Some((_guard, url)) = spawn_server(&[
+        ("SIGNAL_FISH__SECURITY__TRANSPORT__TLS__ENABLED", "true"),
+        (
+            "SIGNAL_FISH__SECURITY__TRANSPORT__TLS__CERTIFICATE_PATH",
+            certificate.as_str(),
+        ),
+        (
+            "SIGNAL_FISH__SECURITY__TRANSPORT__TLS__PRIVATE_KEY_PATH",
+            private_key.as_str(),
+        ),
+        (
+            "SIGNAL_FISH__SECURITY__TRANSPORT__TOKEN_BINDING__ENABLED",
+            "true",
+        ),
+        (
+            "SIGNAL_FISH__SECURITY__TRANSPORT__TOKEN_BINDING__REQUIRED",
+            "true",
+        ),
+    ])
+    .await
+    else {
+        eprintln!("skipping: SIGNAL_FISH_SERVER_BIN not set");
+        return;
+    };
+    let url = url.replacen("ws://127.0.0.1", "wss://localhost", 1);
+    let options = WebSocketConnectOptions::new().with_token_binding(TokenBindingMode::Required);
+    let transport = WebSocketTransport::connect_with_tls_config(&url, options, tls.client_config())
+        .await
+        .expect("required token-binding WSS must connect");
+    assert_eq!(transport.token_binding_status(), TokenBindingStatus::Active);
+
+    let mut config = SignalFishConfig::new(app_id()).enable_v3();
+    config.game_data_format = Some(GameDataEncoding::MessagePack);
+    let (mut client, mut events) = SignalFishClient::start(transport, config);
+    wait_for_event(
+        &mut events,
+        "Authenticated",
+        Duration::from_secs(5),
+        |event| matches!(event, SignalFishEvent::Authenticated { .. }),
+    )
+    .await;
+    client
+        .join_room(JoinRoomParams::new("e2e-token-binding", "protected-client"))
+        .expect("token-bound client must queue JoinRoom");
+    wait_for_event(&mut events, "RoomJoined", Duration::from_secs(5), |event| {
+        matches!(event, SignalFishEvent::RoomJoined { .. })
+    })
+    .await;
+    client
+        .send_game_data(serde_json::json!({"protected": 1}))
+        .expect("token-bound JSON must queue");
+    client
+        .send_binary_game_data(vec![1, 2, 3, 4])
+        .expect("token-bound MessagePack frame must queue");
+    client.ping().expect("token-bound Ping must queue");
+    let pong = wait_for_event(&mut events, "Pong", Duration::from_secs(5), |event| {
+        matches!(
+            event,
+            SignalFishEvent::Pong | SignalFishEvent::Disconnected { .. }
+        )
+    })
+    .await;
+    assert!(
+        matches!(pong, SignalFishEvent::Pong),
+        "Server 0.7 must accept mixed token-bound traffic: {pong:?}"
+    );
+    client.shutdown().await;
+}
+
+/// Raw negative cases prove that the pinned server rejects proof replay,
+/// signature/payload mismatch, a wrong per-connection key, and malformed proof
+/// envelopes. Each case gets a fresh challenge and sequence space.
+#[cfg(all(feature = "tls", feature = "token-binding"))]
+#[tokio::test]
+#[ignore = "requires pinned Signal Fish Server 0.7 and openssl; set SIGNAL_FISH_SERVER_BIN"]
+async fn e2e_server_070_rejects_invalid_token_binding_proofs() {
+    use tokio_tungstenite::tungstenite::Message;
+
+    let tls = TlsFixture::generate();
+    let certificate = tls.certificate.to_string_lossy().into_owned();
+    let private_key = tls.private_key.to_string_lossy().into_owned();
+    let Some((_guard, url)) = spawn_server(&[
+        ("SIGNAL_FISH__SECURITY__TRANSPORT__TLS__ENABLED", "true"),
+        (
+            "SIGNAL_FISH__SECURITY__TRANSPORT__TLS__CERTIFICATE_PATH",
+            certificate.as_str(),
+        ),
+        (
+            "SIGNAL_FISH__SECURITY__TRANSPORT__TLS__PRIVATE_KEY_PATH",
+            private_key.as_str(),
+        ),
+        (
+            "SIGNAL_FISH__SECURITY__TRANSPORT__TOKEN_BINDING__ENABLED",
+            "true",
+        ),
+        (
+            "SIGNAL_FISH__SECURITY__TRANSPORT__TOKEN_BINDING__REQUIRED",
+            "true",
+        ),
+    ])
+    .await
+    else {
+        eprintln!("skipping: SIGNAL_FISH_SERVER_BIN not set");
+        return;
+    };
+    let url = url.replacen("ws://127.0.0.1", "wss://localhost", 1);
+
+    // Replay: the first sequence-1 Ping succeeds, then the same proof fails.
+    let (mut stream, secret) = raw_token_binding_connect(&url, tls.client_config()).await;
+    let signed_ping = raw_signed_json(&secret[..], 1, r#"{"type":"Ping"}"#, "Ping");
+    stream
+        .send(Message::Text(signed_ping.clone().into()))
+        .await
+        .expect("valid raw Ping must send");
+    let pong = tokio::time::timeout(Duration::from_secs(2), async {
+        while let Some(message) = stream.next().await {
+            let message = message.expect("valid Ping response must be a frame");
+            if let Message::Text(text) = message {
+                let value: serde_json::Value =
+                    serde_json::from_str(&text).expect("valid Ping response must parse");
+                if value["type"] == "Pong" {
+                    return true;
+                }
+            }
+        }
+        false
+    })
+    .await
+    .expect("valid signed Ping must receive a prompt response");
+    assert!(pong, "the control Ping must prove sequence 1 was accepted");
+    stream
+        .send(Message::Text(signed_ping.into()))
+        .await
+        .expect("replayed frame must reach the server verifier");
+    expect_token_binding_rejection(&mut stream).await;
+
+    // Tamper: authenticate a different canonical payload than the one sent.
+    let (mut stream, secret) = raw_token_binding_connect(&url, tls.client_config()).await;
+    let tampered = raw_signed_json(&secret[..], 1, r#"{"type":"Pong"}"#, "Ping");
+    stream
+        .send(Message::Text(tampered.into()))
+        .await
+        .expect("tampered frame must reach the server verifier");
+    expect_token_binding_rejection(&mut stream).await;
+
+    // Wrong key/cross-connection reuse: sign B with A's derived key.
+    let (stale_stream, stale_secret) = raw_token_binding_connect(&url, tls.client_config()).await;
+    let (mut stream, _fresh_secret) = raw_token_binding_connect(&url, tls.client_config()).await;
+    drop(stale_stream);
+    let wrong_key = raw_signed_json(&stale_secret[..], 1, r#"{"type":"Ping"}"#, "Ping");
+    stream
+        .send(Message::Text(wrong_key.into()))
+        .await
+        .expect("wrong-key frame must reach the server verifier");
+    expect_token_binding_rejection(&mut stream).await;
+
+    // Malformed envelope: a proof member must be the exact structured object.
+    let (mut stream, _secret) = raw_token_binding_connect(&url, tls.client_config()).await;
+    stream
+        .send(Message::Text(
+            r#"{"type":"Ping","token_binding":"malformed"}"#.into(),
+        ))
+        .await
+        .expect("malformed proof must reach the server verifier");
+    expect_token_binding_rejection(&mut stream).await;
+
+    let (mut stream, _secret) = raw_token_binding_connect(&url, tls.client_config()).await;
+    stream
+        .send(Message::Binary(vec![0x81, 0xad, b't'].into()))
+        .await
+        .expect("malformed binary envelope must reach the server verifier");
+    expect_token_binding_rejection(&mut stream).await;
+}
 
 /// Server 0.7 fallback smoke: an unsupported Rkyv preference produces the
 /// warning-before-authentication sequence, then resolves coherently to JSON.

--- a/tests/token-binding/PROVENANCE.toml
+++ b/tests/token-binding/PROVENANCE.toml
@@ -1,0 +1,11 @@
+server_repository = "https://github.com/Ambiguous-Interactive/signal-fish-server"
+server_release = "0.7.0"
+server_commit = "3f7f43d4cd4b3cc7f8fb893220dc35c9b1fad333"
+synced = "2026-08-21"
+vectors_sha256 = "ea0ce944b5819cdde0c174fae1b79409405266532b93a3e0b803ed8f9a402fe6"
+
+[upstream_sha256]
+"src/security/token_binding.rs" = "63ab131c47f1a61bc64217530e0bbb46e4d138e154178faf668c5d17f2277f52"
+"src/websocket/token_binding.rs" = "2eacb6f0a92bbe189fc4a9e8e8df312b3c434ec6bf2737147b62b8083d7b2fe3"
+"docs/configuration-recipes.md" = "cefa5380830b575f8b7f195afd08759a4a08a09f96aba0b76f2fe34b5c7e2796"
+"tests/mtls_token_binding_e2e.rs" = "b8158e517c52d4433a58fba6ecfb5cdbb718d312be82199de5749a48225e4617"

--- a/tests/token-binding/vectors.toml
+++ b/tests/token-binding/vectors.toml
@@ -1,0 +1,14 @@
+handshake_key_base64 = "MDEyMzQ1Njc4OWFiY2RlZg=="
+nonce_base64 = "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8="
+derived_key_hex = "abb5860d3be9f16fad2763e718d0e9a038b7196fd136f24d62cb3ab6fc631da7"
+hkdf_info = "signalfish.tokenbinding.v2/session-key"
+json_domain_hex = "7369676e616c666973682e746f6b656e62696e64696e672e7632006a736f6e00"
+json_input = '{"zzz":{"y":2,"x":"é"},"type":"Ping","aaa":[3,1]}'
+json_canonical = '{"aaa":[3,1],"type":"Ping","zzz":{"x":"é","y":2}}'
+json_sequence = 1
+json_signature_base64 = "HobFBjbmzHgNF/QoXXFpqNy5s4/InE7+tCYO56+Dqig="
+binary_domain_hex = "7369676e616c666973682e746f6b656e62696e64696e672e76320062696e61727900"
+binary_payload_hex = "81a46461746101"
+binary_sequence = 2
+binary_signature_base64 = "7/4RSNk/Euc4JnPJqlrMVDqp1l8oLXl+A8jAqDZIt1A="
+binary_envelope_hex = "82ad746f6b656e5f62696e64696e6785a776657273696f6e02a6736368656d65b87365727665725f6e6f6e63655f686b64665f736861323536a873657175656e636502a97369676e6174757265d92c372f3452534e6b2f457563344a6e504a716c724d56447170316c386f4c586c2b41386a4171445a497431413dab66696e6765727072696e74c0a77061796c6f6164c40781a46461746101"

--- a/tests/token_binding_conformance_tests.rs
+++ b/tests/token_binding_conformance_tests.rs
@@ -1,0 +1,76 @@
+#![cfg(feature = "token-binding")]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::todo,
+    clippy::unimplemented,
+    clippy::indexing_slicing
+)]
+
+use sha2::{Digest as _, Sha256};
+
+#[test]
+fn pinned_server_070_token_binding_provenance_is_complete() {
+    let provenance_path = "tests/token-binding/PROVENANCE.toml";
+    let vectors_path = "tests/token-binding/vectors.toml";
+    let provenance_text =
+        std::fs::read_to_string(provenance_path).expect("read token-binding provenance");
+    let provenance: toml::Value =
+        toml::from_str(&provenance_text).expect("parse token-binding provenance");
+    assert_eq!(
+        provenance["server_commit"].as_str(),
+        Some("3f7f43d4cd4b3cc7f8fb893220dc35c9b1fad333")
+    );
+    assert_eq!(provenance["server_release"].as_str(), Some("0.7.0"));
+    let upstream = provenance["upstream_sha256"]
+        .as_table()
+        .expect("upstream hashes must be a table");
+    let expected_upstream = [
+        (
+            "src/security/token_binding.rs",
+            "63ab131c47f1a61bc64217530e0bbb46e4d138e154178faf668c5d17f2277f52",
+        ),
+        (
+            "src/websocket/token_binding.rs",
+            "2eacb6f0a92bbe189fc4a9e8e8df312b3c434ec6bf2737147b62b8083d7b2fe3",
+        ),
+        (
+            "docs/configuration-recipes.md",
+            "cefa5380830b575f8b7f195afd08759a4a08a09f96aba0b76f2fe34b5c7e2796",
+        ),
+        (
+            "tests/mtls_token_binding_e2e.rs",
+            "b8158e517c52d4433a58fba6ecfb5cdbb718d312be82199de5749a48225e4617",
+        ),
+    ];
+    assert_eq!(upstream.len(), expected_upstream.len());
+    for (path, expected_hash) in expected_upstream {
+        let actual = upstream[path]
+            .as_str()
+            .unwrap_or_else(|| panic!("missing upstream hash for {path}"));
+        assert_eq!(actual, expected_hash, "upstream hash drifted for {path}");
+        assert_eq!(actual.len(), 64);
+        assert!(actual.bytes().all(|byte| byte.is_ascii_hexdigit()));
+    }
+
+    let vectors = std::fs::read(vectors_path).expect("read token-binding vectors");
+    let checksum: String = Sha256::digest(&vectors)
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect();
+    assert_eq!(
+        provenance["vectors_sha256"].as_str(),
+        Some(checksum.as_str())
+    );
+
+    let vectors_text =
+        std::str::from_utf8(&vectors).expect("token-binding vectors must be UTF-8 TOML");
+    let vectors: toml::Value = toml::from_str(vectors_text).expect("parse token-binding vectors");
+    assert_eq!(
+        vectors["hkdf_info"].as_str(),
+        Some("signalfish.tokenbinding.v2/session-key")
+    );
+    assert_eq!(vectors["json_sequence"].as_integer(), Some(1));
+    assert_eq!(vectors["binary_sequence"].as_integer(), Some(2));
+}


### PR DESCRIPTION
## Summary

- add opt-in native WebSocket token-binding v2 negotiation with Disabled, Optional, and Required policies
- implement the Server 0.7 HKDF/HMAC, canonical JSON, binary MessagePack, shared-sequence, replay-resistant wire contract
- keep the default path byte-identical and crypto-free while exposing typed, redacted negotiation failures
- add exact upstream provenance/goldens, mock handshake and backpressure coverage, and pinned Server 0.7 positive plus adversarial WSS E2E
- document downgrade behavior, threat model, key lifetime, native/browser/Godot/custom-transport capability boundaries, and the unsupported fingerprint-required server profile

## Verification

- `cargo fmt && cargo clippy --workspace --all-targets --all-features -- -D warnings && cargo test --workspace --all-features`
- `cargo clippy --no-default-features --features token-binding --all-targets -- -D warnings`
- `cargo test --no-default-features --features token-binding`
- `cargo +1.87.0 check -p signal-fish-client --all-features --lib`
- strict docs rendering and extracted Rust snippet compilation
- release-policy tests and `cargo package --allow-dirty -p signal-fish-client`
- pinned Server 0.7 required-WSS positive E2E
- pinned Server 0.7 replay/tamper/wrong-key/malformed-envelope negative E2E
- two independent adversarial review passes; zero remaining concrete findings

Closes #88

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Adds handshake-key derivation, HMAC proofs, and fail-closed negotiation on the native WebSocket path, plus breaking public connect/error types. Crypto and transport-security mistakes would affect Server 0.7 required-binding deployments.
> 
> **Overview**
> Adds opt-in native **token-binding v2** so Server 0.7 can require `signalfish.tokenbinding.v2` without changing the default handshake or dependency graph.
> 
> `WebSocketTransport` now owns disabled / optional / required modes. Optional retries once only after an unsigned upgrade; required consumes a strict first-message challenge before the client can send `Authenticate`. Outbound JSON and binary frames share one sequence that advances only after the backend accepts the protected frame. Keys and proofs stay out of `Debug`, tracing, and errors.
> 
> **Breaking:** `WebSocketConnectOptions` gains public token-binding fields, and exhaustive `SignalFishError` matches must handle `TokenBinding(TokenBindingFailure)`. Browser, Emscripten, Godot, and `from_stream` remain incapable of required mode. `connect_with_tls_config` supports custom roots/mTLS, but fingerprint-required server profiles are still unsupported.
> 
> Pinned Server 0.7 goldens plus required-WSS positive and adversarial E2E cover the wire contract. CI now compiles `token-binding` without TLS and runs those E2E cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea332d71effcfd66d0179083b87b16e8505a5ed6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->