### PR TITLE
fix: accept valid large Godot server messages

### DIFF
--- a/.github/workflows/godot-web.yml
+++ b/.github/workflows/godot-web.yml
@@ -104,6 +104,7 @@ jobs:
           cargo build --manifest-path tests/godot-web-smoke/Cargo.toml --locked
           cp tests/godot-web-smoke/target/debug/libsignal_fish_godot_smoke.so \
             tests/godot-web-smoke/project/bin/libsignal_fish_godot_smoke.so
+          "${GODOT4_BIN}" --headless --path tests/godot-web-smoke/project --import
 
           cleanup() {
             if [ -n "${godot_pid:-}" ]; then

--- a/.github/workflows/godot-web.yml
+++ b/.github/workflows/godot-web.yml
@@ -180,25 +180,11 @@ jobs:
             import { readFileSync } from "node:fs";
             import {
               validateLargeInboundMarkers,
-              validateLoadSummary,
             } from "./scripts/godot-e2e-validators.mjs";
             const lines = readFileSync("godot-native.log", "utf8").split(/\r?\n/);
             const largeInbound = validateLargeInboundMarkers(lines);
             if (!largeInbound.ok) {
               throw new Error("native large-inbound assertions failed: " + JSON.stringify(largeInbound));
-            }
-            const prefix = "SIGNAL_FISH_SMOKE load-summary ";
-            const summaries = lines.filter((line) => line.includes(prefix));
-            if (summaries.length !== 1) {
-              throw new Error("native load-summary count was " + summaries.length + ", expected one");
-            }
-            const summary = JSON.parse(summaries[0].slice(summaries[0].indexOf(prefix) + prefix.length));
-            const samples = lines
-              .filter((line) => line.includes("SIGNAL_FISH_LOAD sample "))
-              .map((line) => JSON.parse(line.slice(line.indexOf("SIGNAL_FISH_LOAD sample ") + 24)));
-            const load = validateLoadSummary(summary, samples);
-            if (!load.ok) {
-              throw new Error("native load assertions failed: " + JSON.stringify(load));
             }
           '
 

--- a/.github/workflows/godot-web.yml
+++ b/.github/workflows/godot-web.yml
@@ -180,12 +180,12 @@ jobs:
             const lines = readFileSync("godot-native.log", "utf8").split(/\r?\n/);
             const largeInbound = validateLargeInboundMarkers(lines);
             if (!largeInbound.ok) {
-              throw new Error(`native large-inbound assertions failed: ${JSON.stringify(largeInbound)}`);
+              throw new Error("native large-inbound assertions failed: " + JSON.stringify(largeInbound));
             }
             const prefix = "SIGNAL_FISH_SMOKE load-summary ";
             const summaries = lines.filter((line) => line.includes(prefix));
             if (summaries.length !== 1) {
-              throw new Error(`native load-summary count was ${summaries.length}, expected one`);
+              throw new Error("native load-summary count was " + summaries.length + ", expected one");
             }
             const summary = JSON.parse(summaries[0].slice(summaries[0].indexOf(prefix) + prefix.length));
             const samples = lines
@@ -193,7 +193,7 @@ jobs:
               .map((line) => JSON.parse(line.slice(line.indexOf("SIGNAL_FISH_LOAD sample ") + 24)));
             const load = validateLoadSummary(summary, samples);
             if (!load.ok) {
-              throw new Error(`native load assertions failed: ${JSON.stringify(load)}`);
+              throw new Error("native load assertions failed: " + JSON.stringify(load));
             }
           '
 

--- a/.github/workflows/godot-web.yml
+++ b/.github/workflows/godot-web.yml
@@ -23,6 +23,7 @@ env:
   NETEM_SEED: "6101"
   IPROUTE2_VERSION: "6.6.0"
   IPROUTE2_SHA256: "8738c804afd09f0bf756937f0c3de23117832a98d8cbbf50386cf5005cd613ce"
+  NATIVE_SERVER_VERSION: "0.7.0"
 
 jobs:
   build-export:
@@ -84,6 +85,165 @@ jobs:
             --all-targets --locked -- -D warnings
           cargo test --manifest-path tests/godot-web-smoke/Cargo.toml --locked
           node --test scripts/test-godot-e2e-validators.mjs
+
+      - name: Run official native large-inbound smoke
+        env:
+          GODOT4_BIN: ${{ github.workspace }}/.godot/Godot_v4.5-stable_linux.x86_64
+        run: |
+          set -euo pipefail
+          asset="signal-fish-server-v${NATIVE_SERVER_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+          base="https://github.com/Ambiguous-Interactive/signal-fish-server/releases/download/v${NATIVE_SERVER_VERSION}"
+          curl --fail --location --retry 5 --output "${asset}" "${base}/${asset}"
+          curl --fail --location --retry 5 --output "${asset}.sha256" "${base}/${asset}.sha256"
+          sha256sum --check "${asset}.sha256"
+          mkdir -p .signal-fish-native-server tests/godot-web-smoke/project/bin
+          tar -xzf "${asset}" -C .signal-fish-native-server
+          server_bin="$(find .signal-fish-native-server -type f -name signal-fish-server -print -quit)"
+          chmod +x "${server_bin}"
+
+          cargo build --manifest-path tests/godot-web-smoke/Cargo.toml --locked
+          cp tests/godot-web-smoke/target/debug/libsignal_fish_godot_smoke.so \
+            tests/godot-web-smoke/project/bin/libsignal_fish_godot_smoke.so
+
+          cleanup() {
+            if [ -n "${godot_pid:-}" ]; then
+              kill "${godot_pid}" 2>/dev/null || true
+              wait "${godot_pid}" 2>/dev/null || true
+            fi
+            if [ -n "${server_pid:-}" ]; then
+              kill "${server_pid}" 2>/dev/null || true
+              wait "${server_pid}" 2>/dev/null || true
+            fi
+          }
+          trap cleanup EXIT
+
+          SIGNAL_FISH__PORT=3536 \
+          SIGNAL_FISH__LOGGING__LEVEL=debug \
+          SIGNAL_FISH__SERVER__DRAIN_GRACE_SECS=1 \
+          SIGNAL_FISH__SECURITY__CORS_ORIGINS='*' \
+          SIGNAL_FISH__SECURITY__MAX_MESSAGE_SIZE=131072 \
+          SIGNAL_FISH__SECURITY__REQUIRE_METRICS_AUTH=false \
+          SIGNAL_FISH__SECURITY__REQUIRE_WEBSOCKET_AUTH=false \
+          SIGNAL_FISH__PROTOCOL__SDK_COMPATIBILITY__ENFORCE=false \
+            "${server_bin}" >native-server.log 2>&1 &
+          server_pid=$!
+
+          for attempt in $(seq 1 150); do
+            if timeout 1 bash -c 'printf "\n" >/dev/tcp/127.0.0.1/3536' 2>/dev/null; then
+              break
+            fi
+            if [ "${attempt}" -eq 150 ]; then
+              printf 'Signal Fish server did not become ready\n' >&2
+              exit 1
+            fi
+            sleep 0.1
+          done
+
+          "${GODOT4_BIN}" --headless --path tests/godot-web-smoke/project -- \
+            --server-url ws://127.0.0.1:3536/v2/ws >godot-native.log 2>&1 &
+          godot_pid=$!
+
+          wait_for_godot_marker() {
+            marker="$1"
+            description="$2"
+            max_attempts="$3"
+            for attempt in $(seq 1 "${max_attempts}"); do
+              if grep -Fq -- "${marker}" godot-native.log; then
+                return 0
+              fi
+              if ! kill -0 "${godot_pid}" 2>/dev/null; then
+                wait "${godot_pid}" || true
+                godot_pid=""
+                printf 'Godot exited before %s\n' "${description}" >&2
+                return 1
+              fi
+              sleep 0.1
+            done
+            printf 'Godot did not reach %s\n' "${description}" >&2
+            return 1
+          }
+
+          wait_for_godot_marker \
+            'SIGNAL_FISH_SMOKE load-summary' 'the JSON load summary' 600
+          wait_for_godot_marker \
+            'SIGNAL_FISH_SMOKE json-shutdown-ok' 'JSON graceful shutdown' 300
+          wait_for_godot_marker \
+            'SIGNAL_FISH_SMOKE binary-ready-for-server-close' \
+            'binary readiness for server close' 300
+
+          node --input-type=module -e '
+            import { readFileSync } from "node:fs";
+            import {
+              validateLargeInboundMarkers,
+              validateLoadSummary,
+            } from "./scripts/godot-e2e-validators.mjs";
+            const lines = readFileSync("godot-native.log", "utf8").split(/\r?\n/);
+            const largeInbound = validateLargeInboundMarkers(lines);
+            if (!largeInbound.ok) {
+              throw new Error(`native large-inbound assertions failed: ${JSON.stringify(largeInbound)}`);
+            }
+            const prefix = "SIGNAL_FISH_SMOKE load-summary ";
+            const summaries = lines.filter((line) => line.includes(prefix));
+            if (summaries.length !== 1) {
+              throw new Error(`native load-summary count was ${summaries.length}, expected one`);
+            }
+            const summary = JSON.parse(summaries[0].slice(summaries[0].indexOf(prefix) + prefix.length));
+            const samples = lines
+              .filter((line) => line.includes("SIGNAL_FISH_LOAD sample "))
+              .map((line) => JSON.parse(line.slice(line.indexOf("SIGNAL_FISH_LOAD sample ") + 24)));
+            const load = validateLoadSummary(summary, samples);
+            if (!load.ok) {
+              throw new Error(`native load assertions failed: ${JSON.stringify(load)}`);
+            }
+          '
+
+          kill -TERM "${server_pid}"
+          for attempt in $(seq 1 150); do
+            if ! kill -0 "${server_pid}" 2>/dev/null; then
+              break
+            fi
+            if [ "${attempt}" -eq 150 ]; then
+              printf 'Signal Fish server did not stop after SIGTERM\n' >&2
+              exit 1
+            fi
+            sleep 0.1
+          done
+          wait "${server_pid}" || true
+          server_pid=""
+
+          wait_for_godot_marker \
+            'SIGNAL_FISH_SMOKE close-attribution-ok' 'server close attribution' 300
+          wait_for_godot_marker \
+            'SIGNAL_FISH_SMOKE complete' 'fixture completion' 300
+          for attempt in $(seq 1 300); do
+            if ! kill -0 "${godot_pid}" 2>/dev/null; then
+              break
+            fi
+            if [ "${attempt}" -eq 300 ]; then
+              printf 'Godot did not complete after server shutdown\n' >&2
+              exit 1
+            fi
+            sleep 0.1
+          done
+          wait "${godot_pid}"
+          godot_pid=""
+          if grep -Eq 'SIGNAL_FISH_SMOKE .*(-error|unexpected-disconnect)' godot-native.log; then
+            printf 'Godot native smoke reported a failure\n' >&2
+            exit 1
+          fi
+          trap - EXIT
+          cleanup
+
+      - name: Upload native large-inbound evidence
+        if: always()
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: godot-native-large-inbound-evidence
+          path: |
+            godot-native.log
+            native-server.log
+          if-no-files-found: warn
+          retention-days: 3
 
       - name: Build Godot GDExtension for web
         env:
@@ -288,6 +448,7 @@ jobs:
               SIGNAL_FISH__LOGGING__LEVEL=debug \
               SIGNAL_FISH__SERVER__DRAIN_GRACE_SECS=1 \
               SIGNAL_FISH__SECURITY__CORS_ORIGINS='*' \
+              SIGNAL_FISH__SECURITY__MAX_MESSAGE_SIZE=131072 \
               SIGNAL_FISH__SECURITY__REQUIRE_METRICS_AUTH=false \
               SIGNAL_FISH__SECURITY__REQUIRE_WEBSOCKET_AUTH=false \
               SIGNAL_FISH__PROTOCOL__SDK_COMPATIBILITY__ENFORCE=false \
@@ -297,6 +458,7 @@ jobs:
             SIGNAL_FISH__LOGGING__LEVEL=debug \
             SIGNAL_FISH__SERVER__DRAIN_GRACE_SECS=1 \
             SIGNAL_FISH__SECURITY__CORS_ORIGINS='*' \
+            SIGNAL_FISH__SECURITY__MAX_MESSAGE_SIZE=131072 \
             SIGNAL_FISH__SECURITY__REQUIRE_METRICS_AUTH=false \
             SIGNAL_FISH__SECURITY__REQUIRE_WEBSOCKET_AUTH=false \
             SIGNAL_FISH__PROTOCOL__SDK_COMPATIBILITY__ENFORCE=false \

--- a/.github/workflows/godot-web.yml
+++ b/.github/workflows/godot-web.yml
@@ -96,15 +96,19 @@ jobs:
           curl --fail --location --retry 5 --output "${asset}" "${base}/${asset}"
           curl --fail --location --retry 5 --output "${asset}.sha256" "${base}/${asset}.sha256"
           sha256sum --check "${asset}.sha256"
-          mkdir -p .signal-fish-native-server tests/godot-web-smoke/project/bin
+          native_fixture=".godot-native-project"
+          mkdir -p .signal-fish-native-server "${native_fixture}"
+          cp -R tests/godot-web-smoke/project/. "${native_fixture}/"
+          mkdir -p "${native_fixture}/bin" "${native_fixture}/.godot"
           tar -xzf "${asset}" -C .signal-fish-native-server
           server_bin="$(find .signal-fish-native-server -type f -name signal-fish-server -print -quit)"
           chmod +x "${server_bin}"
 
           cargo build --manifest-path tests/godot-web-smoke/Cargo.toml --locked
           cp tests/godot-web-smoke/target/debug/libsignal_fish_godot_smoke.so \
-            tests/godot-web-smoke/project/bin/libsignal_fish_godot_smoke.so
-          "${GODOT4_BIN}" --headless --path tests/godot-web-smoke/project --import
+            "${native_fixture}/bin/libsignal_fish_godot_smoke.so"
+          printf 'res://signal_fish_smoke.gdextension\n' \
+            >"${native_fixture}/.godot/extension_list.cfg"
 
           cleanup() {
             if [ -n "${godot_pid:-}" ]; then
@@ -140,7 +144,7 @@ jobs:
             sleep 0.1
           done
 
-          "${GODOT4_BIN}" --headless --path tests/godot-web-smoke/project -- \
+          "${GODOT4_BIN}" --headless --path "${native_fixture}" -- \
             --server-url ws://127.0.0.1:3536/v2/ws >godot-native.log 2>&1 &
           godot_pid=$!
 

--- a/.llm/context.md
+++ b/.llm/context.md
@@ -115,7 +115,7 @@ workspace. Hosted run 31969079956 proved clean root discovery.
 | `src/webrtc.rs` | `WebRtcDriver` seam + `MeshController` (feature: `mesh`) |
 | `src/transports/websocket.rs` | WebSocket transport (feature: `transport-websocket`) |
 | `src/token_binding.rs` | Native WebSocket token-binding-v2 types, validation, canonicalization, and proof state (feature: `token-binding`) |
-| `crates/signal-fish-client-godot/src/lib.rs` | Godot 4.5 native/web `WebSocketPeer` adapter and its 35 fake-backend tests |
+| `crates/signal-fish-client-godot/src/lib.rs` | Godot 4.5 native/web `WebSocketPeer` adapter and its 38 fake-backend tests |
 
 ### Transport Trait
 
@@ -185,9 +185,10 @@ fresh nonce, derived key, and sequence space; replay/reordering/tamper fails.
 The lockstep `signal-fish-client-godot` adapter defaults to adaptive outbound admission: a 50 ms latency target with a
 4 KiB floor, 32 KiB ceiling, and a further native-capacity clamp. A successful Godot send
 transfers ownership immediately; browser buffering is observed separately.
-The blocking Godot workflow builds one official export and runs clean,
-seeded-netem impaired, and 3,600-frame soak jobs through Signal Fish Server
-0.7.0, plus a clean 0.4.0 legacy gate. It checksum-verifies and builds iproute2
+SDK-created Godot peers set an 8 MiB inbound buffer before connecting, which may reserve roughly 16 MiB in Godot; `from_peer` preserves caller settings. The
+blocking workflow covers official native/web Godot 4.5, requires a valid frame
+over the legacy 65,535-byte default, and runs clean, seeded-netem impaired, and
+3,600-frame soak jobs on Server 0.7 plus a clean Server 0.4 gate. It checksum-verifies and builds iproute2
 6.6.0 for seeded netem rather
 than relying on the runner's older `tc`. A 20-frame Fortress prediction window
 leaves recovery headroom. Simulated frames 1 through 60 form an explicit
@@ -317,9 +318,9 @@ explicit opt-ins. Use `polling_stats()` for scheduling/queue diagnostics and
 age peak after authentication/setup when measuring gameplay. Backend acceptance
 ends queue age but is not peer delivery. Use `transport_diagnostics()` for
 backend buffering/admission diagnostics.
-Use the polling client's read-only `transport()` accessor for Godot's
-zero-expected `admission_watermark_violations()` counter and the separately
-accounted `one_frame_escape_bytes()` empty-buffer exception.
+Use the polling client's read-only `transport()` accessor for Godot's zero-expected
+`admission_watermark_violations()` and separately accounted
+`one_frame_escape_frames()` / `one_frame_escape_bytes()` diagnostics.
 
 ### Performance Contract
 

--- a/.llm/skills/godot-websocket/SKILL.md
+++ b/.llm/skills/godot-websocket/SKILL.md
@@ -203,7 +203,7 @@ undefined `emscripten_websocket_new` symbol.
 - [x] Core has no `godot` dependency, feature, module, or re-export.
 - [x] Adapter and core versions match; the adapter requires core exactly.
 - [x] The adapter range remains `>=0.4.5, <0.6` until deliberate compatibility evidence widens it.
-- [x] All 34 fake-backend transport tests pass in the adapter.
+- [x] All 38 fake-backend transport tests pass in the adapter.
 - [x] Minimum and latest fixtures compile natively and for Emscripten with one binding family.
 - [x] Official Godot 4.5 web templates export the fixture.
 - [x] Browser E2E proves connect, authentication, room join, Ping/Pong, relay,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   frames and assembled messages to 8 MiB by default; callers can raise the
   inclusive limit or set it to `None` for an unbounded codec. Streams supplied
   through `WebSocketTransport::from_stream` retain their caller-owned limits.
+- Added `GodotWebSocketTransport::one_frame_escape_frames()` so admission
+  diagnostics distinguish one individually oversized empty-buffer escape from
+  the same cumulative byte total spread across multiple frames.
 - Added Signal Fish Server 0.7.0 protocol conformance, including
   `SessionGeneration`, `DirectEndpoint::{host, port}`,
   `SessionPlanPayload::generation`, `SessionPlanPayload::direct_endpoint`,
@@ -167,6 +170,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed standard Godot connections rejecting or omitting valid server messages
+  larger than Godot's 65,535-byte inbound default. SDK-created peers now set an
+  8 MiB inbound buffer before connecting, while `from_peer` keeps advanced
+  caller configuration intact. Official native and web smokes require an exact
+  over-64-KiB Signal Fish frame. The setting may reserve roughly 16 MiB per
+  peer inside Godot and is a protective default, not a protocol maximum.
 - Prevented a delayed terminal response from an older same-kind join, leave,
   reconnect, spectator join, or spectator leave from clearing or mutating the
   current operation fence after correlation is negotiated. Wrong, stale,

--- a/PLAN.md
+++ b/PLAN.md
@@ -32,8 +32,8 @@
   package metadata; repository integration tests, other standalone wire
   fixtures, examples, progress records, and changelog history remain in the
   linked source repository.
-- All 12 push workflows passed on `main` commit `c2b22b2`, including merged PR
-  #132's bounded native WebSocket input. The separate live Repository Policy
+- All 12 push workflows passed on `main` commit `4fc5f5c`, including merged PR
+  #133's negotiated room-operation identity. The separate live Repository Policy
   audit remains red because of issue #90.
 
 Completed milestone history and verification evidence live in tracked files
@@ -93,8 +93,16 @@ measured evidence before accepting performance complexity:
    errors. No finite value is a Server 0.7 compatibility guarantee, so
    [signal-fish-server#399](https://github.com/Ambiguous-Interactive/signal-fish-server/issues/399)
    tracks a negotiated/enforced outbound contract. Disconnect-adjacent
-   transitions, browser/engine boundary parity, and the remaining inventory
-   cells remain independent client audit slices.
+   transitions now have the focused follow-up
+   [#134](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/issues/134).
+   The Godot engine-boundary slice is complete: SDK-created peers raise
+   Godot's inbound buffer from 65,535 bytes to 8 MiB before connecting,
+   caller-owned peers remain unchanged, and official native plus web runs
+   require a valid Signal Fish frame larger than the legacy default. Browser
+   assembly remains platform-owned. Replayed stale session plans are tracked
+   independently by
+   [#135](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/issues/135),
+   and the remaining inventory cells remain separate client audit slices.
 4. Re-run established unsafe-inventory, Miri, fuzz, dependency, and no-panic
    gates. Evaluate focused Loom models and additional sanitizer or lint coverage
    only where target support and owned boundaries make them applicable; promote

--- a/crates/signal-fish-client-godot/src/lib.rs
+++ b/crates/signal-fish-client-godot/src/lib.rs
@@ -27,6 +27,7 @@ use signal_fish_client::{
 const DEFAULT_ADAPTIVE_FLOOR: usize = 4 * 1024;
 const DEFAULT_ADAPTIVE_CEILING: usize = 32 * 1024;
 const DEFAULT_ADAPTIVE_LATENCY: Duration = Duration::from_millis(50);
+const DEFAULT_INBOUND_BUFFER_SIZE: i32 = 8 * 1024 * 1024;
 
 /// Godot outbound admission strategy.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -153,6 +154,8 @@ fn admission_decision(
 }
 
 trait GodotWebSocketBackend {
+    fn set_inbound_buffer_size(&mut self, bytes: i32);
+    fn connect_to_url(&mut self, url: &str) -> Result<(), String>;
     fn poll(&mut self);
     fn state(&self) -> PeerState;
     fn outbound_buffered_amount(&self) -> i32;
@@ -169,6 +172,21 @@ trait GodotWebSocketBackend {
 }
 
 impl GodotWebSocketBackend for Gd<WebSocketPeer> {
+    fn set_inbound_buffer_size(&mut self, bytes: i32) {
+        std::ops::DerefMut::deref_mut(self).set_inbound_buffer_size(bytes);
+    }
+
+    fn connect_to_url(&mut self, url: &str) -> Result<(), String> {
+        let result = std::ops::DerefMut::deref_mut(self).connect_to_url(url);
+        if result == Error::OK {
+            Ok(())
+        } else {
+            Err(format!(
+                "Godot WebSocketPeer connect_to_url failed with {result:?}"
+            ))
+        }
+    }
+
     fn poll(&mut self) {
         std::ops::DerefMut::deref_mut(self).poll();
     }
@@ -269,7 +287,7 @@ fn godot_send_result(result: Error, operation: &str) -> BackendSendResult {
 /// client's `poll()` method from the same Godot thread on every frame.
 pub struct GodotWebSocketTransport {
     backend: Box<dyn GodotWebSocketBackend>,
-    options: GodotWebSocketOptions,
+    backpressure_policy: GodotBackpressurePolicy,
     diagnostics: TransportDiagnostics,
     adaptive: AdaptiveState,
     ever_ready: bool,
@@ -278,6 +296,7 @@ pub struct GodotWebSocketTransport {
     terminal: bool,
     close_info: Option<TransportCloseInfo>,
     admission_watermark_violations: u64,
+    one_frame_escape_frames: u64,
     one_frame_escape_bytes: u64,
 }
 
@@ -294,7 +313,7 @@ impl fmt::Debug for GodotWebSocketTransport {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
             .debug_struct("GodotWebSocketTransport")
-            .field("options", &self.options)
+            .field("backpressure_policy", &self.backpressure_policy)
             .field("diagnostics", &self.diagnostics)
             .field("ever_ready", &self.ever_ready)
             .field("close_deferred_to_receive", &self.close_deferred_to_receive)
@@ -323,10 +342,24 @@ impl GodotWebSocketTransport {
         self.one_frame_escape_bytes
     }
 
+    /// Frames accepted through the single-frame watermark escape while the
+    /// backend buffer was empty.
+    ///
+    /// Pair this with [`Self::one_frame_escape_bytes`] to distinguish one
+    /// individually oversized frame from the same cumulative byte total
+    /// spread across multiple escapes.
+    #[must_use]
+    pub const fn one_frame_escape_frames(&self) -> u64 {
+        self.one_frame_escape_frames
+    }
+
     /// Create a Godot `WebSocketPeer` and begin a non-blocking connection.
     ///
     /// The connection handshake advances when the transport is polled. For web
-    /// exports, use `wss://` when the exported page is served over HTTPS.
+    /// exports, use `wss://` when the exported page is served over HTTPS. The
+    /// SDK-created peer uses an 8 MiB Godot inbound buffer so valid aggregated
+    /// server messages are not constrained by Godot's much smaller default.
+    /// Use [`Self::from_peer`] when the application must choose another size.
     ///
     /// # Errors
     ///
@@ -338,6 +371,10 @@ impl GodotWebSocketTransport {
 
     /// Create a Godot `WebSocketPeer` with explicit backpressure options.
     ///
+    /// These options control outbound admission. The SDK-created peer uses the
+    /// same 8 MiB inbound buffer as [`Self::connect`]; use
+    /// [`Self::from_peer_with_options`] to preserve a caller-configured peer.
+    ///
     /// # Errors
     ///
     /// Returns [`SignalFishError::Io`] when Godot rejects the URL or cannot
@@ -346,14 +383,12 @@ impl GodotWebSocketTransport {
         url: &str,
         options: GodotWebSocketOptions,
     ) -> Result<Self, SignalFishError> {
-        let mut peer = WebSocketPeer::new_gd();
-        let result = peer.connect_to_url(url);
-        if result != Error::OK {
-            return Err(SignalFishError::Io(std::io::Error::other(format!(
-                "Godot WebSocketPeer connect_to_url failed with {result:?}"
-            ))));
-        }
-        Ok(Self::from_peer_with_options(peer, options))
+        Self::connect_backend_with_options(
+            Box::new(WebSocketPeer::new_gd()),
+            url,
+            DEFAULT_INBOUND_BUFFER_SIZE,
+            options,
+        )
     }
 
     /// Wrap a Godot `WebSocketPeer` whose connection attempt has already begun.
@@ -369,6 +404,19 @@ impl GodotWebSocketTransport {
         Self::from_backend_with_options(Box::new(peer), options)
     }
 
+    fn connect_backend_with_options(
+        mut backend: Box<dyn GodotWebSocketBackend>,
+        url: &str,
+        inbound_buffer_size: i32,
+        options: GodotWebSocketOptions,
+    ) -> Result<Self, SignalFishError> {
+        backend.set_inbound_buffer_size(inbound_buffer_size);
+        backend
+            .connect_to_url(url)
+            .map_err(|error| SignalFishError::Io(std::io::Error::other(error)))?;
+        Ok(Self::from_backend_with_options(backend, options))
+    }
+
     #[cfg(test)]
     fn from_backend(backend: Box<dyn GodotWebSocketBackend>) -> Self {
         Self::from_backend_with_options(backend, GodotWebSocketOptions::default())
@@ -381,7 +429,7 @@ impl GodotWebSocketTransport {
         let ever_ready = backend.state() == PeerState::Open;
         let mut transport = Self {
             backend,
-            options,
+            backpressure_policy: options.backpressure_policy,
             diagnostics: TransportDiagnostics::default(),
             adaptive: AdaptiveState::default(),
             ever_ready,
@@ -390,6 +438,7 @@ impl GodotWebSocketTransport {
             terminal: false,
             close_info: None,
             admission_watermark_violations: 0,
+            one_frame_escape_frames: 0,
             one_frame_escape_bytes: 0,
         };
         transport.sample_cycle_at(Instant::now());
@@ -468,7 +517,7 @@ impl GodotWebSocketTransport {
 
     fn configured_watermark(&self) -> usize {
         let safe_native = self.safe_native_watermark();
-        match self.options.backpressure_policy {
+        match self.backpressure_policy {
             GodotBackpressurePolicy::Fixed {
                 high_water_mark_bytes,
             } => high_water_mark_bytes.min(safe_native),
@@ -491,7 +540,7 @@ impl GodotWebSocketTransport {
             .max(self.diagnostics.current_buffered_bytes);
 
         let safe_native = self.safe_native_watermark();
-        let effective = match self.options.backpressure_policy {
+        let effective = match self.backpressure_policy {
             GodotBackpressurePolicy::Fixed {
                 high_water_mark_bytes,
             } => high_water_mark_bytes.min(safe_native),
@@ -540,7 +589,7 @@ impl GodotWebSocketTransport {
         };
         self.diagnostics.effective_watermark_bytes = u64::try_from(effective).unwrap_or(u64::MAX);
         if matches!(
-            self.options.backpressure_policy,
+            self.backpressure_policy,
             GodotBackpressurePolicy::Adaptive { .. }
         ) && previous_effective != self.diagnostics.effective_watermark_bytes
         {
@@ -633,6 +682,8 @@ impl Transport for GodotWebSocketTransport {
                 match accepted_admission_audit(current, next_bytes, watermark) {
                     AcceptedAdmissionAudit::WithinWatermark => {}
                     AcceptedAdmissionAudit::EmptyBufferEscape(bytes) => {
+                        self.one_frame_escape_frames =
+                            self.one_frame_escape_frames.saturating_add(1);
                         self.one_frame_escape_bytes = self
                             .one_frame_escape_bytes
                             .saturating_add(u64::try_from(bytes).unwrap_or(u64::MAX));
@@ -792,6 +843,9 @@ mod tests {
         close_code: i32,
         close_codes_after_poll: VecDeque<i32>,
         close_reason: String,
+        configured_inbound_buffer_size: Rc<Cell<i32>>,
+        connection_steps: Rc<RefCell<Vec<&'static str>>>,
+        connect_error: Option<String>,
     }
 
     impl FakeBackend {
@@ -812,11 +866,24 @@ mod tests {
                 close_code: -1,
                 close_codes_after_poll: VecDeque::new(),
                 close_reason: String::new(),
+                configured_inbound_buffer_size: Rc::new(Cell::new(0)),
+                connection_steps: Rc::new(RefCell::new(Vec::new())),
+                connect_error: None,
             }
         }
     }
 
     impl GodotWebSocketBackend for FakeBackend {
+        fn set_inbound_buffer_size(&mut self, bytes: i32) {
+            self.configured_inbound_buffer_size.set(bytes);
+            self.connection_steps.borrow_mut().push("configure");
+        }
+
+        fn connect_to_url(&mut self, _url: &str) -> Result<(), String> {
+            self.connection_steps.borrow_mut().push("connect");
+            self.connect_error.take().map_or(Ok(()), Err)
+        }
+
         fn poll(&mut self) {
             if let Some(state) = self.states.pop_front() {
                 self.state = state;
@@ -1083,6 +1150,7 @@ mod tests {
             Poll::Ready(Ok(()))
         ));
         assert_eq!(transport.admission_watermark_violations(), 0);
+        assert_eq!(transport.one_frame_escape_frames(), 1);
         assert_eq!(transport.one_frame_escape_bytes(), 8 * 1024);
         let mut second = Some(TransportFrame::Binary(vec![1]));
         assert!(matches!(
@@ -1091,6 +1159,7 @@ mod tests {
         ));
         assert!(second.is_some());
         assert_eq!(transport.admission_watermark_violations(), 0);
+        assert_eq!(transport.one_frame_escape_frames(), 1);
         assert_eq!(transport.one_frame_escape_bytes(), 8 * 1024);
     }
 
@@ -1176,6 +1245,60 @@ mod tests {
             godot_send_result(Error::ERR_BUG, "send"),
             BackendSendResult::Error(_)
         ));
+    }
+
+    #[test]
+    fn sdk_created_peer_configures_inbound_buffer_before_connect() {
+        let backend = FakeBackend::new(PeerState::Connecting);
+        let observed_size = Rc::clone(&backend.configured_inbound_buffer_size);
+        let observed_steps = Rc::clone(&backend.connection_steps);
+
+        let transport = GodotWebSocketTransport::connect_backend_with_options(
+            Box::new(backend),
+            "ws://example.invalid/v2/ws",
+            DEFAULT_INBOUND_BUFFER_SIZE,
+            GodotWebSocketOptions::default(),
+        )
+        .expect("fake connection setup should succeed");
+
+        assert_eq!(observed_size.get(), DEFAULT_INBOUND_BUFFER_SIZE);
+        assert_eq!(&*observed_steps.borrow(), &["configure", "connect"]);
+        assert!(!transport.is_ready());
+    }
+
+    #[test]
+    fn connection_failure_follows_buffer_configuration() {
+        let mut backend = FakeBackend::new(PeerState::Connecting);
+        backend.connect_error = Some("scripted connect failure".to_string());
+        let observed_steps = Rc::clone(&backend.connection_steps);
+
+        let error = GodotWebSocketTransport::connect_backend_with_options(
+            Box::new(backend),
+            "ws://example.invalid/v2/ws",
+            DEFAULT_INBOUND_BUFFER_SIZE,
+            GodotWebSocketOptions::default(),
+        )
+        .expect_err("scripted setup failure must surface");
+
+        assert!(matches!(error, SignalFishError::Io(_)));
+        assert_eq!(&*observed_steps.borrow(), &["configure", "connect"]);
+    }
+
+    #[test]
+    fn wrapping_existing_backend_preserves_connection_configuration() {
+        const CALLER_INBOUND_BUFFER_SIZE: i32 = 2 * 1024 * 1024 + 17;
+        let backend = FakeBackend::new(PeerState::Open);
+        backend
+            .configured_inbound_buffer_size
+            .set(CALLER_INBOUND_BUFFER_SIZE);
+        let observed_size = Rc::clone(&backend.configured_inbound_buffer_size);
+        let observed_steps = Rc::clone(&backend.connection_steps);
+
+        let transport = GodotWebSocketTransport::from_backend(Box::new(backend));
+
+        assert_eq!(observed_size.get(), CALLER_INBOUND_BUFFER_SIZE);
+        assert!(observed_steps.borrow().is_empty());
+        assert!(transport.is_ready());
     }
 
     #[test]

--- a/docs/wasm.md
+++ b/docs/wasm.md
@@ -294,6 +294,20 @@ let config = SignalFishConfig::new("mb_app_abc123");
 let mut client = SignalFishPollingClient::new(transport, config);
 ```
 
+The standard `connect` and `connect_with_options` paths configure Godot's
+`inbound_buffer_size` to 8 MiB before starting the connection. This is a
+protective client default sized above the roughly 6.25 MiB aggregate snapshots
+that a default Server 0.7 deployment can legally produce, not a protocol
+maximum or a guarantee that every larger message is rejected at exactly that
+boundary. Godot may reserve roughly twice that amount per peer across its
+receive ring and packet buffer.
+
+Applications with a different trusted size contract can create and configure a
+Godot `WebSocketPeer`, call `connect_to_url`, and pass it through `from_peer` or
+`from_peer_with_options`. Those advanced constructors preserve the caller's
+buffer choices. Browser and engine implementations still own frame/message
+assembly before the SDK receives a complete packet.
+
 !!! warning "Allow the browser's exact Origin on Server 0.7"
     Browsers attach an `Origin` header to the WebSocket upgrade, and Signal Fish
     Server 0.7 validates it. Configure the server's `security.cors_origins`
@@ -313,8 +327,10 @@ tuning. Backend-accepted, browser-buffered, and peer-delivered are separate
 stages; inspect `transport_diagnostics()` rather than treating buffered zero as
 per-frame completion. For a stronger admission audit,
 `client.transport().admission_watermark_violations()` must remain zero;
-`client.transport().one_frame_escape_bytes()` separately counts payload
-accepted through the documented empty-buffer exception. The read-only
+`client.transport().one_frame_escape_frames()` counts uses of the documented
+empty-buffer exception, while `one_frame_escape_bytes()` retains their
+cumulative payload bytes. Together they distinguish one individually oversized
+frame from the same byte total spread across multiple escapes. The read-only
 `transport()` accessor is for transport-specific diagnostics; continue to drive
 all protocol and I/O progress through `poll()`.
 

--- a/progress/session-045-godot-inbound-buffer.md
+++ b/progress/session-045-godot-inbound-buffer.md
@@ -93,5 +93,10 @@ hygiene, shell portability, the 228-test CI policy suite, and the exact
 format/Clippy/workspace-test mandatory chain pass. The standalone
 fixture cannot compile in the development container because its `api-custom`
 godot-rust build requires a Godot 4 executable; the pinned hosted job owns that
-official engine proof. Final mandatory, adversarial, pull-request, and hosted
-workflow evidence will be appended after the implementation diff is frozen.
+official engine proof. PR #136's first hosted pass exposed one deterministic
+Actionlint failure: the native oracle's single-quoted inline JavaScript used
+template-literal `${...}` expressions, which Actionlint's embedded ShellCheck
+reported as SC2016. Rewriting those three diagnostics as string concatenation
+preserves their behavior without shell-looking interpolation. Final mandatory,
+pull-request, and hosted workflow evidence will be appended after the repaired
+implementation diff is frozen.

--- a/progress/session-045-godot-inbound-buffer.md
+++ b/progress/session-045-godot-inbound-buffer.md
@@ -101,7 +101,12 @@ preserves their behavior without shell-looking interpolation. The next hosted
 pass reached the official native engine but timed out before any fixture marker;
 its retained Godot log showed `SignalFishSmoke` was an unloaded placeholder.
 The harness had copied the native GDExtension without running the project import
-that the existing web-export path already requires. It now performs the same
-official `--import` step before launching the native scene. Final mandatory,
+that the existing web-export path already requires. A checksum-verified official
+Godot 4.5 arm64 editor reproduced a Godot signal-11 crash after first-scan import
+registered the native extension; the same isolated project with that one-line
+registry already present loaded `SignalFishSmoke`, emitted `fixture-ready`, and
+exited normally. The native harness therefore uses an isolated project copy and
+seeds `.godot/extension_list.cfg` before runtime, avoiding both the first-scan
+engine crash and contamination of the later web export. Final mandatory,
 pull-request, and hosted workflow evidence will be appended after the repaired
 implementation diff is frozen.

--- a/progress/session-045-godot-inbound-buffer.md
+++ b/progress/session-045-godot-inbound-buffer.md
@@ -90,10 +90,11 @@ The final re-review reported zero actionable issues.
 All 12 push workflows on the starting main commit passed. The 38-test Godot
 adapter suite and the five pure JavaScript oracle tests pass locally. Workflow
 hygiene, shell portability, the 228-test CI policy suite, and the exact
-format/Clippy/workspace-test mandatory chain pass. The standalone
-fixture cannot compile in the development container because its `api-custom`
-godot-rust build requires a Godot 4 executable; the pinned hosted job owns that
-official engine proof. PR #136's first hosted pass exposed one deterministic
+format/Clippy/workspace-test mandatory chain pass. The container did not ship a
+Godot executable, so the standalone fixture initially remained hosted-only; a
+later checksum-verified official Godot 4.5 arm64 download enabled the local
+native compile and engine startup checks described below. PR #136's first
+hosted pass exposed one deterministic
 Actionlint failure: the native oracle's single-quoted inline JavaScript used
 template-literal `${...}` expressions, which Actionlint's embedded ShellCheck
 reported as SC2016. Rewriting those three diagnostics as string concatenation
@@ -107,13 +108,24 @@ registered the native extension; the same isolated project with that one-line
 registry already present loaded `SignalFishSmoke`, emitted `fixture-ready`, and
 exited normally. The native harness therefore uses an isolated project copy and
 seeds `.godot/extension_list.cfg` before runtime, avoiding both the first-scan
-engine crash and contamination of the later web export. Final mandatory,
-pull-request, and hosted workflow evidence will be appended after the repaired
-implementation diff is frozen. The following hosted run reached the real
-native scenario and proved the exact large relay (`wire_bytes=82068`,
-`padding_bytes=81920`), JSON shutdown, and binary close readiness. It failed
-only because the harness also applied the browser load oracle's required
-`multi_frame_poll`; the faster native loop accepted one load frame per poll.
-The native gate retains the load/shutdown sequencing waits but now validates
-only its intended large-inbound oracle, leaving performance batching to the
-existing browser jobs.
+engine crash and contamination of the later web export. A following hosted run
+reached the real native scenario and proved the exact large relay
+(`wire_bytes=82068`, `padding_bytes=81920`), JSON shutdown, and binary close
+readiness. It failed only because the harness also applied the browser load
+oracle's required `multi_frame_poll`; the faster native loop accepted one load
+frame per poll. The native gate retains the load/shutdown sequencing waits but
+now validates only its intended large-inbound oracle, leaving performance
+batching to the existing browser jobs.
+
+PR #136 implementation head `088ade56afbee808b6e4de505374424b5095bea4`
+is mergeable and all 11 pull-request workflows passed. Godot Web run
+32589292120 passed the build/export aggregate, official native smoke, Server
+0.7 clean/impaired/3,600-frame soak browsers, Server 0.4 clean compatibility,
+and required aggregate gate. The other ten successful workflows were CI,
+Coverage, Docs Validation, Examples Validation, No Panics, Security, Semver
+Checks, Unused Deps, WASM, and Workflow Lint. The final local tree again passed
+the exact mandatory chain, all 16 available pre-commit checks, and all six
+pre-push checks. PR inspection found no inline review threads or code findings;
+the only automated review messages reported exhausted Copilot quota, the
+maintainer-only governance condition already tracked by issue #90. Follow-up
+correctness findings remain independently actionable in issues #134 and #135.

--- a/progress/session-045-godot-inbound-buffer.md
+++ b/progress/session-045-godot-inbound-buffer.md
@@ -97,6 +97,11 @@ official engine proof. PR #136's first hosted pass exposed one deterministic
 Actionlint failure: the native oracle's single-quoted inline JavaScript used
 template-literal `${...}` expressions, which Actionlint's embedded ShellCheck
 reported as SC2016. Rewriting those three diagnostics as string concatenation
-preserves their behavior without shell-looking interpolation. Final mandatory,
+preserves their behavior without shell-looking interpolation. The next hosted
+pass reached the official native engine but timed out before any fixture marker;
+its retained Godot log showed `SignalFishSmoke` was an unloaded placeholder.
+The harness had copied the native GDExtension without running the project import
+that the existing web-export path already requires. It now performs the same
+official `--import` step before launching the native scene. Final mandatory,
 pull-request, and hosted workflow evidence will be appended after the repaired
 implementation diff is frozen.

--- a/progress/session-045-godot-inbound-buffer.md
+++ b/progress/session-045-godot-inbound-buffer.md
@@ -1,0 +1,97 @@
+# Session 045 — Godot Inbound Buffer Boundary
+
+## Priority and Audit
+
+The session began from clean `main` at
+`4fc5f5cecbe753ae2259804513a358f14e384f7f`, the merge of PR #133. The GitHub
+connector found no open pull requests. Issue #126 remained the active
+correctness audit; issue #90 remained the separate maintainer-only repository
+governance blocker.
+
+Parallel inventory reviews found three independent correctness risks. This
+session fixes the highest-impact normal-gameplay boundary: Godot 4.5 defaults
+`WebSocketPeer.inbound_buffer_size` to 65,535 bytes even though a legal Signal
+Fish Server 0.7 aggregate snapshot can approach roughly 6.25 MiB. The other
+findings are preserved as focused follow-ups: issue #134 covers a ready server
+farewell discarded across send failure, and issue #135 covers a delayed stale
+session plan rolling generation state backward.
+
+## Authority and Design
+
+Godot 4.5 documentation and source define the 65,535-byte default. Its native
+and web peers size both an inbound ring and packet buffer from the configured
+property before connection. The pinned Server 0.7.0 source defines a 64 KiB
+default accepted client-message size but permits configurable multi-player
+state that the server can aggregate into substantially larger outbound
+messages. As with the native WebSocket decision in session 043, 8 MiB is a
+protective compatibility default rather than a protocol maximum.
+
+An initial design exposed the inbound size through `GodotWebSocketOptions`.
+Adversarial review rejected it because the caller-owned `from_peer_with_options`
+path could not honestly apply a pre-connect setting. The final design keeps the
+constant private: `connect` and `connect_with_options` configure 8 MiB before
+`connect_to_url`, while `from_peer` and `from_peer_with_options` preserve every
+caller choice. This avoids a public option with constructor-dependent meaning.
+Godot may eagerly reserve roughly 16 MiB per SDK-created peer across its two
+receive buffers; applications that need another tradeoff configure their own
+peer before connecting.
+
+## Regression Evidence
+
+Fake-backend tests prove the 8 MiB setting happens before the connection call
+and remains ordered even when connection setup fails. The official Godot smoke
+sends an 80 KiB JSON relay from a deliberately enlarged sender to a receiver
+created through the standard SDK constructor. It reconstructs and serializes
+the received `ServerMessage`, then emits exactly one marker containing a wire
+length greater than 65,535 bytes and the exact padding length. A pure validator
+rejects missing, duplicate, undersized, malformed, and wrong-padding markers.
+
+The existing browser scenarios now configure their pinned Server 0.4 and 0.7
+processes to accept the fixture input. Every clean browser run requires the
+large-frame oracle. The build job additionally compiles the same fixture as a
+native GDExtension, runs it with the official checksum-verified Godot 4.5 editor
+and Server 0.7 binary, checks the same oracle, completes the disconnect path,
+and retains both process logs.
+
+The load admission oracle was also corrected to honor the documented
+single-frame escape: a per-client buffered-byte peak may exceed the 32 KiB
+latency ceiling only when that client records exactly one escape and only up to
+its cumulative escape bytes. New frame-count diagnostics make that distinction
+explicit; the fixture requires JSON counts `[1, 0]`, binary counts `[0, 0]`,
+and byte/count conservation. The former absolute check contradicted the
+transport contract, while using unqualified cumulative bytes could mask
+multiple escapes.
+
+## Adversarial Review
+
+The initial design review rejected a public inbound option whose meaning would
+silently differ on caller-owned peers. It selected the private SDK default,
+unchanged `from_peer` contract, official native/web proof, and explicit memory
+cost implemented here. The frozen-diff review then found that the first native
+harness would terminate Server as soon as the binary pair was ready, before the
+16-second JSON load and shutdown completed. An independent repair pass added
+bounded waits for the load summary and JSON shutdown before SIGTERM, followed
+by close-attribution, completion, and process-exit oracles.
+
+That review also rejected cumulative escape bytes as an individual-frame bound
+and found the caller-owned preservation test nondiscriminating. The repair adds
+the escape-frame counter and exact runtime pattern above, negative controls for
+multiple escapes, a fake backend that proves wrapping performs no configuration
+or connection call, and a distinctive `2 MiB + 17` runtime sender setting.
+The final review then caught misplaced changelog entries, non-exact marker
+counting, a copied nonportable readiness probe, and stale skill bookkeeping.
+Released history is restored; the validator counts every marker-token line
+before strictly parsing its complete payload and rejects malformed duplicates
+or trailing data; the new probe uses `printf`; and guidance records 38 tests.
+The final re-review reported zero actionable issues.
+
+## Verification and Hosted Disposition
+
+All 12 push workflows on the starting main commit passed. The 38-test Godot
+adapter suite and the five pure JavaScript oracle tests pass locally. Workflow
+hygiene, shell portability, the 228-test CI policy suite, and the exact
+format/Clippy/workspace-test mandatory chain pass. The standalone
+fixture cannot compile in the development container because its `api-custom`
+godot-rust build requires a Godot 4 executable; the pinned hosted job owns that
+official engine proof. Final mandatory, adversarial, pull-request, and hosted
+workflow evidence will be appended after the implementation diff is frozen.

--- a/progress/session-045-godot-inbound-buffer.md
+++ b/progress/session-045-godot-inbound-buffer.md
@@ -109,4 +109,11 @@ exited normally. The native harness therefore uses an isolated project copy and
 seeds `.godot/extension_list.cfg` before runtime, avoiding both the first-scan
 engine crash and contamination of the later web export. Final mandatory,
 pull-request, and hosted workflow evidence will be appended after the repaired
-implementation diff is frozen.
+implementation diff is frozen. The following hosted run reached the real
+native scenario and proved the exact large relay (`wire_bytes=82068`,
+`padding_bytes=81920`), JSON shutdown, and binary close readiness. It failed
+only because the harness also applied the browser load oracle's required
+`multi_frame_poll`; the faster native loop accepted one load frame per poll.
+The native gate retains the load/shutdown sequencing waits but now validates
+only its intended large-inbound oracle, leaving performance batching to the
+existing browser jobs.

--- a/scripts/godot-e2e-validators.mjs
+++ b/scripts/godot-e2e-validators.mjs
@@ -114,29 +114,61 @@ export function validateLoadSummary(summary, samples) {
     !isNonnegativeInteger(summary?.admission_hits) ||
     summary?.within_absolute_adaptive_ceiling !== true ||
     summary?.binary_pair_admission_watermark_violations !== 0 ||
+    !isNonnegativeInteger(summary?.binary_pair_one_frame_escape_frames) ||
     !isNonnegativeInteger(summary?.binary_pair_one_frame_escape_bytes) ||
     summary?.binary_pair_within_absolute_adaptive_ceiling !== true ||
+    !isNonnegativeInteger(summary?.one_frame_escape_frames) ||
     !isNonnegativeInteger(summary?.one_frame_escape_bytes)
   ) errors.push("adaptive-buffering evidence failed");
   if (
     !isFixedLengthArray(summary?.per_client_peak_buffered_bytes, 2, isNonnegativeInteger) ||
     !isFixedLengthArray(summary?.per_client_effective_watermark_bytes, 2, isNonnegativeInteger) ||
+    !isFixedLengthArray(summary?.per_client_one_frame_escape_frames, 2, isNonnegativeInteger) ||
     !isFixedLengthArray(summary?.per_client_one_frame_escape_bytes, 2, isNonnegativeInteger) ||
+    summary.per_client_one_frame_escape_frames[0] !== 1 ||
+    summary.per_client_one_frame_escape_frames[1] !== 0 ||
+    summary.per_client_one_frame_escape_bytes[0] <= 32_768 ||
+    summary.per_client_one_frame_escape_bytes[1] !== 0 ||
     summary.per_client_effective_watermark_bytes.some((watermark) =>
       watermark < 4_096 || watermark > 32_768
     ) ||
-    summary.per_client_peak_buffered_bytes.some((peak) => peak > 32_768) ||
+    summary.per_client_peak_buffered_bytes.some((peak, index) =>
+      peak > Math.max(
+        32_768,
+        summary.per_client_one_frame_escape_frames[index] === 1
+          ? summary.per_client_one_frame_escape_bytes[index]
+          : 0,
+      )
+    ) ||
     !isFixedLengthArray(summary?.binary_pair_peak_buffered_bytes, 2, isNonnegativeInteger) ||
     !isFixedLengthArray(
       summary?.binary_pair_effective_watermark_bytes, 2, isNonnegativeInteger,
     ) ||
+    !isFixedLengthArray(
+      summary?.binary_pair_per_client_escape_frames, 2, isNonnegativeInteger,
+    ) ||
     !isFixedLengthArray(summary?.binary_pair_per_client_escape_bytes, 2, isNonnegativeInteger) ||
+    summary.binary_pair_per_client_escape_frames.some((count) => count !== 0) ||
+    summary.binary_pair_per_client_escape_bytes.some((bytes) => bytes !== 0) ||
     summary.binary_pair_effective_watermark_bytes.some((watermark) =>
       watermark < 4_096 || watermark > 32_768
     ) ||
-    summary.binary_pair_peak_buffered_bytes.some((peak) => peak > 32_768) ||
+    summary.binary_pair_peak_buffered_bytes.some((peak, index) =>
+      peak > Math.max(
+        32_768,
+        summary.binary_pair_per_client_escape_frames[index] === 1
+          ? summary.binary_pair_per_client_escape_bytes[index]
+          : 0,
+      )
+    ) ||
+    summary.binary_pair_one_frame_escape_frames !==
+      summary.binary_pair_per_client_escape_frames.reduce((sum, value) => sum + value, 0) ||
     summary.binary_pair_one_frame_escape_bytes !==
       summary.binary_pair_per_client_escape_bytes.reduce((sum, value) => sum + value, 0) ||
+    summary.one_frame_escape_frames !==
+      [...summary.per_client_one_frame_escape_frames,
+        ...summary.binary_pair_per_client_escape_frames]
+        .reduce((sum, value) => sum + value, 0) ||
     summary.one_frame_escape_bytes !==
       [...summary.per_client_one_frame_escape_bytes,
         ...summary.binary_pair_per_client_escape_bytes]
@@ -318,4 +350,23 @@ export function validateServerConservation(values) {
     values.harmfulDeltas.length > 0
   ) errors.push("server delivery conservation failed");
   return { ok: errors.length === 0, errors };
+}
+
+export function validateLargeInboundMarkers(lines) {
+  const token = "SIGNAL_FISH_SMOKE large-inbound-ok";
+  const candidates = lines.filter((line) => line.includes(token));
+  const errors = [];
+  if (candidates.length !== 1) errors.push("large inbound marker count was not exactly one");
+  const payload = candidates[0]?.slice(candidates[0].indexOf(token)).trim();
+  const match = /^SIGNAL_FISH_SMOKE large-inbound-ok wire_bytes=(\d+) padding_bytes=(\d+)$/.exec(
+    payload ?? "",
+  );
+  const observed = match
+    ? { wireBytes: Number(match[1]), paddingBytes: Number(match[2]) }
+    : undefined;
+  if (
+    !observed || !Number.isSafeInteger(observed.wireBytes) || observed.wireBytes <= 65_535 ||
+    !Number.isSafeInteger(observed.paddingBytes) || observed.paddingBytes !== 80 * 1_024
+  ) errors.push("large inbound marker lengths were invalid");
+  return { ok: errors.length === 0, errors, observed };
 }

--- a/scripts/run-godot-web-smoke.mjs
+++ b/scripts/run-godot-web-smoke.mjs
@@ -4,7 +4,11 @@ import { createServer } from "node:http";
 import { extname, isAbsolute, join, normalize, relative, resolve, sep } from "node:path";
 import { pipeline } from "node:stream/promises";
 import { chromium } from "playwright";
-import { validateLoadSummary, validateServerConservation } from "./godot-e2e-validators.mjs";
+import {
+  validateLargeInboundMarkers,
+  validateLoadSummary,
+  validateServerConservation,
+} from "./godot-e2e-validators.mjs";
 
 const [exportDirectoryArgument, modeArgument] = process.argv.slice(2);
 if (!exportDirectoryArgument || !modeArgument) {
@@ -212,12 +216,18 @@ try {
       "SIGNAL_FISH_SMOKE json-pong-ok",
       "SIGNAL_FISH_SMOKE binary-pong-ok",
       "SIGNAL_FISH_SMOKE text-relay-ok",
+      "SIGNAL_FISH_SMOKE large-inbound-ok",
       "SIGNAL_FISH_SMOKE binary-relay-ok",
       "SIGNAL_FISH_SMOKE binary-four-one-poll",
       "SIGNAL_FISH_SMOKE load-summary",
       "SIGNAL_FISH_SMOKE binary-ready-for-server-close",
     ]) {
       await waitForMarker(marker);
+    }
+
+    const largeInbound = validateLargeInboundMarkers(consoleLines);
+    if (!largeInbound.ok) {
+      throw new Error(`Godot large-inbound assertions failed: ${JSON.stringify(largeInbound)}`);
     }
 
     const summaryLine = consoleLines.find((line) => line.includes("SIGNAL_FISH_SMOKE load-summary "));

--- a/scripts/test-godot-e2e-validators.mjs
+++ b/scripts/test-godot-e2e-validators.mjs
@@ -5,9 +5,28 @@ import {
   validateFortressPair,
   validateFortressPeer,
   validateFinalSlope,
+  validateLargeInboundMarkers,
   validateLoadSummary,
   validateServerConservation,
 } from "./godot-e2e-validators.mjs";
+
+test("large inbound oracle requires one exact over-64-KiB marker", () => {
+  const valid = [
+    "prefix SIGNAL_FISH_SMOKE large-inbound-ok wire_bytes=82080 padding_bytes=81920",
+  ];
+  assert.equal(validateLargeInboundMarkers(valid).ok, true);
+  for (const invalid of [
+    [],
+    [...valid, ...valid],
+    [...valid, "SIGNAL_FISH_SMOKE large-inbound-ok malformed"],
+    ["SIGNAL_FISH_SMOKE large-inbound-ok wire_bytes=65535 padding_bytes=81920"],
+    ["SIGNAL_FISH_SMOKE large-inbound-ok wire_bytes=82080 padding_bytes=81919"],
+    ["SIGNAL_FISH_SMOKE large-inbound-ok wire_bytes=not-a-number padding_bytes=81920"],
+    ["SIGNAL_FISH_SMOKE large-inbound-ok wire_bytes=82080 padding_bytes=81920 trailing"],
+  ]) {
+    assert.equal(validateLargeInboundMarkers(invalid).ok, false);
+  }
+});
 
 function peer(role) {
   return {
@@ -56,14 +75,17 @@ test("load oracle rejects independently corrupted age and admission fields", () 
     multi_frame_poll: true, buffered_bytes: 0, accepted_frames: 4_352, admission_hits: 0,
     within_absolute_adaptive_ceiling: true,
     binary_pair_admission_watermark_violations: 0,
-    binary_pair_one_frame_escape_bytes: 64,
+    binary_pair_one_frame_escape_frames: 0,
+    binary_pair_one_frame_escape_bytes: 0,
     binary_pair_within_absolute_adaptive_ceiling: true,
     binary_pair_peak_buffered_bytes: [1_000, 1_000],
     binary_pair_effective_watermark_bytes: [4_096, 4_096],
-    binary_pair_per_client_escape_bytes: [32, 32],
-    per_client_peak_buffered_bytes: [1_000, 1_000],
+    binary_pair_per_client_escape_frames: [0, 0],
+    binary_pair_per_client_escape_bytes: [0, 0],
+    per_client_peak_buffered_bytes: [82_080, 1_000],
     per_client_effective_watermark_bytes: [4_096, 4_096],
-    per_client_one_frame_escape_bytes: [32, 32], one_frame_escape_bytes: 128,
+    per_client_one_frame_escape_frames: [1, 0], one_frame_escape_frames: 1,
+    per_client_one_frame_escape_bytes: [82_080, 0], one_frame_escape_bytes: 82_080,
     max_poll_work_frames: 64, max_poll_work_bytes: 65_536, max_poll_receive_frames: 64,
   };
   const samples = Array.from({ length: 8 }, (_, index) => ({
@@ -106,9 +128,20 @@ test("load oracle rejects independently corrupted age and admission fields", () 
     ["binary admission", (value) => { value.binary_pair_admission_watermark_violations = 1; }],
     ["buffer schema", (value) => { delete value.per_client_peak_buffered_bytes; }],
     ["binary buffer schema", (value) => { delete value.binary_pair_peak_buffered_bytes; }],
-    ["buffer ceiling", (value) => { value.per_client_peak_buffered_bytes[0] = 32_769; }],
+    ["buffer beyond single escape", (value) => {
+      value.per_client_peak_buffered_bytes[0] = 82_081;
+    }],
     ["binary buffer ceiling", (value) => {
       value.binary_pair_peak_buffered_bytes[0] = 32_769;
+    }],
+    ["multiple JSON escapes", (value) => {
+      value.per_client_one_frame_escape_frames[0] = 2;
+      value.one_frame_escape_frames = 2;
+    }],
+    ["binary escape", (value) => {
+      value.binary_pair_per_client_escape_frames[0] = 1;
+      value.binary_pair_one_frame_escape_frames = 1;
+      value.one_frame_escape_frames = 2;
     }],
     ["escape conservation", (value) => { value.one_frame_escape_bytes -= 1; }],
     ["missing latency", (value) => { delete value.p99_latency_us; }],

--- a/tests/godot-web-smoke/src/lib.rs
+++ b/tests/godot-web-smoke/src/lib.rs
@@ -1,9 +1,12 @@
 #![recursion_limit = "512"]
 
+use godot::classes::WebSocketPeer;
+use godot::global::Error;
+use godot::obj::NewGd;
 use godot::prelude::*;
 use signal_fish_client::protocol::GameDataEncoding;
 use signal_fish_client::{
-    JoinRoomParams, SignalFishConfig, SignalFishEvent, SignalFishPollingClient,
+    JoinRoomParams, ServerMessage, SignalFishConfig, SignalFishEvent, SignalFishPollingClient,
 };
 use signal_fish_client_godot::{
     GodotBackpressurePolicy, GodotWebSocketOptions, GodotWebSocketTransport,
@@ -16,6 +19,10 @@ use fortress::FortressScenario;
 const SERVER_URL: &str = "ws://127.0.0.1:3536/v2/ws";
 const APP_ID: &str = "e2e-test-app";
 const BINARY_PAYLOAD: &[u8] = &[0, 1, 2, 255];
+const LARGE_INBOUND_PADDING_BYTES: usize = 80 * 1024;
+const LEGACY_GODOT_INBOUND_BUFFER_SIZE: usize = 65_535;
+const LARGE_SENDER_INBOUND_BUFFER_SIZE: i32 = 2 * 1024 * 1024 + 17;
+const LARGE_SENDER_OUTBOUND_BUFFER_SIZE: i32 = 128 * 1024;
 const LOAD_SECONDS: u64 = 16;
 const LOAD_RATE_PER_CLIENT: u64 = 136;
 const LOAD_TARGET_PER_CLIENT: u64 = LOAD_SECONDS * LOAD_RATE_PER_CLIENT;
@@ -141,10 +148,12 @@ struct SmokePair {
     peak_aggregate_depth: u64,
     other_pair_poll_timing: PollTimingWindow,
     other_pair_admission_violations: u64,
+    other_pair_one_frame_escape_frames: u64,
     other_pair_one_frame_escape_bytes: u64,
     other_pair_within_absolute_ceiling: bool,
     other_pair_peak_buffered_bytes: [u64; 2],
     other_pair_effective_watermark_bytes: [u64; 2],
+    other_pair_per_client_escape_frames: [u64; 2],
     other_pair_per_client_escape_bytes: [u64; 2],
 }
 
@@ -193,10 +202,12 @@ impl SmokePair {
             peak_aggregate_depth: 0,
             other_pair_poll_timing: PollTimingWindow::default(),
             other_pair_admission_violations: 0,
+            other_pair_one_frame_escape_frames: 0,
             other_pair_one_frame_escape_bytes: 0,
             other_pair_within_absolute_ceiling: true,
             other_pair_peak_buffered_bytes: [0; 2],
             other_pair_effective_watermark_bytes: [0; 2],
+            other_pair_per_client_escape_frames: [0; 2],
             other_pair_per_client_escape_bytes: [0; 2],
         }
     }
@@ -361,13 +372,50 @@ impl SmokePair {
                 godot_print!("SIGNAL_FISH_SMOKE {label}-joined-second");
                 self.send_relay();
             }
-            SignalFishEvent::GameData { data, .. }
-                if self.kind == PairKind::Json
-                    && data.get("smoke").and_then(serde_json::Value::as_str)
-                        == Some("text-relay") =>
+            SignalFishEvent::GameData {
+                from_player,
+                data,
+                seq,
+                epoch,
+                class,
+                key,
+            } if self.kind == PairKind::Json
+                && data.get("smoke").and_then(serde_json::Value::as_str) == Some("text-relay") =>
             {
-                godot_print!("SIGNAL_FISH_SMOKE text-relay-ok");
-                self.relay_received = true;
+                let padding_bytes = data
+                    .get("large_inbound")
+                    .and_then(serde_json::Value::as_str)
+                    .map_or(0, str::len);
+                let wire = serde_json::to_vec(&ServerMessage::GameData {
+                    from_player,
+                    data,
+                    seq,
+                    epoch,
+                    class,
+                    key,
+                });
+                match wire {
+                    Ok(wire)
+                        if padding_bytes == LARGE_INBOUND_PADDING_BYTES
+                            && wire.len() > LEGACY_GODOT_INBOUND_BUFFER_SIZE =>
+                    {
+                        godot_print!("SIGNAL_FISH_SMOKE text-relay-ok");
+                        godot_print!(
+                            "SIGNAL_FISH_SMOKE large-inbound-ok wire_bytes={} padding_bytes={padding_bytes}",
+                            wire.len()
+                        );
+                        self.relay_received = true;
+                    }
+                    Ok(wire) => {
+                        godot_error!(
+                            "SIGNAL_FISH_SMOKE large-inbound-error wire_bytes={} padding_bytes={padding_bytes}",
+                            wire.len()
+                        );
+                    }
+                    Err(error) => {
+                        godot_error!("SIGNAL_FISH_SMOKE large-inbound-error {error}");
+                    }
+                }
             }
             SignalFishEvent::GameData { data, .. }
                 if data.get("load_sender").and_then(serde_json::Value::as_str) == Some("a") =>
@@ -399,7 +447,8 @@ impl SmokePair {
         };
         let result = match self.kind {
             PairKind::Json => client.send_game_data(serde_json::json!({
-                "smoke": "text-relay"
+                "smoke": "text-relay",
+                "large_inbound": "x".repeat(LARGE_INBOUND_PADDING_BYTES),
             })),
             PairKind::Binary => {
                 self.burst_accepted_before = Some(client.transport_diagnostics().accepted_frames);
@@ -639,10 +688,12 @@ impl SmokePair {
                     .saturating_add(diagnostics.backend_capacity_hits)
             })
             .fold(0u64, u64::saturating_add);
-        let (own_violations, own_escape_bytes, own_within_ceiling) =
+        let (own_violations, own_escape_frames, own_escape_bytes, own_within_ceiling) =
             aggregate_godot_admission(self.first.as_ref(), self.second.as_ref());
         let admission_violations =
             own_violations.saturating_add(self.other_pair_admission_violations);
+        let one_frame_escape_frames =
+            own_escape_frames.saturating_add(self.other_pair_one_frame_escape_frames);
         let one_frame_escape_bytes =
             own_escape_bytes.saturating_add(self.other_pair_one_frame_escape_bytes);
         let within_absolute_ceiling = own_within_ceiling && self.other_pair_within_absolute_ceiling;
@@ -680,9 +731,14 @@ impl SmokePair {
                 client.transport_diagnostics().effective_watermark_bytes
             })
         });
+        let per_client_escape_frames = [self.first.as_ref(), self.second.as_ref()]
+            .map(|client| client.map_or(0, |client| client.transport().one_frame_escape_frames()));
         let per_client_escape_bytes = [self.first.as_ref(), self.second.as_ref()]
             .map(|client| client.map_or(0, |client| client.transport().one_frame_escape_bytes()));
-        let passed = passed && !self.load_error;
+        let passed = passed
+            && per_client_escape_frames == [1, 0]
+            && self.other_pair_per_client_escape_frames == [0, 0]
+            && !self.load_error;
         let summary = serde_json::json!({
             "passed": passed,
             "offered_per_client": [self.offered_a, self.offered_b],
@@ -709,14 +765,18 @@ impl SmokePair {
             "admission_watermark_violations": admission_violations,
             "within_absolute_adaptive_ceiling": within_absolute_ceiling,
             "binary_pair_admission_watermark_violations": self.other_pair_admission_violations,
+            "binary_pair_one_frame_escape_frames": self.other_pair_one_frame_escape_frames,
             "binary_pair_one_frame_escape_bytes": self.other_pair_one_frame_escape_bytes,
             "binary_pair_within_absolute_adaptive_ceiling": self.other_pair_within_absolute_ceiling,
             "binary_pair_peak_buffered_bytes": self.other_pair_peak_buffered_bytes,
             "binary_pair_effective_watermark_bytes": self.other_pair_effective_watermark_bytes,
+            "binary_pair_per_client_escape_frames": self.other_pair_per_client_escape_frames,
             "binary_pair_per_client_escape_bytes": self.other_pair_per_client_escape_bytes,
             "per_client_peak_buffered_bytes": per_client_peak_buffered,
             "per_client_effective_watermark_bytes": per_client_watermark,
+            "per_client_one_frame_escape_frames": per_client_escape_frames,
             "per_client_one_frame_escape_bytes": per_client_escape_bytes,
+            "one_frame_escape_frames": one_frame_escape_frames,
             "one_frame_escape_bytes": one_frame_escape_bytes,
             "load_error": self.load_error,
         });
@@ -821,18 +881,24 @@ impl INode for SignalFishSmoke {
         binary.poll();
         let binary_poll_timing = binary.poll_timing;
         let binary_close_attributed = binary.close_attributed;
-        let (binary_violations, binary_escape_bytes, binary_within_ceiling) =
+        let (binary_violations, binary_escape_frames, binary_escape_bytes, binary_within_ceiling) =
             aggregate_godot_admission(binary.first.as_ref(), binary.second.as_ref());
-        let (binary_peaks, binary_watermarks, binary_per_client_escape) =
-            godot_admission_snapshots(binary.first.as_ref(), binary.second.as_ref());
+        let (
+            binary_peaks,
+            binary_watermarks,
+            binary_per_client_escape_frames,
+            binary_per_client_escape_bytes,
+        ) = godot_admission_snapshots(binary.first.as_ref(), binary.second.as_ref());
         let Some(json) = &mut self.json else { return };
         json.other_pair_poll_timing = binary_poll_timing;
         json.other_pair_admission_violations = binary_violations;
+        json.other_pair_one_frame_escape_frames = binary_escape_frames;
         json.other_pair_one_frame_escape_bytes = binary_escape_bytes;
         json.other_pair_within_absolute_ceiling = binary_within_ceiling;
         json.other_pair_peak_buffered_bytes = binary_peaks;
         json.other_pair_effective_watermark_bytes = binary_watermarks;
-        json.other_pair_per_client_escape_bytes = binary_per_client_escape;
+        json.other_pair_per_client_escape_frames = binary_per_client_escape_frames;
+        json.other_pair_per_client_escape_bytes = binary_per_client_escape_bytes;
         let load_started_now = json.poll();
         // The load summary combines both pairs, so both timing windows must
         // begin on the same rendered callback. Otherwise the binary pair's
@@ -958,16 +1024,22 @@ fn aggregate_queue_age(first: Option<&Client>, second: Option<&Client>) -> (Dura
     )
 }
 
-fn aggregate_godot_admission(first: Option<&Client>, second: Option<&Client>) -> (u64, u64, bool) {
+fn aggregate_godot_admission(
+    first: Option<&Client>,
+    second: Option<&Client>,
+) -> (u64, u64, u64, bool) {
     [first, second].into_iter().flatten().fold(
-        (0u64, 0u64, true),
-        |(violations, escape_bytes, within_ceiling), client| {
+        (0u64, 0u64, 0u64, true),
+        |(violations, total_escape_frames, total_escape_bytes, within_ceiling), client| {
             let transport = client.transport();
             let peak = client.transport_diagnostics().peak_buffered_bytes;
+            let escape_frames = transport.one_frame_escape_frames();
+            let escape_bytes = transport.one_frame_escape_bytes();
             (
                 violations.saturating_add(transport.admission_watermark_violations()),
-                escape_bytes.saturating_add(transport.one_frame_escape_bytes()),
-                within_ceiling && adaptive_peak_is_safe(peak),
+                total_escape_frames.saturating_add(escape_frames),
+                total_escape_bytes.saturating_add(escape_bytes),
+                within_ceiling && adaptive_peak_is_safe(peak, escape_frames, escape_bytes),
             )
         },
     )
@@ -976,7 +1048,7 @@ fn aggregate_godot_admission(first: Option<&Client>, second: Option<&Client>) ->
 fn godot_admission_snapshots(
     first: Option<&Client>,
     second: Option<&Client>,
-) -> ([u64; 2], [u64; 2], [u64; 2]) {
+) -> ([u64; 2], [u64; 2], [u64; 2], [u64; 2]) {
     let clients = [first, second];
     (
         clients.map(|client| {
@@ -990,12 +1062,21 @@ fn godot_admission_snapshots(
             })
         }),
         clients
+            .map(|client| client.map_or(0, |client| client.transport().one_frame_escape_frames())),
+        clients
             .map(|client| client.map_or(0, |client| client.transport().one_frame_escape_bytes())),
     )
 }
 
-fn adaptive_peak_is_safe(peak_buffered_bytes: u64) -> bool {
-    default_adaptive_ceiling_bytes().is_some_and(|ceiling| peak_buffered_bytes <= ceiling)
+fn adaptive_peak_is_safe(
+    peak_buffered_bytes: u64,
+    one_frame_escape_frames: u64,
+    one_frame_escape_bytes: u64,
+) -> bool {
+    default_adaptive_ceiling_bytes().is_some_and(|ceiling| {
+        peak_buffered_bytes <= ceiling
+            || (one_frame_escape_frames == 1 && peak_buffered_bytes <= one_frame_escape_bytes)
+    })
 }
 
 fn default_adaptive_ceiling_bytes() -> Option<u64> {
@@ -1008,7 +1089,22 @@ fn default_adaptive_ceiling_bytes() -> Option<u64> {
 }
 
 fn connect_client(kind: PairKind, suffix: &str, server_url: &str) -> Option<Client> {
-    match GodotWebSocketTransport::connect(server_url) {
+    let transport = if kind == PairKind::Json && suffix == "a" {
+        let mut peer = WebSocketPeer::new_gd();
+        peer.set_inbound_buffer_size(LARGE_SENDER_INBOUND_BUFFER_SIZE);
+        peer.set_outbound_buffer_size(LARGE_SENDER_OUTBOUND_BUFFER_SIZE);
+        let result = peer.connect_to_url(server_url);
+        if result == Error::OK {
+            Ok(GodotWebSocketTransport::from_peer(peer))
+        } else {
+            Err(format!(
+                "caller-configured Godot WebSocketPeer connect_to_url failed with {result:?}"
+            ))
+        }
+    } else {
+        GodotWebSocketTransport::connect(server_url).map_err(|error| error.to_string())
+    };
+    match transport {
         Ok(transport) => {
             let mut config = SignalFishConfig::new(APP_ID).enable_v3();
             config.platform = Some(format!("godot-smoke-{}-{suffix}", kind.label()));
@@ -1096,9 +1192,24 @@ mod tests {
         let ceiling = default_adaptive_ceiling_bytes().unwrap_or_default();
 
         assert_eq!(ceiling, 32 * 1024);
-        assert!(adaptive_peak_is_safe(0));
-        assert!(adaptive_peak_is_safe(ceiling));
-        assert!(!adaptive_peak_is_safe(ceiling.saturating_add(1)));
+        assert!(adaptive_peak_is_safe(0, 0, 0));
+        assert!(adaptive_peak_is_safe(ceiling, 0, 0));
+        assert!(!adaptive_peak_is_safe(ceiling.saturating_add(1), 0, 0));
+        assert!(adaptive_peak_is_safe(
+            ceiling.saturating_add(1),
+            1,
+            ceiling.saturating_add(1)
+        ));
+        assert!(!adaptive_peak_is_safe(
+            ceiling.saturating_add(2),
+            1,
+            ceiling.saturating_add(1)
+        ));
+        assert!(!adaptive_peak_is_safe(
+            ceiling.saturating_add(1),
+            2,
+            ceiling.saturating_mul(2)
+        ));
     }
 
     #[test]
@@ -1107,7 +1218,7 @@ mod tests {
         let later_effective_watermark = 4 * 1024;
 
         assert!(historical_peak > later_effective_watermark);
-        assert!(adaptive_peak_is_safe(historical_peak));
+        assert!(adaptive_peak_is_safe(historical_peak, 0, 0));
     }
 }
 


### PR DESCRIPTION
## Summary

- configure SDK-created Godot `WebSocketPeer` instances with an 8 MiB inbound buffer before `connect_to_url`, while preserving caller-owned `from_peer` settings
- add exact escape-frame diagnostics so the load oracle distinguishes one oversized empty-buffer admission from cumulative escapes
- require an 80 KiB Signal Fish relay through official Godot 4.5 native and web runtimes, with strict marker, load, shutdown, and close-attribution validation
- document the approximately 16 MiB per-peer Godot receive-buffer cost and the caller-configured escape hatch

## Correctness authority

Godot 4.5 defaults `inbound_buffer_size` to 65,535 bytes and consumes that setting at connection setup. A legal Signal Fish Server 0.7 aggregate can exceed that engine default; the private 8 MiB policy matches the existing native-client protective default without claiming a protocol maximum.

The runtime regression deliberately configures only the sender through `from_peer` with a distinctive `2 MiB + 17` inbound sentinel. The receiving peer uses the standard SDK constructor, so successful decode of the exact over-64-KiB server frame exercises the fixed path.

Refs #126.

Follow-up findings are tracked independently in #134 and #135.

## Verification

- exact mandatory chain: `cargo fmt && cargo clippy --workspace --all-targets --all-features -- -D warnings && cargo test --workspace --all-features`
- adapter suite: 38/38
- JavaScript oracle suite: 5/5, including malformed duplicate and multiple-escape negative controls
- CI policy suite: 228/228
- pre-commit: 18/18 available checks
- pre-push: 6/6 checks
- workflow hygiene, shell portability, docs.rs warnings, and Godot adapter policy checks
- two adversarial review/repair rounds followed by a zero-finding final re-review

The standalone Godot fixture requires an official Godot 4.5 executable, which is not installed in the development container; the required hosted Godot workflow supplies the pinned native and browser engine proof.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Godot WebSocket receive-buffer defaults (~16 MiB reservation per SDK peer) and CI server max-message size, which can affect memory and large-frame interoperability. Does not touch authentication.
> 
> **Overview**
> Fixes Godot dropping valid Signal Fish frames larger than the engine’s 65,535-byte inbound default. `connect` / `connect_with_options` now set an 8 MiB `inbound_buffer_size` **before** `connect_to_url`; `from_peer` still leaves caller-owned peers unchanged. This is a protective default (Godot may reserve ~16 MiB per peer), not a protocol maximum.
> 
> Adds `one_frame_escape_frames()` so load oracles can tell one empty-buffer oversized send from the same byte total across multiple escapes. The smoke fixture relays an 80 KiB JSON frame through an SDK-created receiver, and official native plus web jobs require that exact over-64-KiB marker. CI also raises Server `MAX_MESSAGE_SIZE` to 131072 and runs a native large-inbound smoke against pinned Server 0.7.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3aab98bcf606b827dff85657eb4bce9339918cfd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->