### PR TITLE
fix: reject superseded session plan replays

### DIFF
--- a/.llm/context.md
+++ b/.llm/context.md
@@ -294,8 +294,8 @@ WebRTC signaling also requires an authoritative `SessionPlan`. Server 0.7
 plans/signals carry a UUID generation; the shared core stamps outgoing signals,
 suppresses stale/unknown inbound generations, rejects self/off-plan/departed
 peers, and snapshots the generation plus selected topology/transport atomically.
-Accepted plans are finalized-room, current-roster shapes limited to the four
-Server 0.7 topology/transport pairs and replace prior peer authority atomically.
+Accepted finalized-room, current-roster plans use one of four Server 0.7 topology/transport pairs and replace peer authority atomically; superseded non-null generations are rejected before authoritative plan fields, peers, or mesh revision change.
+Current-generation duplicates and generation-less Server 0.4 plans remain valid, while authoritative room/session teardown clears replay history.
 `supports_mesh()` reports negotiated WebRTC + Host/Mesh capability, not the
 selected plan. `MeshController` rebuilds retained pairs across generations or
 offerer-role changes. `MeshSession` accepts liveness only for the selected transport.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed delayed or replayed `SessionPlan` messages rolling WebRTC signaling
+  authority back to a superseded generation. Both clients now reject every
+  previously superseded non-null generation before changing the selected
+  generation, topology, transport, peer set, or mesh revision. Current-plan
+  duplicates and generation-less Server 0.4 plans remain compatible, and room
+  or connection teardown clears the replay history.
 - Fixed async and polling clients discarding an immediately ready server
   `Error` farewell when an outbound transport send failed at the same time.
   Both drivers now freeze new commands, process bounded already-ready frames

--- a/PLAN.md
+++ b/PLAN.md
@@ -103,10 +103,14 @@ measured evidence before accepting performance complexity:
    Godot's inbound buffer from 65,535 bytes to 8 MiB before connecting,
    caller-owned peers remain unchanged, and official native plus web runs
    require a valid Signal Fish frame larger than the legacy default. Browser
-   assembly remains platform-owned. Replayed stale session plans are tracked
-   independently by
-   [#135](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/issues/135),
-   and the remaining inventory cells remain separate client audit slices.
+   assembly remains platform-owned. The stale-session-plan replay slice is
+   complete: the shared core retains all superseded non-null generations for
+   the current room/session and rejects a replay before authoritative plan
+   fields, selected path, peer authority, or mesh revision change.
+   Current-generation duplicates, generation-less Server 0.4 plans, both
+   drivers, every violation policy, and teardown boundaries are covered for
+   [#135](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/issues/135).
+   The remaining inventory cells remain separate client audit slices.
 4. Re-run established unsafe-inventory, Miri, fuzz, dependency, and no-panic
    gates. Evaluate focused Loom models and additional sanitizer or lint coverage
    only where target support and owned boundaries make them applicable; promote

--- a/progress/session-047-stale-session-plan-replay.md
+++ b/progress/session-047-stale-session-plan-replay.md
@@ -1,0 +1,72 @@
+# Session 047 — Stale Session-Plan Replay
+
+## Priority and Audit
+
+The session began from clean `main` at
+`b99303849d709355d8fd2f07eca1604b00c95ac8`, the merge of PR #137. The GitHub
+connector found no open pull requests or dependency updates. The actionable
+gameplay-correctness issue was #135 under the #126 audit; #90 remains a
+separate maintainer-administration blocker for live repository governance.
+
+Issue #135 showed that the client accepted any structurally valid
+generation-bearing `SessionPlan`. A delayed plan A arriving after accepted plan
+B therefore restored A's generation, topology, transport, and peer signaling
+authority. A subsequent signal stamped with A became current again, while B's
+real current traffic became stale.
+
+## Design
+
+`ClientCore` now retains every superseded non-null session generation for the
+current room/session. Before accountability or authoritative plan-state,
+peer-set, or async mesh-revision mutation, session-plan validation rejects a
+non-current generation already in that retired set as one lifecycle violation.
+A `HashSet` covers non-adjacent replay such as A → B → C → A rather than
+remembering only the immediately previous plan.
+
+An accepted replacement retires its prior non-null generation. Reasserting the
+current generation remains valid, and generation-less Server 0.4 plans are not
+entered into the UUID replay ledger. Authoritative room baselines, confirmed
+room exits, reconnect baselines, and physical disconnect clear the ledger so a
+UUID from another room/session cannot be rejected by stale local history.
+
+## Regression Evidence
+
+Shared-core tests cover A → B → replayed A under Observe, Quarantine, and
+Disconnect. Plan A is a Mesh/WebRTC plan authorizing one peer; B is a
+Host/WebRTC plan authorizing another. Replayed A emits one lifecycle violation
+without changing B's generation, topology, transport, peer authority, or async
+plan revision; Quarantine changes only its documented quarantine flag. A's
+following signal remains suppressed and B's current signal remains accepted
+for non-terminal policies; Disconnect stops at the replay violation. A separate
+selected-path case proves that a replayed WebRTC plan cannot replace a newer
+Direct plan.
+
+The async/polling parity regression drives the same A → B → A → signal A →
+signal B trace through both public clients for all three policies. Their exact
+event streams, terminal behavior, snapshots, and statistics match. Additional
+tests pin A → B → C → A history, duplicate current generations, repeated
+generation-less plans, room teardown, and physical disconnect.
+
+## Adversarial Review
+
+Parallel code and protocol-authority audits required the ledger to live in the
+shared core, validate before all mutation, accumulate more than one retired
+generation, preserve Server 0.4 omission semantics, and clear at every room or
+connection boundary. Review also rejected an early regression arrangement in
+which old plan A selected Direct transport: it could not prove the reported
+stale-WebRTC reauthorization because signal A would already be invalid. The
+final principal trace makes A WebRTC and verifies both stale-A suppression and
+positive current-B delivery; a separate case isolates transport preservation.
+
+## Verification and Hosted Disposition
+
+The frozen implementation passes the mandatory local chain:
+
+- `cargo fmt`
+- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+- `cargo test --workspace --all-features` (394 core unit tests, 49 polling
+  parity tests, all workspace integration and doc tests; 11 live-server tests
+  remain ignored by their explicit environment contract)
+
+Hosted PR evidence remains pending until the branch is committed, pushed, and
+opened as the session's single pull request.

--- a/progress/session-047-stale-session-plan-replay.md
+++ b/progress/session-047-stale-session-plan-replay.md
@@ -68,5 +68,14 @@ The frozen implementation passes the mandatory local chain:
   parity tests, all workspace integration and doc tests; 11 live-server tests
   remain ignored by their explicit environment contract)
 
-Hosted PR evidence remains pending until the branch is committed, pushed, and
-opened as the session's single pull request.
+PR #138 is the session's single pull request. Its implementation head,
+`54b0f6a033a9305fec245df6f0274516499c8617`, passed all 11 hosted workflows:
+Security, No Panics, Workflow Lint, Unused Deps, WASM, Semver Checks, Examples
+Validation, Coverage, Docs Validation, CI, and Godot Web. The Godot Web matrix
+also passed its official-template build/export and clean Server 0.7, clean
+Server 0.4, soak, and impaired browser scenarios.
+
+The hosted review audit found no inline review threads or actionable review
+feedback. Copilot reported only that its review quota was exhausted; that is a
+known repository-administration limitation tracked separately by #90, not a
+finding against this change.

--- a/src/client_core.rs
+++ b/src/client_core.rs
@@ -133,6 +133,7 @@ pub(crate) struct ClientCore {
     room_players: HashSet<PlayerId>,
     session_plan_seen: bool,
     session_peers: HashSet<PlayerId>,
+    retired_session_generations: HashSet<SessionGeneration>,
     retired_generationless_signal_peers: HashSet<PlayerId>,
     pending_room_operation: Option<PendingRoomOperationState>,
     pending_reconnects: VecDeque<PendingReconnect>,
@@ -236,6 +237,7 @@ impl ClientCore {
             room_players: HashSet::new(),
             session_plan_seen: false,
             session_peers: HashSet::new(),
+            retired_session_generations: HashSet::new(),
             retired_generationless_signal_peers: HashSet::new(),
             pending_room_operation: None,
             pending_reconnects: VecDeque::new(),
@@ -698,6 +700,7 @@ impl ClientCore {
         self.room_players.clear();
         self.session_plan_seen = false;
         self.session_peers.clear();
+        self.retired_session_generations.clear();
         self.retired_generationless_signal_peers.clear();
         self.pending_room_operation = None;
         self.pending_reconnects.clear();
@@ -1387,6 +1390,17 @@ impl ClientCore {
         local_player_id: Option<PlayerId>,
         room_players: &HashSet<PlayerId>,
     ) -> Result<(), String> {
+        if plan.generation != self.snapshot.session_generation
+            && plan
+                .generation
+                .is_some_and(|generation| self.retired_session_generations.contains(&generation))
+        {
+            return Err(format!(
+                "lifecycle violation: SessionPlan generation {:?} was already superseded",
+                plan.generation
+            ));
+        }
+
         if plan.fallback != TransportKind::Relay {
             return Err("lifecycle violation: SessionPlan fallback must be relay".into());
         }
@@ -1785,6 +1799,7 @@ impl ClientCore {
         self.room_players = baseline.players;
         self.session_plan_seen = false;
         self.session_peers.clear();
+        self.retired_session_generations.clear();
         self.retired_generationless_signal_peers.clear();
         self.pending_room_operation = None;
         #[cfg(feature = "tokio-runtime")]
@@ -1807,6 +1822,7 @@ impl ClientCore {
         self.room_players.clear();
         self.session_plan_seen = false;
         self.session_peers.clear();
+        self.retired_session_generations.clear();
         self.retired_generationless_signal_peers.clear();
         self.pending_room_operation = None;
         #[cfg(feature = "tokio-runtime")]
@@ -1820,6 +1836,11 @@ impl ClientCore {
         topology: Topology,
         transport: TransportKind,
     ) {
+        if self.snapshot.session_generation != generation {
+            if let Some(current) = self.snapshot.session_generation {
+                self.retired_session_generations.insert(current);
+            }
+        }
         if self.session_plan_seen
             && self.snapshot.session_generation.is_none()
             && self.snapshot.session_transport == Some(TransportKind::WebRtc)
@@ -3896,14 +3917,173 @@ mod tests {
         let mut core = v3_room(ProtocolViolationPolicy::Observe);
         let mut legacy = plan(Topology::Mesh, TransportKind::WebRtc);
         legacy.generation = None;
-        let outcome = process(&mut core, ServerMessage::SessionPlan(Box::new(legacy)));
-        assert!(matches!(
-            outcome.events.as_slice(),
-            [SignalFishEvent::SessionPlan {
-                generation: None,
-                ..
-            }]
-        ));
+        for _ in 0..2 {
+            let outcome = process(
+                &mut core,
+                ServerMessage::SessionPlan(Box::new(legacy.clone())),
+            );
+            assert!(matches!(
+                outcome.events.as_slice(),
+                [SignalFishEvent::SessionPlan {
+                    generation: None,
+                    ..
+                }]
+            ));
+        }
+        assert!(core.retired_session_generations.is_empty());
+    }
+
+    #[test]
+    fn superseded_session_plan_generation_is_rejected_transactionally_for_every_policy() {
+        let generation_a = SessionGeneration::from_u128(10);
+        let generation_b = SessionGeneration::from_u128(11);
+        let mut plan_a = plan(Topology::Mesh, TransportKind::WebRtc);
+        plan_a.generation = Some(generation_a);
+        plan_a.peers = vec![peer(4)];
+        let mut plan_b = plan(Topology::Host, TransportKind::WebRtc);
+        plan_b.generation = Some(generation_b);
+        plan_b.host = Some(PlayerId::from_u128(LOCAL));
+
+        for policy in [
+            ProtocolViolationPolicy::Observe,
+            ProtocolViolationPolicy::Quarantine,
+            ProtocolViolationPolicy::Disconnect,
+        ] {
+            let mut core = v3_room(policy);
+            assert!(matches!(
+                process(
+                    &mut core,
+                    ServerMessage::SessionPlan(Box::new(plan_a.clone()))
+                )
+                .events
+                .as_slice(),
+                [SignalFishEvent::SessionPlan { .. }]
+            ));
+            assert!(matches!(
+                process(
+                    &mut core,
+                    ServerMessage::SessionPlan(Box::new(plan_b.clone()))
+                )
+                .events
+                .as_slice(),
+                [SignalFishEvent::SessionPlan { .. }]
+            ));
+
+            let before = core.snapshot();
+            let peers_before = core.session_peers.clone();
+            #[cfg(feature = "tokio-runtime")]
+            let revision_before = core.session_plan_revision;
+            let outcome = process(
+                &mut core,
+                ServerMessage::SessionPlan(Box::new(plan_a.clone())),
+            );
+            assert_lifecycle_violation_containing(&outcome, "already superseded");
+            assert_eq!(
+                outcome.disconnect,
+                policy == ProtocolViolationPolicy::Disconnect,
+                "{policy:?}"
+            );
+            assert_eq!(core.snapshot().session_generation, Some(generation_b));
+            assert_eq!(core.snapshot().session_topology, before.session_topology);
+            assert_eq!(core.snapshot().session_transport, before.session_transport);
+            assert_eq!(core.session_peers, peers_before);
+            #[cfg(feature = "tokio-runtime")]
+            assert_eq!(core.session_plan_revision, revision_before);
+            assert_eq!(
+                core.snapshot().quarantined,
+                policy == ProtocolViolationPolicy::Quarantine
+            );
+
+            if policy != ProtocolViolationPolicy::Disconnect {
+                let stale_signal = process(
+                    &mut core,
+                    ServerMessage::Signal {
+                        from: PlayerId::from_u128(4),
+                        generation: Some(generation_a),
+                        signal: serde_json::json!({"Offer": "stale"}),
+                    },
+                );
+                assert!(stale_signal.events.is_empty(), "{policy:?}");
+
+                let current_signal = process(
+                    &mut core,
+                    ServerMessage::Signal {
+                        from: PlayerId::from_u128(PEER),
+                        generation: Some(generation_b),
+                        signal: serde_json::json!({"Offer": "current"}),
+                    },
+                );
+                assert!(matches!(
+                    current_signal.events.as_slice(),
+                    [SignalFishEvent::SignalReceived { .. }]
+                ));
+            }
+        }
+    }
+
+    #[test]
+    fn replayed_webrtc_plan_cannot_replace_the_current_direct_transport() {
+        let mut core = v3_room(ProtocolViolationPolicy::Observe);
+        let mut webrtc = plan(Topology::Mesh, TransportKind::WebRtc);
+        webrtc.generation = Some(SessionGeneration::from_u128(10));
+        let mut direct = plan(Topology::Host, TransportKind::Direct);
+        direct.generation = Some(SessionGeneration::from_u128(11));
+        let _ = process(
+            &mut core,
+            ServerMessage::SessionPlan(Box::new(webrtc.clone())),
+        );
+        let _ = process(&mut core, ServerMessage::SessionPlan(Box::new(direct)));
+
+        let outcome = process(&mut core, ServerMessage::SessionPlan(Box::new(webrtc)));
+        assert_lifecycle_violation_containing(&outcome, "already superseded");
+        assert_eq!(core.snapshot().session_topology, Some(Topology::Host));
+        assert_eq!(
+            core.snapshot().session_transport,
+            Some(TransportKind::Direct)
+        );
+    }
+
+    #[test]
+    fn duplicate_current_session_plan_generation_remains_authoritative() {
+        let mut core = v3_room(ProtocolViolationPolicy::Observe);
+        let current = plan(Topology::Mesh, TransportKind::WebRtc);
+        for _ in 0..2 {
+            let outcome = process(
+                &mut core,
+                ServerMessage::SessionPlan(Box::new(current.clone())),
+            );
+            assert!(matches!(
+                outcome.events.as_slice(),
+                [SignalFishEvent::SessionPlan { .. }]
+            ));
+        }
+        assert!(core.retired_session_generations.is_empty());
+    }
+
+    #[test]
+    fn session_plan_replay_guard_retains_more_than_the_previous_generation() {
+        let mut core = v3_room(ProtocolViolationPolicy::Observe);
+        let mut plan = plan(Topology::Mesh, TransportKind::WebRtc);
+        for generation in [10, 11, 12] {
+            plan.generation = Some(SessionGeneration::from_u128(generation));
+            let outcome = process(
+                &mut core,
+                ServerMessage::SessionPlan(Box::new(plan.clone())),
+            );
+            assert!(matches!(
+                outcome.events.as_slice(),
+                [SignalFishEvent::SessionPlan { .. }]
+            ));
+        }
+        assert_eq!(core.retired_session_generations.len(), 2);
+
+        plan.generation = Some(SessionGeneration::from_u128(10));
+        let outcome = process(&mut core, ServerMessage::SessionPlan(Box::new(plan)));
+        assert_lifecycle_violation_containing(&outcome, "already superseded");
+        assert_eq!(
+            core.snapshot().session_generation,
+            Some(SessionGeneration::from_u128(12))
+        );
     }
 
     #[test]
@@ -4045,6 +4225,54 @@ mod tests {
                 assert_eq!(core.stats(), ClientStats::default());
             }
         }
+    }
+
+    #[test]
+    fn authoritative_reconnect_resets_retired_session_generations_transactionally() {
+        let retired = SessionGeneration::from_u128(10);
+        let reconnecting = || {
+            let mut core = ClientCore::new(
+                Some(GameDataEncoding::Json),
+                ProtocolViolationPolicy::Observe,
+                true,
+            );
+            let _ = process(&mut core, authenticated());
+            let _ = process(&mut core, protocol_info(Some(3)));
+            core.retired_session_generations.insert(retired);
+            core.record_reconnect_admitted(
+                PlayerId::from_u128(LOCAL),
+                RoomId::from_u128(10),
+                "submitted-token".into(),
+            );
+            core
+        };
+
+        let mut accepted = reconnecting();
+        let outcome = process(&mut accepted, reconnected(vec![]));
+        assert!(matches!(
+            outcome.events.as_slice(),
+            [SignalFishEvent::Reconnected { .. }]
+        ));
+        assert!(accepted.retired_session_generations.is_empty());
+        let mut fresh_plan = plan(Topology::Mesh, TransportKind::WebRtc);
+        fresh_plan.generation = Some(retired);
+        let outcome = process(
+            &mut accepted,
+            ServerMessage::SessionPlan(Box::new(fresh_plan)),
+        );
+        assert!(matches!(
+            outcome.events.as_slice(),
+            [SignalFishEvent::SessionPlan { .. }]
+        ));
+
+        let mut rejected = reconnecting();
+        let ServerMessage::Reconnected(mut invalid) = reconnected(vec![]) else {
+            unreachable!("reconnected helper always returns Reconnected")
+        };
+        invalid.replay = None;
+        let outcome = process(&mut rejected, ServerMessage::Reconnected(invalid));
+        assert_lifecycle_violation_containing(&outcome, "replay completeness");
+        assert!(rejected.retired_session_generations.contains(&retired));
     }
 
     #[test]
@@ -4640,11 +4868,34 @@ mod tests {
         assert!(core.snapshot().session_topology.is_none());
         assert!(core.snapshot().session_transport.is_none());
 
+        let mut generated_room = v3_room(ProtocolViolationPolicy::Observe);
+        let _ = process(
+            &mut generated_room,
+            ServerMessage::SessionPlan(Box::new(plan(Topology::Mesh, TransportKind::WebRtc))),
+        );
+        let mut generated_replacement = plan(Topology::Mesh, TransportKind::WebRtc);
+        generated_replacement.generation = Some(SessionGeneration::from_u128(GENERATION + 1));
+        let _ = process(
+            &mut generated_room,
+            ServerMessage::SessionPlan(Box::new(generated_replacement)),
+        );
+        assert!(!generated_room.retired_session_generations.is_empty());
+        generated_room.record_admission(ClientCore::admission_for(&ClientOperation::LeaveRoom));
+        let _ = process(&mut generated_room, ServerMessage::RoomLeft);
+        assert!(generated_room.retired_session_generations.is_empty());
+
         let mut disconnecting = v3_room(ProtocolViolationPolicy::Observe);
         let _ = process(
             &mut disconnecting,
             ServerMessage::SessionPlan(Box::new(plan(Topology::Mesh, TransportKind::WebRtc))),
         );
+        let mut replacement = plan(Topology::Mesh, TransportKind::WebRtc);
+        replacement.generation = Some(SessionGeneration::from_u128(GENERATION + 1));
+        let _ = process(
+            &mut disconnecting,
+            ServerMessage::SessionPlan(Box::new(replacement)),
+        );
+        assert!(!disconnecting.retired_session_generations.is_empty());
         assert_eq!(
             disconnecting.snapshot().session_topology,
             Some(Topology::Mesh)
@@ -4654,6 +4905,7 @@ mod tests {
             Some(TransportKind::WebRtc)
         );
         let _ = disconnecting.disconnect(None);
+        assert!(disconnecting.retired_session_generations.is_empty());
         assert!(disconnecting.snapshot().session_topology.is_none());
         assert!(disconnecting.snapshot().session_transport.is_none());
     }

--- a/tests/polling_parity_tests.rs
+++ b/tests/polling_parity_tests.rs
@@ -3398,6 +3398,118 @@ async fn lifecycle_plan_and_signal_matrix_has_complete_driver_parity() {
     }
 }
 
+#[tokio::test]
+async fn superseded_session_plan_replay_has_complete_driver_policy_parity() {
+    use signal_fish_client::protocol::{SessionPeer, SessionPlanPayload, Topology};
+
+    let local = uuid::Uuid::from_u128(100);
+    let peer_a = uuid::Uuid::from_u128(352);
+    let peer_b = uuid::Uuid::from_u128(350);
+    let generation_a = uuid::Uuid::from_u128(351);
+    let generation_b = uuid::Uuid::from_u128(353);
+    let plan_a = SessionPlanPayload {
+        generation: Some(generation_a),
+        topology: Topology::Mesh,
+        transport: TransportKind::WebRtc,
+        host: None,
+        direct_endpoint: None,
+        peers: vec![SessionPeer {
+            player_id: peer_a,
+            player_name: "old-peer".into(),
+            is_authority: false,
+            initiate: false,
+        }],
+        ice_servers: vec![],
+        fallback: TransportKind::Relay,
+    };
+    let plan_b = SessionPlanPayload {
+        generation: Some(generation_b),
+        topology: Topology::Host,
+        transport: TransportKind::WebRtc,
+        host: Some(local),
+        direct_endpoint: None,
+        peers: vec![SessionPeer {
+            player_id: peer_b,
+            player_name: "current-peer".into(),
+            is_authority: false,
+            initiate: true,
+        }],
+        ice_servers: vec![],
+        fallback: TransportKind::Relay,
+    };
+
+    for policy in [
+        ProtocolViolationPolicy::Observe,
+        ProtocolViolationPolicy::Quarantine,
+        ProtocolViolationPolicy::Disconnect,
+    ] {
+        let mut frames = binary_accountability_prefix(peer_b);
+        frames.push(text_server_frame(ServerMessage::LobbyStateChanged {
+            lobby_state: LobbyState::Finalized,
+            ready_players: vec![local, peer_a, peer_b],
+            all_ready: true,
+        }));
+        frames.extend([
+            text_server_frame(ServerMessage::SessionPlan(Box::new(plan_a.clone()))),
+            text_server_frame(ServerMessage::SessionPlan(Box::new(plan_b.clone()))),
+            text_server_frame(ServerMessage::SessionPlan(Box::new(plan_a.clone()))),
+            text_server_frame(ServerMessage::Signal {
+                from: peer_a,
+                generation: Some(generation_a),
+                signal: serde_json::json!({"Offer": "stale"}),
+            }),
+            text_server_frame(ServerMessage::Signal {
+                from: peer_b,
+                generation: Some(generation_b),
+                signal: serde_json::json!({"Offer": "current"}),
+            }),
+        ]);
+
+        let events = assert_frame_trace_parity(
+            frames,
+            SignalFishConfig::new("app")
+                .enable_v3()
+                .with_protocol_violation_policy(policy),
+        )
+        .await;
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| event.starts_with("SessionPlan|"))
+                .count(),
+            2,
+            "replayed A must not replace B under {policy:?}: {events:?}"
+        );
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| event.starts_with("ProtocolViolation|Lifecycle|"))
+                .count(),
+            1,
+            "replayed A must emit exactly one lifecycle violation under {policy:?}: {events:?}"
+        );
+        let signals = events
+            .iter()
+            .filter(|event| event.starts_with("SignalReceived|"))
+            .collect::<Vec<_>>();
+        if policy == ProtocolViolationPolicy::Disconnect {
+            assert!(
+                signals.is_empty(),
+                "disconnect must terminate before signals"
+            );
+            assert!(events
+                .iter()
+                .any(|event| event.starts_with("Disconnected|")));
+        } else {
+            assert_eq!(signals.len(), 1, "{policy:?}: {events:?}");
+            assert!(
+                signals[0].contains(&generation_b.to_string()) && signals[0].contains("current"),
+                "only B's current signal may survive under {policy:?}: {events:?}"
+            );
+        }
+    }
+}
+
 fn mixed_coalesced_unsupported_report(sender: PlayerId) -> TransportFrame {
     text_server_frame(ServerMessage::DeliveryReport(Box::new(
         DeliveryReportPayload {


### PR DESCRIPTION
## Summary

- retain every superseded non-null `SessionPlan` generation for the current room/session
- reject replayed plans before authoritative generation/topology/transport/peer/mesh-revision mutation
- preserve current-generation duplicates and generation-less Server 0.4 compatibility
- clear replay history transactionally on authoritative room/reconnect baselines, room exit, and physical disconnect
- cover A → B → replayed A → stale/current signals across async and polling clients under Observe, Quarantine, and Disconnect

## Correctness evidence

The primary regression makes plan A a Mesh/WebRTC plan authorizing peer A and plan B a Host/WebRTC plan authorizing peer B. Replayed A emits exactly one lifecycle violation; stale signal A remains suppressed; current signal B remains accepted for non-terminal policies; Disconnect terminates at the replay. Separate cases cover WebRTC → Direct rollback, A → B → C → A, duplicate current generations, repeated generation-less plans, valid/invalid reconnect reset transactionality, room exit, and physical disconnect.

The behavior is bound to the pinned Server 0.7/post-0.7 protocol authority, which uses fresh UUID generations for authoritative plan publications. Server 0.4's omitted generation remains an explicit compatibility case.

## Validation

- `cargo fmt`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- all 18 pre-commit checks
- all 6 pre-push checks
- three independent code/protocol/frozen-diff audits, with all findings resolved

Fixes #135

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared-core session-plan authority and signaling acceptance, so incorrect rejection or ledger reset could drop valid plans or re-enable stale WebRTC peers.
> 
> **Overview**
> Fixes delayed or replayed `SessionPlan` messages restoring a superseded generation, topology, transport, and peer signaling authority.
> 
> `ClientCore` now keeps every retired non-null generation for the current room/session and rejects those replays as a lifecycle violation *before* plan fields, peers, or mesh revision change. Current-generation duplicates and generation-less Server 0.4 plans still apply. Room baselines, reconnect, leave, and disconnect clear the ledger so UUIDs cannot leak across sessions.
> 
> Tests cover A→B→replayed A (and A→B→C→A) under Observe/Quarantine/Disconnect for both drivers, plus WebRTC→Direct rollback and teardown reset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82c2dd0c41de217d869b7b9c48bec46eec718865. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->