### PR TITLE
fix: preserve ready farewells after send failure

### DIFF
--- a/.llm/context.md
+++ b/.llm/context.md
@@ -143,15 +143,15 @@ idempotent; on error, logical I/O terminates and fallible cleanup remains safe f
 prompt, nonblocking, non-panicking, idempotent fallback that releases or safely detaches backend resources,
 discards retained sends, and ends driver polling; completed cleanup is not repeated, while failed cleanup may retry safely. See `skills/transport-abstraction/SKILL.md`.
 
-The async driver retains an in-flight send in its main select loop and polls
-send and receive with the same runtime waker, so outbound backpressure cannot
-hide inbound frames, peer close, or shutdown. Once a transport takes ownership
-of a frame, graceful termination finishes that send before close under the
-configured deadline; expiry invokes `Transport::abort`. Terminal core
-state/event delivery and close progress are concurrent, so a full event channel
-cannot strand the backend.
+The async driver polls retained sends and receives with one runtime waker, so
+outbound backpressure cannot hide inbound work, peer close, or shutdown.
+Graceful termination finishes transport-owned sends before close under one
+deadline; expiry aborts. After terminal send failure both drivers freeze command
+admission and boundedly process immediately ready frames through `ClientCore`
+until `Pending`, terminal input, work bound, protocol stop, or deadline. A ready farewell precedes
+`Disconnected`; only peer-close metadata replaces the send cause; native WebSocket retains buffered read state.
 
-Public `Debug` and built-in transport tracing form an ambient-log boundary:
+Public `Debug`/tracing form an ambient-log boundary:
 reconnect/relay/TURN credentials, WebRTC SDP/ICE, arbitrary application data,
 buffered protocol frames, peer close reasons, and URL userinfo/query values
 must never be formatted. Safe diagnostics expose only variants, state flags,

--- a/.llm/skills/websocket-client/SKILL.md
+++ b/.llm/skills/websocket-client/SKILL.md
@@ -141,10 +141,15 @@ immediately and is idempotent. Async task cancellation is protected by an
 owner guard that invokes abort unless graceful close completed; client drivers
 perform no later transport polls.
 
-EOF and terminal receive/send failures drop the stream, clear retained send and
-control state, and fuse the transport. Report the first receive failure as
-`TransportReceive`; later receives return `None`, sends return
-`TransportClosed` without taking their frame, and close remains idempotent.
+EOF and terminal receive failures drop the stream, clear retained send and
+control state, and fuse the transport. A terminal sink failure rejects later
+sends but retains the stream just long enough for `poll_recv` to surface
+already-buffered application frames; its first backend `Pending`, receive
+failure, EOF, close, or abort then drops the stream. Pre-acceptance token-
+binding errors and an exactly restored `WriteBufferFull` remain retryable.
+Report the first receive failure as `TransportReceive`; later receives return
+`None`, terminal sends return `TransportClosed` without taking their frame, and
+close remains idempotent.
 
 ## Wakers
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed async and polling clients discarding an immediately ready server
+  `Error` farewell when an outbound transport send failed at the same time.
+  Both drivers now freeze new commands, process bounded already-ready frames
+  before `Disconnected`, preserve `last_server_error` attribution, and retain
+  the original send error unless peer-initiated close metadata is available.
+  Native WebSockets retain buffered inbound frames after send failure, async
+  reliable sends cannot bypass the terminal freeze through an outstanding
+  channel permit, and polling error reasons no longer repeat their prefix.
 - Fixed standard Godot connections rejecting or omitting valid server messages
   larger than Godot's 65,535-byte inbound default. SDK-created peers now set an
   8 MiB inbound buffer before connecting, while `from_peer` keeps advanced

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ rustls = { version = "0.23", default-features = false, features = ["ring"], opti
 uuid = { version = "1", features = ["v4", "serde", "js"] }
 
 [dev-dependencies]
-tokio = { version = "1.21", features = ["full"] }
+tokio = { version = "1.21", features = ["full", "test-util"] }
 futures-util = "0.3"
 serde_json = "1.0"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/PLAN.md
+++ b/PLAN.md
@@ -92,9 +92,13 @@ measured evidence before accepting performance complexity:
    `ClientCore`, preserve caller-owned `from_stream` limits, and fuse capacity
    errors. No finite value is a Server 0.7 compatibility guarantee, so
    [signal-fish-server#399](https://github.com/Ambiguous-Interactive/signal-fish-server/issues/399)
-   tracks a negotiated/enforced outbound contract. Disconnect-adjacent
-   transitions now have the focused follow-up
-   [#134](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/issues/134).
+   tracks a negotiated/enforced outbound contract. The disconnect-adjacent
+   send-failure slice is complete: both drivers freeze command admission,
+   process bounded already-ready server frames through the shared core, retain
+   farewell attribution and exact event order, and preserve the original send
+   cause unless peer-initiated close metadata is stronger. Capacity-one event
+   backpressure, shutdown/deadline preemption, work bounds, terminal outcomes,
+   and no-retry behavior cover [#134](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/issues/134).
    The Godot engine-boundary slice is complete: SDK-created peers raise
    Godot's inbound buffer from 65,535 bytes to 8 MiB before connecting,
    caller-owned peers remain unchanged, and official native plus web runs

--- a/docs/delivery.md
+++ b/docs/delivery.md
@@ -164,6 +164,12 @@ graceful transport close without waiting for event-channel capacity. A close
 error or the configured close deadline invokes `Transport::abort` before the
 driver stops. If draining ever resumes instead, the buffered events (often
 including the eviction farewell) arrive, followed by `Disconnected`.
+After an outbound send failure, the clients process immediately ready frames in
+order before finalizing the disconnect. This terminal drain remains bounded by
+its deadline and frame/byte work limits, stops on protocol-directed disconnect
+or the transport's first `Pending`, and retains normal event-channel
+backpressure; shutdown may preempt it. A bound reached before a farewell means
+that farewell is intentionally not observed.
 
 ## Sizing the channels
 

--- a/docs/events.md
+++ b/docs/events.md
@@ -55,6 +55,10 @@ Use these to track the raw connection lifecycle.
 | `reason` | `Option<String>` | Human-readable close explanation with structured transport code/reason when available. Servers use semantic codes such as `4000 server_shutdown` and `4002 slow_consumer`; Server 0.7 also uses `4005 room_inactive`. |
 | `last_server_error` | `Option<ServerErrorInfo>` | The most recent `Error`/`AuthenticationError` received on this connection — a correlation aid for attributing the disconnect. A server that evicts a slow consumer writes a best-effort `Error { error_code: SlowConsumer }` farewell before closing; when that frame arrives, it shows up here. See the [Delivery Contract](delivery.md). |
 
+After outbound send failure, ready server errors can still populate
+`last_server_error`; the exact bounded-drain and cause-precedence rules are in
+the [Delivery Contract](delivery.md#the-wedged-consumer-hazard).
+
 !!! note "Delivery of the terminal `Disconnected`"
     During normal operation `Disconnected` is delivered with backpressure
     like every other event — it is not dropped merely because the consumer

--- a/progress/session-046-send-failure-farewell-drain.md
+++ b/progress/session-046-send-failure-farewell-drain.md
@@ -97,4 +97,12 @@ rendering is the sole local skip because MkDocs is not installed. Three
 independent frozen-diff reviews report zero actionable correctness, test/docs,
 or simplicity findings after the fix loop.
 
-Hosted PR and CI disposition will be appended after the branch is published.
+PR [#137](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/pull/137)
+was opened from implementation commit `eb04991`. All 12 hosted workflows passed
+on that implementation head: CI, Coverage, Deep Safety, Docs Validation,
+Examples Validation, Godot Web, No Panics, Security, Semver Checks, Unused
+Deps, WASM, and Workflow Lint. The PR is open, mergeable, and has no inline
+review threads. Copilot could not review because the requesting account had
+reached its quota; that governance limitation produced no code feedback. This
+evidence-only follow-up will be monitored to the same green state before
+handoff.

--- a/progress/session-046-send-failure-farewell-drain.md
+++ b/progress/session-046-send-failure-farewell-drain.md
@@ -1,0 +1,100 @@
+# Session 046 — Send-Failure Farewell Drain
+
+## Priority and Audit
+
+The session began from clean `main` at
+`c1fbdb4141295d7fadea99a138db2aa276fca1b2`, the merge of PR #136. The GitHub
+connector found no open pull requests. Open client work was the #126
+correctness/performance audit, focused issues #134 and #135, and the separate
+maintainer-only repository-policy blocker #90. This session takes #134 first,
+the roadmap's next disconnect-adjacent correctness slice.
+
+Both drivers previously treated an outbound `poll_send` error as immediately
+terminal. The async combined I/O poll returned without polling receive, and the
+polling client returned before its receive drain. A complete server
+`Error(SlowConsumer)` already ready at that duplex boundary was therefore lost,
+so `Disconnected.last_server_error` could not attribute the server farewell.
+The polling driver also prefixed already-formatted send and receive transport
+errors a second time.
+
+## Design
+
+A driver-internal `ReadyFrameDrain` now owns common frame/byte accounting and
+returns at most one immediately available complete frame per call. The frame
+that reaches or crosses a byte bound is processed before the drain stops, so an
+oversized first frame remains valid and no later frame is consumed without
+normal `ClientCore` processing. `Pending`, EOF, receive error, the bounded work
+limit, deadline, and protocol-directed disconnect all stop the drain.
+
+On async send failure a mutex-serialized bit freezes both fail-fast and waiting
+admission, including a reliable sender that already reserved a Tokio channel
+permit. The command receiver then closes before the drain. One absolute
+terminal deadline covers ready-frame processing, backpressured event delivery,
+`Disconnected`, and transport cleanup. Shutdown can preempt a blocked terminal
+event without replacing the already-established send cause. The native
+WebSocket backend rejects later sends but retains buffered read state until the
+first non-ready receive boundary; retriable tungstenite `WriteBufferFull`
+refusals retain their exact-frame and token-binding sequence behavior.
+
+The polling driver immediately abandons the failed caller-owned frame and all
+queued commands. It uses the smaller of its configured receive budget and the
+shared 64-frame/64-KiB terminal safety cap, then marks receive terminal so the
+close phase cannot poll and discard frames beyond the chosen stop. Both drivers
+prefer only peer-initiated `TransportCloseInfo` over the original send error;
+bare EOF, receive error, local close metadata, bounds, and deadlines do not
+replace it.
+
+## Regression Evidence
+
+One shared transport drives the principal async/polling regression:
+authentication succeeds, the first queued `Ping` fails without transferring
+its frame, a complete slow-consumer farewell and EOF are immediately ready,
+and a second queued `Ping` must never be offered. Both clients emit exact
+`Error` then `Disconnected` order, retain `SlowConsumer` in
+`last_server_error`, preserve the single-prefix send reason, freeze subsequent
+admission, and close without retrying queued work.
+
+The same transport covers `Pending`, EOF, receive error, peer and non-peer
+close metadata, capacity-one event backpressure, shutdown preemption, a paused
+terminal deadline, protocol-directed stop, shared and caller frame/byte limits,
+oversized-first processing, prefetched polling input, statistics, and
+close-phase no-repoll behavior. Native WebSocket and multithreaded reserved-
+permit regressions cover the backend and admission boundaries independently.
+
+## Adversarial Review
+
+The first parallel reviews rejected a draft that pre-collected every terminal
+event before async channel delivery because it weakened event backpressure.
+They also found an over-budget frame could be consumed without processing, a
+peer-close shortcut bypassed the farewell drain, shutdown could overwrite the
+send cause, polling close could resume receive after a terminal stop, and each
+phase started a fresh timeout. The final design above resolves the entire
+class: one-frame scheduling, crossing-frame processing, one absolute deadline,
+cause preservation, and a persistent polling receive stop.
+
+The frozen-diff reviews then found that closing a Tokio receiver does not revoke
+an outstanding permit, native WebSocket send errors dropped buffered reads,
+and the draft lacked protocol-stop, byte-budget, prefetched-frame,
+deterministic-deadline, and EOF-only metadata cases. They also identified
+misplaced driver policy and duplicate accounting in `transport.rs`. The final
+revision adds the serialized admission freeze, split WebSocket send/receive
+terminal state, all missing acceptance cases, and a small `terminal_drain`
+driver module with one shared budget, payload counter, and close formatter.
+
+## Verification and Hosted Disposition
+
+The frozen implementation passes the mandatory local chain:
+
+- `cargo fmt`
+- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+- `cargo test --workspace --all-features` (389 core unit tests, 48 polling
+  parity tests, all workspace integration and doc tests; 11 live-server tests
+  remain ignored by their explicit environment contract)
+
+The no-default-feature Clippy build, LLM pre-commit/context limit, panic-policy,
+test-quality, target-gated doc-link, format, and diff checks also pass. MkDocs
+rendering is the sole local skip because MkDocs is not installed. Three
+independent frozen-diff reviews report zero actionable correctness, test/docs,
+or simplicity findings after the fix loop.
+
+Hosted PR and CI disposition will be appended after the branch is published.

--- a/src/client.rs
+++ b/src/client.rs
@@ -100,6 +100,10 @@ use crate::protocol::{
 #[cfg(feature = "tokio-runtime")]
 use crate::signal::PeerSignal;
 #[cfg(feature = "tokio-runtime")]
+use crate::terminal_drain::{
+    close_reason, peer_close_reason, ReadyFrameDrain, ReadyFrameDrainBudget, ReadyFrameDrainPoll,
+};
+#[cfg(feature = "tokio-runtime")]
 use crate::transport::{close_transport, Transport, TransportFrame};
 
 /// Default capacity of the bounded event channel.
@@ -1494,7 +1498,16 @@ impl SignalFishClient {
         result
     }
 
-    async fn send_operation_reliable(&self, mut operation: ClientOperation) -> Result<()> {
+    async fn send_operation_reliable(&self, operation: ClientOperation) -> Result<()> {
+        self.send_operation_reliable_after_reserve(operation, || {})
+            .await
+    }
+
+    async fn send_operation_reliable_after_reserve(
+        &self,
+        mut operation: ClientOperation,
+        after_reserve: impl FnOnce(),
+    ) -> Result<()> {
         // Preserve immediate state/negotiation errors even when the queue is
         // full, then revalidate after waiting because room, plan, and format
         // state can change while capacity is unavailable.
@@ -1511,6 +1524,7 @@ impl SignalFishClient {
             .reserve()
             .await
             .map_err(|_| SignalFishError::NotConnected)?;
+        after_reserve();
         let core = lock_core(&self.state);
         let command = core.prepare_reliable(operation, binding)?;
         permit.send(command);
@@ -1797,6 +1811,11 @@ async fn finish_send_and_close_bounded(
     state: &Arc<Mutex<ClientCore>>,
     timeout: Duration,
 ) {
+    if timeout.is_zero() {
+        *pending_send = None;
+        transport.abort();
+        return;
+    }
     let accepted_send = pending_send
         .as_ref()
         .is_some_and(|pending| pending.frame.is_none());
@@ -1880,19 +1899,8 @@ async fn poll_transport_io(
                     return std::task::Poll::Ready(TransportIo::Sent);
                 }
                 std::task::Poll::Ready(Err(error)) => {
-                    let peer_closed = transport
-                        .close_info()
-                        .is_some_and(|info| info.initiated_by_peer);
                     *pending_send = None;
-                    return std::task::Poll::Ready(if peer_closed {
-                        // A duplex transport can discover a peer close while
-                        // an accepted send is still flushing. Prefer the
-                        // authoritative terminal receive state and its close
-                        // metadata over the consequential send refusal.
-                        TransportIo::Received(None)
-                    } else {
-                        TransportIo::SendFailed(error)
-                    });
+                    return std::task::Poll::Ready(TransportIo::SendFailed(error));
                 }
                 std::task::Poll::Pending => {}
             }
@@ -1910,6 +1918,104 @@ async fn poll_transport_io(
         }
     })
     .await
+}
+
+#[cfg(feature = "tokio-runtime")]
+async fn wait_for_terminal_deadline(deadline: Option<tokio::time::Instant>) {
+    if let Some(deadline) = deadline {
+        tokio::time::sleep_until(deadline).await;
+    } else {
+        std::future::pending::<()>().await;
+    }
+}
+
+#[cfg(feature = "tokio-runtime")]
+async fn emit_terminal_event(
+    event_tx: &mpsc::Sender<SignalFishEvent>,
+    shutdown_rx: &mut tokio::sync::oneshot::Receiver<()>,
+    deadline: Option<tokio::time::Instant>,
+    event: SignalFishEvent,
+) -> bool {
+    tokio::select! {
+        biased;
+        result = event_tx.send(event) => {
+            if result.is_err() {
+                debug!("event channel closed, receiver dropped");
+            }
+            true
+        }
+        _ = &mut *shutdown_rx => false,
+        () = wait_for_terminal_deadline(deadline) => false,
+    }
+}
+
+#[cfg(feature = "tokio-runtime")]
+async fn finish_send_failure(
+    transport: &mut impl Transport,
+    pending_send: &mut Option<PendingSend>,
+    event_tx: &mpsc::Sender<SignalFishEvent>,
+    shutdown_rx: &mut tokio::sync::oneshot::Receiver<()>,
+    state: &Arc<Mutex<ClientCore>>,
+    error: SignalFishError,
+    timeout: Duration,
+) {
+    let deadline = tokio::time::Instant::now().checked_add(timeout);
+    let mut drain = ReadyFrameDrain::new(None, ReadyFrameDrainBudget::standard());
+    let mut delivery_preempted = false;
+    loop {
+        let polled = std::future::poll_fn(|cx| {
+            std::task::Poll::Ready(drain.poll_next(
+                transport,
+                cx,
+                deadline.is_some_and(|deadline| tokio::time::Instant::now() >= deadline),
+            ))
+        })
+        .await;
+        let ReadyFrameDrainPoll::Frame {
+            frame,
+            budget_reached,
+        } = polled
+        else {
+            match polled {
+                ReadyFrameDrainPoll::ReceiveFailed(receive_error) => {
+                    debug!(%receive_error, "ready-frame drain stopped at receive failure after send failure");
+                }
+                ReadyFrameDrainPoll::DeadlineReached => {
+                    debug!("ready-frame drain reached the shutdown deadline after send failure");
+                }
+                ReadyFrameDrainPoll::Pending | ReadyFrameDrainPoll::Closed => {}
+                ReadyFrameDrainPoll::Frame { .. } => {}
+            }
+            break;
+        };
+
+        let outcome = lock_core(state).process_frame(frame);
+        let protocol_stop = outcome.disconnect;
+        for event in outcome.events {
+            if !emit_terminal_event(event_tx, shutdown_rx, deadline, event).await {
+                delivery_preempted = true;
+                break;
+            }
+        }
+        if delivery_preempted || protocol_stop || budget_reached {
+            break;
+        }
+    }
+
+    let reason = peer_close_reason(transport).or_else(|| Some(error.to_string()));
+    let disconnected = lock_core(state).disconnect(reason);
+    let remaining = deadline.map_or(timeout, |deadline| {
+        deadline.saturating_duration_since(tokio::time::Instant::now())
+    });
+    let deliver_disconnected = async {
+        if delivery_preempted
+            || !emit_terminal_event(event_tx, shutdown_rx, deadline, disconnected.clone()).await
+        {
+            let _ = event_tx.try_send(disconnected);
+        }
+    };
+    let close = finish_send_and_close_bounded(transport, pending_send, state, remaining);
+    let ((), ()) = tokio::join!(deliver_disconnected, close);
 }
 
 /// Background transport loop that multiplexes send/receive via `tokio::select!`.
@@ -2043,13 +2149,19 @@ async fn transport_loop(
                 match io {
                     TransportIo::Ready | TransportIo::Sent => {}
                     TransportIo::SendFailed(error) => {
-                        emit_core_disconnected_or_shutdown(
+                        // The transport has made outbound I/O terminal. Freeze
+                        // admission before processing any already-ready
+                        // inbound farewell frames so no concurrent caller can
+                        // enqueue work that will never be attempted.
+                        lock_core(&state).freeze_admission();
+                        cmd_rx.close();
+                        finish_send_failure(
                             &mut transport,
                             &mut pending_send,
                             &event_tx,
                             &mut shutdown_rx,
                             &state,
-                            Some(error.to_string()),
+                            error,
                             shutdown_timeout,
                         ).await;
                         break;
@@ -2103,12 +2215,7 @@ async fn transport_loop(
                         break;
                     }
                     TransportIo::Received(None) => {
-                        let reason = transport.close_info().map(|info| {
-                            format!(
-                                "closed by server: code={:?}, reason={:?}",
-                                info.code, info.reason
-                            )
-                        });
+                        let reason = close_reason(&transport);
                         emit_core_disconnected_or_shutdown(
                             &mut transport,
                             &mut pending_send,
@@ -2184,7 +2291,7 @@ mod tests {
     use std::collections::VecDeque;
     use std::future::Future;
     use std::pin::Pin;
-    use std::sync::Mutex as StdMutex;
+    use std::sync::{Barrier, Mutex as StdMutex};
     use std::task::{Context, Poll, Waker};
 
     #[test]
@@ -3963,6 +4070,51 @@ mod tests {
         wait_for_sent_len(&sent, 3).await;
 
         let mut client = Arc::into_inner(client).expect("all clones dropped");
+        client.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn reliable_send_revalidates_admission_after_reserving_capacity() {
+        let (transport, entered_send, permits, _sent) = GatedSendTransport::new(0);
+        let config = SignalFishConfig::new("mb_test").with_command_channel_capacity(1);
+        let (client, mut events) = SignalFishClient::start(transport, config);
+
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Connected)
+        ));
+        wait_until(|| entered_send.load(Ordering::Acquire)).await;
+        prime_player_room(&client);
+
+        let reserved = Arc::new(Barrier::new(2));
+        let release = Arc::new(Barrier::new(2));
+        let client = Arc::new(client);
+        let sender = Arc::clone(&client);
+        let reserved_by_sender = Arc::clone(&reserved);
+        let release_sender = Arc::clone(&release);
+        let send = tokio::spawn(async move {
+            sender
+                .send_operation_reliable_after_reserve(
+                    ClientOperation::GameData(
+                        serde_json::json!({ "reserved": true }),
+                        GameDataDelivery::Reliable,
+                    ),
+                    || {
+                        reserved_by_sender.wait();
+                        release_sender.wait();
+                    },
+                )
+                .await
+        });
+
+        reserved.wait();
+        lock_core(&client.state).freeze_admission();
+        release.wait();
+        let result = send.await.expect("reliable-send task must not panic");
+        assert!(matches!(result, Err(SignalFishError::NotConnected)));
+
+        permits.add_permits(1);
+        let mut client = Arc::into_inner(client).expect("all client clones must be dropped");
         client.shutdown().await;
     }
 

--- a/src/client_core.rs
+++ b/src/client_core.rs
@@ -137,6 +137,8 @@ pub(crate) struct ClientCore {
     pending_room_operation: Option<PendingRoomOperationState>,
     pending_reconnects: VecDeque<PendingReconnect>,
     #[cfg(feature = "tokio-runtime")]
+    admission_frozen: bool,
+    #[cfg(feature = "tokio-runtime")]
     session_plan_revision: u64,
     #[cfg(feature = "tokio-runtime")]
     room_revision: u64,
@@ -238,6 +240,8 @@ impl ClientCore {
             pending_room_operation: None,
             pending_reconnects: VecDeque::new(),
             #[cfg(feature = "tokio-runtime")]
+            admission_frozen: false,
+            #[cfg(feature = "tokio-runtime")]
             session_plan_revision: 0,
             #[cfg(feature = "tokio-runtime")]
             room_revision: 0,
@@ -331,6 +335,10 @@ impl ClientCore {
     }
 
     pub(crate) fn validate(&self, operation: &ClientOperation) -> crate::error::Result<()> {
+        #[cfg(feature = "tokio-runtime")]
+        if self.admission_frozen {
+            return Err(crate::SignalFishError::NotConnected);
+        }
         if !self.is_connected() {
             return Err(crate::SignalFishError::NotConnected);
         }
@@ -438,6 +446,11 @@ impl ClientCore {
             _ => {}
         }
         Ok(())
+    }
+
+    #[cfg(feature = "tokio-runtime")]
+    pub(crate) fn freeze_admission(&mut self) {
+        self.admission_frozen = true;
     }
 
     #[cfg(feature = "tokio-runtime")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,6 +125,8 @@ pub mod error_codes;
 pub mod event;
 pub mod protocol;
 pub mod signal;
+#[cfg(any(feature = "tokio-runtime", feature = "polling-client"))]
+mod terminal_drain;
 #[cfg(feature = "transport-websocket")]
 pub mod token_binding;
 pub mod transport;

--- a/src/polling_client.rs
+++ b/src/polling_client.rs
@@ -35,10 +35,14 @@ use crate::protocol::{
     TransportKind,
 };
 use crate::signal::PeerSignal;
+use crate::terminal_drain::{
+    close_reason, frame_payload_len, peer_close_reason, ReadyFrameDrain, ReadyFrameDrainBudget,
+    ReadyFrameDrainPoll, DEFAULT_DRIVER_WORK_BYTES, DEFAULT_DRIVER_WORK_FRAMES,
+};
 use crate::transport::{Transport, TransportDiagnostics, TransportFrame};
 
-const DEFAULT_POLL_FRAMES: usize = 64;
-const DEFAULT_POLL_BYTES: usize = 64 * 1024;
+const DEFAULT_POLL_FRAMES: usize = DEFAULT_DRIVER_WORK_FRAMES;
+const DEFAULT_POLL_BYTES: usize = DEFAULT_DRIVER_WORK_BYTES;
 
 /// Maximum send and receive work performed by one [`poll`](SignalFishPollingClient::poll).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -208,6 +212,7 @@ pub struct SignalFishPollingClient<T: Transport> {
     send_in_flight: bool,
     pending_frame_is_game_data: bool,
     pending_inbound: Option<TransportFrame>,
+    terminal_receive_stopped: bool,
     close_phase: ClosePhase,
 }
 
@@ -265,6 +270,7 @@ impl<T: Transport> SignalFishPollingClient<T> {
             send_in_flight: false,
             pending_frame_is_game_data: false,
             pending_inbound: None,
+            terminal_receive_stopped: false,
             close_phase: ClosePhase::Open,
         };
         client.refresh_queue_diagnostics_at(now);
@@ -306,6 +312,14 @@ impl<T: Transport> SignalFishPollingClient<T> {
     }
 
     fn poll_at(&mut self, now: Instant) -> Vec<SignalFishEvent> {
+        self.poll_at_with_terminal_clock(now, Instant::now)
+    }
+
+    fn poll_at_with_terminal_clock(
+        &mut self,
+        now: Instant,
+        mut terminal_now: impl FnMut() -> Instant,
+    ) -> Vec<SignalFishEvent> {
         let mut events = Vec::new();
         if matches!(self.close_phase, ClosePhase::Closed) {
             return events;
@@ -336,12 +350,11 @@ impl<T: Transport> SignalFishPollingClient<T> {
 
         if let Err(error) = self.drive_outbound(&mut cx, now) {
             error!(%error, "transport send failed");
-            self.handle_disconnect_at(
-                &mut events,
-                Some(format!("transport send error: {error}")),
-                &mut cx,
-                now,
-            );
+            self.abandon_client_owned(false, now);
+            self.drain_ready_after_send_failure(&mut events, &mut cx, now, &mut terminal_now);
+            let reason = peer_close_reason(&self.transport).or_else(|| Some(error.to_string()));
+            let close_now = terminal_now().max(now);
+            self.handle_disconnect_between(&mut events, reason, &mut cx, now, close_now);
             return events;
         }
 
@@ -360,22 +373,12 @@ impl<T: Transport> SignalFishPollingClient<T> {
                     std::task::Poll::Ready(Some(Ok(frame))) => frame,
                     std::task::Poll::Ready(Some(Err(e))) => {
                         error!("transport receive error: {e}");
-                        self.handle_disconnect_at(
-                            &mut events,
-                            Some(format!("transport receive error: {e}")),
-                            &mut cx,
-                            now,
-                        );
+                        self.handle_disconnect_at(&mut events, Some(e.to_string()), &mut cx, now);
                         break;
                     }
                     std::task::Poll::Ready(None) => {
                         debug!("transport closed by server");
-                        let reason = self.transport.close_info().map(|info| {
-                            format!(
-                                "closed by server: code={:?}, reason={:?}",
-                                info.code, info.reason
-                            )
-                        });
+                        let reason = close_reason(&self.transport);
                         self.handle_disconnect_at(&mut events, reason, &mut cx, now);
                         break;
                     }
@@ -1088,6 +1091,60 @@ impl<T: Transport> SignalFishPollingClient<T> {
         Ok(())
     }
 
+    fn drain_ready_after_send_failure(
+        &mut self,
+        events: &mut Vec<SignalFishEvent>,
+        cx: &mut std::task::Context<'_>,
+        started_at: Instant,
+        terminal_now: &mut impl FnMut() -> Instant,
+    ) {
+        let standard = ReadyFrameDrainBudget::standard();
+        let budget = ReadyFrameDrainBudget::new(
+            self.options.work_budget.receive_frames.min(standard.frames),
+            self.options.work_budget.receive_bytes.min(standard.bytes),
+        );
+        let deadline = started_at.checked_add(self.shutdown_timeout);
+        let first = self.pending_inbound.take();
+        let transport = &mut self.transport;
+        let core = &mut self.core;
+        let mut drain = ReadyFrameDrain::new(first, budget);
+        loop {
+            let polled = drain.poll_next(
+                transport,
+                cx,
+                deadline.is_some_and(|deadline| terminal_now() >= deadline),
+            );
+            match polled {
+                ReadyFrameDrainPoll::Frame {
+                    frame,
+                    budget_reached,
+                } => {
+                    let outcome = core.process_frame(frame);
+                    events.extend(outcome.events);
+                    if budget_reached {
+                        self.polling_stats.receive_budget_exhaustions = self
+                            .polling_stats
+                            .receive_budget_exhaustions
+                            .saturating_add(1);
+                    }
+                    if outcome.disconnect || budget_reached {
+                        break;
+                    }
+                }
+                ReadyFrameDrainPoll::ReceiveFailed(error) => {
+                    debug!(%error, "ready-frame drain stopped at receive failure after send failure");
+                    break;
+                }
+                ReadyFrameDrainPoll::DeadlineReached => {
+                    debug!("ready-frame drain reached the shutdown deadline after send failure");
+                    break;
+                }
+                ReadyFrameDrainPoll::Pending | ReadyFrameDrainPoll::Closed => break,
+            }
+        }
+        self.terminal_receive_stopped = true;
+    }
+
     fn drive_close_at(&mut self, now: Instant, cx: &mut std::task::Context<'_>) {
         let started_at = match self.close_phase {
             ClosePhase::Flushing { started_at } | ClosePhase::Closing { started_at } => started_at,
@@ -1105,7 +1162,9 @@ impl<T: Transport> SignalFishPollingClient<T> {
             return;
         }
 
-        self.drain_closing_inbound(cx);
+        if !self.terminal_receive_stopped {
+            self.drain_closing_inbound(cx);
+        }
 
         if matches!(self.close_phase, ClosePhase::Flushing { .. }) {
             if let Err(error) = self.drive_outbound(cx, now) {
@@ -1180,12 +1239,23 @@ impl<T: Transport> SignalFishPollingClient<T> {
         cx: &mut std::task::Context<'_>,
         now: Instant,
     ) {
+        self.handle_disconnect_between(events, reason, cx, now, now);
+    }
+
+    fn handle_disconnect_between(
+        &mut self,
+        events: &mut Vec<SignalFishEvent>,
+        reason: Option<String>,
+        cx: &mut std::task::Context<'_>,
+        started_at: Instant,
+        now: Instant,
+    ) {
         self.abandon_client_owned(false, now);
         self.pending_inbound = None;
         self.close_phase = if self.send_in_flight {
-            ClosePhase::Flushing { started_at: now }
+            ClosePhase::Flushing { started_at }
         } else {
-            ClosePhase::Closing { started_at: now }
+            ClosePhase::Closing { started_at }
         };
         events.push(self.core.disconnect(reason));
         self.drive_close_at(now, cx);
@@ -1260,13 +1330,6 @@ impl<T: Transport> SignalFishPollingClient<T> {
     fn reset_queue_age_peak_at(&mut self, now: Instant) {
         self.refresh_queue_diagnostics_at(now);
         self.queue_age_stats.peak_oldest_queue_age = self.queue_age_stats.current_oldest_queue_age;
-    }
-}
-
-fn frame_payload_len(frame: &TransportFrame) -> usize {
-    match frame {
-        TransportFrame::Text(text) => text.len(),
-        TransportFrame::Binary(bytes) => bytes.len(),
     }
 }
 
@@ -3306,6 +3369,49 @@ mod tests {
         }
     }
 
+    #[derive(Default)]
+    struct DeadlineDuringSendFailureTransport {
+        recv_calls: usize,
+        close_calls: usize,
+        abort_calls: usize,
+    }
+
+    impl Transport for DeadlineDuringSendFailureTransport {
+        fn abort(&mut self) {
+            self.abort_calls = self.abort_calls.saturating_add(1);
+        }
+
+        fn poll_send(
+            &mut self,
+            _cx: &mut std::task::Context<'_>,
+            _frame: &mut Option<TransportFrame>,
+        ) -> std::task::Poll<std::result::Result<(), SignalFishError>> {
+            std::task::Poll::Ready(Err(SignalFishError::TransportSend(
+                "deadline fixture".into(),
+            )))
+        }
+
+        fn poll_recv(
+            &mut self,
+            _cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<Option<std::result::Result<TransportFrame, SignalFishError>>> {
+            self.recv_calls = self.recv_calls.saturating_add(1);
+            if self.recv_calls == 1 {
+                std::task::Poll::Ready(Some(Ok(TransportFrame::Text(r#"{"type":"Pong"}"#.into()))))
+            } else {
+                std::task::Poll::Pending
+            }
+        }
+
+        fn poll_close(
+            &mut self,
+            _cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<std::result::Result<(), SignalFishError>> {
+            self.close_calls = self.close_calls.saturating_add(1);
+            std::task::Poll::Pending
+        }
+    }
+
     /// A transport whose `poll_send` always returns `Pending`.
     struct PendingOnSendTransport;
 
@@ -4467,6 +4573,38 @@ mod tests {
             );
         }
         assert!(!client.is_connected());
+    }
+
+    #[test]
+    fn send_failure_deadline_includes_ready_drain_time_before_close() {
+        let transport = DeadlineDuringSendFailureTransport::default();
+        let config = default_config().with_shutdown_timeout(Duration::from_millis(5));
+        let mut client = SignalFishPollingClient::new(transport, config);
+        let started_at = Instant::now();
+        let mut clock_calls = 0usize;
+
+        let events = client.poll_at_with_terminal_clock(started_at, || {
+            clock_calls = clock_calls.saturating_add(1);
+            if clock_calls == 1 {
+                started_at + Duration::from_millis(1)
+            } else {
+                started_at + Duration::from_millis(6)
+            }
+        });
+
+        assert!(matches!(
+            events.as_slice(),
+            [
+                SignalFishEvent::Connected,
+                SignalFishEvent::Pong,
+                SignalFishEvent::Disconnected { .. }
+            ]
+        ));
+        assert_eq!(client.transport.recv_calls, 1);
+        assert_eq!(client.transport.close_calls, 0);
+        assert_eq!(client.transport.abort_calls, 1);
+        assert_eq!(client.polling_stats.close_deadline_expirations, 1);
+        assert!(matches!(client.close_phase, ClosePhase::Closed));
     }
 
     /// Transport whose `poll_send` stays `Pending` until `allow` is set, so tests

--- a/src/terminal_drain.rs
+++ b/src/terminal_drain.rs
@@ -1,0 +1,106 @@
+use std::task::{Context, Poll};
+
+use crate::error::SignalFishError;
+use crate::transport::{Transport, TransportFrame};
+
+pub(crate) const DEFAULT_DRIVER_WORK_FRAMES: usize = 64;
+pub(crate) const DEFAULT_DRIVER_WORK_BYTES: usize = 64 * 1024;
+
+#[derive(Clone, Copy)]
+pub(crate) struct ReadyFrameDrainBudget {
+    pub(crate) frames: usize,
+    pub(crate) bytes: usize,
+}
+
+impl ReadyFrameDrainBudget {
+    pub(crate) const fn new(frames: usize, bytes: usize) -> Self {
+        Self { frames, bytes }
+    }
+
+    pub(crate) const fn standard() -> Self {
+        Self::new(DEFAULT_DRIVER_WORK_FRAMES, DEFAULT_DRIVER_WORK_BYTES)
+    }
+}
+
+pub(crate) enum ReadyFrameDrainPoll {
+    Frame {
+        frame: TransportFrame,
+        budget_reached: bool,
+    },
+    Pending,
+    Closed,
+    ReceiveFailed(SignalFishError),
+    DeadlineReached,
+}
+
+pub(crate) struct ReadyFrameDrain {
+    first: Option<TransportFrame>,
+    budget: ReadyFrameDrainBudget,
+    frames: usize,
+    bytes: usize,
+}
+
+impl ReadyFrameDrain {
+    pub(crate) fn new(first: Option<TransportFrame>, budget: ReadyFrameDrainBudget) -> Self {
+        Self {
+            first,
+            budget,
+            frames: 0,
+            bytes: 0,
+        }
+    }
+
+    pub(crate) fn poll_next<T: Transport + ?Sized>(
+        &mut self,
+        transport: &mut T,
+        cx: &mut Context<'_>,
+        deadline_reached: bool,
+    ) -> ReadyFrameDrainPoll {
+        if deadline_reached {
+            return ReadyFrameDrainPoll::DeadlineReached;
+        }
+        let frame = if let Some(frame) = self.first.take() {
+            frame
+        } else {
+            match transport.poll_recv(cx) {
+                Poll::Ready(Some(Ok(frame))) => frame,
+                Poll::Ready(Some(Err(error))) => {
+                    return ReadyFrameDrainPoll::ReceiveFailed(error);
+                }
+                Poll::Ready(None) => return ReadyFrameDrainPoll::Closed,
+                Poll::Pending => return ReadyFrameDrainPoll::Pending,
+            }
+        };
+        self.frames = self.frames.saturating_add(1);
+        self.bytes = self.bytes.saturating_add(frame_payload_len(&frame));
+        ReadyFrameDrainPoll::Frame {
+            frame,
+            budget_reached: self.frames >= self.budget.frames || self.bytes >= self.budget.bytes,
+        }
+    }
+}
+
+pub(crate) fn frame_payload_len(frame: &TransportFrame) -> usize {
+    match frame {
+        TransportFrame::Text(text) => text.len(),
+        TransportFrame::Binary(bytes) => bytes.len(),
+    }
+}
+
+fn format_close_reason(info: crate::transport::TransportCloseInfo) -> String {
+    format!(
+        "closed by server: code={:?}, reason={:?}",
+        info.code, info.reason
+    )
+}
+
+pub(crate) fn close_reason<T: Transport + ?Sized>(transport: &T) -> Option<String> {
+    transport.close_info().map(format_close_reason)
+}
+
+pub(crate) fn peer_close_reason<T: Transport + ?Sized>(transport: &T) -> Option<String> {
+    transport
+        .close_info()
+        .filter(|info| info.initiated_by_peer)
+        .map(format_close_reason)
+}

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -136,6 +136,12 @@ pub trait Transport {
     fn begin_poll_cycle(&mut self) {}
 
     /// Advance one outbound frame.
+    ///
+    /// The clients treat an error as outbound-terminal. It must not take a
+    /// caller-owned frame unless the backend had already accepted it. They may
+    /// still call [`poll_recv`](Self::poll_recv) to process a bounded sequence
+    /// of complete frames that are immediately ready, stopping at its first
+    /// `Pending`, error, or EOF, before they close or abort the transport.
     fn poll_send(
         &mut self,
         cx: &mut Context<'_>,

--- a/src/transports/websocket.rs
+++ b/src/transports/websocket.rs
@@ -510,6 +510,11 @@ impl WebSocketConnectOptions {
 /// receive state across `Poll::Pending`, registers the supplied waker, and
 /// bounds skipped control-frame work. EOF and terminal socket errors fuse the
 /// transport so later receives, sends, and closes have deterministic outcomes.
+/// After a terminal sink error, later sends are rejected while `poll_recv` may
+/// still return already-buffered frames; the first backend `Pending`, receive
+/// failure, EOF, close, or abort then fully fuses the transport. Pre-acceptance
+/// token-binding errors and `WriteBufferFull` with exact frame restoration are
+/// retryable refusals instead.
 pub struct WebSocketTransport {
     state: WebSocketState<WsStream>,
 }
@@ -519,6 +524,7 @@ struct WebSocketState<S> {
     closed: bool,
     close_info: Option<TransportCloseInfo>,
     send_started: bool,
+    send_failed: bool,
     control_flush_pending: bool,
     peer_close_pending: bool,
     token_binding: WebSocketTokenBinding,
@@ -593,6 +599,7 @@ impl std::fmt::Debug for WebSocketTransport {
             .field("closed", &self.state.closed)
             .field("has_close_info", &self.state.close_info.is_some())
             .field("send_started", &self.state.send_started)
+            .field("send_failed", &self.state.send_failed)
             .field("control_flush_pending", &self.state.control_flush_pending)
             .field("peer_close_pending", &self.state.peer_close_pending)
             .field("token_binding", &self.state.token_binding.status())
@@ -611,6 +618,7 @@ impl<S> WebSocketState<S> {
             closed: false,
             close_info: None,
             send_started: false,
+            send_failed: false,
             control_flush_pending: false,
             peer_close_pending: false,
             token_binding,
@@ -621,12 +629,25 @@ impl<S> WebSocketState<S> {
         self.stream = None;
         self.closed = true;
         self.send_started = false;
+        self.send_failed = true;
         self.control_flush_pending = false;
         self.peer_close_pending = false;
         #[cfg(feature = "token-binding")]
         if let WebSocketTokenBinding::Active(session) = &mut self.token_binding {
             // Drop and zeroize the derived key/challenge as soon as the
             // physical connection becomes terminal while preserving status.
+            *session = None;
+        }
+    }
+
+    fn mark_send_failed(&mut self) {
+        self.send_started = false;
+        self.send_failed = true;
+        // A failed sink cannot safely flush auto-generated control output.
+        // Keep only the read state needed to surface already-ready frames.
+        self.control_flush_pending = false;
+        #[cfg(feature = "token-binding")]
+        if let WebSocketTokenBinding::Active(session) = &mut self.token_binding {
             *session = None;
         }
     }
@@ -907,7 +928,7 @@ where
         cx: &mut Context<'_>,
         frame: &mut Option<TransportFrame>,
     ) -> Poll<Result<(), SignalFishError>> {
-        if self.closed || self.peer_close_pending {
+        if self.closed || self.send_failed || self.peer_close_pending {
             return Poll::Ready(Err(SignalFishError::TransportClosed));
         }
         if self.stream.is_none() {
@@ -928,7 +949,7 @@ where
             match ready {
                 Poll::Pending => return Poll::Pending,
                 Poll::Ready(Err(error)) => {
-                    self.mark_terminal();
+                    self.mark_send_failed();
                     return Poll::Ready(Err(SignalFishError::TransportSend(error.to_string())));
                 }
                 Poll::Ready(Ok(())) => {}
@@ -961,7 +982,7 @@ where
             };
             if let Err(error) = send_result {
                 let detail = error.to_string();
-                if let WebSocketError::WriteBufferFull(message) = error {
+                let retryable = if let WebSocketError::WriteBufferFull(message) = error {
                     let restored = if token_binding_active {
                         // The exact original remains in the caller slot. Never
                         // restore the protected envelope or a retry would wrap it twice.
@@ -1001,18 +1022,19 @@ where
                             _ => false,
                         }
                     };
-                    if !restored {
-                        self.mark_terminal();
-                    }
+                    restored
                 } else {
-                    self.mark_terminal();
+                    false
+                };
+                if !retryable {
+                    self.mark_send_failed();
                 }
                 return Poll::Ready(Err(SignalFishError::TransportSend(detail)));
             }
             if token_binding_active {
                 let _accepted_original = frame.take();
                 if let Err(error) = self.token_binding.commit() {
-                    self.mark_terminal();
+                    self.mark_send_failed();
                     return Poll::Ready(Err(error));
                 }
             }
@@ -1031,7 +1053,7 @@ where
                 Poll::Ready(Ok(()))
             }
             Poll::Ready(Err(error)) => {
-                self.mark_terminal();
+                self.mark_send_failed();
                 Poll::Ready(Err(SignalFishError::TransportSend(error.to_string())))
             }
             Poll::Pending => Poll::Pending,
@@ -1079,6 +1101,10 @@ where
             }
 
             if skipped_control_frames == MAX_SKIPPED_CONTROL_FRAMES_PER_POLL {
+                if self.send_failed {
+                    self.mark_terminal();
+                    return Poll::Ready(None);
+                }
                 cx.waker().wake_by_ref();
                 return Poll::Pending;
             }
@@ -1091,7 +1117,13 @@ where
                 Pin::new(stream).poll_next(cx)
             };
             let msg = match next {
-                Poll::Pending => return Poll::Pending,
+                Poll::Pending => {
+                    if self.send_failed {
+                        self.mark_terminal();
+                        return Poll::Ready(None);
+                    }
+                    return Poll::Pending;
+                }
                 Poll::Ready(value) => match value {
                     Some(Ok(msg)) => msg,
                     Some(Err(e)) => {
@@ -1141,12 +1173,18 @@ where
                     // its flush before reporting the terminal receive state so a
                     // polling client cannot strand the handshake after seeing
                     // `None` and ceasing to poll the transport.
+                    if self.send_failed {
+                        self.mark_terminal();
+                        return Poll::Ready(None);
+                    }
                     self.peer_close_pending = true;
                     self.control_flush_pending = true;
                 }
                 Message::Ping(_) => {
                     tracing::trace!("received WebSocket ping (auto-pong handled by tungstenite)");
-                    self.control_flush_pending = true;
+                    if !self.send_failed {
+                        self.control_flush_pending = true;
+                    }
                     skipped_control_frames += 1;
                 }
                 Message::Pong(_) => {
@@ -1169,6 +1207,10 @@ where
             return Poll::Ready(Ok(()));
         }
         if self.stream.is_none() {
+            self.mark_terminal();
+            return Poll::Ready(Ok(()));
+        }
+        if self.send_failed {
             self.mark_terminal();
             return Poll::Ready(Ok(()));
         }
@@ -1258,6 +1300,7 @@ mod tests {
     use futures_util::{SinkExt, StreamExt};
     #[cfg(all(feature = "tls", feature = "token-binding"))]
     use rustls::client::ResolvesClientCert as _;
+    use std::collections::VecDeque;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
     use std::task::{Wake, Waker};
@@ -1901,6 +1944,49 @@ mod tests {
         ended: bool,
     }
 
+    struct SendErrorBufferedWebSocket {
+        buffered: VecDeque<Message>,
+    }
+
+    impl Stream for SendErrorBufferedWebSocket {
+        type Item = Result<Message, WebSocketError>;
+
+        fn poll_next(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+            self.buffered
+                .pop_front()
+                .map_or(Poll::Pending, |message| Poll::Ready(Some(Ok(message))))
+        }
+    }
+
+    impl Sink<Message> for SendErrorBufferedWebSocket {
+        type Error = WebSocketError;
+
+        fn poll_ready(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Err(WebSocketError::ConnectionClosed))
+        }
+
+        fn start_send(self: Pin<&mut Self>, _item: Message) -> Result<(), Self::Error> {
+            Err(WebSocketError::ConnectionClosed)
+        }
+
+        fn poll_flush(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Err(WebSocketError::ConnectionClosed))
+        }
+
+        fn poll_close(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Err(WebSocketError::ConnectionClosed))
+        }
+    }
+
     impl Stream for SyntheticWebSocket {
         type Item = Result<Message, WebSocketError>;
 
@@ -2059,6 +2145,7 @@ mod tests {
                     ..TransportCloseInfo::default()
                 }),
                 send_started: false,
+                send_failed: true,
                 control_flush_pending: false,
                 peer_close_pending: false,
                 token_binding: WebSocketTokenBinding::Disabled,
@@ -2070,7 +2157,7 @@ mod tests {
         assert_eq!(
             output,
             "WebSocketTransport { has_stream: false, closed: true, has_close_info: true, \
-             send_started: false, control_flush_pending: false, peer_close_pending: false, \
+             send_started: false, send_failed: true, control_flush_pending: false, peer_close_pending: false, \
              token_binding: Disabled }"
         );
     }
@@ -2337,6 +2424,41 @@ mod tests {
     }
 
     #[test]
+    fn send_error_preserves_one_buffered_inbound_farewell_until_ready_drain() {
+        let farewell = r#"{"type":"Error","data":{"message":"Disconnected as a slow consumer","error_code":"SLOW_CONSUMER"}}"#;
+        let mut state = WebSocketState::new(SendErrorBufferedWebSocket {
+            buffered: VecDeque::from([
+                Message::Ping(b"before-farewell".to_vec().into()),
+                Message::Text(farewell.into()),
+            ]),
+        });
+        let (_wake_counter, waker) = counting_waker();
+        let mut cx = Context::from_waker(&waker);
+        let expected = TransportFrame::Text("caller-owned".into());
+        let mut offered = Some(expected.clone());
+
+        assert!(matches!(
+            state.poll_send(&mut cx, &mut offered),
+            Poll::Ready(Err(SignalFishError::TransportSend(_)))
+        ));
+        assert_eq!(offered, Some(expected));
+        assert!(state.send_failed);
+        assert!(!state.closed);
+        assert!(state.stream.is_some());
+
+        assert_eq!(
+            expect_received_frame(match state.poll_recv(&mut cx) {
+                Poll::Ready(received) => received,
+                Poll::Pending => panic!("buffered farewell must remain immediately ready"),
+            }),
+            TransportFrame::Text(farewell.into())
+        );
+        assert!(matches!(state.poll_recv(&mut cx), Poll::Ready(None)));
+        assert!(state.closed);
+        assert!(state.stream.is_none());
+    }
+
+    #[test]
     fn raw_eof_fuses_receive_send_and_close_operations() {
         let mut state = WebSocketState::new(SyntheticWebSocket { ended: true });
         state.send_started = true;
@@ -2391,10 +2513,8 @@ mod tests {
                 Poll::Ready(Err(SignalFishError::TransportSend(_)))
             ));
             assert_eq!(frame, Some(expected));
-            assert!(
-                !state.closed,
-                "a per-message buffer refusal is not terminal"
-            );
+            assert!(!state.closed, "a per-message refusal is retryable");
+            assert!(!state.send_failed, "the restored frame may be retried");
             assert!(!state.send_started);
         }
     }
@@ -2834,7 +2954,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn socket_send_error_maps_to_transport_send_and_becomes_terminal() {
+    async fn socket_send_error_rejects_later_sends_and_receive_fuses_transport() {
         let mut transport = connect_to_reset_peer().await;
         tokio::time::timeout(
             std::time::Duration::from_secs(1),
@@ -2851,15 +2971,18 @@ mod tests {
         .await
         .expect("reset socket must wake the send poll");
         assert!(matches!(first, Err(SignalFishError::TransportSend(_))));
-        assert!(transport.state.closed);
-        assert!(transport.state.stream.is_none());
+        assert!(transport.state.send_failed);
+        assert!(!transport.state.closed);
+        assert!(transport.state.stream.is_some());
 
         let expected = TransportFrame::Text("second".into());
         let mut offered = Some(expected.clone());
         let second = std::future::poll_fn(|cx| transport.poll_send(cx, &mut offered)).await;
         assert!(matches!(second, Err(SignalFishError::TransportClosed)));
         assert_eq!(offered, Some(expected));
-        assert!(crate::transport::recv_frame(&mut transport).await.is_none());
+        let _ = crate::transport::recv_frame(&mut transport).await;
+        assert!(transport.state.closed);
+        assert!(transport.state.stream.is_none());
         crate::transport::close_transport(&mut transport)
             .await
             .expect("close after send failure must be idempotent");

--- a/tests/polling_parity_tests.rs
+++ b/tests/polling_parity_tests.rs
@@ -22,7 +22,9 @@ use std::sync::{Arc, Mutex};
 
 use signal_fish_client::client::{SignalFishClient, SignalFishConfig};
 use signal_fish_client::error::SignalFishError;
-use signal_fish_client::polling_client::SignalFishPollingClient;
+use signal_fish_client::polling_client::{
+    PollingClientOptions, PollingWorkBudget, SignalFishPollingClient,
+};
 use signal_fish_client::protocol::{
     ClientMessage, ConnectionInfo, DeliveryClass, DeliveryCountersByClass, DeliveryGap,
     DeliveryGapReason, DeliveryReportPayload, GameDataEncoding, LatestDeliveryCounters, LobbyState,
@@ -943,6 +945,282 @@ struct SharedMock {
     required_room_commands: Arc<Mutex<RoomCommandRequirements>>,
     gate_room_responses: bool,
     gate_reconnect_responses: bool,
+}
+
+#[derive(Clone)]
+enum PostFailureRecv {
+    Farewell,
+    Pong,
+    PongBytes(usize),
+    ProtocolViolation,
+    Pending,
+    Eof,
+    Error,
+}
+
+struct SendFailureFarewellState {
+    authenticate_sent: bool,
+    authenticated_delivered: bool,
+    send_failed: bool,
+    pre_failure: VecDeque<PostFailureRecv>,
+    post_failure: VecDeque<PostFailureRecv>,
+    post_failure_recv_calls: usize,
+    ping_attempts: usize,
+    close_calls: usize,
+    abort_calls: usize,
+    close_info: Option<signal_fish_client::TransportCloseInfo>,
+    waker: Option<std::task::Waker>,
+}
+
+/// Refuses the first post-authentication Ping without taking its frame, then
+/// makes a complete server farewell and EOF immediately ready. The same mock
+/// drives both clients at the duplex send/receive failure boundary.
+#[derive(Clone)]
+struct SendFailureFarewellTransport {
+    state: Arc<Mutex<SendFailureFarewellState>>,
+}
+
+impl SendFailureFarewellTransport {
+    fn new(
+        post_failure: impl IntoIterator<Item = PostFailureRecv>,
+        close_info: Option<signal_fish_client::TransportCloseInfo>,
+    ) -> Self {
+        Self {
+            state: Arc::new(Mutex::new(SendFailureFarewellState {
+                authenticate_sent: false,
+                authenticated_delivered: false,
+                send_failed: false,
+                pre_failure: VecDeque::new(),
+                post_failure: post_failure.into_iter().collect(),
+                post_failure_recv_calls: 0,
+                ping_attempts: 0,
+                close_calls: 0,
+                abort_calls: 0,
+                close_info,
+                waker: None,
+            })),
+        }
+    }
+
+    fn with_pre_failure(self, steps: impl IntoIterator<Item = PostFailureRecv>) -> Self {
+        self.state.lock().unwrap().pre_failure = steps.into_iter().collect();
+        self
+    }
+
+    fn ping_attempts(&self) -> usize {
+        self.state.lock().unwrap().ping_attempts
+    }
+
+    fn send_failed(&self) -> bool {
+        self.state.lock().unwrap().send_failed
+    }
+
+    fn close_calls(&self) -> usize {
+        self.state.lock().unwrap().close_calls
+    }
+
+    fn abort_calls(&self) -> usize {
+        self.state.lock().unwrap().abort_calls
+    }
+
+    fn post_failure_recv_calls(&self) -> usize {
+        self.state.lock().unwrap().post_failure_recv_calls
+    }
+
+    fn poll_recv_step(
+        step: PostFailureRecv,
+    ) -> std::task::Poll<Option<Result<TransportFrame, SignalFishError>>> {
+        let result = match step {
+            PostFailureRecv::Farewell => Ok(TransportFrame::Text(
+                r#"{"type":"Error","data":{"message":"Disconnected as a slow consumer","error_code":"SLOW_CONSUMER"}}"#.into(),
+            )),
+            PostFailureRecv::Pong => Ok(TransportFrame::Text(r#"{"type":"Pong"}"#.into())),
+            PostFailureRecv::PongBytes(bytes) => {
+                let mut pong = r#"{"type":"Pong"}"#.to_string();
+                pong.extend(std::iter::repeat_n(' ', bytes.saturating_sub(pong.len())));
+                Ok(TransportFrame::Text(pong))
+            }
+            PostFailureRecv::ProtocolViolation => Ok(TransportFrame::Text(AUTH.into())),
+            PostFailureRecv::Pending => return std::task::Poll::Pending,
+            PostFailureRecv::Eof => return std::task::Poll::Ready(None),
+            PostFailureRecv::Error => Err(SignalFishError::TransportReceive(
+                "scripted read failure".into(),
+            )),
+        };
+        std::task::Poll::Ready(Some(result))
+    }
+}
+
+impl Default for SendFailureFarewellTransport {
+    fn default() -> Self {
+        Self::new([PostFailureRecv::Farewell, PostFailureRecv::Eof], None)
+    }
+}
+
+impl Transport for SendFailureFarewellTransport {
+    fn abort(&mut self) {
+        let mut state = self.state.lock().unwrap();
+        state.abort_calls = state.abort_calls.saturating_add(1);
+        let _ = state.waker.take();
+    }
+
+    fn poll_send(
+        &mut self,
+        _cx: &mut std::task::Context<'_>,
+        frame: &mut Option<TransportFrame>,
+    ) -> std::task::Poll<Result<(), SignalFishError>> {
+        let message = frame.as_ref().and_then(|frame| match frame {
+            TransportFrame::Text(json) => serde_json::from_str::<ClientMessage>(json).ok(),
+            TransportFrame::Binary(_) => None,
+        });
+        let mut state = self.state.lock().unwrap();
+        match message {
+            Some(ClientMessage::Authenticate { .. }) => {
+                let _ = frame.take();
+                state.authenticate_sent = true;
+                if let Some(waker) = state.waker.take() {
+                    waker.wake();
+                }
+                std::task::Poll::Ready(Ok(()))
+            }
+            Some(ClientMessage::Ping) => {
+                state.ping_attempts = state.ping_attempts.saturating_add(1);
+                state.send_failed = true;
+                if let Some(waker) = state.waker.take() {
+                    waker.wake();
+                }
+                std::task::Poll::Ready(Err(SignalFishError::TransportSend(
+                    "scripted write failure".into(),
+                )))
+            }
+            _ => panic!("farewell transport received an unexpected outbound frame"),
+        }
+    }
+
+    fn poll_recv(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Result<TransportFrame, SignalFishError>>> {
+        let mut state = self.state.lock().unwrap();
+        if state.authenticate_sent && !state.authenticated_delivered {
+            state.authenticated_delivered = true;
+            return std::task::Poll::Ready(Some(Ok(TransportFrame::Text(AUTH.into()))));
+        }
+        if !state.send_failed {
+            if let Some(step) = state.pre_failure.pop_front() {
+                let polled = Self::poll_recv_step(step);
+                if polled.is_ready() {
+                    return polled;
+                }
+            }
+        }
+        if state.send_failed {
+            state.post_failure_recv_calls = state.post_failure_recv_calls.saturating_add(1);
+            if let Some(step) = state.post_failure.pop_front() {
+                let polled = Self::poll_recv_step(step);
+                if polled.is_ready() {
+                    return polled;
+                }
+            }
+        }
+        state.waker = Some(cx.waker().clone());
+        std::task::Poll::Pending
+    }
+
+    fn poll_close(
+        &mut self,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), SignalFishError>> {
+        let mut state = self.state.lock().unwrap();
+        state.close_calls = state.close_calls.saturating_add(1);
+        std::task::Poll::Ready(Ok(()))
+    }
+
+    fn close_info(&self) -> Option<signal_fish_client::TransportCloseInfo> {
+        self.state.lock().unwrap().close_info.clone()
+    }
+}
+
+async fn wait_until(condition: impl Fn() -> bool) {
+    tokio::time::timeout(std::time::Duration::from_secs(1), async {
+        while !condition() {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("scripted transport state should advance promptly");
+}
+
+async fn count_async_terminal_pongs(
+    steps: impl IntoIterator<Item = PostFailureRecv>,
+) -> (usize, usize) {
+    let transport = SendFailureFarewellTransport::new(steps, None);
+    let observer = transport.clone();
+    let (mut client, mut events) = SignalFishClient::start(transport, SignalFishConfig::new("app"));
+    assert!(matches!(
+        events.recv().await,
+        Some(SignalFishEvent::Connected)
+    ));
+    assert!(matches!(
+        events.recv().await,
+        Some(SignalFishEvent::Authenticated { .. })
+    ));
+    client
+        .ping()
+        .expect("scripted async Ping should be admitted");
+    let pongs = tokio::time::timeout(std::time::Duration::from_secs(1), async {
+        let mut pongs = 0usize;
+        loop {
+            match events
+                .recv()
+                .await
+                .expect("terminal event channel must remain open through Disconnected")
+            {
+                SignalFishEvent::Pong => pongs = pongs.saturating_add(1),
+                SignalFishEvent::Disconnected { .. } => break pongs,
+                other => panic!("unexpected async terminal event: {other:?}"),
+            }
+        }
+    })
+    .await
+    .expect("bounded terminal drain must reach Disconnected");
+    client.shutdown().await;
+    (pongs, observer.post_failure_recv_calls())
+}
+
+fn count_polling_terminal_pongs(
+    steps: impl IntoIterator<Item = PostFailureRecv>,
+    receive_frames: usize,
+    receive_bytes: usize,
+) -> (usize, usize, u64) {
+    let transport = SendFailureFarewellTransport::new(steps, None);
+    let observer = transport.clone();
+    let options = PollingClientOptions {
+        work_budget: PollingWorkBudget {
+            receive_frames,
+            receive_bytes,
+            ..PollingWorkBudget::default()
+        },
+        ..PollingClientOptions::default()
+    };
+    let mut client =
+        SignalFishPollingClient::new_with_options(transport, SignalFishConfig::new("app"), options);
+    let _ = client.poll();
+    client.ping().expect("polling Ping should be admitted");
+    let events = client.poll();
+    let pongs = events
+        .iter()
+        .filter(|event| matches!(event, SignalFishEvent::Pong))
+        .count();
+    assert!(matches!(
+        events.last(),
+        Some(SignalFishEvent::Disconnected { .. })
+    ));
+    let recv_calls = observer.post_failure_recv_calls();
+    let exhaustions = client.polling_stats().receive_budget_exhaustions;
+    let _ = client.poll();
+    assert_eq!(observer.post_failure_recv_calls(), recv_calls);
+    (pongs, recv_calls, exhaustions)
 }
 
 impl SharedMock {
@@ -4662,4 +4940,567 @@ async fn parity_disconnected_carries_last_server_error() {
         async_info.error_code,
         Some(signal_fish_client::ErrorCode::SlowConsumer)
     );
+}
+
+#[tokio::test]
+async fn parity_ready_farewell_survives_simultaneous_send_failure() {
+    let async_transport = SendFailureFarewellTransport::default();
+    let async_observer = async_transport.clone();
+    let async_config = SignalFishConfig::new("app")
+        .with_event_channel_capacity(1)
+        .with_command_channel_capacity(4);
+    let (mut async_client, mut async_events) =
+        SignalFishClient::start(async_transport, async_config);
+
+    assert!(matches!(
+        async_events.recv().await,
+        Some(SignalFishEvent::Connected)
+    ));
+    wait_until(|| async_client.is_authenticated() && async_events.capacity() == 0).await;
+    async_client
+        .ping()
+        .expect("first Ping should enter the async command queue");
+    async_client
+        .ping()
+        .expect("second Ping should queue behind the failing command");
+    wait_until(|| async_observer.send_failed()).await;
+    assert!(matches!(
+        async_client.ping(),
+        Err(SignalFishError::NotConnected)
+    ));
+    assert!(matches!(
+        async_events.recv().await,
+        Some(SignalFishEvent::Authenticated { .. })
+    ));
+
+    let async_farewell =
+        tokio::time::timeout(std::time::Duration::from_secs(1), async_events.recv())
+            .await
+            .expect("ready farewell should make progress through event delivery")
+            .expect("farewell event channel should remain open");
+    assert!(matches!(
+        async_farewell,
+        SignalFishEvent::Error {
+            error_code: Some(ErrorCode::SlowConsumer),
+            ..
+        }
+    ));
+    let async_terminal =
+        tokio::time::timeout(std::time::Duration::from_secs(1), async_events.recv())
+            .await
+            .expect("Disconnected should follow the farewell")
+            .expect("terminal event channel should remain open");
+    let SignalFishEvent::Disconnected {
+        reason: async_reason,
+        last_server_error: async_error,
+    } = async_terminal
+    else {
+        panic!("expected async Disconnected after farewell");
+    };
+    assert_eq!(
+        async_reason.as_deref(),
+        Some("transport send error: scripted write failure")
+    );
+    let async_error = async_error.expect("async disconnect should attribute the farewell");
+    assert_eq!(async_error.error_code, Some(ErrorCode::SlowConsumer));
+    assert_eq!(async_observer.ping_attempts(), 1);
+    assert_eq!(async_observer.close_calls(), 1);
+    assert!(
+        tokio::time::timeout(std::time::Duration::from_secs(1), async_events.recv())
+            .await
+            .expect("terminal event sender should be dropped")
+            .is_none(),
+        "no event may follow Disconnected"
+    );
+
+    let polling_transport = SendFailureFarewellTransport::default();
+    let polling_observer = polling_transport.clone();
+    let mut polling_client =
+        SignalFishPollingClient::new(polling_transport, SignalFishConfig::new("app"));
+    let setup_events = polling_client.poll();
+    assert!(matches!(
+        setup_events.as_slice(),
+        [
+            SignalFishEvent::Connected,
+            SignalFishEvent::Authenticated { .. }
+        ]
+    ));
+    polling_client
+        .ping()
+        .expect("first Ping should enter the polling command queue");
+    polling_client
+        .ping()
+        .expect("second Ping should queue behind the failing command");
+
+    let polling_events = polling_client.poll();
+    assert!(matches!(
+        polling_events.as_slice(),
+        [
+            SignalFishEvent::Error {
+                error_code: Some(ErrorCode::SlowConsumer),
+                ..
+            },
+            SignalFishEvent::Disconnected { .. }
+        ]
+    ));
+    let SignalFishEvent::Disconnected {
+        reason: polling_reason,
+        last_server_error: polling_error,
+    } = &polling_events[1]
+    else {
+        unreachable!("slice shape asserted above")
+    };
+    assert_eq!(polling_reason, &async_reason);
+    assert_eq!(
+        polling_error.as_ref(),
+        Some(&async_error),
+        "both drivers must attribute the same terminal server farewell"
+    );
+    assert_eq!(polling_observer.ping_attempts(), 1);
+    assert!(matches!(
+        polling_client.ping(),
+        Err(SignalFishError::NotConnected)
+    ));
+
+    async_client.shutdown().await;
+}
+
+#[tokio::test]
+async fn shutdown_preempts_capacity_one_send_failure_drain() {
+    let transport = SendFailureFarewellTransport::default();
+    let observer = transport.clone();
+    let config = SignalFishConfig::new("app")
+        .with_event_channel_capacity(1)
+        .with_command_channel_capacity(4)
+        .with_shutdown_timeout(std::time::Duration::from_secs(5));
+    let (mut client, mut events) = SignalFishClient::start(transport, config);
+
+    assert!(matches!(
+        events.recv().await,
+        Some(SignalFishEvent::Connected)
+    ));
+    wait_until(|| client.is_authenticated() && events.capacity() == 0).await;
+    client
+        .ping()
+        .expect("Ping should enter the async command queue");
+    client
+        .ping()
+        .expect("queued work behind the failing Ping should be discarded");
+    wait_until(|| observer.send_failed()).await;
+
+    tokio::time::timeout(std::time::Duration::from_millis(250), client.shutdown())
+        .await
+        .expect("shutdown should preempt blocked farewell delivery");
+    assert!(!client.is_connected());
+    assert!(!client.is_authenticated());
+    assert_eq!(observer.ping_attempts(), 1);
+    assert_eq!(observer.close_calls(), 1);
+
+    assert!(matches!(
+        events.recv().await,
+        Some(SignalFishEvent::Authenticated { .. })
+    ));
+    assert!(events.recv().await.is_none());
+}
+
+#[tokio::test(start_paused = true)]
+async fn terminal_deadline_bounds_blocked_async_farewell_delivery() {
+    let transport = SendFailureFarewellTransport::default();
+    let observer = transport.clone();
+    let config = SignalFishConfig::new("app")
+        .with_event_channel_capacity(1)
+        .with_shutdown_timeout(std::time::Duration::from_millis(20));
+    let (mut client, mut events) = SignalFishClient::start(transport, config);
+
+    assert!(matches!(
+        events.recv().await,
+        Some(SignalFishEvent::Connected)
+    ));
+    wait_until(|| client.is_authenticated() && events.capacity() == 0).await;
+    client
+        .ping()
+        .expect("Ping should enter the async command queue");
+    wait_until(|| observer.send_failed()).await;
+    tokio::time::advance(std::time::Duration::from_millis(20)).await;
+    wait_until(|| !client.is_connected()).await;
+
+    assert_eq!(observer.ping_attempts(), 1);
+    assert_eq!(observer.post_failure_recv_calls(), 1);
+    assert_eq!(observer.close_calls(), 0);
+    assert_eq!(observer.abort_calls(), 1);
+    assert!(matches!(
+        events.recv().await,
+        Some(SignalFishEvent::Authenticated { .. })
+    ));
+    assert!(events.recv().await.is_none());
+    client.shutdown().await;
+}
+
+#[test]
+fn zero_terminal_deadline_skips_polling_farewell_drain() {
+    let transport = SendFailureFarewellTransport::default();
+    let observer = transport.clone();
+    let config = SignalFishConfig::new("app").with_shutdown_timeout(std::time::Duration::ZERO);
+    let mut client = SignalFishPollingClient::new(transport, config);
+    let _ = client.poll();
+    client
+        .ping()
+        .expect("Ping should enter the polling command queue");
+
+    let events = client.poll();
+    assert!(matches!(
+        events.as_slice(),
+        [SignalFishEvent::Disconnected {
+            last_server_error: None,
+            ..
+        }]
+    ));
+    assert_eq!(observer.post_failure_recv_calls(), 0);
+    assert_eq!(observer.ping_attempts(), 1);
+    assert_eq!(observer.abort_calls(), 1);
+}
+
+#[tokio::test]
+async fn terminal_send_failure_cause_precedence_and_ready_stop_are_driver_aligned() {
+    struct Case {
+        name: &'static str,
+        steps: Vec<PostFailureRecv>,
+        close_info: Option<signal_fish_client::TransportCloseInfo>,
+        expected_reason: &'static str,
+        expected_error_event: bool,
+        expected_recv_calls: usize,
+    }
+
+    let peer_close = signal_fish_client::TransportCloseInfo {
+        code: Some(4000),
+        reason: Some("peer ended".into()),
+        clean: Some(true),
+        initiated_by_peer: true,
+    };
+    let local_close = signal_fish_client::TransportCloseInfo {
+        initiated_by_peer: false,
+        ..peer_close.clone()
+    };
+    let cases = [
+        Case {
+            name: "Pending preserves the send failure and is never repolled",
+            steps: vec![PostFailureRecv::Pending, PostFailureRecv::Pong],
+            close_info: None,
+            expected_reason: "transport send error: scripted write failure",
+            expected_error_event: false,
+            expected_recv_calls: 1,
+        },
+        Case {
+            name: "bare EOF preserves the send failure",
+            steps: vec![PostFailureRecv::Eof],
+            close_info: None,
+            expected_reason: "transport send error: scripted write failure",
+            expected_error_event: false,
+            expected_recv_calls: 1,
+        },
+        Case {
+            name: "peer close metadata overrides the send failure at EOF",
+            steps: vec![PostFailureRecv::Eof],
+            close_info: Some(peer_close.clone()),
+            expected_reason: "closed by server: code=Some(4000), reason=Some(\"peer ended\")",
+            expected_error_event: false,
+            expected_recv_calls: 1,
+        },
+        Case {
+            name: "receive error preserves the send failure",
+            steps: vec![PostFailureRecv::Error],
+            close_info: None,
+            expected_reason: "transport send error: scripted write failure",
+            expected_error_event: false,
+            expected_recv_calls: 1,
+        },
+        Case {
+            name: "peer metadata and farewell attribution remain independent",
+            steps: vec![PostFailureRecv::Farewell, PostFailureRecv::Eof],
+            close_info: Some(peer_close),
+            expected_reason: "closed by server: code=Some(4000), reason=Some(\"peer ended\")",
+            expected_error_event: true,
+            expected_recv_calls: 2,
+        },
+        Case {
+            name: "non-peer metadata does not override the send failure",
+            steps: vec![PostFailureRecv::Farewell, PostFailureRecv::Eof],
+            close_info: Some(local_close),
+            expected_reason: "transport send error: scripted write failure",
+            expected_error_event: true,
+            expected_recv_calls: 2,
+        },
+    ];
+
+    for case in cases {
+        let async_transport =
+            SendFailureFarewellTransport::new(case.steps.clone(), case.close_info.clone());
+        let async_observer = async_transport.clone();
+        let (mut async_client, mut async_events) =
+            SignalFishClient::start(async_transport, SignalFishConfig::new("app"));
+        assert!(matches!(
+            async_events.recv().await,
+            Some(SignalFishEvent::Connected)
+        ));
+        assert!(matches!(
+            async_events.recv().await,
+            Some(SignalFishEvent::Authenticated { .. })
+        ));
+        async_client
+            .ping()
+            .expect("scripted async Ping should be admitted");
+
+        let mut async_terminal_events = Vec::new();
+        for _ in 0..3 {
+            let event =
+                tokio::time::timeout(std::time::Duration::from_secs(1), async_events.recv())
+                    .await
+                    .unwrap_or_else(|_| panic!("{}: async terminal event timed out", case.name))
+                    .unwrap_or_else(|| panic!("{}: async event channel closed early", case.name));
+            let disconnected = matches!(event, SignalFishEvent::Disconnected { .. });
+            async_terminal_events.push(event);
+            if disconnected {
+                break;
+            }
+        }
+
+        let polling_transport = SendFailureFarewellTransport::new(case.steps, case.close_info);
+        let polling_observer = polling_transport.clone();
+        let mut polling_client =
+            SignalFishPollingClient::new(polling_transport, SignalFishConfig::new("app"));
+        let setup = polling_client.poll();
+        assert_eq!(setup.len(), 2, "{}: polling setup events", case.name);
+        polling_client
+            .ping()
+            .expect("scripted polling Ping should be admitted");
+        let polling_terminal_events = polling_client.poll();
+
+        for (driver, events) in [
+            ("async", async_terminal_events.as_slice()),
+            ("polling", polling_terminal_events.as_slice()),
+        ] {
+            assert_eq!(
+                events
+                    .iter()
+                    .filter(|event| matches!(event, SignalFishEvent::Error { .. }))
+                    .count(),
+                usize::from(case.expected_error_event),
+                "{}: {driver} Error event count",
+                case.name
+            );
+            let terminal = events
+                .last()
+                .unwrap_or_else(|| panic!("{}: {driver} terminal events", case.name));
+            let SignalFishEvent::Disconnected {
+                reason,
+                last_server_error,
+            } = terminal
+            else {
+                panic!("{}: {driver} must end with Disconnected", case.name);
+            };
+            assert_eq!(
+                reason.as_deref(),
+                Some(case.expected_reason),
+                "{}: {driver} terminal cause",
+                case.name
+            );
+            assert_eq!(
+                last_server_error.is_some(),
+                case.expected_error_event,
+                "{}: {driver} farewell attribution",
+                case.name
+            );
+        }
+        assert_eq!(
+            async_observer.post_failure_recv_calls(),
+            case.expected_recv_calls,
+            "{}: async receive bound",
+            case.name
+        );
+        assert_eq!(
+            polling_observer.post_failure_recv_calls(),
+            case.expected_recv_calls,
+            "{}: polling receive bound",
+            case.name
+        );
+        let _ = polling_client.poll();
+        assert_eq!(
+            polling_observer.post_failure_recv_calls(),
+            case.expected_recv_calls,
+            "{}: polling close must not resume terminal receive",
+            case.name
+        );
+        async_client.shutdown().await;
+    }
+}
+
+#[tokio::test]
+async fn protocol_directed_disconnect_stops_send_failure_drain_in_both_drivers() {
+    let steps = [PostFailureRecv::ProtocolViolation, PostFailureRecv::Pong];
+    let config = || {
+        SignalFishConfig::new("app")
+            .with_protocol_violation_policy(ProtocolViolationPolicy::Disconnect)
+    };
+
+    let async_transport = SendFailureFarewellTransport::new(steps.clone(), None);
+    let async_observer = async_transport.clone();
+    let (mut async_client, mut async_events) = SignalFishClient::start(async_transport, config());
+    assert!(matches!(
+        async_events.recv().await,
+        Some(SignalFishEvent::Connected)
+    ));
+    assert!(matches!(
+        async_events.recv().await,
+        Some(SignalFishEvent::Authenticated { .. })
+    ));
+    async_client.ping().expect("async Ping should be admitted");
+    assert!(matches!(
+        async_events.recv().await,
+        Some(SignalFishEvent::ProtocolViolation { .. })
+    ));
+    assert!(matches!(
+        async_events.recv().await,
+        Some(SignalFishEvent::Disconnected {
+            last_server_error: None,
+            ..
+        })
+    ));
+    assert_eq!(async_observer.post_failure_recv_calls(), 1);
+
+    let polling_transport = SendFailureFarewellTransport::new(steps, None);
+    let polling_observer = polling_transport.clone();
+    let mut polling_client = SignalFishPollingClient::new(polling_transport, config());
+    let _ = polling_client.poll();
+    polling_client
+        .ping()
+        .expect("polling Ping should be admitted");
+    assert!(matches!(
+        polling_client.poll().as_slice(),
+        [
+            SignalFishEvent::ProtocolViolation { .. },
+            SignalFishEvent::Disconnected {
+                last_server_error: None,
+                ..
+            }
+        ]
+    ));
+    assert_eq!(polling_observer.post_failure_recv_calls(), 1);
+
+    async_client.shutdown().await;
+}
+
+#[test]
+fn polling_send_failure_drain_processes_a_prefetched_farewell_first() {
+    let transport = SendFailureFarewellTransport::new([PostFailureRecv::Pong], None)
+        .with_pre_failure([PostFailureRecv::Farewell]);
+    let observer = transport.clone();
+    let options = PollingClientOptions {
+        work_budget: PollingWorkBudget {
+            receive_frames: 1,
+            ..PollingWorkBudget::default()
+        },
+        ..PollingClientOptions::default()
+    };
+    let mut client =
+        SignalFishPollingClient::new_with_options(transport, SignalFishConfig::new("app"), options);
+    assert!(matches!(
+        client.poll().as_slice(),
+        [
+            SignalFishEvent::Connected,
+            SignalFishEvent::Authenticated { .. }
+        ]
+    ));
+    assert_eq!(client.polling_stats().receive_budget_exhaustions, 1);
+    client.ping().expect("polling Ping should be admitted");
+
+    assert!(matches!(
+        client.poll().as_slice(),
+        [
+            SignalFishEvent::Error {
+                error_code: Some(ErrorCode::SlowConsumer),
+                ..
+            },
+            SignalFishEvent::Disconnected {
+                last_server_error: Some(_),
+                ..
+            }
+        ]
+    ));
+    assert_eq!(observer.post_failure_recv_calls(), 0);
+    assert_eq!(client.polling_stats().receive_budget_exhaustions, 2);
+}
+
+#[tokio::test]
+async fn terminal_send_failure_drain_honors_shared_and_polling_receive_budgets() {
+    const SHARED_LIMIT: usize = 64;
+
+    for (name, steps, expected_frames) in [
+        (
+            "shared frame limit",
+            std::iter::repeat_n(PostFailureRecv::Pong, SHARED_LIMIT + 1).collect::<Vec<_>>(),
+            SHARED_LIMIT,
+        ),
+        (
+            "shared byte limit crossing",
+            vec![
+                PostFailureRecv::PongBytes(32 * 1024),
+                PostFailureRecv::PongBytes(32 * 1024),
+                PostFailureRecv::Pong,
+            ],
+            2,
+        ),
+        (
+            "shared oversized first frame",
+            vec![
+                PostFailureRecv::PongBytes(64 * 1024 + 1),
+                PostFailureRecv::Pong,
+            ],
+            1,
+        ),
+    ] {
+        let (pongs, recv_calls) = count_async_terminal_pongs(steps).await;
+        assert_eq!(pongs, expected_frames, "{name}");
+        assert_eq!(recv_calls, expected_frames, "{name}");
+    }
+
+    for (name, receive_frames, receive_bytes, steps, expected_frames) in [
+        (
+            "smaller caller frame budget",
+            2,
+            usize::MAX,
+            std::iter::repeat_n(PostFailureRecv::Pong, SHARED_LIMIT + 1).collect::<Vec<_>>(),
+            2,
+        ),
+        (
+            "shared polling safety cap",
+            100,
+            usize::MAX,
+            std::iter::repeat_n(PostFailureRecv::Pong, SHARED_LIMIT + 1).collect::<Vec<_>>(),
+            SHARED_LIMIT,
+        ),
+        (
+            "polling byte limit crossing",
+            usize::MAX,
+            32,
+            vec![
+                PostFailureRecv::PongBytes(20),
+                PostFailureRecv::PongBytes(20),
+                PostFailureRecv::Pong,
+            ],
+            2,
+        ),
+        (
+            "polling oversized first frame",
+            usize::MAX,
+            32,
+            vec![PostFailureRecv::PongBytes(33), PostFailureRecv::Pong],
+            1,
+        ),
+    ] {
+        let (pongs, recv_calls, exhaustions) =
+            count_polling_terminal_pongs(steps, receive_frames, receive_bytes);
+        assert_eq!(pongs, expected_frames, "{name}");
+        assert_eq!(recv_calls, expected_frames, "{name}");
+        assert_eq!(exhaustions, 1, "{name}");
+    }
 }


### PR DESCRIPTION
## Summary

- freeze async and polling command admission when a transport send becomes terminal
- drain bounded immediately-ready inbound frames through `ClientCore` before `Disconnected`, preserving farewell attribution and peer-close cause precedence
- retain native WebSocket buffered reads after terminal sink errors while preserving retryable pre-acceptance/`WriteBufferFull` behavior
- apply one absolute deadline across terminal drain, event delivery, and cleanup in both drivers

## Regression coverage

- exact async/polling `Error(SlowConsumer) -> Disconnected` parity
- capacity-one event backpressure, shutdown preemption, and outstanding reliable-send permit race
- frame/byte caps, oversized first frame, prefetched polling input, protocol-directed stop, and no close repoll
- paused async deadline and injected-clock polling deadline
- native WebSocket buffered farewell with a preceding Ping

## Validation

- `cargo fmt`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- no-default-feature Clippy and all repository pre-commit/pre-push policy checks
- three frozen-diff adversarial reviews: zero actionable findings

Closes #134

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes disconnect sequencing, command admission, and native WebSocket send/receive terminal state. Behavior is bounded and well-tested, but it sits on the session-end path.
> 
> **Overview**
> Fixes a duplex race where an outbound `poll_send` error immediately disconnected and dropped an already-ready server `Error` farewell, so `last_server_error` could not attribute SlowConsumer (and similar) evictions.
> 
> Both drivers now freeze new commands, process a bounded set of immediately ready frames through `ClientCore` under one shutdown deadline, then emit `Disconnected`. Only peer-initiated close metadata replaces the original send cause. Native WebSocket keeps buffered reads after a terminal sink error; retryable `WriteBufferFull` and token-binding refusals stay non-terminal. Polling no longer double-prefixes transport errors and will not resume receive after the terminal stop.
> 
> Closes #134.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 904bf45664fc0707ec30393843ef796c10fe065a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->