### PR TITLE
docs: simplify the user guide

### DIFF
--- a/.llm/skills/websocket-client/SKILL.md
+++ b/.llm/skills/websocket-client/SKILL.md
@@ -14,7 +14,7 @@ machine.
 Connection setup remains outside `Transport`:
 
 ```rust,ignore
-let transport = WebSocketTransport::connect("ws://signal.example/ws").await?;
+let transport = WebSocketTransport::connect("ws://signal.example/v2/ws").await?;
 let transport = WebSocketTransport::connect_with_timeout(url, timeout).await?;
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Reorganized the guide around first connection, SDK usage, multiplayer
+  choices, and advanced reference topics. The README is now a concise on-ramp
+  that links to the canonical setup, engine, protocol, and transport pages
+  instead of duplicating their detailed instructions.
 - **Breaking:** `WebSocketConnectOptions` gains token-binding mode and challenge
   timeout fields, and exhaustive `SignalFishError` matches must handle
   `TokenBinding(TokenBindingFailure)`. Browser, Emscripten, Godot, and
@@ -120,6 +124,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Corrected the built-in examples and API documentation to use Signal Fish
+  Server's versioned `/v2/ws` endpoint instead of the nonexistent unversioned
+  `/ws` or `/signal` paths.
 - Fixed player-only commands being queued before join, after leave, or by a
   spectator, where Server 0.7 could silently discard gameplay data. Authority
   baselines and changes are validated before they affect local guards,

--- a/PLAN.md
+++ b/PLAN.md
@@ -4,18 +4,21 @@
 
 - Latest released client: 0.10.0.
 - Canonical protocol fixture: Signal Fish Server 0.7.0 at commit
-  `3f7f43d4cd4b3cc7f8fb893220dc35c9b1fad333`; server 0.4 generation-less
-  signaling remains an explicit compatibility case.
+  `3f7f43d4cd4b3cc7f8fb893220dc35c9b1fad333`; Server 0.4
+  generation-less signaling remains an explicit compatibility case.
 - The async and polling clients share protocol behavior through `ClientCore`.
 - The lockstep Godot adapter supports native and official Godot 4.5 web
   exports, with blocking real-server gameplay coverage.
+- Native WebSocket token binding supports disabled, optional, and required
+  Server 0.7 profiles except the explicit client-certificate-fingerprint
+  profile tracked in issue #120.
 - Release preparation and publication are workspace-aware, reproducible, and
   protected by required aggregate checks.
-- Signal Fish Server 0.7 compatibility shipped on `main` in
-  [PR #89](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/pull/89),
-  closing issue #86.
+- All 11 required project workflows are green on current `main` commit
+  `3115c2b`; the separate live Repository Policy audit remains red because of
+  issue #90.
 
-Curated milestone history and verification evidence live in tracked files
+Completed milestone history and verification evidence live in tracked files
 under `progress/`.
 
 ## Priority Order
@@ -34,235 +37,62 @@ not stack dependent PRs.
 
 [Issue #90](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/issues/90)
 tracks live drift from `.github/required-checks.json`. Ruleset #14801090 still
-lacks approval and required-status-check rules, the scheduled Repository Policy
-workflow is genuinely red, and PRs #91, #92, and #94 demonstrated the impact
-by merging without an approval or enforced required checks. PR #92 auto-merged
-while a required aggregate was still running, then produced no push CI on its
-zero-file merge commit. The checked-in `GITHUB_TOKEN` Dependabot auto-merge path
-is now removed; repository policy rejects Dependabot-specific workflows,
-automated-merge primitives, and non-allowlisted workflow write permissions.
-PR #94 then merged despite its explicit do-not-merge gates and zero approvals.
-PR #118 likewise merged into current `main` with zero approvals after all
-code-tree workflows succeeded; its only review was the quota-exhausted Copilot
-comment. The latest scheduled Repository Policy run remains red.
-Ordinary reviewed merges remain policy but are not enforced until issue #90 is
-fixed. Restoring the live ruleset, disabling or funding the quota-broken
-Copilot review gate, adding an eligible independent reviewer (the repository
-currently has only the PR author's collaborator account), and dispatching a
-green policy audit still require maintainer administration. The next valid
-non-bot PR remains the end-to-end enforcement proof.
+lacks approval and required-status-check rules, and the scheduled Repository
+Policy workflow is genuinely red. Multiple PRs, most recently #119, merged
+without an approval or enforced required checks; #119 merged as current `main`
+commit `3115c2b` with zero approvals and four quota-exhausted Copilot comments.
 
-## Completed Milestone — Safety and Static Analysis
+Restoring the live ruleset, disabling or funding the quota-broken Copilot
+review rule, adding an eligible independent reviewer, confirming an empty
+bypass list in the ruleset UI, and dispatching a green policy audit require
+maintainer administration unavailable through the connected tools. The first
+substantive non-bot PR opened after restoration must prove that approval,
+thread resolution, branch freshness, and all 11 aggregate checks are enforced.
 
-[Issues #78](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/issues/78)
-and [#84](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/issues/84)
-were delivered by PR #91 and closed when it merged as `963a9fc`.
+## Current Work — Simplified Documentation
 
-- Required compiler, rustdoc, dependency, panic, coverage, target-build, and
-  FFI gates are complemented by scheduled fail-closed Miri, fuzz, and mutation
-  lanes. Broad pedantic/nursery lint expansion remains rejected as noisy, and
-  native ASan still cannot execute the Emscripten-only owned unsafe path.
-- Core unsafe Rust is denied by default, the Godot adapter forbids it, and the
-  sole Emscripten FFI exception is source-audited and target-compiled.
-- Deep Safety runs the 125 production protocol tests under Miri, all JSON and
-  binary v2/v3 fuzz targets with isolated corpora, and a zero-survivor mutation
-  scope. Change-scoped PR triggers provide hosted evidence when covered inputs
-  change.
-- PR #91 passed all eleven project aggregates plus Deep Safety and Protocol
-  Sync, but merged without the approval and quota-green state it explicitly
-  required. That governance failure remains tracked in issue #90.
-- Issue #117's later umbrella request for fuzzing, mutation, and formal methods
-  was closed as completed after confirming this existing fail-closed program.
-  TLA+/Z3 remains applicability-driven: add a formal model only for a concrete
-  invariant with a useful counterexample oracle, not as an unscoped tool-count
-  target.
+Track [issue #110](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/issues/110).
+Its server-side prerequisite, Signal Fish Server issue #383, is complete.
 
-## Completed Correctness Follow-up — FFI and Dependency Automation
+- Keep the repository README as a concise on-ramp instead of a duplicate
+  reference manual.
+- Organize the guide around first connection, SDK use, multiplayer choices,
+  and advanced reference.
+- Preserve exact protocol, transport, delivery, and platform contracts in
+  dedicated pages without requiring newcomers to read them before connecting.
+- Keep user-facing WebSocket examples aligned with the pinned Server 0.7
+  `/v2/ws` and `/v3/ws` routes.
 
-- Emscripten callback state is reclaimed only when its owner consumes a typed
-  authorization produced after native close was attempted or observed and browser callback
-  unregistration succeeded. Logical receive failures still drive native close,
-  deletion failures remain retryable, and terminal cleanup deliberately leaks
-  the small allocation instead of risking a late-callback use-after-free. The
-  host-tested state machine and required FFI checker enforce this condition
-  with 50 checker self-tests.
-- Dependabot's first default-branch Cargo run after PR #91 failed because its
-  temporary file set omitted `crates/signal-fish-client-godot/Cargo.toml`, then
-  opened zero-file PR #92. The three-directory attempt also failed in run
-  31964370221 with eleven resolution errors and opened zero-file PR #96:
-  Dependabot processes each Cargo directory independently rather than as one
-  file set. The corrective updater now starts only at `/`, where Cargo
-  discovers the adapter workspace member. The exact minimum/latest Godot
-  fixtures stay standalone and are maintained through their dedicated locked
-  E2E compatibility evidence. Post-merge root-workspace updater run
-  [31969079956](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/actions/runs/31969079956)
-  completed successfully on `main`, discovered both workspace crates, reported
-  no dependency-resolution errors, and opened no Cargo PR. This satisfies the
-  hosted proof tracked by issue #95.
-- The checked-in `GITHUB_TOKEN` Dependabot auto-merge path is removed. Until
-  issue #90 is fixed, dependency PRs must not bypass review/check policy or
-  suppress CI for their merge SHA.
+This coherent docs session was already in progress when issue #120 was opened;
+finish and green it before starting the next correctness PR.
 
-## Completed Correctness Study — First Hardening Slice
+## Next Correctness Milestone — Certificate-Fingerprint Token Binding
 
-Track [issue #97](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/issues/97).
+Track [issue #120](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/issues/120).
 
-- Audited protocol/state, public API, transport/network behavior, the pinned
-  Server 0.7 contract, and native/browser reference-client assumptions through
-  three independent subsystem matrices and adversarial review loops.
-- Fixed stale reliable signaling and game data across queue waits, including
-  legacy generation-less plans and room changes; async send/receive/close
-  liveness; and the ambient `Debug`/tracing credential and payload leak class.
-- Decomposed every unresolved finding into issues #99–#107 with explicit
-  invariants and executable acceptance evidence. Session 026 records the
-  finding matrix and proof.
-
-## Completed Correctness Milestone — Protocol State Validation
-
-[Issue #99](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/issues/99)
-adds shared-core lifecycle/version gates, canonical Server 0.7 SessionPlan
-shape and roster validation, and bidirectional signal-peer authorization.
-Lifecycle/plan/signaling-invalid frames are observable but transactional under
-every policy; async and polling drivers retain identical behavior. Session 027
-records the rule-to-test/source matrix and verification evidence.
-
-## Completed Correctness Milestone — Negotiation and Reconnect State
-
-Issues #100 and #101 shipped together in PR #111 because both depend on the
-first authoritative `ProtocolInfo` and reconnect state transaction.
-
-- Requested and effective game-data formats are distinct public state. The
-  shared core resolves Server 0.7's canonical format advertisement atomically,
-  and async/polling plus pinned-server evidence covers supported and fallback
-  paths before transport admission.
-- Reconnect restoration is version-strict and transactional across replay,
-  token rotation, accountability, membership, and plan state under every
-  violation policy. The old WebRTC plan is fenced until Server 0.7's fresh live
-  post-reconnect plan arrives.
-- Session 028 records the rule-to-source-to-test matrix, pinned-server evidence,
-  hosted review fixes, and green aggregate checks.
-
-## Completed Correctness Milestone — Mesh Capability and Liveness
-
-[Issue #102](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/issues/102)
-separates negotiated local capability from the authoritative selected plan,
-normalizes controller-owned WebRTC configuration, and makes peer liveness
-transport-specific. Session 029 records the configuration, state, transition,
-and async/polling/controller parity evidence.
-
-## Completed Correctness Milestone — WebSocket Liveness
-
-[Issue #105](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/issues/105)
-bounds native WebSocket control-frame work, preserves automatic Pong/Close
-flush ordering, and makes EOF and socket errors terminal for direct Transport
-callers. Session 030 records socket, ownership, wake, and terminal-state evidence.
-
-## Completed Correctness Milestone — Client Membership and Operation State
-
-[Issue #103](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/issues/103)
-shipped in [PR #114](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/pull/114). It
-exposes authoritative player/spectator role state, clears room-scoped identity
-on exit, and enforces one shared operation matrix across async and polling
-drivers. Admission-time room transitions fence later FIFO commands, authority
-state is validated and tracked, and invalid calls fail before consuming bounded
-queue capacity. The code-bearing head passed all twelve hosted workflow suites;
-Session 031 records the operation/state matrix, pinned-server contract, review
-fixes, and exact verification evidence.
-
-## Completed Correctness Milestone — Readiness and Traffic Counters
-
-[Issue #104](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/issues/104)
-shipped in [PR #115](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/pull/115). It defines connection state as nested client-owned, transport-ready,
-server-authenticated, and room-membership phases without preventing FIFO
-queueing during an asynchronous handshake. Traffic statistics count outbound
-transport ownership transfer and inbound decoded receipt, including
-accepted-then-error, stale, and quarantined cases. Session 032 records the
-contract, review, and green hosted evidence.
-
-## Completed Correctness Milestone — Enforceable Transport Abandonment
-
-[Issue #106](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/issues/106)
-shipped in [PR #116](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/pull/116).
-It makes `Transport::abort` a required backend-lifetime decision and invokes it
-after close deadlines/errors and owner cancellation/drop. Async and polling
-drivers must preserve accepted-send-before-close ordering while proving
-deadline abandonment, resource release, and no later transport polling.
-Session 033 records the contract and evidence.
-
-## Completed Correctness Decision — Datagram Scope
-
-[Issue #107](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/issues/107)
-shipped in [PR #118](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/pull/118)
-as an out-of-scope decision for this SDK's current transport abstraction.
-
-- `Transport` begins at one complete, ordered text/binary frame stream bound to
-  the intended server. A raw stream/datagram backend owns framing,
-  trust/source binding, fragmentation, loss/duplicate/reorder policy, and must
-  surface unrecoverable violations instead of silently skipping frames.
-- Pinned Signal Fish Server 0.7 exposes one WebSocket signaling/relay lane,
-  ignores legacy `JoinRoom.relay_transport`, and contains no separate relay
-  server. `ConnectionInfo::Relay` remains self-declared peer metadata.
-- WebRTC implementations own ICE/DTLS/SCTP and underlying UDP behavior and
-  yield only assembled data-channel messages to `MeshController`.
-- No UDP parser, fuzz corpus, or loopback test is added for a nonexistent
-  envelope. A future datagram protocol belongs first in its owning server/data
-  component and needs a separate abstraction unless it reconstructs the full
-  ordered framed contract.
-- Server [issue #393](https://github.com/Ambiguous-Interactive/signal-fish-server/issues/393)
-  tracks clarification or retirement of the ignored legacy relay fields.
-
-Session 034 records the source-to-decision matrix and verification evidence.
-
-## Current Correctness Milestone — Negotiated Token Binding
-
-Track [issue #88](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/issues/88).
-
-[PR #119](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/pull/119)
-implements the milestone and is open, non-draft, mergeable, and fully green on
-code-bearing head `3bf73fdd1eebadf9aa3821b224492575fe8da312`. All twelve hosted workflows
-passed, including required-WSS positive and adversarial Server 0.7 E2E, Deep
-Safety, and the full Godot Web matrix. Two independent adversarial review
-passes found no remaining concrete issue, and hosted review has zero threads.
-It remains intentionally unmerged because the repository has no eligible
-independent collaborator, Copilot review is quota-exhausted, and issue #90's
-approval/ruleset administration is still incomplete.
-
-- Preserve byte-for-byte default connections while adding explicit disabled,
-  optional, and required token-binding-v2 modes.
-- Bind the native proof algorithm and negative cases to one exact server
-  release/commit, including replay, tamper, downgrade, and malformed envelopes.
-- Make handshake-material capability differences explicit for native, browser,
-  Godot, polling, and custom transports, with typed required-mode failures.
-- Keep keys, proofs, and handshake secrets out of `Debug`, tracing, and errors.
-- The implementation keeps this state in native `WebSocketTransport`, gates the
-  crypto dependency graph behind `token-binding`, consumes the challenge before
-  client construction, and advances one JSON/binary sequence only at backend
-  ownership transfer. Exact Server 0.7 goldens and a required-WSS pinned-server
-  smoke provide interoperability evidence; browser/Godot/Emscripten and
-  post-handshake `from_stream` paths remain explicitly incapable.
+- Bind the native token proof to the exact leaf certificate presented by the
+  configured rustls client for Server 0.7 profiles that require a client
+  fingerprint.
+- Pin positive and adversarial mTLS/fingerprint interoperability evidence to
+  the exact server contract without changing disabled/default connections.
+- Preserve explicit incapability boundaries for browser, Emscripten, Godot,
+  and post-handshake transports.
 
 ## Later Milestone — Allocation and Performance Evidence
 
 Track [issue #82](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/issues/82).
 
-- Define representative lobby, JSON relay, binary relay, classified-delivery,
-  reconnect, and polling workloads.
+- Define representative lobby, JSON relay, binary relay,
+  classified-delivery, reconnect, and polling workloads.
 - Establish deterministic throughput, latency, allocation, and queue-age
   baselines before optimizing.
-- Optimize only measured bottlenecks and retain regression thresholds that are
-  stable enough for CI.
+- Optimize only measured bottlenecks and retain stable regression thresholds.
 - Preserve frame ownership, backpressure, exact accountability, and event
   delivery invariants in every optimization.
 
-The stale `agent/fortress-rollback-throughput-e2e` branch is retained only as
-research input for #82. Its pre-session-018 standalone fixture was superseded
-by the merged two-browser Godot Fortress suite and is not an active PR.
-
-## Later Milestone — Simplified Documentation
-
-Track [issue #110](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/issues/110)
-and its completed server-side prerequisite to define a smaller onboarding path
-without duplicating or weakening the strict reference documentation.
+The stale `agent/fortress-rollback-throughput-e2e` branch is research input
+only. Its pre-session-018 fixture was superseded by the merged two-browser
+Godot Fortress suite and must not be cherry-picked.
 
 ## Later Milestone — Documentation Design System
 
@@ -271,8 +101,8 @@ Track [issue #80](https://github.com/Ambiguous-Interactive/signal-fish-client-ru
 - Inventory and validate the supplied design assets and their licensing.
 - Translate the design system into MkDocs theme overrides without weakening
   strict builds, accessibility, responsive behavior, or code readability.
-- Update repository and published-site branding together, with rendered visual
-  review at desktop and mobile sizes.
+- Update repository and published-site branding together, with rendered
+  desktop and mobile review.
 
 ## Permanent Acceptance Gates
 
@@ -287,7 +117,7 @@ In addition:
 - all relevant repository policy, docs, MSRV, packaging, coverage,
   server-E2E, and Godot-E2E checks pass;
 - user-visible changes appear under `CHANGELOG.md` `[Unreleased]`;
-- `PLAN.md`, `.llm/context.md`, and `progress/` reflect the actual state;
+- `PLAN.md`, `.llm/context.md`, and `progress/` reflect actual state;
 - all actionable reviewer feedback is resolved;
-- the PR has one uniquely named required aggregate result per blocking
-  workflow and reaches a fully green state.
+- the PR has one uniquely named required aggregate per blocking workflow and
+  reaches a fully green state.

--- a/README.md
+++ b/README.md
@@ -3,68 +3,31 @@
 </p>
 
 <p align="center">
-  <a href="https://Ambiguous-Interactive.github.io/signal-fish-client-rust/">
-    <img src="https://img.shields.io/badge/docs-GitHub%20Pages-blue?logo=github" alt="Documentation">
-  </a>
-  <a href="https://crates.io/crates/signal-fish-client">
-    <img src="https://img.shields.io/crates/v/signal-fish-client.svg" alt="Crates.io">
-  </a>
-  <a href="https://docs.rs/signal-fish-client">
-    <img src="https://img.shields.io/docsrs/signal-fish-client" alt="docs.rs">
-  </a>
-  <a href="https://github.com/Ambiguous-Interactive/signal-fish-client-rust/actions/workflows/ci.yml">
-    <img src="https://github.com/Ambiguous-Interactive/signal-fish-client-rust/actions/workflows/ci.yml/badge.svg" alt="CI">
-  </a>
-  <a href="https://doc.rust-lang.org/stable/releases.html#version-1870-2025-05-15">
-    <img src="https://img.shields.io/badge/MSRV-1.87.0-blue.svg" alt="MSRV">
-  </a>
-  <a href="LICENSE">
-    <img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT">
-  </a>
+  <a href="https://Ambiguous-Interactive.github.io/signal-fish-client-rust/"><img src="https://img.shields.io/badge/docs-GitHub%20Pages-blue?logo=github" alt="Documentation"></a>
+  <a href="https://crates.io/crates/signal-fish-client"><img src="https://img.shields.io/crates/v/signal-fish-client.svg" alt="Crates.io"></a>
+  <a href="https://docs.rs/signal-fish-client"><img src="https://img.shields.io/docsrs/signal-fish-client" alt="docs.rs"></a>
+  <a href="https://github.com/Ambiguous-Interactive/signal-fish-client-rust/actions/workflows/ci.yml"><img src="https://github.com/Ambiguous-Interactive/signal-fish-client-rust/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://doc.rust-lang.org/stable/releases.html#version-1870-2025-05-15"><img src="https://img.shields.io/badge/MSRV-1.87.0-blue.svg" alt="MSRV"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT"></a>
 </p>
 
-Framed-transport-agnostic Rust client SDK for the **Signal Fish** multiplayer
-signaling protocol. Choose the Tokio background driver or the caller-driven
-polling client to connect through a backend that provides one ordered
-text/binary frame stream for the intended server, authenticate, join rooms,
-and receive strongly typed events.
+Signal Fish is a multiplayer signaling service. This Rust SDK connects a game
+to a Signal Fish server, joins players to rooms, relays game data, and exposes
+server activity as typed events. It supports ordinary Tokio applications and
+frame-driven engines such as Godot.
 
----
+The SDK does not provide a game engine, rollback implementation, or WebRTC
+backend. It handles the Signal Fish protocol while your game owns simulation
+and peer networking.
 
-> **🤖 AI Disclosure**
->
-> This project was developed with **substantial AI assistance**. The protocol
-> design and core technology concepts were created entirely by humans, but the
-> vast majority of the code, documentation, and tests were written with the
-> help of **Claude Opus 4.6** and **Codex 5.3**. Human oversight covered code
-> review and architectural decisions, but day-to-day implementation was
-> primarily AI-driven. This transparency is provided so users can make informed
-> decisions about using this crate.
+## Start here
 
----
+Need a local server or app ID? Follow the server's [five-minute quick
+start](https://ambiguous-interactive.github.io/signal-fish-server/quickstart/).
+Its development setup accepts a test app ID. The App ID is a public application
+label, not a secret; production servers use the operator's configured policy.
 
-## Features
-
-- **Framed-transport-agnostic** — implement `Transport` for a backend that
-  supplies complete text/binary frames; stream or datagram framing,
-  signaling-server trust/source binding, and packet recovery remain backend
-  responsibilities
-- **Wire-compatible** — protocol types are conformance-tested against the server's published wire samples and error-code registry; undecodable frames surface as a typed `DecodeFailed` event
-- **Protocol support: v2 relay + server 0.7.0 v3** — opt-in v3 adds classified delivery, accountability, binary frames, reconnect tokens, graceful drain, and generation-fenced WebRTC mesh signaling; the default remains byte-identical to v2. Generation-less server 0.4 plans remain supported. Use `enable_v3()` for relay-only support or `enable_mesh()` with a WebRTC driver.
-- **Feature-gated WebSocket transport** — the default `transport-websocket` feature provides a ready-to-use `WebSocketTransport`
-- **Native token binding** — the opt-in `token-binding` feature negotiates Server 0.7's `signalfish.tokenbinding.v2` extension with disabled, optional, and required policies while preserving the default handshake
-- **Typed events for both drivers** — receive `SignalFishEvent`s through the
-  async driver's bounded Tokio MPSC channel or directly from each polling call
-- **Structured errors** — typed client errors, server error codes, decode failures, and categorized protocol-accountability violations
-- **Typed negotiated-protocol coverage** — typed v2/v3 messages and events, including strict physical MessagePack envelopes
-- **No silent loss while receivers remain active** — event delivery uses backpressure, and the bounded send queue surfaces congestion as `SignalFishError::SendBufferFull` instead of buffering without bound; receiver/handle drop and shutdown remain explicit terminal boundaries, while `stats()` exposes transport-acceptance and decoded-receipt diagnostics
-- **Configurable** — tune event channel capacity, command queue capacity, shutdown timeout, and more via `SignalFishConfig` builder methods
-- **WebAssembly ready** — compiles to `wasm32-unknown-unknown` and `wasm32-unknown-emscripten` with zero unsafe panics
-- **Godot 4.5 native + web adapter** — the lockstep `signal-fish-client-godot` crate wraps Godot's own `WebSocketPeer`, including official no-thread web exports
-- **Advanced Emscripten transport** — `transport-websocket-emscripten` remains available for custom hosts that explicitly link Emscripten's WebSocket library
-- **Polling client** — `SignalFishPollingClient` drives the protocol from a game loop without an async runtime, ideal for frame-driven engines and wasm targets (e.g. Godot 4.5 web exports)
-
-## Installation
+Add the client and Tokio:
 
 ```toml
 [dependencies]
@@ -72,342 +35,105 @@ signal-fish-client = "0.10.0"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ```
 
-Without the built-in WebSocket transport (bring your own):
+Connect, wait for authentication, and join a room:
 
-```toml
-[dependencies]
-signal-fish-client = { version = "0.10.0", default-features = false }
-```
-
-The published `0.10.0` crate is the stable release. This `main`-branch README
-also documents fixes listed under [`Unreleased`](CHANGELOG.md), including the
-issue #61 browser polling guarantees and the breaking Server 0.7 surface planned
-for 0.11. Until the next release, test those APIs and fixes with:
-
-```toml
-[dependencies]
-signal-fish-client = { git = "https://github.com/Ambiguous-Interactive/signal-fish-client-rust" }
-```
-
-Server deployments that require `signalfish.tokenbinding.v2` need the native
-`token-binding` and `tls` features plus required-mode WebSocket options. See
-[WebSocket Token Binding](docs/token-binding.md). Browser, Emscripten, and Godot
-WebSocket APIs cannot expose the handshake key and therefore cannot use a
-required token-binding server profile.
-
-## Quick Start
-
-```rust,no_run
+```rust
 use signal_fish_client::{
-    WebSocketTransport, SignalFishClient, SignalFishConfig,
-    JoinRoomParams, SignalFishEvent,
+    JoinRoomParams, SignalFishClient, SignalFishConfig, SignalFishEvent,
+    WebSocketTransport,
 };
 
 #[tokio::main]
 async fn main() -> Result<(), signal_fish_client::SignalFishError> {
-    // 1. Connect a WebSocket transport to the signaling server.
-    let transport = WebSocketTransport::connect("ws://localhost:3536/ws").await?;
-
-    // 2. Build a client config with your application ID.
+    let transport = WebSocketTransport::connect("ws://localhost:3536/v2/ws").await?;
     let config = SignalFishConfig::new("mb_app_abc123");
+    let (mut client, mut events) = SignalFishClient::start(transport, config);
 
-    // 3. Start the client — returns a handle and an event receiver.
-    //    The client automatically sends Authenticate on start.
-    let (mut client, mut event_rx) = SignalFishClient::start(transport, config);
-
-    // 4. Process events — wait for Authenticated before joining a room.
-    while let Some(event) = event_rx.recv().await {
+    while let Some(event) = events.recv().await {
         match event {
-            SignalFishEvent::Authenticated { app_name, .. } => {
-                println!("Authenticated as {app_name}");
-                // Now it's safe to join a room.
+            SignalFishEvent::Authenticated { .. } => {
                 client.join_room(JoinRoomParams::new("my-game", "Alice"))?;
             }
             SignalFishEvent::RoomJoined { room_code, .. } => {
-                println!("Joined room {room_code}");
+                println!("joined {room_code}");
             }
             SignalFishEvent::Disconnected { .. } => break,
             _ => {}
         }
     }
 
-    // 5. Shut down gracefully.
     client.shutdown().await;
     Ok(())
 }
 ```
 
-## Feature Flags
-
-| Feature               | Default | Description                                                             |
-| --------------------- | ------- | ----------------------------------------------------------------------- |
-| `transport-websocket` | **yes** | Built-in WebSocket transport via `tokio-tungstenite` and `futures-util` |
-| `transport-websocket-emscripten` | no | Emscripten WebSocket transport via raw FFI to `<emscripten/websocket.h>` |
-| `token-binding` | no | Native `WebSocketTransport` support for `signalfish.tokenbinding.v2`; preserves the crypto-free default build |
-| `tls` | no | Native `wss://` support with rustls and bundled webpki roots |
-| `polling-client` | no | Synchronous protocol pump for frame-driven and single-threaded hosts |
-| `mesh` | no | v3 mesh state, signaling orchestration, and WebRTC driver seam |
-| `tokio-runtime` | **yes** (via `transport-websocket`) | Tokio runtime integration (`rt`, `time`); disable for pure WASM targets |
-
-## Architecture
-
-| Module        | Purpose                                                           |
-| ------------- | ----------------------------------------------------------------- |
-| `client`      | `SignalFishClient` handle, `SignalFishConfig`, `JoinRoomParams`   |
-| `event`       | Typed application, transport, delivery, and violation events      |
-| `protocol`    | Wire-compatible v2/v3 client and server message types             |
-| `error`       | `SignalFishError` unified client/transport error type             |
-| `error_codes` | Typed server error-code registry                                  |
-| `transport`   | `Transport` trait for pluggable backends                          |
-| `transports`  | Built-in Tokio and advanced Emscripten WebSocket transports |
-| `polling_client` | `SignalFishPollingClient` — synchronous, game-loop-driven client |
-| `mesh`        | `MeshSession` — zero-dep v3 mesh state tracker (`mesh` feature)    |
-| `webrtc`      | `WebRtcDriver` seam + `MeshController` v3 orchestrator (`mesh` feature) |
-
-## Examples
-
-### Basic Lobby
-
-Full lifecycle: connect, authenticate, join a room, handle events, and shut down gracefully with Ctrl+C support.
+Run the complete example, which also handles readiness, game start,
+reconnection state, errors, and Ctrl+C:
 
 ```sh
 cargo run --example basic_lobby
-
-# Override the server URL:
-SIGNAL_FISH_URL=ws://my-server:3536/ws cargo run --example basic_lobby
 ```
 
-See [`examples/basic_lobby.rs`](examples/basic_lobby.rs).
+Set `SIGNAL_FISH_URL` to use a server other than
+`ws://localhost:3536/v2/ws`.
 
-### Custom Transport
+The published `0.10.0` crate is the stable release. This branch also documents
+unreleased changes planned for 0.11. Use the [0.10.0 API
+docs](https://docs.rs/signal-fish-client/0.10.0/) for the published surface, or
+see the [changelog](CHANGELOG.md) before depending on `main`.
 
-Implement a channel-based loopback transport, wire it into the client, and verify events flow correctly — no network required.
+## Choose your integration
 
-```sh
-cargo run --example custom_transport
-```
+| Your application | Use |
+| --- | --- |
+| Tokio application | `SignalFishClient` with the built-in `WebSocketTransport` |
+| Native or web Godot 4.5 game | `SignalFishPollingClient` with `signal-fish-client-godot` |
+| Browser or another frame-driven host | `SignalFishPollingClient` with your own `Transport` |
+| Custom async network stack | `SignalFishClient` with your own `Transport + Send` |
 
-See [`examples/custom_transport.rs`](examples/custom_transport.rs).
+Start with protocol v2 relay unless you need Server 0.7 delivery
+accountability or WebRTC mesh signaling. Opt into those features deliberately;
+the [protocol versioning guide](docs/protocol-versioning.md) explains the
+choice.
 
-### WebAssembly
+## Documentation
 
-The SDK compiles to WebAssembly. See the [WebAssembly Guide](docs/wasm.md) for Godot gdext integration examples and build instructions.
+- [Installation and first connection](docs/getting-started.md)
+- [Basic lobby walkthrough](docs/examples.md)
+- [Client commands and configuration](docs/client.md)
+- [Events](docs/events.md) and [errors](docs/errors.md)
+- [Godot and WebAssembly](docs/wasm.md)
+- [Protocol v2, v3, and mesh](docs/protocol-versioning.md)
+- [Custom transports](docs/transport.md)
+- [API reference](https://docs.rs/signal-fish-client)
 
-## Custom Transport
+The [full guide](https://Ambiguous-Interactive.github.io/signal-fish-client-rust/)
+keeps advanced protocol, delivery, transport, and migration material separate
+from the onboarding path.
 
-Implement the `Transport` trait for any framed I/O backend that fulfills the
-complete-frame contract:
+## Before production
 
-```rust,ignore
-use std::task::{Context, Poll};
-use signal_fish_client::transport::TransportFrame;
-use signal_fish_client::{SignalFishError, Transport};
+- Enable the `tls` feature and use `wss://` outside a trusted local environment.
+- Drain events continuously; a full event channel intentionally backpressures
+  the transport loop.
+- Treat `SendBufferFull` as congestion and retry according to your game policy.
+- Call `shutdown().await` when possible so the transport can close cleanly.
+- Allow the exact HTTPS origin serving a browser or Godot web build in the
+  Signal Fish server configuration.
 
-struct MyTransport { /* … */ }
+## Project notes
 
-impl Transport for MyTransport {
-    fn poll_send(
-        &mut self,
-        cx: &mut Context<'_>,
-        frame: &mut Option<TransportFrame>,
-    ) -> Poll<Result<(), SignalFishError>> {
-        // Leave `frame` in place until accepted. If you take it and return
-        // Pending, retain that exact send internally until it completes.
-        todo!()
-    }
+The core crate supports Rust 1.87.0 and newer. The Godot adapter requires Rust
+1.94.0 because of its godot-rust dependency.
 
-    fn poll_recv(
-        &mut self,
-        cx: &mut Context<'_>,
-    ) -> Poll<Option<Result<TransportFrame, SignalFishError>>> {
-        todo!()
-    }
+<details>
+<summary>AI disclosure</summary>
 
-    fn poll_close(
-        &mut self,
-        cx: &mut Context<'_>,
-    ) -> Poll<Result<(), SignalFishError>> {
-        // Drive one idempotent close handshake across as many polls as needed.
-        todo!()
-    }
+This project was developed with substantial AI assistance. Humans created the
+protocol and core technology concepts and retained responsibility for
+architecture and review; AI tools assisted heavily with implementation,
+documentation, and tests.
 
-    fn abort(&mut self) {
-        // Promptly abandon retained work and release or safely detach resources.
-        // This method must be non-blocking, non-panicking, and idempotent.
-        todo!()
-    }
-}
-```
+</details>
 
-Key requirements:
-
-- Preserve both `TransportFrame::Text` and `TransportFrame::Binary` boundaries
-- Supply exactly one complete protocol frame per successful receive; raw byte
-  streams and UDP sockets need an external framing and signaling-server
-  trust/source-binding policy before they satisfy `Transport`
-- Retain accepted outbound frames and partial receives across `Poll::Pending`
-- Register the supplied waker when async progress becomes possible
-- Make `poll_close` idempotent and expose structured peer metadata via `close_info`
-- Make `abort` prompt, non-blocking, non-panicking, and idempotent; it must
-  release or safely detach owned resources and discard retained sends
-- A transport constructor may begin an asynchronous connection attempt; both clients defer `Connected` until `is_ready()`, and the transport retains sends and wakes blocked async I/O when the handshake completes
-- The trait has no `Send` bound; only `SignalFishClient::start` requires
-  `Send + 'static`, while `SignalFishPollingClient` accepts non-`Send` transports
-
-## WebAssembly Support
-
-The SDK supports two WASM targets:
-
-| Target | Use Case | Transport | Client |
-| --- | --- | --- | --- |
-| `wasm32-unknown-unknown` | Browser apps (wasm-pack, wasm-bindgen) | Bring your own | `SignalFishPollingClient` (with `polling-client` feature) |
-| `wasm32-unknown-emscripten` | Godot native/web exports | `GodotWebSocketTransport`; Emscripten transport only with custom link-enabled templates | `SignalFishPollingClient` |
-
-The async `SignalFishClient` needs a *driven* tokio runtime (its transport loop runs under `tokio::spawn`); manually "ticking" a runtime once per frame starves it. Frame-driven or single-threaded environments — game loops on native as well as wasm — should use `SignalFishPollingClient` (feature `polling-client`), a synchronous pump you call once per frame.
-
-### Godot 4.5 Quick Start
-
-`GodotWebSocketTransport` uses Godot's own `WebSocketPeer`, so the same Rust
-code works in native builds and official no-thread web export templates.
-
-```rust,ignore
-use signal_fish_client::{
-    SignalFishPollingClient, SignalFishConfig, JoinRoomParams, SignalFishEvent,
-};
-use signal_fish_client_godot::GodotWebSocketTransport;
-
-// 1. Connect (synchronous — no .await needed).
-let transport = GodotWebSocketTransport::connect("wss://server/ws")
-    .expect("WebSocket creation failed");
-
-// 2. Create the polling client (auto-sends Authenticate).
-let config = SignalFishConfig::new("mb_app_abc123");
-let mut client = SignalFishPollingClient::new(transport, config);
-
-// Reset after authentication/setup, then monitor both queue depth and age.
-client.reset_queue_age_peak();
-let queue_age = client.queue_age_stats();
-assert!(queue_age.current_oldest_queue_age <= queue_age.peak_oldest_queue_age);
-
-// Optional: tune the bounded per-frame work and flush queued commands on close
-// with SignalFishPollingClient::new_with_options(...).
-// Godot admission defaults to an adaptive 50 ms target in the 4-32 KiB range,
-// further limited by the native backend; use connect_with_options to override it.
-
-// 3. Each frame, poll and handle events.
-for event in client.poll() {
-    match event {
-        SignalFishEvent::Authenticated { app_name, .. } => {
-            println!("Authenticated as {app_name}");
-            client.join_room(JoinRoomParams::new("my-game", "Alice")).ok();
-        }
-        SignalFishEvent::RoomJoined { room_code, .. } => {
-            println!("Joined room {room_code}");
-        }
-        _ => {}
-    }
-}
-```
-
-Browser and Godot-web handshakes include an `Origin` header. Signal Fish Server
-0.7 validates it, so production deployments must allow the exact HTTPS origin
-that serves the game. The wildcard `SIGNAL_FISH__SECURITY__CORS_ORIGINS='*'`
-setting is appropriate only for isolated local/CI fixtures.
-
-Enable it in a Godot GDExtension crate with:
-
-```toml
-godot = { version = "0.5.4", features = ["api-custom", "experimental-wasm", "experimental-wasm-nothreads", "lazy-function-tables"] }
-signal-fish-client = { git = "https://github.com/Ambiguous-Interactive/signal-fish-client-rust", default-features = false, features = ["polling-client"] }
-signal-fish-client-godot = { git = "https://github.com/Ambiguous-Interactive/signal-fish-client-rust" }
-```
-
-The adapter supports godot-rust `0.4.5` through `0.5.x` and requires Rust
-1.94 or newer. The framed-transport-agnostic core remains at Rust 1.87. If Cargo
-selects two binding families, inspect `cargo tree -d` and align the direct
-`godot` version with the adapter before compiling; Godot binding types from
-different versions are not interchangeable.
-
-The custom Godot API binding is required for the 32-bit Emscripten ABI. Set
-`GODOT4_BIN` to the Godot 4.5 editor when compiling the web extension.
-
-For rollback games, the [Godot + Fortress guide](docs/fortress.md) documents
-the bounded binary relay and exact frame order exercised by the real
-two-process browser test in CI.
-
-`EmscriptenWebSocketTransport` is retained for advanced custom-template
-integrations. It requires the final host to link Emscripten's WebSocket
-JavaScript library; official Godot templates do not.
-
-### Building the Advanced Emscripten Transport
-
-```sh
-# Install prerequisites
-rustup toolchain install nightly
-rustup component add rust-src --toolchain nightly
-
-# Build
-cargo +nightly build -Zbuild-std \
-    --target wasm32-unknown-emscripten \
-    --no-default-features \
-    --features transport-websocket-emscripten
-```
-
-See the [WebAssembly Guide](docs/wasm.md) for the full reference including Godot integration examples and toolchain setup.
-
-## Development
-
-### Run CI Locally
-
-A unified script runs all CI checks locally:
-
-```sh
-# Run all checks (matches CI exactly)
-bash scripts/check-all.sh
-
-# Quick mode: fmt + clippy + test only
-bash scripts/check-all.sh --quick
-```
-
-### Mandatory baseline
-
-```sh
-cargo fmt && cargo clippy --workspace --all-targets --all-features -- -D warnings && cargo test --workspace --all-features
-```
-
-### Additional quality checks
-
-| Command | CI Workflow | Install |
-| ------- | ----------- | ------- |
-| `cargo deny check` | ci.yml | `cargo install cargo-deny` |
-| `cargo audit` | security-supply-chain.yml | `cargo install cargo-audit` |
-| `bash scripts/check-no-panics.sh` | no-panics.yml | (built-in) |
-| `typos` | ci.yml | `cargo install typos-cli` |
-| `markdownlint-cli2 "**/*.md"` | docs-validation.yml | `npm install -g markdownlint-cli2` |
-| `lychee --config .lychee.toml "**/*.md"` | docs-validation.yml | `cargo install lychee` |
-| `cargo machete` | unused-deps.yml | `cargo install cargo-machete` |
-| `cargo semver-checks check-release` | semver-checks.yml | `cargo install cargo-semver-checks` |
-| `bash scripts/check-workflows.sh` | workflow-lint.yml | (built-in) |
-| `cargo +nightly miri test --test protocol_tests` | deep-safety.yml | `rustup component add miri --toolchain nightly` |
-| `cd fuzz && cargo +nightly fuzz run ...` | deep-safety.yml | `cargo install cargo-fuzz` |
-| `cargo mutants --file src/protocol.rs ...` | deep-safety.yml | `cargo install cargo-mutants` |
-| `cargo llvm-cov --all-features --summary-only` | coverage.yml | `cargo install cargo-llvm-cov` + `rustup component add llvm-tools-preview` |
-
-Release operators should follow the [release runbook](docs/releasing.md) for
-the reviewed preparation workflow, protected crates.io publication, and
-fail-closed recovery procedure.
-
-## Minimum Supported Rust Version (MSRV)
-
-<!-- markdownlint-disable-next-line MD036 -->
-**1.87.0**
-
-Tested against the latest stable Rust and the declared MSRV. Bumping the MSRV is considered a minor version change.
-
-## License
-
-[MIT](LICENSE) — Copyright (c) 2025-2026 Ambiguous Interactive
-
----
-
-📖 **[Full guide on GitHub Pages](https://Ambiguous-Interactive.github.io/signal-fish-client-rust/)** | 📚 **[API reference on docs.rs](https://docs.rs/signal-fish-client)**
+Signal Fish Client SDK is available under the [MIT License](LICENSE).

--- a/docs/client.md
+++ b/docs/client.md
@@ -184,7 +184,7 @@ use signal_fish_client::{
     SignalFishClient, SignalFishConfig, WebSocketTransport,
 };
 
-let transport = WebSocketTransport::connect("ws://localhost:3536/ws").await?;
+let transport = WebSocketTransport::connect("ws://localhost:3536/v2/ws").await?;
 let config = SignalFishConfig::new("mb_app_abc123");
 let (mut client, mut event_rx) = SignalFishClient::start(transport, config);
 ```
@@ -734,7 +734,7 @@ fn new_with_options(
 use signal_fish_client::{SignalFishPollingClient, SignalFishConfig};
 use signal_fish_client_godot::GodotWebSocketTransport;
 
-let transport = GodotWebSocketTransport::connect("wss://server/ws")
+let transport = GodotWebSocketTransport::connect("wss://server/v2/ws")
     .expect("connection failed");
 let config = SignalFishConfig::new("mb_app_abc123");
 let mut client = SignalFishPollingClient::new(transport, config);

--- a/docs/delivery.md
+++ b/docs/delivery.md
@@ -8,9 +8,10 @@ consumer falls behind. This page documents the **end-to-end** contract
 Numbers on this page were originally measured against the reliable v2 relay.
 Protocol-v3 behavior and accountability were verified against Signal Fish
 Server 0.4.0 at commit `50b28a9`. The repository's
-[`load_lab`](examples.md#load-lab-measurement-harness) example. Localhost figures are lower bounds —
-real networks add RTT — but the *shapes* (where queues form, who waits,
-who gets evicted) are configuration-driven and transfer directly.
+[`load_lab`](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/blob/main/examples/load_lab.rs)
+example captures repeatable measurements. Localhost figures are lower bounds —
+real networks add RTT — but the *shapes* (where queues form, who waits, who gets
+evicted) are configuration-driven and transfer directly.
 
 ## The pipeline
 

--- a/docs/events.md
+++ b/docs/events.md
@@ -640,7 +640,7 @@ use signal_fish_client::{
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let url = std::env::var("SIGNAL_FISH_URL")
-        .unwrap_or_else(|_| "ws://localhost:3536/ws".to_string());
+        .unwrap_or_else(|_| "ws://localhost:3536/v2/ws".to_string());
 
     let transport = WebSocketTransport::connect(&url).await?;
     let config = SignalFishConfig::new("your-app-id");

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,797 +1,109 @@
-# Example Walkthroughs
+# Basic Lobby Walkthrough
 
-Hands-on examples that demonstrate the Signal Fish Client SDK in realistic
-scenarios. Each walkthrough links its authoritative compiling source and then
-breaks the important patterns down step by step.
+The repository's complete, compiling lobby example connects to a Signal Fish
+server, joins a room, reacts to lobby events, and shuts down cleanly. This page
+explains that flow without duplicating its source.
 
-!!! tip "Running the examples"
-
-    Every example lives in the `examples/` directory and can be launched with
-    `cargo run --example <name>`.
-
----
-
-## Basic Lobby
-
-**Source:** `examples/basic_lobby.rs`
-
-Demonstrates the **full WebSocket lifecycle** — connecting to a Signal Fish
-server, authenticating, joining a room, reacting to lobby events, and shutting
-down gracefully.
-
-!!! info "This is a v2 / relay example"
-    `basic_lobby` uses the default relay-floor configuration
-    (`SignalFishConfig::new(...)`), so all traffic is relayed through the server.
-    For peer-to-peer WebRTC mesh see the
-    [Mesh Session example](#mesh-session-protocol-v3) and the
-    [Mesh Guide](mesh-guide.md).
-
-### Core pattern
-
-The authoritative, compiling
+**Source:**
 [`examples/basic_lobby.rs`](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/blob/main/examples/basic_lobby.rs)
-also handles authority changes and reconnection state so it sends exactly one
-eligible start request. This shorter excerpt shows the non-authority-room path:
 
-```rust
-use signal_fish_client::{
-    JoinRoomParams, SignalFishClient, SignalFishConfig, SignalFishEvent, WebSocketTransport,
-};
+!!! info "Protocol v2 relay"
+    The example uses the default protocol-v2 relay configuration. Get this path
+    working before choosing protocol v3 or WebRTC mesh.
 
-const DEFAULT_URL: &str = "ws://localhost:3536/ws";
+## Run it
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
-        )
-        .init();
-
-    let url = std::env::var("SIGNAL_FISH_URL").unwrap_or_else(|_| DEFAULT_URL.to_string());
-    tracing::info!("Connecting to {url}");
-
-    let transport = WebSocketTransport::connect(&url).await?;
-    let config = SignalFishConfig::new("mb_app_abc123");
-    let (mut client, mut event_rx) = SignalFishClient::start(transport, config);
-    let mut start_request_sent = false;
-
-    loop {
-        tokio::select! {
-            event = event_rx.recv() => {
-                let Some(event) = event else {
-                    tracing::info!("Event channel closed, exiting");
-                    break;
-                };
-
-                match event {
-                    SignalFishEvent::Connected => {
-                        tracing::info!("Transport connected, awaiting authentication…");
-                    }
-                    SignalFishEvent::Authenticated { app_name, .. } => {
-                        tracing::info!("Authenticated as app: {app_name}");
-                        let params = JoinRoomParams::new("example-game", "RustPlayer")
-                            .with_max_players(4);
-                        client.join_room(params)?;
-                        tracing::info!("Join-room request sent");
-                    }
-                    SignalFishEvent::RoomJoined {
-                        room_code, player_id, current_players, ..
-                    } => {
-                        tracing::info!(
-                            "Joined room {room_code} as player {player_id} ({} player(s) present)",
-                            current_players.len()
-                        );
-                        client.set_ready()?;
-                        tracing::info!("Set ready");
-                    }
-                    SignalFishEvent::PlayerJoined { player } => {
-                        tracing::info!("Player joined: {} ({})", player.name, player.id);
-                    }
-                    SignalFishEvent::PlayerLeft { player_id, .. } => {
-                        tracing::info!("Player left: {player_id}");
-                    }
-                    SignalFishEvent::LobbyStateChanged { lobby_state, all_ready, .. } => {
-                        tracing::info!("Lobby state → {lobby_state:?} (all_ready={all_ready})");
-                        if all_ready && !start_request_sent {
-                            // JoinRoomParams above creates a non-authority room.
-                            client.start_game()?;
-                            start_request_sent = true;
-                        }
-                    }
-                    SignalFishEvent::GameStarting { peer_connections } => {
-                        tracing::info!(
-                            "Game starting with {} peer connection(s)!",
-                            peer_connections.len()
-                        );
-                    }
-                    SignalFishEvent::AuthenticationError { error, error_code } => {
-                        tracing::error!("Auth failed [{error_code:?}]: {error}");
-                        break;
-                    }
-                    SignalFishEvent::Error { message, error_code } => {
-                        tracing::error!("Server error [{error_code:?}]: {message}");
-                    }
-                    SignalFishEvent::Disconnected { reason, .. } => {
-                        tracing::warn!("Disconnected: {}", reason.as_deref().unwrap_or("unknown"));
-                        break;
-                    }
-                    other => {
-                        tracing::debug!("Event: {other:?}");
-                    }
-                }
-            }
-            _ = tokio::signal::ctrl_c() => {
-                tracing::info!("Ctrl+C received, shutting down…");
-                break;
-            }
-        }
-    }
-
-    client.shutdown().await;
-    tracing::info!("Client shut down. Goodbye!");
-    Ok(())
-}
-```
-
-### Step-by-step walkthrough
-
-#### 1. Connect to the server via WebSocket
-
-```rust,ignore
-let transport = WebSocketTransport::connect(&url).await?;
-```
-
-`WebSocketTransport::connect` opens a WebSocket connection to the Signal Fish
-server. The URL can be overridden with the **`SIGNAL_FISH_URL`** environment
-variable; it defaults to `ws://localhost:3536/ws`.
-
-#### 2. Configure and start the client
-
-```rust,ignore
-let config = SignalFishConfig::new("mb_app_abc123");
-let (mut client, mut event_rx) = SignalFishClient::start(transport, config);
-```
-
-`SignalFishConfig` carries your **App ID** (issued by the server).
-`SignalFishClient::start` consumes the transport and config, returning:
-
-- a `SignalFishClient` handle for sending commands, and
-- an `mpsc::Receiver<SignalFishEvent>` for incoming events.
-
-#### 3. Event loop with `tokio::select!`
-
-```rust,ignore
-loop {
-    tokio::select! {
-        event = event_rx.recv() => { /* … */ }
-        _ = tokio::signal::ctrl_c() => { break; }
-    }
-}
-```
-
-The outer `loop` + `tokio::select!` pattern lets the example react to **server
-events** while also catching **Ctrl+C** for a clean exit.
-
-#### 4. Handle authentication, room join, and lobby events
-
-| Event | Action taken |
-|---|---|
-| `Connected` | Log that the transport is up; wait for authentication. |
-| `Authenticated` | Build `JoinRoomParams` and call `client.join_room(…)`. |
-| `RoomJoined` | Log the room code and player list, then call `client.set_ready()`. |
-| `PlayerJoined` / `PlayerLeft` | Log the change. |
-| `LobbyStateChanged` | Log readiness and send one explicit `start_game()` request when all players are ready. |
-| `GameStarting` | Log the peer connections — the game is about to begin. |
-| `AuthenticationError` / `Error` | Log the error (and break on auth failure). |
-| `Disconnected` | Log the reason and exit the loop. |
-
-#### 5. Graceful shutdown
-
-```rust,ignore
-client.shutdown().await;
-```
-
-`shutdown()` asks the transport loop to close gracefully and waits up to
-`SignalFishConfig::shutdown_timeout`; if that deadline expires, it invokes the
-transport's abort path, stops the task, and may omit the terminal
-`Disconnected` event.
-
-### Running it
+From a repository checkout:
 
 ```sh
 cargo run --example basic_lobby
 ```
 
-!!! info "Environment variable"
-
-    Set **`SIGNAL_FISH_URL`** to point at your server if it is not running on
-    the default `ws://localhost:3536/ws`.
-
-    ```sh
-    SIGNAL_FISH_URL=ws://my-server:3536/ws cargo run --example basic_lobby
-    ```
-
----
-
-## Custom Transport
-
-**Source:** `examples/custom_transport.rs`
-
-Demonstrates how to **implement the `Transport` trait** with a simple in-memory
-loopback, then wire it into the SDK — perfect for **unit testing without a
-network**.
-
-!!! info "This is a v2 / relay example"
-    Like `basic_lobby`, this example uses the default relay-floor configuration.
-    The `Transport` trait being implemented here is the byte channel to the
-    *signaling server* — distinct from the v3 `WebRtcDriver` peer-to-peer seam in
-    the [Mesh Guide](mesh-guide.md).
-
-### Simplified source
-
-!!! note
-    The actual [`examples/custom_transport.rs`](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/blob/main/examples/custom_transport.rs) uses the `tracing` crate for structured logging. The version below uses `println!` for simplicity.
-
-```rust
-use signal_fish_client::{
-    SignalFishClient, SignalFishConfig, SignalFishError, SignalFishEvent,
-    Transport, TransportFrame,
-};
-use tokio::sync::mpsc;
-
-pub struct LoopbackTransport {
-    tx: Option<mpsc::UnboundedSender<String>>,
-    rx: mpsc::UnboundedReceiver<String>,
-    closed: bool,
-}
-
-pub struct LoopbackServer {
-    pub rx: mpsc::UnboundedReceiver<String>,
-    pub tx: mpsc::UnboundedSender<String>,
-}
-
-fn loopback_pair() -> (LoopbackTransport, LoopbackServer) {
-    let (client_tx, server_rx) = mpsc::unbounded_channel();
-    let (server_tx, client_rx) = mpsc::unbounded_channel();
-    let transport = LoopbackTransport {
-        tx: Some(client_tx),
-        rx: client_rx,
-        closed: false,
-    };
-    let server = LoopbackServer { rx: server_rx, tx: server_tx };
-    (transport, server)
-}
-
-impl Transport for LoopbackTransport {
-    fn poll_send(
-        &mut self,
-        _cx: &mut std::task::Context<'_>,
-        frame: &mut Option<TransportFrame>,
-    ) -> std::task::Poll<Result<(), SignalFishError>> {
-        let Some(tx) = self.tx.as_ref() else {
-            return std::task::Poll::Ready(Err(SignalFishError::TransportClosed));
-        };
-        let result = match frame.take() {
-            Some(TransportFrame::Text(message)) => tx.send(message)
-                .map_err(|e| SignalFishError::TransportSend(e.to_string())),
-            Some(TransportFrame::Binary(_)) => Err(SignalFishError::TransportSend(
-                "text-only loopback does not accept binary frames".into(),
-            )),
-            None => Ok(()),
-        };
-        std::task::Poll::Ready(result)
-    }
-    fn poll_recv(
-        &mut self,
-        cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Option<Result<TransportFrame, SignalFishError>>> {
-        if self.closed {
-            return std::task::Poll::Ready(None);
-        }
-        self.rx.poll_recv(cx)
-            .map(|message| message.map(|text| Ok(TransportFrame::Text(text))))
-    }
-    fn poll_close(
-        &mut self,
-        _cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Result<(), SignalFishError>> {
-        self.closed = true;
-        self.tx = None;
-        self.rx.close();
-        std::task::Poll::Ready(Ok(()))
-    }
-
-    fn abort(&mut self) {
-        self.closed = true;
-        self.tx = None;
-        self.rx.close();
-    }
-}
-
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (transport, mut server) = loopback_pair();
-    let config = SignalFishConfig::new("mb_app_test");
-    let (mut client, mut event_rx) = SignalFishClient::start(transport, config);
-
-    let auth_msg = server.rx.recv().await.expect("should receive Authenticate");
-    println!("Server received: {auth_msg}");
-
-    let auth_response = serde_json::json!({
-        "type": "Authenticated",
-        "data": {
-            "app_name": "Test App",
-            "organization": null,
-            "rate_limits": { "per_minute": 60, "per_hour": 3600, "per_day": 86400 }
-        }
-    });
-    server.tx.send(auth_response.to_string())?;
-
-    let mut events_seen = 0;
-    while let Some(event) = event_rx.recv().await {
-        match &event {
-            SignalFishEvent::Connected => println!("Event: Connected (synthetic)"),
-            SignalFishEvent::Authenticated { app_name, .. } => {
-                println!("Event: Authenticated — app_name={app_name}");
-            }
-            SignalFishEvent::Disconnected { reason, .. } => {
-                println!("Event: Disconnected — {}", reason.as_deref().unwrap_or("clean"));
-                break;
-            }
-            _ => println!("Event: {event:?}"),
-        }
-        events_seen += 1;
-        if events_seen >= 2 { break; }
-    }
-
-    client.shutdown().await;
-    println!("Done — saw {events_seen} event(s). Custom transport works!");
-    Ok(())
-}
-```
-
-### Step-by-step walkthrough
-
-#### 1. Define `LoopbackTransport` with mpsc channels
-
-```rust,ignore
-pub struct LoopbackTransport {
-    tx: Option<mpsc::UnboundedSender<String>>,
-    rx: mpsc::UnboundedReceiver<String>,
-    closed: bool,
-}
-```
-
-Two unbounded channels form a **bidirectional pipe**: one for messages the
-client sends *to* the server, one for messages the server sends *back*.
-
-The helper `loopback_pair()` wires the channels so that each side's `tx` feeds
-the other side's `rx`.
-
-#### 2. Implement the `Transport` trait
-
-```rust,ignore
-impl Transport for LoopbackTransport {
-    fn poll_send(
-        &mut self,
-        _cx: &mut std::task::Context<'_>,
-        frame: &mut Option<TransportFrame>,
-    ) -> std::task::Poll<Result<(), SignalFishError>> {
-        let Some(tx) = self.tx.as_ref() else {
-            return std::task::Poll::Ready(Err(SignalFishError::TransportClosed));
-        };
-        let result = match frame.take() {
-            Some(TransportFrame::Text(message)) => tx.send(message)
-                .map_err(|e| SignalFishError::TransportSend(e.to_string())),
-            Some(TransportFrame::Binary(_)) => Err(SignalFishError::TransportSend(
-                "text-only loopback does not accept binary frames".into(),
-            )),
-            None => Ok(()),
-        };
-        std::task::Poll::Ready(result)
-    }
-    fn poll_recv(
-        &mut self,
-        cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Option<Result<TransportFrame, SignalFishError>>> {
-        if self.closed {
-            return std::task::Poll::Ready(None);
-        }
-        self.rx.poll_recv(cx)
-            .map(|message| message.map(|text| Ok(TransportFrame::Text(text))))
-    }
-    fn poll_close(
-        &mut self,
-        _cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Result<(), SignalFishError>> {
-        self.closed = true;
-        self.tx = None;
-        self.rx.close();
-        std::task::Poll::Ready(Ok(()))
-    }
-
-    fn abort(&mut self) {
-        self.closed = true;
-        self.tx = None;
-        self.rx.close();
-    }
-}
-```
-
-Four lifecycle methods are required:
-
-| Method | Purpose |
-|---|---|
-| `poll_send` | Accept and progress a text or binary frame. |
-| `poll_recv` | Poll the next frame (returns `Ready(None)` on close). |
-| `poll_close` | Progress cleanup idempotently (immediately ready here). |
-| `abort` | Immediately abandon work and release owned resources. |
-
-#### 3. Create a fake server that injects responses
-
-```rust,ignore
-let auth_msg = server.rx.recv().await.expect("should receive Authenticate");
-let auth_response = serde_json::json!({ /* … */ });
-server.tx.send(auth_response.to_string())?;
-```
-
-The "server" side reads the auto-sent `Authenticate` message, then replies with
-a hand-crafted `Authenticated` JSON payload — no network required.
-
-#### 4. Wire into the client and observe events
-
-```rust,ignore
-let (mut client, mut event_rx) = SignalFishClient::start(transport, config);
-```
-
-From the SDK's perspective the loopback behaves identically to a real WebSocket.
-The example collects two events (`Connected` and `Authenticated`) before
-shutting down.
-
-!!! note "Use case: unit testing without a network"
-
-    This pattern is the recommended way to **test application logic** that
-    depends on Signal Fish without needing a live server. Inject whatever
-    server messages you like and assert on the resulting events.
-
-### Running it
+The default server URL is `ws://localhost:3536/v2/ws`. Override it when your
+server runs elsewhere:
 
 ```sh
-cargo run --example custom_transport
+SIGNAL_FISH_URL=ws://my-server:3536/v2/ws cargo run --example basic_lobby
 ```
 
-Expected output (from the simplified source above; the actual example uses
-`tracing` so output includes timestamps and log levels):
+Need a server? The Signal Fish Server
+[five-minute quick start](https://ambiguous-interactive.github.io/signal-fish-server/quickstart/)
+provides a development setup.
 
-```text
-Server received: {"type":"Authenticate","data":{"app_id":"mb_app_test","sdk_version":"<version>"}}
-Event: Connected (synthetic)
-Event: Authenticated — app_name=Test App
-Done — saw 2 event(s). Custom transport works!
-```
+## What the example does
 
----
-
-## Mesh Session (protocol v3)
-
-**Source:** `examples/mesh_session.rs`
-
-Demonstrates the **batteries-included mesh path**: implement the `WebRtcDriver`
-trait against your WebRTC stack, hand it to `MeshController`, and the SDK drives
-the entire v3 signaling handshake for you — obeying the server's `initiate`
-directives, relaying offers/answers/ICE, reporting transport status, and
-surfacing a clean `MeshEvent` stream. The example is fully self-contained: a
-scripted in-process "server" plays the v3 handshake and a tiny in-memory driver
-completes it, so the whole stack runs end-to-end with no network.
-
-!!! info "Requires the `mesh` and `tokio-runtime` features"
-    Run it with:
-    ```sh
-    cargo run --example mesh_session --features mesh,tokio-runtime
-    ```
-    See the [Mesh Guide](mesh-guide.md) for the full concepts behind this flow.
-
-### Step-by-step walkthrough
-
-#### 1. Implement `WebRtcDriver`
-
-The example's `DemoDriver` models a realistic handshake without real WebRTC: the
-initiator emits an offer on `connect`; the answerer emits an answer (and "opens"
-the channel) when it receives an offer; the initiator "opens" the channel when it
-receives the answer. The integration points are marked `// REAL DRIVER:`.
+### 1. Connect and start
 
 ```rust,ignore
-impl WebRtcDriver for DemoDriver {
-    fn set_ice_servers(&mut self, servers: &[IceServer]) { /* configure STUN/TURN */ }
+tracing::info!("connecting…");
+let transport = WebSocketTransport::connect(&url).await?;
+let config = SignalFishConfig::new("mb_app_abc123");
+let (mut client, mut events) = SignalFishClient::start(transport, config);
+```
 
-    fn connect(&mut self, peer: PlayerId, initiate: bool) {
-        // Obey `initiate`: only the designated offerer creates an offer.
-        if initiate {
-            self.outbox.push_back(DriverEvent::Signal {
-                peer,
-                signal: PeerSignal::Offer("<sdp-offer>".into()),
-            });
-        }
-    }
+The App ID is a public application label, not a secret. An open development
+server accepts a test label; a managed or production server may restrict the
+allowed labels.
 
-    fn on_signal(&mut self, peer: PlayerId, signal: PeerSignal) {
-        match signal {
-            PeerSignal::Offer(_) => {
-                self.outbox.push_back(DriverEvent::Signal {
-                    peer, signal: PeerSignal::Answer("<sdp-answer>".into()),
-                });
-                self.outbox.push_back(DriverEvent::Connected { peer });
-            }
-            PeerSignal::Answer(_) => self.outbox.push_back(DriverEvent::Connected { peer }),
-            PeerSignal::IceCandidate(_) => {}
-        }
-    }
+Starting the client queues authentication and returns a command handle plus an
+event receiver. Keep receiving events while the client is active.
 
-    fn send(&mut self, peer: PlayerId, data: &[u8]) { /* write to data channel */ }
-    fn disconnect(&mut self, peer: PlayerId) { /* close the peer connection */ }
-    fn poll(&mut self) -> Option<DriverEvent> { self.outbox.pop_front() }
+### 2. Wait for authentication
+
+```rust,ignore
+SignalFishEvent::Authenticated { app_name, .. } => {
+    let params = JoinRoomParams::new("example-game", "RustPlayer")
+        .with_max_players(4);
+    client.join_room(params)?;
 }
 ```
 
-A **real** driver wraps str0m, webrtc-rs, or the browser's `RtcPeerConnection`
-(via web-sys) — see [Integrating a real backend](mesh-guide.md#integrating-a-real-backend).
+Room commands are valid only after `Authenticated`. Authentication failures
+arrive as `AuthenticationError`; the example logs the server error code and
+exits.
 
-#### 2. Start the `MeshController`
-
-`MeshController::start` ensures the config advertises v3, WebRTC, and at least
-one P2P topology, then drives the handshake. Compatible explicit transport,
-topology, and future-version choices are preserved. The plain relay-floor
-`SignalFishConfig::new("demo-app")` therefore works directly.
+### 3. Join and become ready
 
 ```rust,ignore
-let mut mesh = MeshController::start(
-    transport,
-    SignalFishConfig::new("demo-app"),
-    DemoDriver::default(),
-);
-```
-
-#### 3. Drive the event loop
-
-A handful of lines drive the whole flow. The controller surfaces every underlying
-event as `MeshEvent::Signaling`, plus the high-level `PeerConnected` /
-`PeerDisconnected` / `Data` events.
-
-```rust,ignore
-while let Some(event) = mesh.recv().await {
-    match event {
-        MeshEvent::Signaling(sig) => match *sig {
-            SignalFishEvent::Authenticated { .. } =>
-                mesh.join_room(JoinRoomParams::new("demo-game", "Alice"))?,
-            SignalFishEvent::LobbyStateChanged { all_ready: true, .. } =>
-                mesh.start_game()?,
-            SignalFishEvent::SessionPlan { peers, .. } =>
-                println!("session plan: {} peer(s) to connect", peers.len()),
-            _ => {}
-        },
-        MeshEvent::PeerConnected(peer) => {
-            mesh.send_to(peer, b"hello peer"); // data channel is open
-            break; // demo complete
-        }
-        MeshEvent::PeerDisconnected(peer) => println!("peer {peer} disconnected"),
-        MeshEvent::Data { from, data } => println!("{} bytes from {from}", data.len()),
-    }
-}
-
-mesh.shutdown().await;
-```
-
-The flow end to end: authenticate → join room → `start_game()` → the scripted
-server sends a `SessionPlan` (`initiate=true`) → the driver offers → the
-controller relays the offer → the peer's answer arrives → the driver opens the
-channel → `MeshEvent::PeerConnected` fires and the example sends a packet.
-
-### Running it
-
-```sh
-cargo run --example mesh_session --features mesh,tokio-runtime
-```
-
----
-
-## Godot Web Export (Polling Client)
-
-Demonstrates the supported `SignalFishPollingClient` integration with
-`GodotWebSocketTransport`. It delegates to Godot's own `WebSocketPeer` and
-works with native builds and official no-thread Godot web export templates.
-
-!!! note "Companion crate"
-    This example requires the `signal-fish-client-godot` adapter and the
-    `wasm32-unknown-emscripten` target. It cannot be run with
-    `cargo run --example` — it must be compiled as part of a GDExtension
-    library. See the [WebAssembly Guide](wasm.md) for full build
-    instructions.
-
-### Cargo.toml
-
-```toml
-[package]
-name = "my-godot-game"
-version = "0.1.0"
-edition = "2021"
-
-[lib]
-crate-type = ["cdylib"]
-
-[dependencies]
-godot = { version = "0.5.4", features = ["api-custom", "experimental-wasm", "experimental-wasm-nothreads", "lazy-function-tables"] }
-# The issue #61 throughput/admission fix is currently unreleased on `main`.
-signal-fish-client = { git = "https://github.com/Ambiguous-Interactive/signal-fish-client-rust", default-features = false, features = ["polling-client"] }
-signal-fish-client-godot = { git = "https://github.com/Ambiguous-Interactive/signal-fish-client-rust" }
-serde_json = "1.0"  # Required for send_game_data(serde_json::Value)
-```
-
-The stable crates.io dependency is
-`signal-fish-client = { version = "0.10.0", ... }`, but 0.10.0 predates the
-issue #61 polling-throughput fix documented in this current-`main` guide.
-
-### Source
-
-```rust,ignore
-use godot::prelude::*;
-use signal_fish_client::{
-    JoinRoomParams, SignalFishConfig, SignalFishEvent, SignalFishPollingClient,
-};
-use signal_fish_client_godot::GodotWebSocketTransport;
-
-#[derive(GodotClass)]
-#[class(base=Node)]
-struct SignalFishNode {
-    base: Base<Node>,
-    client: Option<SignalFishPollingClient<GodotWebSocketTransport>>,
-}
-
-#[godot_api]
-impl INode for SignalFishNode {
-    fn init(base: Base<Node>) -> Self {
-        Self {
-            base,
-            client: None,
-        }
-    }
-
-    fn ready(&mut self) {
-        let transport = GodotWebSocketTransport::connect("wss://server/ws")
-            .expect("WebSocket creation failed");
-
-        let config = SignalFishConfig::new("mb_app_abc123");
-        self.client = Some(SignalFishPollingClient::new(transport, config));
-
-        godot_print!("Signal Fish client initialized");
-    }
-
-    fn process(&mut self, _delta: f64) {
-        let Some(client) = &mut self.client else { return };
-
-        for event in client.poll() {
-            match event {
-                SignalFishEvent::Connected => {
-                    godot_print!("Transport connected");
-                }
-                SignalFishEvent::Authenticated { app_name, .. } => {
-                    godot_print!("Authenticated as {}", app_name);
-                    let params = JoinRoomParams::new("my-game", "WebPlayer")
-                        .with_max_players(4);
-                    if let Err(e) = client.join_room(params) {
-                        godot_print!("Failed to join room: {e}");
-                    }
-                }
-                SignalFishEvent::RoomJoined { room_code, player_id, .. } => {
-                    godot_print!("Joined room {} as {}", room_code, player_id);
-                }
-                SignalFishEvent::GameData { data, from_player, .. } => {
-                    godot_print!("Game data from {}: {}", from_player, data);
-                }
-                SignalFishEvent::Disconnected { reason, .. } => {
-                    godot_print!(
-                        "Disconnected: {}",
-                        reason.as_deref().unwrap_or("unknown")
-                    );
-                    self.client = None;
-                    return;
-                }
-                _ => {}
-            }
-        }
-    }
+SignalFishEvent::RoomJoined { room_code, .. } => {
+    tracing::info!("joined room {room_code}");
+    client.set_ready()?;
 }
 ```
 
-### Step-by-step walkthrough
+The example also reports players joining or leaving and observes
+`LobbyStateChanged`. When everyone is ready, it sends one `start_game()`
+request.
 
-#### 1. Define the GDExtension node
+### 4. Handle connection state
 
-```rust,ignore
-#[derive(GodotClass)]
-#[class(base=Node)]
-struct SignalFishNode {
-    base: Base<Node>,
-    client: Option<SignalFishPollingClient<GodotWebSocketTransport>>,
-}
-```
+The event loop reports `Connected`, errors, and disconnects. It also keeps the
+authority/start-request state correct if a `Reconnected` event arrives. The
+example exits on `Disconnected`; it does not initiate a reconnect itself.
 
-The `client` field is `Option` because the transport connection is
-established in `ready()`, not at construction time. The generic parameter
-`GodotWebSocketTransport` satisfies the `Transport` bound without requiring
-`Send`, which is important for Godot's main-thread object model.
-
-#### 2. Connect in `ready()`
+### 5. Shut down
 
 ```rust,ignore
-fn ready(&mut self) {
-    let transport = GodotWebSocketTransport::connect("wss://server/ws")
-        .expect("WebSocket creation failed");
-    let config = SignalFishConfig::new("mb_app_abc123");
-    self.client = Some(SignalFishPollingClient::new(transport, config));
-}
+client.shutdown().await;
 ```
 
-`GodotWebSocketTransport::connect` is **synchronous** — no `.await`
-needed. The polling client constructor queues an `Authenticate` message
-automatically.
+Pressing Ctrl+C leaves the event loop and asks the transport to close cleanly.
+Shutdown waits up to `SignalFishConfig::shutdown_timeout`, then uses the
+transport abort path if needed.
 
-#### 3. Poll in `process()`
+## Advanced examples
 
-```rust,ignore
-fn process(&mut self, _delta: f64) {
-    let Some(client) = &mut self.client else { return };
-    for event in client.poll() {
-        // handle events
-    }
-}
-```
+After the lobby flow works, use these compiling repository examples with the
+canonical guide for that subsystem:
 
-Godot calls `_process` once per frame. `poll()` processes outgoing and incoming
-work up to its configured frame/byte budgets, preserving remaining FIFO work
-for later callbacks, and returns that cycle's `Vec<SignalFishEvent>`. When idle,
-it returns an empty vector.
+- [`custom_transport.rs`](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/blob/main/examples/custom_transport.rs)
+  with the [custom transport guide](transport.md)
+- [`mesh_session.rs`](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/blob/main/examples/mesh_session.rs)
+  with the [mesh guide](mesh-guide.md)
+- [`load_lab.rs`](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/blob/main/examples/load_lab.rs)
+  with the [delivery and backpressure guide](delivery.md)
+- the complete [`tests/godot-web-smoke`](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/tree/main/tests/godot-web-smoke)
+  fixture with the [Godot and WebAssembly guide](wasm.md)
 
-#### 4. Build for web export
-
-After setting the `GODOT4_BIN`, bindgen, and side-module environment variables
-from the [WebAssembly Guide](wasm.md#building):
-
-```sh
-cargo +nightly-2026-03-01 build -Zbuild-std=std \
-    --target wasm32-unknown-emscripten --release
-```
-
-The resulting `.wasm` file is used by Godot's HTML5 export template.
-
----
-
-## Load Lab (measurement harness)
-
-[`examples/load_lab.rs`](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/blob/main/examples/load_lab.rs)
-is a CSV-emitting measurement harness for running controlled relay
-experiments against a **local** Signal Fish server — the tool behind the
-numbers in [Delivery Contract & Backpressure](delivery.md).
-
-```sh
-# Run a local server in open lab mode first:
-#   SIGNAL_FISH__SECURITY__REQUIRE_WEBSOCKET_AUTH=false \
-#   SIGNAL_FISH__SECURITY__REQUIRE_METRICS_AUTH=false \
-#   SIGNAL_FISH__PROTOCOL__SDK_COMPATIBILITY__ENFORCE=false \
-#   signal-fish-server
-
-cargo run --example load_lab --features transport-websocket -- ping
-cargo run --example load_lab --features transport-websocket -- \
-    throughput rates=50,100,200,400 payload=1024 recipients=3
-cargo run --example load_lab --features transport-websocket -- \
-    slow-consumer rate=120 drain_ms=100
-cargo run --example load_lab --features transport-websocket -- \
-    control-starvation drain_ms=5
-```
-
-Four modes: `ping` (baseline RTT), `throughput` (offered-rate sweep with
-latency percentiles), `slow-consumer` (one slow-draining room member —
-measures how much it paces the sender and the healthy recipients), and
-`control-starvation` (Pong RTT at a backlogged recipient). Never point it
-at a production deployment you don't own.
+The focused guides own platform setup and protocol contracts so those details
+have one maintained source of truth.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,189 +1,160 @@
 # Installation & Quick Start
 
-Get up and running with the Signal Fish Client SDK in minutes.
+This guide connects one Rust client, authenticates it, and joins a room. You
+need Rust **1.87.0** or newer, a Signal Fish server URL, and an app ID accepted
+by that server.
 
-## Prerequisites
+If you do not have a server yet, follow the Signal Fish Server [five-minute
+quick start](https://ambiguous-interactive.github.io/signal-fish-server/quickstart/).
+Its development setup accepts a test app ID. The App ID is a public application
+label, not a secret. For production, use a label allowed by the server
+operator's policy.
 
-Before you begin, make sure you have:
+## Install the SDK
 
-- **Rust 1.87.0** or newer (`rustup update stable`)
-- A **Tokio** runtime for `SignalFishClient`, or a frame loop for
-  `SignalFishPollingClient`
-- A running **Signal Fish server** URL (e.g., `ws://localhost:3536/ws`)
-- An **App ID** registered with your Signal Fish server
-
-## Installation
-
-Add the crate to your project:
+Add the client and the Tokio features used by this example:
 
 ```sh
 cargo add signal-fish-client
-cargo add tokio --features macros,rt-multi-thread,signal
+cargo add tokio --features macros,rt-multi-thread
 ```
 
-The first command installs the stable crates.io release, currently **0.10.0**.
-The second is a direct Tokio dependency for the async example below; Rust code
-cannot use the SDK's transitive Tokio dependency directly.
+The equivalent manifest entries are:
 
-!!! note "Current-main documentation"
-    This guide tracks the repository's unreleased `main` branch. To use
-    post-0.10.0 APIs such as polling work budgets, queue-age diagnostics, and
-    the issue #61 Godot admission fix, use:
+```toml
+[dependencies]
+signal-fish-client = "0.10.0"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+```
+
+`signal-fish-client` enables its built-in WebSocket transport by default.
+
+!!! note "Published release and main"
+    **0.10.0** is the current crates.io release. This guide follows unreleased
+    `main`, which includes breaking APIs planned for 0.11. Use the [0.10.0
+    docs.rs pages](https://docs.rs/signal-fish-client/0.10.0/) with the versioned
+    dependency above. To evaluate unreleased changes, use:
 
     ```toml
     signal-fish-client = { git = "https://github.com/Ambiguous-Interactive/signal-fish-client-rust" }
     ```
 
-    For the published 0.10.0 surface, use the version dependency below and the
-    [0.10.0 docs.rs pages](https://docs.rs/signal-fish-client/0.10.0/).
+## Connect and join a room
 
-### Feature Flags
-
-| Feature                | Default | Description                                      |
-|------------------------|---------|--------------------------------------------------|
-| `transport-websocket`  | Yes     | WebSocket transport via `tokio-tungstenite`       |
-| `transport-websocket-emscripten` | No | Emscripten WebSocket transport for `wasm32-unknown-emscripten` |
-| `token-binding` | No | Native `WebSocketTransport` support for Server 0.7 token binding |
-| `tls` | No | Native `wss://` via rustls; required by token-binding-required Server 0.7 profiles |
-| `polling-client` | No | Synchronous, caller-driven `SignalFishPollingClient` |
-| `tokio-runtime` | No (enabled by default `transport-websocket`) | Tokio task/time integration used by the async client |
-| `mesh` | No | Protocol-v3 `MeshSession`, `WebRtcDriver`, and `MeshController` helpers |
-
-#### With default features (includes WebSocket transport)
-
-```toml
-[dependencies]
-signal-fish-client = "0.10.0"
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
-```
-
-#### Without default features (bring your own transport)
-
-```toml
-[dependencies]
-signal-fish-client = { version = "0.10.0", default-features = false }
-```
-
-!!! tip
-    If you only need the core `Transport` trait to implement a custom backend, disable default features to avoid pulling in `tokio-tungstenite` and `futures-util`.
-
-#### For Godot 4.5 native and web exports
-
-```toml
-[dependencies]
-godot = { version = "0.5.4", features = ["api-custom", "experimental-wasm", "experimental-wasm-nothreads", "lazy-function-tables"] }
-# The issue #61 transport-admission fix is currently unreleased on `main`.
-signal-fish-client = { git = "https://github.com/Ambiguous-Interactive/signal-fish-client-rust", default-features = false, features = ["polling-client"] }
-signal-fish-client-godot = { git = "https://github.com/Ambiguous-Interactive/signal-fish-client-rust" }
-```
-
-!!! tip
-    The lockstep `signal-fish-client-godot` adapter provides `GodotWebSocketTransport`; core provides `SignalFishPollingClient`. This synchronous, game-loop-driven path uses Godot's own `WebSocketPeer`, works with official no-thread web export templates, and requires no GDScript glue. The adapter supports godot-rust 0.4.5 through 0.5.x and requires Rust 1.94, while core remains on Rust 1.87. See the [WebAssembly Guide](wasm.md) for complete setup instructions.
-
-## Minimal Example
-
-Below is a complete working example that connects to a Signal Fish server, authenticates, joins a room, and shuts down gracefully.
+Create `src/main.rs`:
 
 ```rust
 use signal_fish_client::{
-    JoinRoomParams, SignalFishClient, SignalFishConfig, SignalFishEvent, WebSocketTransport,
+    JoinRoomParams, SignalFishClient, SignalFishConfig, SignalFishEvent,
+    WebSocketTransport,
 };
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Read the server URL from the environment, or fall back to localhost.
+async fn main() -> Result<(), signal_fish_client::SignalFishError> {
     let url = std::env::var("SIGNAL_FISH_URL")
-        .unwrap_or_else(|_| "ws://localhost:3536/ws".to_string());
+        .unwrap_or_else(|_| "ws://localhost:3536/v2/ws".to_owned());
 
-    // 1. Connect a WebSocket transport to the signaling server.
     let transport = WebSocketTransport::connect(&url).await?;
+    let config = SignalFishConfig::new("mb_app_abc123");
+    let (mut client, mut events) = SignalFishClient::start(transport, config);
 
-    // 2. Build a client config with your application ID.
-    let config = SignalFishConfig::new("your-app-id");
-
-    // 3. Start the client — returns a handle and an event receiver.
-    let (mut client, mut event_rx) = SignalFishClient::start(transport, config);
-    let mut start_request_sent = false;
-
-    // 4. Drive the event loop.
-    loop {
-        tokio::select! {
-            event = event_rx.recv() => {
-                let Some(event) = event else {
-                    // Channel closed — background task exited.
-                    break;
-                };
-
-                match event {
-                    SignalFishEvent::Connected => {
-                        println!("Transport connected");
-                    }
-                    SignalFishEvent::Authenticated { app_name, .. } => {
-                        println!("Authenticated as {app_name}");
-                        // Safe to join a room now.
-                        client.join_room(JoinRoomParams::new("my-game", "Alice"))?;
-                    }
-                    SignalFishEvent::RoomJoined { room_code, player_id, .. } => {
-                        println!("Joined room {room_code} as {player_id}");
-                        client.set_ready()?;
-                    }
-                    SignalFishEvent::LobbyStateChanged { all_ready: true, .. }
-                        if !start_request_sent =>
-                    {
-                        // JoinRoomParams above creates a non-authority room.
-                        client.start_game()?;
-                        start_request_sent = true;
-                    }
-                    SignalFishEvent::Disconnected { .. } => break,
-                    _ => {}
-                }
+    while let Some(event) = events.recv().await {
+        match event {
+            SignalFishEvent::Connected => println!("transport connected"),
+            SignalFishEvent::Authenticated { app_name, .. } => {
+                println!("authenticated as {app_name}");
+                client.join_room(JoinRoomParams::new("my-game", "Alice"))?;
             }
-            // Graceful shutdown on Ctrl+C.
-            _ = tokio::signal::ctrl_c() => {
-                println!("Shutting down...");
+            SignalFishEvent::RoomJoined { room_code, .. } => {
+                println!("joined room {room_code}");
+            }
+            SignalFishEvent::AuthenticationError { error, .. } => {
+                eprintln!("authentication failed: {error}");
                 break;
             }
+            SignalFishEvent::Disconnected { reason, .. } => {
+                eprintln!("disconnected: {}", reason.as_deref().unwrap_or("unknown"));
+                break;
+            }
+            _ => {}
         }
     }
 
-    // 5. Shut down gracefully.
     client.shutdown().await;
     Ok(())
 }
 ```
 
-!!! note
-    `WebSocketTransport` requires the `transport-websocket` feature, which is enabled by default. If you disabled default features you will need to re-enable it explicitly:
-    ```toml
-    signal-fish-client = { version = "0.10.0", default-features = false, features = ["transport-websocket"] }
-    ```
+Replace `mb_app_abc123` with your app ID, then run:
 
-## What Happens Under the Hood
+```sh
+SIGNAL_FISH_URL=ws://localhost:3536/v2/ws cargo run
+```
 
-When you call `SignalFishClient::start`, the SDK:
+Authentication is queued when the client starts. Wait for `Authenticated`
+before sending room commands, and keep receiving events for as long as the
+client is active. A full event channel pauses protocol progress instead of
+silently dropping events.
 
-1. **Spawns a background task** that drives the transport — reading incoming messages and writing outgoing ones.
-2. **Auto-authenticates** by immediately sending an `Authenticate` message with the App ID from your `SignalFishConfig`.
-3. **Emits typed events** on a bounded `tokio::sync::mpsc` channel (default capacity **256**, configurable via [`SignalFishConfig::event_channel_capacity`](client.md#signalfishconfig)). Your application consumes these via the `event_rx` receiver returned from `start`.
+## Add the game lifecycle
 
-You interact with the server by calling methods on the `SignalFishClient` handle (e.g., `join_room`, `send_game_data`). These enqueue outgoing messages on a bounded queue that the background task drains over the transport; if you outpace the transport, sends fail fast with `SendBufferFull` instead of silently dropping (see [Core Concepts](concepts.md#non-blocking-command-sending)).
+Most games continue with these events and commands:
 
-!!! note
-    Events are not dropped merely because the event channel overflows. If your event-processing loop
-    cannot keep up with the server, the transport loop pauses until the channel
-    has room — backpressure propagates to the server instead of losing events.
-    An event can only be missed if the receiver is dropped, the client handle
-    is dropped without calling `shutdown()`, or on
-    [`shutdown()`](client.md#shutdown) — which delivers the terminal
-    `Disconnected` best-effort and may abandon at most one in-flight event. A
-    shutdown-timeout abort can also prevent the terminal event. Keep
-    your handler responsive so the connection keeps flowing;
-    `event_channel_capacity` on your `SignalFishConfig` controls how much
-    buffering you get before backpressure kicks in.
+1. On `RoomJoined`, call `set_ready()` when the local player is ready.
+2. Observe `LobbyStateChanged` and authority events.
+3. Call `start_game()` once the server's room rules allow it.
+4. Exchange JSON game data after `GameStarting`. Binary frames require
+   [protocol v3](protocol-versioning.md#opting-in) and an effectively negotiated
+   binary format; see [Game Data](client.md#game-data).
+5. Handle reconnect or disconnect events and call `shutdown().await` on exit.
 
-## Next Steps
+The [`basic_lobby` example](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/blob/main/examples/basic_lobby.rs)
+implements this flow without hiding authority changes or reconnect state. Run
+the repository copy with:
 
-- [Core Concepts](concepts.md) — rooms, players, relays, and the event model
-- [Client API](client.md) — full reference for `SignalFishClient` methods
-- [Events](events.md) — every `SignalFishEvent` variant explained
-- [WebAssembly Guide](wasm.md) — building for `wasm32-unknown-unknown` and `wasm32-unknown-emscripten`, Godot integration
+```sh
+cargo run --example basic_lobby
+```
+
+## Choose a different runtime
+
+The async client runs a Tokio background task. Use the polling client when the
+host gives your code one callback per frame and does not continuously drive a
+Tokio runtime.
+
+| Environment | Client and transport |
+| --- | --- |
+| Tokio native application | `SignalFishClient` + `WebSocketTransport` |
+| Godot 4.5 native or web | `SignalFishPollingClient` + `GodotWebSocketTransport` |
+| Browser with a custom binding | `SignalFishPollingClient` + your `Transport` |
+| Custom async backend | `SignalFishClient` + your `Transport + Send` |
+
+See [WebAssembly](wasm.md) for Godot and browser setup, or [Transport](transport.md)
+to implement a backend.
+
+## Optional capabilities
+
+The default feature set is enough for the example above. Add features only for
+the capability you need:
+
+| Feature | Purpose |
+| --- | --- |
+| `transport-websocket` | Built-in native WebSocket transport; enabled by default |
+| `tokio-runtime` | Async driver task and timing support; enabled by the default transport |
+| `tls` | Native `wss://` connections |
+| `polling-client` | Caller-driven client for game loops |
+| `mesh` | Protocol-v3 WebRTC mesh state and controller APIs |
+| `token-binding` | Native Server 0.7 token-binding negotiation |
+| `transport-websocket-emscripten` | Advanced custom Emscripten hosts |
+
+The default `transport-websocket` feature also enables `tokio-runtime`, which
+provides the task and timing support required by `SignalFishClient`. If you
+disable default features, select both capabilities explicitly.
+
+## Next steps
+
+- [Basic Lobby Walkthrough](examples.md) for the complete lobby flow
+- [Client API Reference](client.md) for commands and configuration
+- [Events Reference](events.md) and [Error Handling](errors.md) for event loops
+- [Protocol Versioning](protocol-versioning.md) before enabling v3 or mesh
+- [Delivery Contract & Backpressure](delivery.md) before tuning queue capacity

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,4 @@
 ---
-title: Home
 description: "Connect Rust and Godot games to the Signal Fish multiplayer signaling service"
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,104 +1,53 @@
 ---
 title: Home
-description: "Signal Fish Client SDK — A framed-transport-agnostic Rust client SDK for the Signal Fish multiplayer signaling protocol"
+description: "Connect Rust and Godot games to the Signal Fish multiplayer signaling service"
 ---
 
 <p align="center">
   <img src="assets/logo-banner.svg" alt="Signal Fish Client SDK" width="600">
 </p>
 
-**A framed-transport-agnostic Rust client SDK for the Signal Fish multiplayer signaling protocol.**
-
-!!! note "Release status"
-    **0.10.0** is the current crates.io release. This site follows unreleased
-    `main`; use the [0.10.0 API docs](https://docs.rs/signal-fish-client/0.10.0/)
-    for the published surface.
-
-[![Crates.io](https://img.shields.io/crates/v/signal-fish-client?style=flat-square&logo=rust)](https://crates.io/crates/signal-fish-client)
-[![docs.rs](https://img.shields.io/docsrs/signal-fish-client?style=flat-square&logo=docs.rs)](https://docs.rs/signal-fish-client)
-[![CI](https://img.shields.io/github/actions/workflow/status/Ambiguous-Interactive/signal-fish-client-rust/ci.yml?branch=main&style=flat-square&logo=github&label=CI)](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/actions/workflows/ci.yml)
-[![License: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat-square)](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/blob/main/LICENSE)
 [![MSRV](https://img.shields.io/badge/MSRV-1.87.0-brightgreen?style=flat-square&logo=rust)](https://doc.rust-lang.org/stable/releases.html#version-1870-2025-05-15)
 
----
+# Signal Fish Client SDK
 
-## Key Features
+Use this SDK to connect a Rust game to Signal Fish, place players in rooms,
+relay game data, and react to server events. Choose an async Tokio client or a
+polling client that runs inside your game loop.
 
-- :material-swap-horizontal: **Framed-Transport-Agnostic** — Plug in a backend that yields complete, ordered text/binary frames; raw stream/datagram framing and signaling-server trust remain backend responsibilities.
-- :material-lightning-bolt: **Async or Frame-Driven** — Use the Tokio background driver or the synchronous polling client. Command admission is bounded and explicit in both.
-- :material-message-flash: **Typed Event Architecture** — The async driver
-  delivers strongly typed `SignalFishEvent` variants on a bounded `mpsc`
-  channel; the polling driver returns them directly from each `poll()` call.
-- :material-lan: **Protocol v2 relay + v3 mesh** — v3 WebRTC mesh signaling is opt-in and a default client keeps the v2 authentication wire shape; game start is now an explicit `start_game()` request. See [Protocol Versioning](protocol-versioning.md) and the [Mesh Guide](mesh-guide.md).
-- :material-web: **WebSocket Built-In** — `WebSocketTransport` ships out of the box (enabled by default via the `transport-websocket` feature) so you can connect in one line.
-- :material-gamepad-variant: **Godot Adapter** — the lockstep `signal-fish-client-godot` crate provides the Godot 4.5 native/web `WebSocketPeer` transport without coupling core to godot-rust.
-- :material-refresh: **Reconnection Support** — Gracefully handle disconnects and reconnect to your session without losing context.
-- :material-eye: **Spectator Mode** — Join rooms as a spectator to observe game state without participating.
-- :material-shield-check: **Explicit Flow Control** — Event-channel overflow applies backpressure during normal operation, and the bounded send queue surfaces congestion explicitly. Shutdown and receiver-drop boundaries are documented. See [Core Concepts](concepts.md#reliability-and-flow-control).
-- :material-tune-variant: **Configurable** — Tune event channel capacity, command queue capacity, shutdown timeout, and more via `SignalFishConfig` builder methods.
+!!! note "Release status"
+    **0.10.0** is the current crates.io release and supports Rust **1.87.0** or
+    newer. This site follows unreleased `main`; use the [0.10.0 API
+    docs](https://docs.rs/signal-fish-client/0.10.0/) for the published surface.
 
----
+## Get connected
 
-## Quick Start
+1. Run or obtain a Signal Fish server and choose an App ID. It is a public
+   application label, not a secret. The server's
+   [five-minute quick start](https://ambiguous-interactive.github.io/signal-fish-server/quickstart/)
+   provides a development setup.
+2. Add `signal-fish-client` to your game.
+3. Connect a transport and start a client.
+4. Wait for `Authenticated`, then join a room.
+5. Keep draining events while the client is active.
 
-Add the crate to your project:
+The [installation guide](getting-started.md) includes a complete first client.
+The repository's [`basic_lobby` example](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/blob/main/examples/basic_lobby.rs)
+adds readiness, game start, reconnection state, error, and shutdown handling.
 
-```bash
-cargo add signal-fish-client
-cargo add tokio --features macros,rt-multi-thread
-```
+## Pick the right path
 
-Then connect, authenticate, and join a room in just a few lines:
+| If you are building | Start with |
+| --- | --- |
+| A Tokio-based Rust game or service | `SignalFishClient` and the built-in WebSocket transport |
+| A Godot 4.5 native or web game | `SignalFishPollingClient` and the Godot adapter |
+| A browser or frame-driven engine | `SignalFishPollingClient` and a platform transport |
+| A game with WebRTC peers | Protocol v3 and the mesh guide after the relay path works |
 
-```rust
-use signal_fish_client::{
-    WebSocketTransport, SignalFishClient, SignalFishConfig,
-    JoinRoomParams, SignalFishEvent,
-};
+Protocol v2 relay is the simplest starting point. Protocol v3 adds delivery
+accountability and mesh signaling when your game needs them.
 
-#[tokio::main]
-async fn main() -> Result<(), signal_fish_client::SignalFishError> {
-    let transport = WebSocketTransport::connect("ws://example.com/signal").await?;
-    let config = SignalFishConfig::new("mb_app_abc123");
-    let (mut client, mut event_rx) = SignalFishClient::start(transport, config);
-    let mut start_request_sent = false;
-
-    while let Some(event) = event_rx.recv().await {
-        match event {
-            SignalFishEvent::Authenticated { app_name, .. } => {
-                println!("Authenticated as {app_name}");
-                client.join_room(JoinRoomParams::new("my-game", "Alice"))?;
-            }
-            SignalFishEvent::RoomJoined { room_code, .. } => {
-                println!("Joined room {room_code}");
-                client.set_ready()?;
-            }
-            SignalFishEvent::LobbyStateChanged { all_ready: true, .. }
-                if !start_request_sent =>
-            {
-                // The default JoinRoomParams creates a non-authority room.
-                client.start_game()?;
-                start_request_sent = true;
-            }
-            SignalFishEvent::Disconnected { .. } => break,
-            _ => {}
-        }
-    }
-
-    client.shutdown().await;
-    Ok(())
-}
-```
-
-!!! tip "Feature flag"
-    `WebSocketTransport` requires the **`transport-websocket`** feature, which is enabled by default. If you disabled default features, re-enable it explicitly:
-    ```toml
-    signal-fish-client = { version = "0.10.0", default-features = false, features = ["transport-websocket"] }
-    ```
-
----
-
-## Explore the Docs
+## Read by task
 
 <div class="grid cards" markdown>
 
@@ -106,49 +55,45 @@ async fn main() -> Result<(), signal_fish_client::SignalFishError> {
 
     ---
 
-    Install the crate, set up Tokio, and make your first connection in under five minutes.
+    Install the crate, connect, authenticate, and join a room.
 
     [:octicons-arrow-right-24: Installation & Quick Start](getting-started.md)
 
-- :material-book-open-variant:{ .lg .middle } **Client API Reference**
+- :material-code-tags:{ .lg .middle } **Basic Lobby Walkthrough**
 
     ---
 
-    Configuration, builder methods, and command reference for `SignalFishClient`.
+    Add readiness, game start, error handling, and graceful shutdown.
+
+    [:octicons-arrow-right-24: Basic Lobby Walkthrough](examples.md)
+
+- :material-gamepad-variant:{ .lg .middle } **Client API Reference**
+
+    ---
+
+    Find client configuration, room commands, game-data methods, and state.
 
     [:octicons-arrow-right-24: Client API Reference](client.md)
 
-- :material-code-tags:{ .lg .middle } **Example Walkthroughs**
+- :material-web:{ .lg .middle } **WebAssembly (WASM)**
 
     ---
 
-    Walkthroughs of real-world usage patterns — lobby management, custom transports, and more.
+    Integrate browser, Emscripten, or Godot native/web builds.
 
-    [:octicons-arrow-right-24: Example Walkthroughs](examples.md)
-
-- :material-file-document:{ .lg .middle } **API Docs (docs.rs)**
-
-    ---
-
-    Auto-generated API documentation with full type signatures and doc comments.
-
-    [:octicons-arrow-right-24: docs.rs](https://docs.rs/signal-fish-client)
+    [:octicons-arrow-right-24: WebAssembly (WASM)](wasm.md)
 
 </div>
 
----
+## When you need more detail
 
-## Links
+- [Events](events.md) and [errors](errors.md) describe what your event loop can
+  receive.
+- [Protocol versioning](protocol-versioning.md) helps you choose v2 relay or
+  v3 delivery and mesh features.
+- [Delivery and backpressure](delivery.md) explains queue sizing and congestion.
+- [Transport](transport.md) is the contract for custom network backends.
+- [docs.rs](https://docs.rs/signal-fish-client) is the exact Rust API reference.
 
-| Resource | URL |
-|----------|-----|
-| **GitHub Repository** | [Ambiguous-Interactive/signal-fish-client-rust](https://github.com/Ambiguous-Interactive/signal-fish-client-rust) |
-| **Guide (GitHub Pages)** | [Signal Fish Client SDK](https://Ambiguous-Interactive.github.io/signal-fish-client-rust/) |
-| **crates.io** | [signal-fish-client](https://crates.io/crates/signal-fish-client) |
-| **docs.rs** | [signal-fish-client](https://docs.rs/signal-fish-client) |
-
----
-
-<p style="text-align: center; opacity: 0.7;">
-Built with :heart: by <strong>Ambiguous Interactive</strong>
-</p>
+The navigation groups these deeper topics separately so you can start without
+reading the protocol internals first.

--- a/docs/mesh-guide.md
+++ b/docs/mesh-guide.md
@@ -331,7 +331,7 @@ machine does not authenticate or sequence `MeshEvent::Data`.
 
 ## See also
 
-- [Mesh Session example walkthrough](examples.md#mesh-session-protocol-v3) — a runnable end-to-end demo.
+- [`mesh_session.rs`](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/blob/main/examples/mesh_session.rs) — a runnable end-to-end demo.
 - [Protocol Versioning](protocol-versioning.md) — negotiation, the fail-fast guard, migration.
 - [Events: Mesh Events](events.md#mesh-events-protocol-v3) — the four v3 events.
 - [Protocol Types](protocol.md#topology-protocol-v3) — `Topology`, `TransportKind`, `SessionPlanPayload`, `PeerSignal`.

--- a/docs/token-binding.md
+++ b/docs/token-binding.md
@@ -1,7 +1,7 @@
 # WebSocket Token Binding
 
 Signal Fish Server 0.7 can require the negotiated
-`signalfish.tokenbinding.v2` WebSocket extension. The built-in native
+`signalfish.tokenbinding.v2` WebSocket subprotocol. The built-in native
 `WebSocketTransport` supports it behind the opt-in `token-binding` Cargo
 feature.
 
@@ -48,7 +48,7 @@ not acceptable.
 
 ## Threat model and lifetime
 
-Token binding authenticates the order and contents of client-to-server
+The token-binding subprotocol authenticates the order and contents of client-to-server
 application frames to the one physical WebSocket handshake. It does not protect
 server-to-client frames and is not a substitute for TLS server authentication
 or confidentiality. On plain `ws://`, an on-path observer can read both
@@ -110,6 +110,6 @@ Fish protocol core:
   wrapping, shared sequence state, and key zeroization itself.
 - Browser WebSocket APIs do not expose `Sec-WebSocket-Key`. Consequently the
   browser, Emscripten, and Godot `WebSocketPeer` transports cannot support
-  required token binding. Use a server profile where the extension is not
+  required token binding. Use a server profile where token binding is not
   required, or terminate the connection through a capable trusted native
   component.

--- a/docs/transport.md
+++ b/docs/transport.md
@@ -235,10 +235,10 @@ Nagle's algorithm (`TCP_NODELAY`) by default; see `WebSocketConnectOptions` to
 override.
 
 ```rust,ignore
-let transport = WebSocketTransport::connect("ws://example.com/signal").await?;
+let transport = WebSocketTransport::connect("ws://example.com/v2/ws").await?;
 
 let transport = WebSocketTransport::connect_with_timeout(
-    "ws://example.com/signal",
+    "ws://example.com/v2/ws",
     std::time::Duration::from_secs(5),
 )
 .await?;

--- a/docs/wasm.md
+++ b/docs/wasm.md
@@ -174,7 +174,7 @@ into the transport's `poll_recv()` method.
 ```rust,ignore
 use signal_fish_client::EmscriptenWebSocketTransport;
 
-let transport = EmscriptenWebSocketTransport::connect("wss://example.com/signal")?;
+let transport = EmscriptenWebSocketTransport::connect("wss://example.com/v2/ws")?;
 ```
 
 `connect()` is **synchronous** — the WebSocket object is created immediately,
@@ -289,7 +289,7 @@ the client by calling `poll()` once per frame from the game loop.
 use signal_fish_client::{SignalFishPollingClient, SignalFishConfig};
 use signal_fish_client_godot::GodotWebSocketTransport;
 
-let transport = GodotWebSocketTransport::connect("wss://example.com/signal")?;
+let transport = GodotWebSocketTransport::connect("wss://example.com/v2/ws")?;
 let config = SignalFishConfig::new("mb_app_abc123");
 let mut client = SignalFishPollingClient::new(transport, config);
 ```
@@ -510,7 +510,7 @@ impl INode for SignalFishNode {
     }
 
     fn ready(&mut self) {
-        let transport = GodotWebSocketTransport::connect("wss://example.com/signal")
+        let transport = GodotWebSocketTransport::connect("wss://example.com/v2/ws")
             .expect("failed to create WebSocket");
         let config = SignalFishConfig::new("mb_app_abc123");
         self.client = Some(SignalFishPollingClient::new(transport, config));

--- a/examples/basic_lobby.rs
+++ b/examples/basic_lobby.rs
@@ -15,7 +15,7 @@
 //! cargo run --example basic_lobby
 //!
 //! # Override the server URL:
-//! SIGNAL_FISH_URL=ws://my-server:3536/ws cargo run --example basic_lobby
+//! SIGNAL_FISH_URL=ws://my-server:3536/v2/ws cargo run --example basic_lobby
 //! ```
 
 use signal_fish_client::protocol::LobbyState;
@@ -24,7 +24,7 @@ use signal_fish_client::{
 };
 
 /// Default server URL when `SIGNAL_FISH_URL` is not set.
-const DEFAULT_URL: &str = "ws://localhost:3536/ws";
+const DEFAULT_URL: &str = "ws://localhost:3536/v2/ws";
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Signal Fish Client SDK
-site_description: "Framed-transport-agnostic Rust client SDK for the Signal Fish multiplayer signaling protocol"
+site_description: "Connect Rust and Godot games to the Signal Fish multiplayer signaling service"
 site_url: https://Ambiguous-Interactive.github.io/signal-fish-client-rust/
 repo_url: https://github.com/Ambiguous-Interactive/signal-fish-client-rust
 repo_name: signal-fish-client-rust
@@ -131,24 +131,24 @@ validation:
 
 nav:
   - Home: index.md
-  - Getting Started:
+  - Start Here:
       - Installation & Quick Start: getting-started.md
+      - Basic Lobby Walkthrough: examples.md
+  - Use the SDK:
+      - Client Commands & State: client.md
+      - Events: events.md
+      - Errors: errors.md
+      - WebAssembly & Godot: wasm.md
+      - Godot + Fortress: fortress.md
+  - Multiplayer Choices:
       - Core Concepts: concepts.md
       - Protocol Versioning: protocol-versioning.md
+      - Delivery Contract & Backpressure: delivery.md
+      - Mesh (v3): mesh-guide.md
+  - Advanced Reference:
+      - Custom Transports: transport.md
+      - Protocol Types: protocol.md
       - WebSocket Token Binding: token-binding.md
       - Migrating 0.7 to 0.8: migration-0.8.md
       - Migrating 0.8 to 0.9: migration-0.9.md
-  - API Reference:
-      - Client: client.md
-      - Transport: transport.md
-      - Events: events.md
-      - Errors: errors.md
-      - Protocol Types: protocol.md
-  - Guides:
-      - Delivery Contract & Backpressure: delivery.md
-      - Mesh (v3): mesh-guide.md
-      - WebAssembly: wasm.md
-      - Godot + Fortress: fortress.md
       - Release Operations: releasing.md
-  - Examples:
-      - Walkthroughs: examples.md

--- a/progress/session-035-token-binding-v2.md
+++ b/progress/session-035-token-binding-v2.md
@@ -124,9 +124,8 @@ cargo fmt && cargo clippy --workspace --all-targets --all-features -- -D warning
   cargo test --workspace --all-features
 ```
 
-The exact mandatory repository gate passes with zero warnings on the final
-local diff. Hosted PR checks/reviews and issue closure remain pending until the
-branch head is published.
+The exact mandatory repository gate passed with zero warnings on the final
+local diff. The final hosted and merge outcome is recorded below.
 
 ## Adversarial Review
 
@@ -150,41 +149,25 @@ status, and the test pins that behavior. The exact provenance paths/hashes and
 every golden field are consumed by tests. Pass 2 reached zero remaining concrete
 findings.
 
-## Hosted Checkpoint
+## Hosted Completion
 
-PR #119 (`feat!: support negotiated WebSocket token binding v2`) links and
-closes #88 when merged. The first published head, `7751e32`, reached ten green
-hosted workflows while Godot Web and Deep Safety were still running. Semver
-Checks correctly identified the two documented breaking surfaces—new public
-fields on exhaustively constructible `WebSocketConnectOptions` and the new
-exhaustive `SignalFishError::TokenBinding` variant—but its original event had
-the pre-classification `feat:` title. The PR title now carries the repository's
-required `feat!:` major marker; the next head event re-evaluates that policy.
+The final PR head, `ea332d71effcfd66d0179083b87b16e8505a5ed6`, passed all
+twelve project workflows:
 
-The automated review inventory contains one quota-exhausted Copilot comment,
-no approval, and no review threads. An eligible human approval and the separate
-#90 branch-protection administration therefore remain external merge blockers.
-
-The fresh major-classified head passed Semver Checks. Deep Safety then exposed
-one missed mutation that replaced `TokenBindingFailure::fmt` with an empty
-success; an exhaustive actionable-display regression test now kills that
-mutant for every static failure reason.
-
-The resulting code-bearing head,
-`3bf73fdd1eebadf9aa3821b224492575fe8da312`, passed every hosted workflow:
-
-- CI 32444513502, including both pinned Server 0.7 token-binding E2Es;
-- Deep Safety 32444513103, including the corrected mutation lane, Miri, and all
-  protocol fuzz smokes;
-- Godot Web 32444513087, including build/export and clean, impaired, and soak
+- CI 32445499765, including both pinned Server 0.7 token-binding E2Es;
+- Deep Safety 32445499749, including Miri, fuzzing, and mutation testing;
+- Godot Web 32445499698, including build/export and clean, impaired, and soak
   browser scenarios;
-- Semver Checks 32444513016 under the `feat!:` major-change policy; and
+- Semver Checks 32445499911 under the `feat!:` major-change policy; and
 - WASM, Docs Validation, Workflow Lint, Security, Coverage, Unused Deps,
   Examples Validation, and No Panics.
 
-PR #119 is open, non-draft, mergeable, and has zero review threads. Three
-Copilot attempts ended before analysis because the requesting account has no
-remaining quota, and the only repository collaborator is also the PR author.
-The implementation and hosted verification are complete; an eligible external
-approval plus issue #90's live ruleset and Repository Policy administration are
-the remaining merge/issue-closure dependencies.
+PR #119 merged as `3115c2b70ca2b68f6e833ec958a91db0adbfe462` on
+2026-08-21 and closed issue #88. It had zero review threads, zero approvals,
+and four Copilot quota-exhaustion comments. The merge therefore completed the
+token-binding implementation while adding another direct proof of issue #90's
+unenforced approval and required-check policy.
+
+The explicit Server 0.7 `require_client_fingerprint=true` limitation is tracked
+separately in issue #120 with pinned positive, adversarial, API-binding, and
+redaction acceptance criteria.

--- a/progress/session-036-simplified-user-documentation.md
+++ b/progress/session-036-simplified-user-documentation.md
@@ -125,6 +125,9 @@ All 12 pull-request workflows passed on code-bearing head
 | Deep Safety | 32450769867 |
 | Godot Web | 32450769908 |
 
-The PR has no review threads or actionable hosted comments. Its two submitted
-reviews are quota-exhausted Copilot notices, the known governance limitation
-tracked by issue #90.
+Cursor Bugbot later found that the endpoint scanner treated `]` as a URL
+terminator and therefore falsely rejected a valid bracketed-IPv6 host. The
+final fix preserves an IPv6 authority bracket while trimming a prose-closing
+bracket, with table regressions for both forms. The submitted hosted reviews
+are this addressed Bugbot comment and two quota-exhausted Copilot notices; the
+Copilot limitation remains tracked by issue #90.

--- a/progress/session-036-simplified-user-documentation.md
+++ b/progress/session-036-simplified-user-documentation.md
@@ -128,6 +128,6 @@ All 12 pull-request workflows passed on code-bearing head
 Cursor Bugbot later found that the endpoint scanner treated `]` as a URL
 terminator and therefore falsely rejected a valid bracketed-IPv6 host. The
 final fix preserves an IPv6 authority bracket while trimming a prose-closing
-bracket, with table regressions for both forms. The submitted hosted reviews
-are this addressed Bugbot comment and two quota-exhausted Copilot notices; the
-Copilot limitation remains tracked by issue #90.
+bracket, with table regressions for both forms. The Bugbot thread was answered
+and resolved. Submitted hosted reviews otherwise contain only quota-exhausted
+Copilot notices; that limitation remains tracked by issue #90.

--- a/progress/session-036-simplified-user-documentation.md
+++ b/progress/session-036-simplified-user-documentation.md
@@ -1,0 +1,100 @@
+# Session 036 — Simplified User Documentation
+
+## Scope and Priority
+
+The live audit found current `main` at `3115c2b`, no open or draft pull
+requests, no dependency update pull requests, and four initial open client
+issues: #90, #110, #80, and #82. Issue #90 remains the highest-priority correctness
+item, but its remaining ruleset, reviewer, Copilot quota, and workflow-dispatch
+work requires maintainer administration unavailable through the connected
+tools. The latest Repository Policy run remains red for the missing
+`pull_request` and `required_status_checks` rules.
+
+Issue #110 is therefore the highest-priority actionable usability work and was
+already in progress when this audit opened correctness follow-up #120 for the
+explicitly unsupported client-certificate-fingerprint token-binding profile.
+Issue #120 is next after this coherent documentation PR. Issue #110's
+Signal Fish Server prerequisite, issue #383, is closed completed. Performance
+issue #82 and design-system issue #80 remain later milestones.
+
+Current `main` commit `3115c2b` has all 11 required project workflows green;
+Godot Web run 32448708101 completed its Server 0.7 soak and required aggregate
+successfully. The separate scheduled Repository Policy failure is the live
+governance drift tracked by issue #90, not a code-tree CI failure.
+
+## Onboarding Audit
+
+The pre-change first-contact path duplicated the advanced manual:
+
+| Surface | Before | Problem |
+| --- | ---: | --- |
+| `README.md` | 413 lines | Repeated feature, transport, WASM/Godot, and contributor CI reference material |
+| `docs/index.md` | 154 lines | Repeated installation and a full client example before routing by task |
+| `docs/getting-started.md` | 189 lines | Mixed the first connection with the full feature and platform setup matrix |
+
+The detailed material already had canonical homes in `docs/client.md`,
+`docs/transport.md`, `docs/wasm.md`, `docs/protocol-versioning.md`, and the
+other reference pages. Removing those pages would discard useful contracts;
+making them advanced destinations keeps the information while shortening the
+path to a first room join.
+
+## Server Endpoint Correctness Sweep
+
+Adversarial review found that the README, `basic_lobby`, Rustdoc, and multiple
+guide examples used `ws://localhost:3536/ws` or `/signal`. The pinned Server
+0.7 AsyncAPI fixture exposes only `/v2/ws` and `/v3/ws`; the unversioned paths
+do not connect to that server.
+
+The whole user-facing class is corrected, including native WebSocket,
+Emscripten, Godot, polling-client, event-loop, transport, and example
+documentation. The default v2 configuration now consistently uses `/v2/ws`.
+A recursive regression test scans README, every guide and agent-skill Markdown
+page, every example, and all Rustdoc under `src/` and `crates/` while accepting
+only the two routes proven by the pinned server fixture.
+
+## Documentation Shape
+
+- The README is a short install/connect/join path, integration chooser,
+  production checklist, and set of canonical links.
+- The docs home contains no duplicate Rust example. It routes readers by task
+  to quick start, the basic-lobby walkthrough, client commands, and platform
+  integration.
+- The quick-start page explains only installation, first connection, the basic
+  lobby lifecycle, runtime choice, and a compact optional-capability table.
+- The former 814-line multi-subsystem examples page is now a 109-line
+  basic-lobby walkthrough. Custom transport, mesh, Godot, and load-lab details
+  route to their compiling sources or canonical advanced guides.
+- MkDocs navigation now separates Start Here, Use the SDK, Multiplayer Choices,
+  and Advanced Reference. Contributor release operations sit at the end of the
+  advanced group instead of occupying the onboarding path.
+- A narrow test caps README growth, rejects the former duplicate reference
+  sections, and requires links to each canonical detailed page.
+- The user-visible guidance change and corrected server paths are recorded in
+  `CHANGELOG.md` under `[Unreleased]`.
+
+## Evidence
+
+The focused documentation-policy tests pass: seven onboarding/endpoint tests
+and ten MkDocs navigation/orphan tests. They include URL-parser table cases,
+recursive endpoint coverage, and onboarding-size guards:
+
+```text
+cargo test --all-features --test ci_config_tests docs_onboarding_shape -- --nocapture
+cargo test --all-features --test ci_config_tests mkdocs_nav_validation -- --nocapture
+```
+
+Strict documentation rendering passes all 17 checks, including `mkdocs build
+--strict`. Extracted compilable Rust snippets pass; deliberately incomplete and
+platform-specific `rust,ignore` fragments remain excluded by policy. The exact
+mandatory repository gate passes with zero warnings or failures:
+
+```text
+cargo fmt
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo test --workspace --all-features
+```
+
+Two fresh independent adversarial reviews followed the final content changes.
+The verifier and documentation UX reviewer both reported zero remaining
+findings. Hosted PR and workflow evidence will be appended after the pull
+request exists.

--- a/progress/session-036-simplified-user-documentation.md
+++ b/progress/session-036-simplified-user-documentation.md
@@ -96,5 +96,35 @@ cargo test --workspace --all-features
 
 Two fresh independent adversarial reviews followed the final content changes.
 The verifier and documentation UX reviewer both reported zero remaining
-findings. Hosted PR and workflow evidence will be appended after the pull
-request exists.
+findings.
+
+## Hosted Pull Request
+
+[PR #121](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/pull/121)
+opened non-draft and mergeable. Its first Docs Validation run `32450621351`
+found one hosted-only Markdownlint failure: `docs/index.md` combined a YAML
+`title` with its visible H1, which violates MD025. Removing the redundant YAML
+title preserved the rendered page and made the replacement Docs Validation run
+green.
+
+All 12 pull-request workflows passed on code-bearing head
+`792539205f8b1ac130fedc6ed1e2753f6903a0c8`:
+
+| Workflow | Run |
+| --- | ---: |
+| Docs Validation | 32450770155 |
+| No Panics | 32450769678 |
+| Security | 32450769971 |
+| Workflow Lint | 32450769817 |
+| Unused Deps | 32450769844 |
+| Coverage | 32450769783 |
+| Examples Validation | 32450769872 |
+| Semver Checks | 32450769831 |
+| WASM | 32450769796 |
+| CI | 32450769805 |
+| Deep Safety | 32450769867 |
+| Godot Web | 32450769908 |
+
+The PR has no review threads or actionable hosted comments. Its two submitted
+reviews are quota-exhausted Copilot notices, the known governance limitation
+tracked by issue #90.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,7 @@
 //! #[tokio::main]
 //! async fn main() -> Result<(), signal_fish_client::SignalFishError> {
 //!     // 1. Connect a WebSocket transport to the signaling server.
-//!     let transport = WebSocketTransport::connect("ws://localhost:3536/ws").await?;
+//!     let transport = WebSocketTransport::connect("ws://localhost:3536/v2/ws").await?;
 //!
 //!     // 2. Build a client config with your application ID.
 //!     let config = SignalFishConfig::new("mb_app_abc123");

--- a/src/polling_client.rs
+++ b/src/polling_client.rs
@@ -164,7 +164,7 @@ enum ClosePhase {
 ///
 /// impl MyNode {
 ///     fn ready(&mut self) {
-///         let transport = GodotWebSocketTransport::connect("wss://server/ws")
+///         let transport = GodotWebSocketTransport::connect("wss://server/v2/ws")
 ///             .expect("failed to create WebSocket");
 ///         let config = SignalFishConfig::new("my_app_id");
 ///         self.client = Some(SignalFishPollingClient::new(transport, config));

--- a/src/transports/emscripten_websocket.rs
+++ b/src/transports/emscripten_websocket.rs
@@ -61,7 +61,7 @@
 //!     EmscriptenWebSocketTransport, SignalFishConfig, SignalFishPollingClient,
 //! };
 //!
-//! let transport = EmscriptenWebSocketTransport::connect("wss://server/ws")?;
+//! let transport = EmscriptenWebSocketTransport::connect("wss://server/v2/ws")?;
 //! let config = SignalFishConfig::new("mb_app_abc123");
 //! let mut client = SignalFishPollingClient::new(transport, config);
 //! let events = client.poll();
@@ -272,7 +272,7 @@ impl RegisteredCallbackState {
 /// ```rust,ignore
 /// use signal_fish_client::EmscriptenWebSocketTransport;
 ///
-/// let transport = EmscriptenWebSocketTransport::connect("wss://server/ws")?;
+/// let transport = EmscriptenWebSocketTransport::connect("wss://server/v2/ws")?;
 /// ```
 ///
 /// # Threading

--- a/src/transports/mod.rs
+++ b/src/transports/mod.rs
@@ -16,7 +16,7 @@
 //! # async fn example() -> Result<(), signal_fish_client::SignalFishError> {
 //! use signal_fish_client::{SignalFishClient, SignalFishConfig, WebSocketTransport};
 //!
-//! let transport = WebSocketTransport::connect("ws://localhost:3536/ws").await?;
+//! let transport = WebSocketTransport::connect("ws://localhost:3536/v2/ws").await?;
 //! let config = SignalFishConfig::new("mb_app_example");
 //! let (mut client, mut events) = SignalFishClient::start(transport, config);
 //!

--- a/src/transports/websocket.rs
+++ b/src/transports/websocket.rs
@@ -20,7 +20,7 @@
 //! # async fn example() -> Result<(), signal_fish_client::SignalFishError> {
 //! use signal_fish_client::WebSocketTransport;
 //!
-//! let transport = WebSocketTransport::connect("ws://localhost:3536/ws").await?;
+//! let transport = WebSocketTransport::connect("ws://localhost:3536/v2/ws").await?;
 //! let _transport = transport; // pass it to SignalFishClient::start
 //! # Ok(())
 //! # }
@@ -215,7 +215,7 @@ async fn receive_token_binding_challenge(
 /// // Restore the OS default (Nagle enabled) for a throughput-oriented link.
 /// let options = WebSocketConnectOptions::new().with_disable_nagle(false);
 /// let transport =
-///     WebSocketTransport::connect_with_options("ws://localhost:3536/ws", options).await?;
+///     WebSocketTransport::connect_with_options("ws://localhost:3536/v2/ws", options).await?;
 /// # let _ = transport;
 /// # Ok(())
 /// # }
@@ -300,7 +300,7 @@ impl WebSocketConnectOptions {
 /// # async fn example() -> Result<(), signal_fish_client::SignalFishError> {
 /// use signal_fish_client::WebSocketTransport;
 ///
-/// let transport = WebSocketTransport::connect("ws://localhost:3536/ws").await?;
+/// let transport = WebSocketTransport::connect("ws://localhost:3536/v2/ws").await?;
 /// # Ok(())
 /// # }
 /// ```

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -5582,6 +5582,334 @@ mod markdown_policy_validation {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Module: docs_onboarding_shape
+// ─────────────────────────────────────────────────────────────────────────────
+
+mod docs_onboarding_shape {
+    use super::*;
+
+    fn collect_files_with_extension(dir: &Path, extension: &str, out: &mut Vec<PathBuf>) {
+        for entry in std::fs::read_dir(dir)
+            .unwrap_or_else(|error| panic!("Failed to read '{}': {error}", dir.display()))
+        {
+            let path = entry.expect("directory entry must be readable").path();
+            if path.is_dir() {
+                collect_files_with_extension(&path, extension, out);
+            } else if path.extension().and_then(|value| value.to_str()) == Some(extension) {
+                out.push(path);
+            }
+        }
+    }
+
+    fn server_pathname<'a>(spec: &'a str, server_name: &str) -> Option<&'a str> {
+        let mut in_servers = false;
+        let mut current_server = None;
+        for line in spec.lines() {
+            if line == "servers:" {
+                in_servers = true;
+                continue;
+            }
+            if !in_servers {
+                continue;
+            }
+            if !line.is_empty() && !line.starts_with(' ') {
+                break;
+            }
+            if let Some(name) = line
+                .strip_prefix("  ")
+                .filter(|value| !value.starts_with(' '))
+                .and_then(|value| value.strip_suffix(':'))
+            {
+                current_server = Some(name);
+                continue;
+            }
+            if current_server == Some(server_name) {
+                if let Some(pathname) = line.strip_prefix("    pathname: ") {
+                    return Some(pathname.trim_matches(['\'', '"']));
+                }
+            }
+        }
+        None
+    }
+
+    fn websocket_urls(line: &str) -> Vec<&str> {
+        let mut urls = Vec::new();
+        let lowercase = line.to_ascii_lowercase();
+        let mut offset = 0;
+        while offset < line.len() {
+            let remaining = &lowercase[offset..];
+            let Some((relative_start, scheme)) = ["ws://", "wss://"]
+                .iter()
+                .filter_map(|scheme| remaining.find(scheme).map(|start| (start, *scheme)))
+                .min_by_key(|(start, _)| *start)
+            else {
+                break;
+            };
+            let start = offset + relative_start;
+            let at_scheme_boundary = start == 0
+                || !line.as_bytes()[start - 1].is_ascii_alphanumeric()
+                    && !matches!(line.as_bytes()[start - 1], b'+' | b'-' | b'.');
+            let after_scheme = start + scheme.len();
+            let candidate = &line[start..];
+            let end = candidate
+                .find(|character: char| {
+                    character.is_whitespace()
+                        || matches!(character, '"' | '\'' | '`' | ')' | ']' | '<' | '>')
+                })
+                .unwrap_or(candidate.len());
+            if at_scheme_boundary && end > scheme.len() {
+                urls.push(candidate[..end].trim_end_matches(['.', ',', ';', ':']));
+            }
+            offset = after_scheme;
+        }
+        urls
+    }
+
+    fn websocket_path(url: &str) -> Option<&str> {
+        let scheme_end = url.find("://")? + 3;
+        let after_scheme = &url[scheme_end..];
+        let path_start = after_scheme.find(['/', '?', '#'])?;
+        if after_scheme.as_bytes().get(path_start) != Some(&b'/') {
+            return None;
+        }
+        let path_and_suffix = &after_scheme[path_start..];
+        Some(
+            path_and_suffix
+                .split(['?', '#'])
+                .next()
+                .expect("split always returns the path"),
+        )
+    }
+
+    fn line_is_rustdoc(line: &str, in_block_doc: &mut bool) -> bool {
+        let trimmed = line.trim_start();
+        let starts_block = trimmed.starts_with("/**") || trimmed.starts_with("/*!");
+        let is_doc = *in_block_doc
+            || starts_block
+            || trimmed.starts_with("///")
+            || trimmed.starts_with("//!")
+            || trimmed.starts_with("#[doc")
+            || trimmed.starts_with("#![doc");
+        if starts_block && !trimmed.contains("*/") {
+            *in_block_doc = true;
+        }
+        if *in_block_doc && trimmed.contains("*/") {
+            *in_block_doc = false;
+        }
+        is_doc
+    }
+
+    #[test]
+    fn readme_remains_a_concise_on_ramp() {
+        let readme = read_project_file("README.md");
+        let word_count = readme.split_whitespace().count();
+        assert!(
+            word_count <= 1_000,
+            "README.md has {word_count} words; keep the repository landing page at or below \
+             1,000 words and move detailed guidance into docs/"
+        );
+        assert!(
+            readme.lines().count() <= 220 && readme.len() <= 16_000,
+            "README.md must remain a readable on-ramp (at most 220 lines and 16 KiB)"
+        );
+
+        for duplicate_section in [
+            "feature flags",
+            "custom transport",
+            "custom transports",
+            "webassembly",
+            "webassembly support",
+            "development",
+            "run ci locally",
+            "godot quick start",
+        ] {
+            assert!(
+                !readme.lines().any(|line| {
+                    let trimmed = line.trim();
+                    trimmed.starts_with('#')
+                        && trimmed.trim_start_matches('#').trim().to_ascii_lowercase()
+                            == duplicate_section
+                }),
+                "README.md must not recreate the dedicated `{duplicate_section}` manual; \
+                 link to the canonical docs page instead"
+            );
+        }
+
+        for canonical_page in [
+            "docs/getting-started.md",
+            "docs/examples.md",
+            "docs/client.md",
+            "docs/wasm.md",
+            "docs/protocol-versioning.md",
+            "docs/transport.md",
+        ] {
+            assert!(
+                readme.contains(&format!("]({canonical_page})")),
+                "README.md must route users to the canonical `{canonical_page}` page"
+            );
+        }
+    }
+
+    #[test]
+    fn docs_home_routes_to_tasks_instead_of_duplicating_setup() {
+        let home = read_project_file("docs/index.md");
+        assert!(
+            !home.contains("use signal_fish_client") && !home.contains("SignalFishClient::start"),
+            "docs/index.md must link to the installation guide instead of duplicating its client program"
+        );
+        for task_page in ["getting-started.md", "examples.md", "client.md", "wasm.md"] {
+            assert!(
+                home.contains(&format!("]({task_page})")),
+                "docs/index.md must route users to `{task_page}`"
+            );
+        }
+    }
+
+    #[test]
+    fn basic_lobby_walkthrough_stays_beginner_focused() {
+        let walkthrough = read_project_file("docs/examples.md");
+        assert!(
+            walkthrough.lines().count() <= 150 && walkthrough.len() <= 8_000,
+            "docs/examples.md must remain a focused basic-lobby walkthrough; move advanced \
+             integration detail into its canonical guide"
+        );
+
+        for advanced_section in [
+            "custom transport",
+            "mesh session (protocol v3)",
+            "godot web export (polling client)",
+            "load lab (measurement harness)",
+        ] {
+            assert!(
+                !walkthrough.lines().any(|line| {
+                    let trimmed = line.trim();
+                    trimmed.starts_with('#')
+                        && trimmed.trim_start_matches('#').trim().to_ascii_lowercase()
+                            == advanced_section
+                }),
+                "docs/examples.md must link to the `{advanced_section}` guide or source \
+                 instead of duplicating its advanced walkthrough"
+            );
+        }
+
+        for canonical_guide in ["transport.md", "mesh-guide.md", "delivery.md", "wasm.md"] {
+            assert!(
+                walkthrough.contains(&format!("]({canonical_guide})")),
+                "docs/examples.md must route advanced readers to `{canonical_guide}`"
+            );
+        }
+    }
+
+    #[test]
+    fn user_facing_websocket_urls_use_a_server_070_versioned_route() {
+        let server_spec = read_project_file("tests/server-spec/signal-fish-protocol.asyncapi.yaml");
+        assert_eq!(server_pathname(&server_spec, "v2"), Some("/v2/ws"));
+        assert_eq!(server_pathname(&server_spec, "v3"), Some("/v3/ws"));
+
+        let root = project_root();
+        let mut all_content_paths = vec![root.join("README.md")];
+        collect_files_with_extension(&root.join("docs"), "md", &mut all_content_paths);
+        collect_files_with_extension(&root.join(".llm"), "md", &mut all_content_paths);
+        collect_files_with_extension(&root.join("examples"), "rs", &mut all_content_paths);
+        let mut rustdoc_paths = Vec::new();
+        collect_files_with_extension(&root.join("src"), "rs", &mut rustdoc_paths);
+        collect_files_with_extension(&root.join("crates"), "rs", &mut rustdoc_paths);
+
+        let mut invalid = Vec::new();
+        for (path, scan_all_content) in all_content_paths
+            .into_iter()
+            .map(|path| (path, true))
+            .chain(rustdoc_paths.into_iter().map(|path| (path, false)))
+        {
+            let content = std::fs::read_to_string(&path)
+                .unwrap_or_else(|error| panic!("Failed to read '{}': {error}", path.display()));
+            let mut in_block_doc = false;
+            for (line_index, line) in content.lines().enumerate() {
+                if !scan_all_content && !line_is_rustdoc(line, &mut in_block_doc) {
+                    continue;
+                }
+                for url in websocket_urls(line) {
+                    if !matches!(websocket_path(url), Some("/v2/ws" | "/v3/ws")) {
+                        invalid.push(format!(
+                            "{}:{}: {url}",
+                            path.strip_prefix(&root).unwrap_or(&path).display(),
+                            line_index + 1
+                        ));
+                    }
+                }
+            }
+        }
+
+        assert!(
+            invalid.is_empty(),
+            "User-facing WebSocket URLs must use the pinned Server 0.7 `/v2/ws` \
+             or `/v3/ws` route:\n{}",
+            invalid.join("\n")
+        );
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn websocket_url_parser_is_boundary_path_and_suffix_aware() {
+            let cases = [
+                ("connect ws://host/v2/ws", Some("/v2/ws")),
+                ("connect WSS://host/v3/ws.", Some("/v3/ws")),
+                ("connect ws://host/v2/ws, then poll", Some("/v2/ws")),
+                ("connect ws://host/old?next=/v2/ws", Some("/old")),
+                ("connect ws://host?next=/v2/ws", None),
+                ("connect ws://host#example=/v2/ws", None),
+                ("not a WebSocket news://host/ws", None),
+                ("the bare scheme `wss://`", None),
+            ];
+            for (line, expected_path) in cases {
+                let urls = websocket_urls(line);
+                assert_eq!(
+                    urls.first().and_then(|url| websocket_path(url)),
+                    expected_path,
+                    "unexpected parsed WebSocket path for `{line}`"
+                );
+            }
+
+            let urls = websocket_urls(
+                "valid ws://host/v2/ws, invalid WSS://host/legacy; valid ws://host/v3/ws",
+            );
+            let paths: Vec<_> = urls.iter().map(|url| websocket_path(url)).collect();
+            assert_eq!(
+                paths,
+                [Some("/v2/ws"), Some("/legacy"), Some("/v3/ws")],
+                "every same-line WebSocket URL must be parsed independently"
+            );
+        }
+
+        #[test]
+        fn server_pathname_parser_reads_only_the_named_servers_mapping() {
+            let spec = "# pathname: /wrong\nservers:\n  v2:\n    description: pathname: /also-wrong\n    pathname: /v2/ws\n  v3:\n    pathname: '/v3/ws'\nchannels:\n  pathname: /wrong\n";
+            assert_eq!(server_pathname(spec, "v2"), Some("/v2/ws"));
+            assert_eq!(server_pathname(spec, "v3"), Some("/v3/ws"));
+            assert_eq!(server_pathname(spec, "v4"), None);
+        }
+
+        #[test]
+        fn rustdoc_detection_covers_line_block_and_attribute_forms() {
+            let mut in_block = false;
+            assert!(line_is_rustdoc("/// line docs", &mut in_block));
+            assert!(line_is_rustdoc("/** block docs", &mut in_block));
+            assert!(line_is_rustdoc(" * continued", &mut in_block));
+            assert!(line_is_rustdoc(" */", &mut in_block));
+            assert!(!in_block);
+            assert!(line_is_rustdoc(
+                "#[doc = \"attribute docs\"]",
+                &mut in_block
+            ));
+            assert!(!line_is_rustdoc("let value = 1;", &mut in_block));
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Module: docs_nav_card_consistency
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -5654,11 +5654,11 @@ mod docs_onboarding_shape {
             let end = candidate
                 .find(|character: char| {
                     character.is_whitespace()
-                        || matches!(character, '"' | '\'' | '`' | ')' | ']' | '<' | '>')
+                        || matches!(character, '"' | '\'' | '`' | ')' | '<' | '>')
                 })
                 .unwrap_or(candidate.len());
             if at_scheme_boundary && end > scheme.len() {
-                urls.push(candidate[..end].trim_end_matches(['.', ',', ';', ':']));
+                urls.push(candidate[..end].trim_end_matches(['.', ',', ';', ':', ']']));
             }
             offset = after_scheme;
         }
@@ -5858,6 +5858,8 @@ mod docs_onboarding_shape {
                 ("connect ws://host/v2/ws", Some("/v2/ws")),
                 ("connect WSS://host/v3/ws.", Some("/v3/ws")),
                 ("connect ws://host/v2/ws, then poll", Some("/v2/ws")),
+                ("connect ws://[::1]:3536/v2/ws", Some("/v2/ws")),
+                ("connect [ws://host/v2/ws]", Some("/v2/ws")),
                 ("connect ws://host/old?next=/v2/ws", Some("/old")),
                 ("connect ws://host?next=/v2/ws", None),
                 ("connect ws://host#example=/v2/ws", None),


### PR DESCRIPTION
## Summary

- turn the README, docs home, quick start, and navigation into a beginner-first path to a first room join
- replace the multi-subsystem examples manual with a focused basic-lobby walkthrough and route advanced integrations to their canonical guides and compiling sources
- correct every user-facing WebSocket example to Server 0.7's versioned `/v2/ws` or `/v3/ws` route
- add recursive regression coverage for onboarding shape and documented WebSocket endpoints
- synchronize the current roadmap and session evidence

## Verification

- `cargo fmt`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- strict MkDocs rendering: 17/17 checks
- Rust snippet extraction/compilation
- two independent final adversarial reviews: zero findings

Closes #110

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation, examples, and CI policy tests only; no runtime protocol or transport behavior changes. Wrong documented URLs would mislead users, but the new scanner is meant to prevent that.
> 
> **Overview**
> Turns first-contact docs into a short path to connect, authenticate, and join a room. The README, docs home, and quick start no longer duplicate feature/transport/WASM manuals; MkDocs nav is grouped as Start Here, Use the SDK, Multiplayer Choices, and Advanced Reference.
> 
> `docs/examples.md` is now a basic-lobby walkthrough that links compiling sources and canonical guides instead of inlining custom transport, mesh, Godot, and load-lab tutorials.
> 
> Corrects user-facing WebSocket examples (README, guides, rustdoc, `basic_lobby`) from unversioned `/ws` or `/signal` to Server 0.7 `/v2/ws` (and `/v3/ws` where applicable). Adds CI tests that cap onboarding size, require canonical links, and scan docs/examples/rustdoc for those routes. Roadmap and session notes mark #110 as current work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f36aebc7eb0460ef7ae7f6ab6348b6ac6eb2bf3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->