### PR TITLE
fix!: bound native WebSocket inbound messages

### DIFF
--- a/.llm/context.md
+++ b/.llm/context.md
@@ -377,12 +377,11 @@ Emscripten SDK version are independent compatibility axes.
 
 ### Low-Latency Socket Defaults
 
-Socket-owning transports disable Nagle's algorithm (`TCP_NODELAY`) by default;
-`WebSocketTransport` callers override with
-`WebSocketConnectOptions::with_disable_nagle(false)`. Its receive poll bounds
-skipped control frames, flushes automatic Pong/Close responses before further
-reads, and fuses EOF or terminal socket errors. Browser/engine backends leave
-tuning to the platform. See the `transport-abstraction` and `websocket-client` skills.
+Socket-owning transports disable Nagle (`TCP_NODELAY`) by default; `WebSocketTransport`
+callers override with `WebSocketConnectOptions::with_disable_nagle(false)`. Native
+connections cap frames and assembled messages at 8 MiB; `None` disables both and
+`from_stream` preserves caller policy. This is not a Server 0.7 maximum; signal-fish-server#399 tracks that contract.
+Receive polls bound skipped controls, flush Pong/Close, and fuse terminal errors.
 
 ### Wire Compatibility
 

--- a/.llm/skills/websocket-client/SKILL.md
+++ b/.llm/skills/websocket-client/SKILL.md
@@ -21,8 +21,14 @@ let transport = WebSocketTransport::connect_with_timeout(url, timeout).await?;
 `wss://` needs the optional `tls` feature (see the [TLS](#tls) section).
 
 `from_stream(WsStream)` wraps a stream built with custom TLS, proxy, headers,
-or cookies. Connection failures map to `SignalFishError::Io`, preserving an
-underlying I/O error kind when possible.
+or cookies and preserves its caller-selected frame/message limits. New native
+connections instead apply `WebSocketConnectOptions::max_inbound_message_size`
+to tungstenite's frame and assembled-message limits together. The default is
+an inclusive 8 MiB; `None` disables both and `Some(0)` is rejected before
+network I/O. This is a protective client policy, not a Server 0.7 protocol
+maximum; signal-fish-server#399 tracks the missing outbound contract.
+Connection failures map to `SignalFishError::Io`, preserving an underlying I/O
+error kind when possible.
 
 The opt-in `token-binding` feature adds `TokenBindingMode` to
 `WebSocketConnectOptions`. Keep disabled mode on the exact old connect path.
@@ -36,7 +42,7 @@ opt in after losing the exact generated handshake key.
 ## Low-Latency Socket Defaults
 
 `connect` and `connect_with_timeout` disable Nagle's algorithm (`TCP_NODELAY`)
-by default via `connect_async_with_config(url, None, /*disable_nagle=*/ true)`.
+by default via `connect_async_with_config(url, Some(config), /*disable_nagle=*/ true)`.
 Small, latency-sensitive game messages are then sent without waiting on TCP's
 delayed-ACK timer — the Nagle + delayed-ACK stall costs tens of milliseconds per
 round trip. The flag is applied to the raw socket *before* any TLS handshake, so
@@ -190,6 +196,11 @@ closed WebSocket object.
 - A real waker is notified when socket readiness changes.
 - The connected TCP socket has `TCP_NODELAY` set by default; `connect_with_options`
   can turn it off.
+- Native connect paths apply the same configured inclusive limit to individual
+  inbound frames and fragmented-message assembly; boundary, limit+1,
+  fragmentation, override/disable, token-binding offer/fallback, and terminal
+  error behavior use real tungstenite codecs.
+- `from_stream` preserves the caller's WebSocket codec limits.
 - Disabled token binding offers no subprotocol and keeps application bytes exact.
 - Optional fallback occurs only for `NoSubProtocol`; HTTP rejection is not retried.
 - Required negotiation consumes a strict first-message challenge under timeout.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Certificate-capable custom rustls connections automatically bind proofs to
   the exact selected mTLS leaf certificate, supporting Server 0.7's
   `require_client_fingerprint=true` profile without a caller-supplied claim.
-  The default connection path and dependency graph remain unchanged.
+  With token binding disabled, the handshake does not offer its subprotocol;
+  the default dependency graph remains unchanged.
+- Added `WebSocketConnectOptions::max_inbound_message_size` and its matching
+  builder. New native WebSocket connections limit both individual inbound
+  frames and assembled messages to 8 MiB by default; callers can raise the
+  inclusive limit or set it to `None` for an unbounded codec. Streams supplied
+  through `WebSocketTransport::from_stream` retain their caller-owned limits.
 - Added Signal Fish Server 0.7.0 protocol conformance, including
   `SessionGeneration`, `DirectEndpoint::{host, port}`,
   `SessionPlanPayload::generation`, `SessionPlanPayload::direct_endpoint`,
@@ -61,6 +67,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Breaking:** `WebSocketConnectOptions` gains the public
+  `max_inbound_message_size` field, and built-in native WebSocket connections
+  no longer inherit tungstenite's larger receive defaults. Oversized input is
+  reported once as `SignalFishError::TransportReceive`, then the transport
+  becomes terminal. The 8 MiB default is a protective client policy rather
+  than a protocol maximum; larger deployments must configure it explicitly.
 - Reduced the published `signal-fish-client` crate archive to library source,
   its required token-binding unit-test vector, and package metadata.
   Repository integration tests, other standalone wire fixtures, examples,

--- a/PLAN.md
+++ b/PLAN.md
@@ -27,12 +27,12 @@
   package metadata; repository integration tests, other standalone wire
   fixtures, examples, progress records, and changelog history remain in the
   linked source repository.
-- All 12 push workflows pass on current `main` commit `00e9d84`. Godot Web's
-  first attempt failed only a scheduler-sensitive 50 ms maximum-poll oracle
-  after every deterministic soak outcome passed, then the unchanged 3,600-frame
-  soak and aggregate passed on retry. This branch replaces that single-sample
-  gate with a one-percent outlier budget and 500 ms emergency cap. The separate
-  live Repository Policy audit remains red because of issue #90.
+- All 12 push workflows pass on current `main` commit `c7790e8`, including
+  merged PR #131's package minimization and robust Godot poll-timing gate. Docs
+  Validation attempt 1 hit its 180-second Playwright accessibility watchdog;
+  the unchanged attempt 2 passed in under a minute, confirming a hosted-runner
+  stall rather than deterministic product failure. The separate live Repository
+  Policy audit remains red because of issue #90.
 
 Completed milestone history and verification evidence live in tracked files
 under `progress/`.
@@ -81,9 +81,15 @@ measured evidence before accepting performance complexity:
    operation identifier tracked by
    [signal-fish-server#395](https://github.com/Ambiguous-Interactive/signal-fish-server/issues/395)
    before the client can distinguish old and current same-kind responses
-   without timing heuristics. Oversized complete frames, disconnect-adjacent
-   transitions, and the remaining inventory cells remain independent client
-   audit slices.
+   without timing heuristics. The native WebSocket oversized-input slice is
+   complete: all built-in connect paths now bound individual frames and
+   fragmented-message assembly at a configurable 8 MiB default before
+   `ClientCore`, preserve caller-owned `from_stream` limits, and fuse capacity
+   errors. No finite value is a Server 0.7 compatibility guarantee, so
+   [signal-fish-server#399](https://github.com/Ambiguous-Interactive/signal-fish-server/issues/399)
+   tracks a negotiated/enforced outbound contract. Disconnect-adjacent
+   transitions, browser/engine boundary parity, and the remaining inventory
+   cells remain independent client audit slices.
 4. Re-run established unsafe-inventory, Miri, fuzz, dependency, and no-panic
    gates. Evaluate focused Loom models and additional sanitizer or lint coverage
    only where target support and owned boundaries make them applicable; promote

--- a/docs/transport.md
+++ b/docs/transport.md
@@ -232,9 +232,12 @@ The default `transport-websocket` feature provides `WebSocketTransport`, backed
 by `tokio-tungstenite`. `ws://` is always available; `wss://` requires the
 optional `tls` feature (rustls with bundled webpki roots). Connections disable
 Nagle's algorithm (`TCP_NODELAY`) by default; see `WebSocketConnectOptions` to
-override.
+override. They also limit each inbound WebSocket frame and complete assembled
+message to 8 MiB by default, before it can reach `ClientCore`:
 
 ```rust,ignore
+use signal_fish_client::{WebSocketConnectOptions, WebSocketTransport};
+
 let transport = WebSocketTransport::connect("ws://example.com/v2/ws").await?;
 
 let transport = WebSocketTransport::connect_with_timeout(
@@ -242,12 +245,30 @@ let transport = WebSocketTransport::connect_with_timeout(
     std::time::Duration::from_secs(5),
 )
 .await?;
+
+let options = WebSocketConnectOptions::new()
+    .with_max_inbound_message_size(Some(16 * 1024 * 1024));
+let transport = WebSocketTransport::connect_with_options(
+    "ws://example.com/v2/ws",
+    options,
+)
+.await?;
 ```
+
+The size limit is inclusive and applies equally to a single frame and to the
+aggregate payload of fragmented frames. Set it to `None` only when another
+trusted layer supplies an appropriate bound; `Some(0)` is invalid. The 8 MiB
+default accommodates ordinary Server 0.7 room snapshots, but it is a client
+resource policy, not a protocol maximum. Deployments with unusually large
+player metadata, spectator rosters, replay buffers, or server limits must
+raise it. The server-side contract gap is tracked in
+[signal-fish-server#399](https://github.com/Ambiguous-Interactive/signal-fish-server/issues/399).
 
 `from_stream` wraps an already-established `WsStream` for custom TLS, proxy,
 headers, or cookie setup. It cannot turn on token binding after the handshake;
 a custom constructor/transport must retain the exact handshake key and own the
-complete extension state machine.
+complete extension state machine. It also retains the stream's existing
+tungstenite frame/message limits instead of replacing them.
 
 The opt-in native `token-binding` feature adds disabled, optional, and required
 `signalfish.tokenbinding.v2` policies to `WebSocketConnectOptions`. Negotiation,

--- a/progress/session-042-minimal-crate-packages.md
+++ b/progress/session-042-minimal-crate-packages.md
@@ -143,3 +143,14 @@ proves that only the load-start transition clears all three windows, and proves
 that subsequent callbacks retain their measurements. Three slow JSON polls in
 100 plus 100 fast binary polls correctly fail at 3/200 even when the binary
 window previously contained 1,000 extra fast setup polls.
+
+## Final Hosted Result
+
+Commit `c0b3ae773709430e752c97eab5b613ad098dde15` was the final PR head. All 12
+pull-request workflows passed. The Cursor Bugbot finding above was fixed,
+answered, and resolved; two Copilot attempts failed only because the configured
+review account had exhausted quota and supplied no feedback. PR #131 merged as
+`c7790e8feb4090383cef9635e09847118e88b099`. All 12 push workflows on that
+exact main SHA are green; Docs Validation attempt 1 alone hit the 180-second
+accessibility watchdog, and the unchanged failed-jobs retry passed in under one
+minute.

--- a/progress/session-043-native-websocket-size-limits.md
+++ b/progress/session-043-native-websocket-size-limits.md
@@ -1,0 +1,114 @@
+# Session 043 — Native WebSocket Size Limits
+
+## Priority and Hosted Audit
+
+The session began from clean `main` at
+`c7790e8feb4090383cef9635e09847118e88b099`, the merge of PR #131. The GitHub
+connector found no open or draft pull requests and no dependency pull requests.
+All 12 push workflows on that exact commit are green. Docs Validation attempt 1
+timed out in its Playwright accessibility watchdog; the unchanged failed-jobs
+retry passed in under one minute, so no deterministic product failure remained.
+
+Issue #128 remains the highest-impact correctness item and remains legitimately
+blocked on the negotiated operation identifier in signal-fish-server#395.
+Issue #126 therefore supplied the next independent correctness slice: prevent a
+grossly oversized native WebSocket message from being assembled before it can
+reach `ClientCore`.
+
+## Authority and Limit Selection
+
+The audit used the pinned Signal Fish Server 0.7.0 source at commit
+`3f7f43d4cd4b3cc7f8fb893220dc35c9b1fad333`. Its default inbound application
+limit is 64 KiB and its server-side WebSocket decoder allows twice that value,
+but neither value bounds messages sent by the server. A legal server message
+can aggregate many separately accepted values: the default deployment's
+configurable 100-player ceiling (room default 8) and near-cap per-player
+metadata can approach roughly 6.25 MiB before snapshot envelope or replay
+overhead. Spectator rosters are not room-bounded, and replayable spectator
+events contain complete snapshots.
+
+The client therefore uses an inclusive 8 MiB protective default for both an
+individual inbound frame and a fragmented message's assembled payload. It is a
+resource policy, not a protocol maximum. Callers can raise it or choose `None`
+when a trusted layer provides another bound. `Some(0)` is rejected before
+network I/O. Detailed upstream issue
+[signal-fish-server#399](https://github.com/Ambiguous-Interactive/signal-fish-server/issues/399)
+tracks a discoverable and enforced outbound-message contract.
+
+## Implementation and Contract
+
+Every SDK-owned native connection path supplies the same `WebSocketConfig` to
+tungstenite: ordinary disabled mode, token-binding offer and Optional fallback,
+and custom-rustls disabled and selected paths. `WebSocketConnectOptions` exposes
+`max_inbound_message_size` plus a matching builder. Oversize codec errors map to
+the existing one-shot `TransportReceive` outcome and terminalize the transport;
+later receive, send, and close behavior remains fused. Token-binding feature
+errors retain precedence over an independently invalid size option.
+
+`WebSocketTransport::from_stream` is deliberately different. Its caller owns
+the completed handshake and codec, so wrapping the stream preserves the
+caller's frame and message limits. Browser, Emscripten, Godot, and custom
+transport size policies likewise remain their platform/implementor boundary and
+are not silently represented as covered by the native option.
+
+## Consolidated Audit Matrix
+
+This is the living issue #126 inventory. “Pinned” means a source authority and
+repeatable regression exist; “open” names the next evidence needed rather than
+implying a defect.
+
+| Surface | Authority and current regression evidence | Status / next gap |
+|---|---|---|
+| JSON and binary protocol codecs | Server 0.7 fixture, protocol tests, wire goldens, error-code conformance | Pinned; extend only for newly negotiated wire fields |
+| `ClientCore` transitions and admission | Public lifecycle contract, shared-core policy tests, client integration traces | Pinned for room-operation kind correlation; same-kind identity blocked by #128/#395 |
+| Async and polling drivers | Shared-core architecture, client tests, 39-trace parity suite | Pinned for current lifecycle/ownership surface; disconnect-adjacent parity remains open |
+| Native WebSocket setup and receive bounds | tungstenite 0.30 codec contract plus Server 0.7 aggregation audit; real socket boundary/overflow tests | Pinned for frame, fragmentation, override, token-binding, and terminal behavior in this session |
+| Emscripten WebSocket | Emscripten API boundary, target build and FFI policy tests | Platform owns assembly; explicit browser size-policy evidence remains open |
+| Godot native/web adapter | Godot 4.5 `WebSocketPeer`, 35 fake-backend tests, native/web real-server scenarios and soak | Engine owns assembly; explicit engine size-policy evidence remains open |
+| Token binding v2 | Server 0.7 contract, canonical vectors, unit/conformance and required-WSS E2E | Pinned; size cap now covered on selected and fallback physical connections |
+| Mesh/WebRTC generations | Server 0.7 plan/generation wire contract, controller unit/integration/parity tests | Pinned for stale-generation fencing; fresh race/adversarial sweep remains open |
+| Setup, configuration, recovery, and misuse | Public API docs, compile/policy tests, lifecycle and timeout regressions | Partially pinned; continue cancellation, queue saturation, and reconnect race cells |
+| Safety and performance gates | unsafe inventory, no-panic, Miri/fuzz/mutation CI, 28-cell semantic/performance laboratory | Established; rerun fresh analyzers and profile before accepting new performance complexity |
+
+## Regression Evidence
+
+Real tungstenite codecs prove that the exact configured boundary is accepted,
+one unfragmented byte beyond it is rejected, and individually valid fragments
+whose aggregate exceeds it are rejected. Data-driven cases cover a larger
+custom limit and `None`. Separate paths prove Required token binding and
+Optional fallback retain the cap, while a caller-configured `from_stream` cap
+is not replaced. The oversize regression also proves one error followed by
+exact fused receive/send/close semantics and retained caller frame ownership.
+
+The focused 47-test WebSocket suite passes with all features. A no-default,
+WebSocket-only run proves unavailable token binding still reports
+`FeatureDisabled` before size validation. All-feature Clippy passes with
+warnings denied. Final mandatory and adversarial evidence is recorded below.
+Publication and hosted disposition belong in the PR conversation and the
+following session record because appending them here would create a different
+head.
+
+## Final Local Verification and Review
+
+The first adversarial design review rejected a symmetric 128 KiB limit after
+finding valid multi-megabyte Server 0.7 aggregates. Its 8 MiB configurable
+policy, all-path wiring, caller-owned `from_stream`, error precedence, and
+changelog recommendations were implemented. A frozen-diff review then found no
+production defect but identified weak `None`, fragmented-boundary, explicit
+rustls-constructor, and public zero-limit coverage. An independent repair pass
+made those tests behaviorally discriminating without adding a TLS fixture or
+dependency, and the final adversarial and GOAL/evidence audits reported no
+remaining finding.
+
+The exact mandatory command passed on the final local tree: formatting was
+unchanged, workspace/all-target/all-feature Clippy emitted zero warnings, and
+the complete all-feature workspace test suite passed. Focused no-token-feature
+tests separately retain feature-error precedence over the invalid size option.
+
+## Remaining Issue #126 Work
+
+Disconnect-adjacent transition parity is the next independent client-owned
+correctness slice. Browser/engine receive-limit ownership needs explicit
+authority before adding SDK policy, and the fresh analyzer/performance phases
+remain after the correctness inventory. Same-kind room response identity must
+wait for the negotiated server contract rather than use timing heuristics.

--- a/src/transports/websocket.rs
+++ b/src/transports/websocket.rs
@@ -7,7 +7,8 @@
 //! transparently via [`MaybeTlsStream`](tokio_tungstenite::MaybeTlsStream).
 //!
 //! Connections disable Nagle's algorithm (`TCP_NODELAY`) by default for low
-//! latency; see [`WebSocketConnectOptions`] to override.
+//! latency and reject inbound frames or assembled messages larger than 8 MiB;
+//! see [`WebSocketConnectOptions`] to override either policy.
 //!
 //! # Feature gate
 //!
@@ -32,7 +33,10 @@ use std::task::{Context, Poll};
 use futures_util::{Sink, Stream};
 #[cfg(feature = "token-binding")]
 use futures_util::{SinkExt as _, StreamExt as _};
-use tokio_tungstenite::tungstenite::{protocol::Message, Error as WebSocketError};
+use tokio_tungstenite::tungstenite::{
+    protocol::{Message, WebSocketConfig},
+    Error as WebSocketError,
+};
 
 use crate::error::SignalFishError;
 use crate::token_binding::{TokenBindingChallenge, TokenBindingMode, TokenBindingStatus};
@@ -46,6 +50,7 @@ pub type WsStream =
     tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>;
 
 const MAX_SKIPPED_CONTROL_FRAMES_PER_POLL: usize = 64;
+const DEFAULT_MAX_INBOUND_MESSAGE_SIZE: usize = 8 * 1024 * 1024;
 
 fn map_connect_error(error: WebSocketError) -> SignalFishError {
     let kind = match &error {
@@ -53,6 +58,18 @@ fn map_connect_error(error: WebSocketError) -> SignalFishError {
         _ => std::io::ErrorKind::Other,
     };
     SignalFishError::Io(std::io::Error::new(kind, error))
+}
+
+fn websocket_config(options: WebSocketConnectOptions) -> Result<WebSocketConfig, SignalFishError> {
+    if options.max_inbound_message_size == Some(0) {
+        return Err(SignalFishError::Io(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "WebSocket max_inbound_message_size must be greater than zero or None",
+        )));
+    }
+    Ok(WebSocketConfig::default()
+        .max_frame_size(options.max_inbound_message_size)
+        .max_message_size(options.max_inbound_message_size))
 }
 
 #[cfg(feature = "tls")]
@@ -208,6 +225,7 @@ impl rustls::client::ResolvesClientCert for TrackingClientCertificateResolver {
 async fn connect_with_token_binding(
     url: &str,
     options: WebSocketConnectOptions,
+    websocket_config: WebSocketConfig,
     #[cfg(feature = "tls")] connector: Option<tokio_tungstenite::Connector>,
     #[cfg(feature = "tls")] client_fingerprint: Option<ClientCertificateFingerprintTracker>,
 ) -> Result<(WsStream, WebSocketTokenBinding), SignalFishError> {
@@ -236,14 +254,18 @@ async fn connect_with_token_binding(
     #[cfg(feature = "tls")]
     let connected = tokio_tungstenite::connect_async_tls_with_config(
         request,
-        None,
+        Some(websocket_config),
         options.disable_nagle,
         connector.clone(),
     )
     .await;
     #[cfg(not(feature = "tls"))]
-    let connected =
-        tokio_tungstenite::connect_async_with_config(request, None, options.disable_nagle).await;
+    let connected = tokio_tungstenite::connect_async_with_config(
+        request,
+        Some(websocket_config),
+        options.disable_nagle,
+    )
+    .await;
     let (mut stream, _response) = match connected {
         Ok(connected) => connected,
         Err(WebSocketError::Protocol(ProtocolError::SecWebSocketSubProtocolError(
@@ -255,15 +277,18 @@ async fn connect_with_token_binding(
             #[cfg(feature = "tls")]
             let fallback = tokio_tungstenite::connect_async_tls_with_config(
                 url,
-                None,
+                Some(websocket_config),
                 options.disable_nagle,
                 connector,
             )
             .await;
             #[cfg(not(feature = "tls"))]
-            let fallback =
-                tokio_tungstenite::connect_async_with_config(url, None, options.disable_nagle)
-                    .await;
+            let fallback = tokio_tungstenite::connect_async_with_config(
+                url,
+                Some(websocket_config),
+                options.disable_nagle,
+            )
+            .await;
             let (stream, _response) = fallback.map_err(|error| match error {
                 WebSocketError::Http(_) => {
                     SignalFishError::TokenBinding(crate::TokenBindingFailure::NegotiationRejected)
@@ -378,6 +403,18 @@ pub struct WebSocketConnectOptions {
     /// Applied to the raw socket before any TLS handshake, so it covers both
     /// `ws://` and `wss://`.
     pub disable_nagle: bool,
+    /// Maximum payload bytes accepted in one inbound WebSocket frame or
+    /// assembled message.
+    ///
+    /// Defaults to 8 MiB, substantially below tungstenite's 64 MiB assembled
+    /// message default while retaining headroom for ordinary Server 0.7 room
+    /// snapshots. This is a protective client policy, not a protocol maximum:
+    /// deployments with larger player metadata, spectator rosters, replay
+    /// buffers, or server message limits must raise it. Set it to `None` to
+    /// disable both tungstenite receive limits.
+    ///
+    /// `Some(0)` is invalid and makes connection setup fail before network I/O.
+    pub max_inbound_message_size: Option<usize>,
     /// Token-binding-v2 negotiation policy.
     ///
     /// Defaults to [`TokenBindingMode::Disabled`]. Optional or required mode
@@ -395,6 +432,7 @@ impl Default for WebSocketConnectOptions {
         // NB: a *derived* `Default` would yield `false`; the low-latency default is `true`.
         Self {
             disable_nagle: true,
+            max_inbound_message_size: Some(DEFAULT_MAX_INBOUND_MESSAGE_SIZE),
             token_binding: TokenBindingMode::Disabled,
             token_binding_challenge_timeout: std::time::Duration::from_secs(10),
         }
@@ -414,6 +452,17 @@ impl WebSocketConnectOptions {
     #[must_use]
     pub fn with_disable_nagle(mut self, disable_nagle: bool) -> Self {
         self.disable_nagle = disable_nagle;
+        self
+    }
+
+    /// Set the maximum payload size for an inbound WebSocket frame or
+    /// assembled message.
+    ///
+    /// The limit is inclusive. Set `None` to disable both receive limits.
+    /// `Some(0)` is rejected by the connection methods.
+    #[must_use]
+    pub fn with_max_inbound_message_size(mut self, max_size: Option<usize>) -> Self {
+        self.max_inbound_message_size = max_size;
         self
     }
 
@@ -452,7 +501,8 @@ impl WebSocketConnectOptions {
 ///
 /// For advanced use-cases (custom TLS, proxy, headers) construct the stream
 /// yourself and use [`WebSocketTransport::from_stream`]. Because that receives
-/// an already-completed handshake, it cannot enable token binding.
+/// an already-completed handshake, it cannot enable token binding and retains
+/// the caller's WebSocket codec limits.
 ///
 /// # Polling Safety
 ///
@@ -597,8 +647,10 @@ impl WebSocketTransport {
     /// without it a `wss://` URL fails with [`SignalFishError::Io`].
     ///
     /// Nagle's algorithm is **disabled by default** (`TCP_NODELAY`) so small,
-    /// latency-sensitive game messages are sent without delay. Use
-    /// [`connect_with_options`](Self::connect_with_options) to override that.
+    /// latency-sensitive game messages are sent without delay. Inbound frames
+    /// and assembled messages are limited to 8 MiB by default. Use
+    /// [`connect_with_options`](Self::connect_with_options) to override either
+    /// policy.
     ///
     /// # Errors
     ///
@@ -614,10 +666,10 @@ impl WebSocketTransport {
     /// [`WebSocketConnectOptions`].
     ///
     /// Behaves like [`connect`](Self::connect) but lets the caller control
-    /// socket tuning and token-binding negotiation policy. Socket options are
-    /// applied before any TLS handshake, so they cover both `ws://` and
-    /// `wss://`. A selected token-binding challenge is consumed before this
-    /// method returns.
+    /// socket tuning, inbound frame/message size limits, and token-binding
+    /// negotiation policy. Socket options are applied before any TLS handshake,
+    /// so they cover both `ws://` and `wss://`. A selected token-binding
+    /// challenge is consumed before this method returns.
     ///
     /// # Errors
     ///
@@ -627,7 +679,10 @@ impl WebSocketTransport {
     /// mapped to [`ErrorKind::Other`](std::io::ErrorKind::Other). Optional or
     /// required mode returns [`SignalFishError::TokenBinding`] when the feature
     /// is disabled or negotiation, challenge validation, or key derivation
-    /// fails.
+    /// fails. A zero inbound size limit returns [`SignalFishError::Io`] with
+    /// [`ErrorKind::InvalidInput`](std::io::ErrorKind::InvalidInput) before URL
+    /// parsing or network I/O. When token binding is requested without the
+    /// `token-binding` feature, its feature-disabled error takes precedence.
     pub async fn connect_with_options(
         url: &str,
         options: WebSocketConnectOptions,
@@ -638,6 +693,7 @@ impl WebSocketTransport {
                 crate::TokenBindingFailure::FeatureDisabled,
             ));
         }
+        let websocket_config = websocket_config(options)?;
 
         #[cfg(feature = "tls")]
         install_tls_provider();
@@ -645,31 +701,39 @@ impl WebSocketTransport {
         tracing::debug!(
             secure = url.starts_with("wss://"),
             disable_nagle = options.disable_nagle,
+            max_inbound_message_size = options.max_inbound_message_size,
             token_binding = ?options.token_binding,
             "connecting to WebSocket server"
         );
 
         #[cfg(feature = "token-binding")]
         let (stream, token_binding) = if options.token_binding == TokenBindingMode::Disabled {
-            let (stream, _response) =
-                tokio_tungstenite::connect_async_with_config(url, None, options.disable_nagle)
-                    .await
-                    .map_err(map_connect_error)?;
+            let (stream, _response) = tokio_tungstenite::connect_async_with_config(
+                url,
+                Some(websocket_config),
+                options.disable_nagle,
+            )
+            .await
+            .map_err(map_connect_error)?;
             (stream, WebSocketTokenBinding::Disabled)
         } else {
             #[cfg(feature = "tls")]
-            let connected = connect_with_token_binding(url, options, None, None).await?;
+            let connected =
+                connect_with_token_binding(url, options, websocket_config, None, None).await?;
             #[cfg(not(feature = "tls"))]
-            let connected = connect_with_token_binding(url, options).await?;
+            let connected = connect_with_token_binding(url, options, websocket_config).await?;
             connected
         };
 
         #[cfg(not(feature = "token-binding"))]
         let (stream, token_binding) = {
-            let (stream, _response) =
-                tokio_tungstenite::connect_async_with_config(url, None, options.disable_nagle)
-                    .await
-                    .map_err(map_connect_error)?;
+            let (stream, _response) = tokio_tungstenite::connect_async_with_config(
+                url,
+                Some(websocket_config),
+                options.disable_nagle,
+            )
+            .await
+            .map_err(map_connect_error)?;
             (stream, WebSocketTokenBinding::Disabled)
         };
 
@@ -696,7 +760,10 @@ impl WebSocketTransport {
     /// # Errors
     ///
     /// Returns the same connection and token-binding errors as
-    /// [`connect_with_options`](Self::connect_with_options).
+    /// [`connect_with_options`](Self::connect_with_options), including
+    /// [`SignalFishError::Io`] with
+    /// [`ErrorKind::InvalidInput`](std::io::ErrorKind::InvalidInput) for a zero
+    /// inbound size limit.
     #[cfg(feature = "tls")]
     pub async fn connect_with_tls_config(
         url: &str,
@@ -709,12 +776,14 @@ impl WebSocketTransport {
                 crate::TokenBindingFailure::FeatureDisabled,
             ));
         }
+        let websocket_config = websocket_config(options)?;
 
         install_tls_provider();
         let connector = tokio_tungstenite::Connector::Rustls(tls_config.clone());
         tracing::debug!(
             secure = url.starts_with("wss://"),
             disable_nagle = options.disable_nagle,
+            max_inbound_message_size = options.max_inbound_message_size,
             token_binding = ?options.token_binding,
             custom_tls = true,
             "connecting to WebSocket server"
@@ -724,7 +793,7 @@ impl WebSocketTransport {
         let (stream, token_binding) = if options.token_binding == TokenBindingMode::Disabled {
             let (stream, _response) = tokio_tungstenite::connect_async_tls_with_config(
                 url,
-                None,
+                Some(websocket_config),
                 options.disable_nagle,
                 Some(connector),
             )
@@ -735,14 +804,21 @@ impl WebSocketTransport {
             let (tls_config, fingerprint_tracker) =
                 ClientCertificateFingerprintTracker::wrap(tls_config);
             let connector = tokio_tungstenite::Connector::Rustls(tls_config);
-            connect_with_token_binding(url, options, Some(connector), fingerprint_tracker).await?
+            connect_with_token_binding(
+                url,
+                options,
+                websocket_config,
+                Some(connector),
+                fingerprint_tracker,
+            )
+            .await?
         };
 
         #[cfg(not(feature = "token-binding"))]
         let (stream, token_binding) = {
             let (stream, _response) = tokio_tungstenite::connect_async_tls_with_config(
                 url,
-                None,
+                Some(websocket_config),
                 options.disable_nagle,
                 Some(connector),
             )
@@ -769,6 +845,9 @@ impl WebSocketTransport {
     /// Unlike [`connect`](Self::connect), this does **not** touch socket options:
     /// the caller owns the stream and is responsible for `TCP_NODELAY` (Nagle) or
     /// any other tuning on the underlying socket before wrapping it here.
+    /// The caller likewise owns the stream's WebSocket codec configuration,
+    /// including frame and assembled-message size limits; this constructor
+    /// does not replace them.
     /// It also cannot enable token binding: an established stream no longer
     /// exposes the exact generated `Sec-WebSocket-Key`, so callers needing that
     /// extension must own the full handshake/proof wrapper or use a connect API.
@@ -1196,6 +1275,58 @@ mod tests {
         assert_debug::<WebSocketTransport>();
     }
 
+    #[test]
+    fn connect_options_apply_inbound_frame_and_message_limits_together() {
+        let default_config = websocket_config(WebSocketConnectOptions::default())
+            .expect("default inbound limit must be valid");
+        assert_eq!(
+            default_config.max_frame_size,
+            Some(DEFAULT_MAX_INBOUND_MESSAGE_SIZE)
+        );
+        assert_eq!(
+            default_config.max_message_size,
+            Some(DEFAULT_MAX_INBOUND_MESSAGE_SIZE)
+        );
+
+        for (limit, expected) in [(Some(1_024), Some(1_024)), (None, None)] {
+            let config = websocket_config(
+                WebSocketConnectOptions::new().with_max_inbound_message_size(limit),
+            )
+            .expect("positive or disabled inbound limit must be valid");
+            assert_eq!(config.max_frame_size, expected);
+            assert_eq!(config.max_message_size, expected);
+        }
+    }
+
+    #[tokio::test]
+    async fn zero_inbound_message_limit_is_rejected_before_url_parsing() {
+        let error = WebSocketTransport::connect_with_options(
+            "not-a-valid-url",
+            WebSocketConnectOptions::new().with_max_inbound_message_size(Some(0)),
+        )
+        .await
+        .expect_err("zero must not create a degenerate WebSocket codec");
+        assert!(
+            matches!(error, SignalFishError::Io(ref io) if io.kind() == std::io::ErrorKind::InvalidInput)
+        );
+    }
+
+    #[cfg(feature = "token-binding")]
+    #[tokio::test]
+    async fn zero_inbound_limit_precedes_token_binding_network_work_when_supported() {
+        let error = WebSocketTransport::connect_with_options(
+            "not-a-valid-url",
+            WebSocketConnectOptions::new()
+                .with_token_binding(TokenBindingMode::Required)
+                .with_max_inbound_message_size(Some(0)),
+        )
+        .await
+        .expect_err("zero must be rejected before token-binding handshake work");
+        assert!(
+            matches!(error, SignalFishError::Io(ref io) if io.kind() == std::io::ErrorKind::InvalidInput)
+        );
+    }
+
     #[cfg(all(feature = "tls", feature = "token-binding"))]
     #[test]
     fn client_certificate_fingerprint_is_lowercase_sha256_and_redacted() {
@@ -1368,6 +1499,24 @@ mod tests {
         ));
     }
 
+    #[cfg(not(feature = "token-binding"))]
+    #[tokio::test]
+    async fn unavailable_token_binding_precedes_an_invalid_inbound_limit() {
+        let result = WebSocketTransport::connect_with_options(
+            "not-a-valid-url",
+            WebSocketConnectOptions::new()
+                .with_token_binding(TokenBindingMode::Required)
+                .with_max_inbound_message_size(Some(0)),
+        )
+        .await;
+        assert!(matches!(
+            result,
+            Err(SignalFishError::TokenBinding(
+                crate::TokenBindingFailure::FeatureDisabled
+            ))
+        ));
+    }
+
     // ── Mock-stream helpers ──────────────────────────────────────────────
 
     use tokio::net::TcpListener;
@@ -1516,11 +1665,14 @@ mod tests {
             assert_eq!(signed["type"], "Ping");
             assert_eq!(signed["token_binding"]["sequence"], 1);
             assert!(signed["token_binding"]["signature"].is_string());
+            ws.send(Message::Binary(vec![0xA5; 257].into()))
+                .await
+                .expect("server must send an oversized post-challenge message");
         });
 
         let mut transport = WebSocketTransport::connect_with_options(
             &format!("ws://{addr}"),
-            required_token_binding_options(),
+            required_token_binding_options().with_max_inbound_message_size(Some(256)),
         )
         .await
         .expect("required token binding must connect");
@@ -1531,6 +1683,10 @@ mod tests {
             .await
             .expect("signed Ping must send");
         assert!(frame.is_none());
+        assert!(matches!(
+            crate::transport::recv_frame(&mut transport).await,
+            Some(Err(SignalFishError::TransportReceive(_)))
+        ));
         finish_mock_server(server_task).await;
     }
 
@@ -1571,12 +1727,17 @@ mod tests {
             )
             .await
             .expect("unsigned fallback handshake must succeed");
-            while second.next().await.is_some() {}
+            second
+                .send(Message::Binary(vec![0x5A; 257].into()))
+                .await
+                .expect("server must send an oversized fallback message");
         });
 
-        let transport = WebSocketTransport::connect_with_options(
+        let mut transport = WebSocketTransport::connect_with_options(
             &format!("ws://{addr}"),
-            WebSocketConnectOptions::new().with_token_binding(TokenBindingMode::Optional),
+            WebSocketConnectOptions::new()
+                .with_token_binding(TokenBindingMode::Optional)
+                .with_max_inbound_message_size(Some(256)),
         )
         .await
         .expect("optional mode must accept server-permitted fallback");
@@ -1584,7 +1745,10 @@ mod tests {
             transport.token_binding_status(),
             TokenBindingStatus::NotNegotiated
         );
-        drop(transport);
+        assert!(matches!(
+            crate::transport::recv_frame(&mut transport).await,
+            Some(Err(SignalFishError::TransportReceive(_)))
+        ));
         finish_mock_server(server_task).await;
     }
 
@@ -2487,6 +2651,156 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn inbound_limit_is_inclusive_and_can_be_disabled() {
+        for limit in [Some(257), None] {
+            let (url, server_task) = start_mock_server(|mut ws| async move {
+                ws.send(Message::Binary(vec![0xC7; 257].into()))
+                    .await
+                    .expect("server must send the boundary message");
+            })
+            .await;
+            let options = WebSocketConnectOptions::new().with_max_inbound_message_size(limit);
+            let mut transport = WebSocketTransport::connect_with_options(&url, options)
+                .await
+                .expect("custom inbound policy must connect");
+
+            let live_config = transport
+                .state
+                .stream
+                .as_ref()
+                .expect("connected transport must retain its WebSocket stream")
+                .get_config();
+            assert_eq!(live_config.max_frame_size, limit);
+            assert_eq!(live_config.max_message_size, limit);
+
+            assert_eq!(
+                expect_received_frame(crate::transport::recv_frame(&mut transport).await),
+                TransportFrame::Binary(vec![0xC7; 257]),
+                "limit {limit:?} must admit this complete message"
+            );
+            finish_mock_server(server_task).await;
+        }
+    }
+
+    #[cfg(feature = "tls")]
+    #[tokio::test]
+    async fn explicit_rustls_connect_path_applies_inbound_size_policy() {
+        let (url, server_task) = start_mock_server(|mut ws| async move {
+            ws.send(Message::Binary(vec![0xC6; 257].into()))
+                .await
+                .expect("server must send the oversized message");
+        })
+        .await;
+        install_tls_provider();
+        let tls_config = Arc::new(
+            rustls::ClientConfig::builder()
+                .with_root_certificates(rustls::RootCertStore::empty())
+                .with_no_client_auth(),
+        );
+        let options = WebSocketConnectOptions::new().with_max_inbound_message_size(Some(256));
+        let mut transport = WebSocketTransport::connect_with_tls_config(&url, options, tls_config)
+            .await
+            .expect("explicit rustls connect path must support a plain ws endpoint");
+
+        let live_config = transport
+            .state
+            .stream
+            .as_ref()
+            .expect("connected transport must retain its WebSocket stream")
+            .get_config();
+        assert_eq!(live_config.max_frame_size, Some(256));
+        assert_eq!(live_config.max_message_size, Some(256));
+        assert!(matches!(
+            crate::transport::recv_frame(&mut transport).await,
+            Some(Err(SignalFishError::TransportReceive(_)))
+        ));
+        finish_mock_server(server_task).await;
+    }
+
+    #[tokio::test]
+    async fn oversized_inbound_frame_is_reported_once_and_fuses_transport() {
+        let (url, server_task) = start_mock_server(|mut ws| async move {
+            ws.send(Message::Binary(vec![0xC8; 257].into()))
+                .await
+                .expect("server must send the oversized message");
+        })
+        .await;
+        let options = WebSocketConnectOptions::new().with_max_inbound_message_size(Some(256));
+        let mut transport = WebSocketTransport::connect_with_options(&url, options)
+            .await
+            .expect("bounded WebSocket must connect");
+
+        assert!(matches!(
+            crate::transport::recv_frame(&mut transport).await,
+            Some(Err(SignalFishError::TransportReceive(_)))
+        ));
+        assert!(transport.state.closed);
+        assert!(transport.state.stream.is_none());
+        assert!(crate::transport::recv_frame(&mut transport).await.is_none());
+
+        let expected = TransportFrame::Text("caller-retains-oversize-retry".into());
+        let mut offered = Some(expected.clone());
+        let send_result = std::future::poll_fn(|cx| transport.poll_send(cx, &mut offered)).await;
+        assert!(matches!(send_result, Err(SignalFishError::TransportClosed)));
+        assert_eq!(offered, Some(expected));
+        crate::transport::close_transport(&mut transport)
+            .await
+            .expect("close after size rejection must be idempotent");
+        crate::transport::close_transport(&mut transport)
+            .await
+            .expect("repeated close after size rejection must remain idempotent");
+        finish_mock_server(server_task).await;
+    }
+
+    #[tokio::test]
+    async fn inbound_fragmented_limit_is_inclusive_and_rejects_boundary_plus_one() {
+        use tokio_tungstenite::tungstenite::protocol::frame::coding::{Data, OpCode};
+        use tokio_tungstenite::tungstenite::protocol::frame::Frame;
+
+        for (final_fragment_size, accepted) in [(128, true), (129, false)] {
+            let (url, server_task) = start_mock_server(move |mut ws| async move {
+                ws.send(Message::Frame(Frame::message(
+                    vec![0xC9; 128],
+                    OpCode::Data(Data::Binary),
+                    false,
+                )))
+                .await
+                .expect("server must send the first fragment");
+                ws.send(Message::Frame(Frame::message(
+                    vec![0xCA; final_fragment_size],
+                    OpCode::Data(Data::Continue),
+                    true,
+                )))
+                .await
+                .expect("server must send the final fragment");
+            })
+            .await;
+            let options = WebSocketConnectOptions::new().with_max_inbound_message_size(Some(256));
+            let mut transport = WebSocketTransport::connect_with_options(&url, options)
+                .await
+                .expect("bounded WebSocket must connect");
+
+            let received = crate::transport::recv_frame(&mut transport).await;
+            if accepted {
+                let mut expected = vec![0xC9; 128];
+                expected.extend(vec![0xCA; final_fragment_size]);
+                assert_eq!(
+                    expect_received_frame(received),
+                    TransportFrame::Binary(expected),
+                    "an assembled message exactly at the limit must be accepted"
+                );
+            } else {
+                assert!(matches!(
+                    received,
+                    Some(Err(SignalFishError::TransportReceive(_)))
+                ));
+                assert!(crate::transport::recv_frame(&mut transport).await.is_none());
+            }
+            finish_mock_server(server_task).await;
+        }
+    }
+
+    #[tokio::test]
     async fn socket_receive_error_is_reported_once_then_transport_is_terminal() {
         let mut transport = connect_to_reset_peer().await;
         let first = tokio::time::timeout(
@@ -2691,6 +3005,30 @@ mod tests {
             .expect("recv must return Ok");
         assert_eq!(msg, TransportFrame::Text("from_stream_msg".into()));
         drop(transport);
+        finish_mock_server(server_task).await;
+    }
+
+    #[tokio::test]
+    async fn from_stream_preserves_the_callers_codec_limit() {
+        let (url, server_task) = start_mock_server(|mut ws| async move {
+            ws.send(Message::Binary(vec![0xCB; 129].into()))
+                .await
+                .expect("server must send the caller-oversized message");
+        })
+        .await;
+        let caller_config = WebSocketConfig::default()
+            .max_frame_size(Some(128))
+            .max_message_size(Some(128));
+        let (ws_stream, _) =
+            tokio_tungstenite::connect_async_with_config(&url, Some(caller_config), false)
+                .await
+                .expect("raw WebSocket connect must succeed");
+        let mut transport = WebSocketTransport::from_stream(ws_stream);
+
+        assert!(matches!(
+            crate::transport::recv_frame(&mut transport).await,
+            Some(Err(SignalFishError::TransportReceive(_)))
+        ));
         finish_mock_server(server_task).await;
     }
 


### PR DESCRIPTION
## Summary

- bound every SDK-owned native WebSocket connection to an inclusive 8 MiB inbound frame and assembled-message default before data can reach `ClientCore`
- expose `WebSocketConnectOptions::max_inbound_message_size` plus a builder so deployments can raise the policy or choose `None`; reject `Some(0)` before network work
- preserve caller-owned `from_stream` codec limits and existing feature-error precedence
- document the compatibility rationale and advance the issue #126 authority matrix

## Why 8 MiB

The pinned Server 0.7 source has a 64 KiB default inbound application limit, but server messages aggregate many separately accepted values. A deployment can permit up to 100 players, whose near-cap connection metadata can approach roughly 6.25 MiB before snapshot envelope or replay overhead. Spectator/replay aggregation means no finite client value is a protocol-wide compatibility guarantee.

The missing discoverable/enforced server outbound contract is tracked in [signal-fish-server#399](https://github.com/Ambiguous-Interactive/signal-fish-server/issues/399). Same-kind room response identity remains independently blocked by #128 and signal-fish-server#395.

## Regression coverage

Real tungstenite codecs cover:

- exact single-frame and fragmented aggregate boundaries
- boundary + 1 for unfragmented and fragmented input
- live custom and `None` codec configuration
- Required token-binding selection and Optional fallback
- the explicit rustls constructor
- caller-owned `from_stream` limits
- one-shot `TransportReceive` mapping and fused receive/send/close behavior
- zero-limit and feature-disabled validation precedence

## Verification

- `cargo fmt && cargo clippy --workspace --all-targets --all-features -- -D warnings && cargo test --workspace --all-features`
- all 18 pre-commit checks
- all six pre-push checks
- two adversarial review rounds and an independent GOAL/evidence audit: zero remaining findings

Advances #126.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking public options and receive-default change: oversized input now terminalizes the native transport. Not auth, but it can drop otherwise-legal large Server 0.7 snapshots unless callers raise the limit.
> 
> **Overview**
> **Breaking:** SDK-owned native WebSocket connections now apply an inclusive **8 MiB** inbound cap to both individual frames and fragmented-message assembly, instead of inheriting tungstenite’s larger defaults. Oversized input is reported once as `SignalFishError::TransportReceive`, then the transport fuses.
> 
> `WebSocketConnectOptions` gains public `max_inbound_message_size` and `with_max_inbound_message_size`. Callers can raise the limit or set `None` to disable both codec bounds; `Some(0)` fails before network I/O. Token-binding `FeatureDisabled` still wins over an invalid size. `from_stream` keeps the caller’s codec limits.
> 
> This is a client resource policy, not a Server 0.7 maximum (tracked in signal-fish-server#399). Browser/engine transports are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7085134d7e21641a22d118b201d7c522d90bc06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->