### PR TITLE
fix!: gate room operations on authentication and bound terminal delivery

### DIFF
--- a/.llm/context.md
+++ b/.llm/context.md
@@ -300,13 +300,14 @@ Current-generation duplicates and generation-less Server 0.4 plans remain valid,
 selected plan. `MeshController` rebuilds retained pairs across generations or
 offerer-role changes. `MeshSession` accepts liveness only for the selected transport.
 
-Membership pairs `room_role` with room/participant IDs. Commands validate
-connection, transition, role, authority, protocol/session, then queue capacity.
+Membership pairs `room_role` with room/participant IDs. Commands validate connection, authentication (directed room
+operations refuse with `NotAuthenticated` before the server confirms it), transition, role, authority, protocol/session, then queue capacity.
 Admitted joins/leaves/reconnects fence later work until a matching typed terminal response; generic errors/absence stay fenced until teardown.
 A v3-capable config requests `room_operation_ids`; after an exact echo, the core records one fresh UUID at successful queue admission for all five room operations, and only the matching ID/result kind releases it.
-Pre-echo admissions and missing-capability servers stay legacy for that operation's lifetime. Terminal responses without a compatible pending operation violate lifecycle; authoritative spectator removal, disconnect, and room-close need no voluntary leave. Events are never dropped: a full event
-channel backpressures; undecodable frames surface as `DecodeFailed`; events are
-missed only on receiver/handle drop or shutdown (abandons ≤1 in-flight).
+Pre-echo admissions and missing-capability servers stay legacy for that operation's lifetime. Terminal responses without a compatible pending operation violate lifecycle; authoritative spectator removal, disconnect, and room-close need no voluntary leave. Events are never dropped: a full event channel backpressures; undecodable frames surface as `DecodeFailed`;
+events are missed only on receiver/handle drop or preempted delivery — `shutdown`, or an async terminal disconnect facing a
+non-draining consumer, abandons at most the one in-flight delivery (remaining batch events get one nonblocking attempt) after
+`shutdown_timeout` and terminates the loop so parked reliable senders resolve; the polling driver emits synchronously from `poll()`.
 Snapshots distinguish nonterminal `connected`, observed `transport_ready`, server-confirmed `authenticated`, and authoritative room membership.
 Decoded game-data receipt counts before suppression; counters are diagnostic boundaries, not cross-peer delivery equality.
 `SignalFishPollingClient` shares the classified/binary sends, queue bound,
@@ -435,9 +436,8 @@ TLS is opt-in: the default build pulls no crypto stack; `wss://` support
 3. Server responds with `ServerMessage::Authenticated` → `SignalFishEvent::Authenticated`.
 4. Client may then call `join_room`, etc.
 5. Both clients emit synthetic `SignalFishEvent::Connected` when their driver first observes `Transport::is_ready() == true`.
-   `SignalFishEvent::Disconnected` is emitted when the transport closes
-   (best-effort; missed only if the receiver is dropped, shutdown times out,
-   or the handle is dropped without `shutdown()`).
+   `SignalFishEvent::Disconnected` is emitted when the transport closes (best-effort; missed only if the receiver is dropped,
+   delivery was preempted as bounded above, or the handle is dropped without `shutdown()`).
 
 ## Protocol Overview
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,7 +99,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Breaking:** Directed room operations are now refused before the server
   confirms authentication. `join_room`, `leave_room`, `reconnect`,
   `join_as_spectator`, and `leave_spectator` return the new
-  `SignalFishError::NotAuthenticated` variant without queueing anything,
+  `SignalFishError::NotAuthenticated` variant without enqueuing it,
   in both drivers, instead of admitting a command whose admission fence the
   inbound lifecycle gates could never release (a permanent
   `RoomOperationPending` after any early server response). Exhaustive

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Breaking:** Directed room operations are now refused before the server
+  confirms authentication. `join_room`, `leave_room`, `reconnect`,
+  `join_as_spectator`, and `leave_spectator` return the new
+  `SignalFishError::NotAuthenticated` variant without queueing anything,
+  in both drivers, instead of admitting a command whose admission fence the
+  inbound lifecycle gates could never release (a permanent
+  `RoomOperationPending` after any early server response). Exhaustive
+  `SignalFishError` matches must handle the new variant. Follow the documented
+  flow and wait for `SignalFishEvent::Authenticated`; non-room commands keep
+  their existing pre-authentication behavior.
 - **Breaking:** `WebSocketConnectOptions` gains the public
   `max_inbound_message_size` field, and built-in native WebSocket connections
   no longer inherit tungstenite's larger receive defaults. Oversized input is
@@ -181,6 +191,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed a terminal disconnect wedging the async transport loop forever when
+  the event consumer stops draining and `shutdown` is never called. Terminal
+  delivery is now bounded by [`shutdown_timeout`](SignalFishConfig::shutdown_timeout):
+  on expiry the loop attempts one nonblocking delivery of the terminal
+  `Disconnected` event, closes or aborts the transport, and exits — releasing
+  every sender parked on the command queue instead of leaking the task.
+  Shutdown-preempted multi-event frames now attempt their remaining events
+  through the same nonblocking fallback before abandoning them. (The polling
+  client emits events synchronously from `poll()` and was never affected.)
 - Fixed delayed or replayed `SessionPlan` messages rolling WebRTC signaling
   authority back to a superseded generation. Both clients now reject every
   previously superseded non-null generation before changing the selected

--- a/PLAN.md
+++ b/PLAN.md
@@ -34,10 +34,10 @@
   package metadata; repository integration tests, other standalone wire
   fixtures, examples, progress records, and changelog history remain in the
   linked source repository.
-- All 12 push workflows passed on `main` commit `4fc5f5c`, including merged PR
-  #133's negotiated room-operation identity, and on every subsequent merged
-  audit PR through #138. The separate live Repository Policy
-  audit remains red because of issue #90.
+- All 12 push workflows passed on `main` through merged PR #139, and the
+  #126 audit's correctness slices (#128/#129, #132–#136, #139, #140, #141,
+  #142) are all incorporated. The separate live Repository Policy audit
+  remains red because of issue #90.
 
 Completed milestone history and verification evidence live in tracked files
 under `progress/`.
@@ -121,13 +121,22 @@ measured evidence before accepting performance complexity:
     [#135](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/issues/135).
     The negotiated outbound-size contract slice landed via
     [#139](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/pull/139).
-    The remaining inventory cells are tracked as narrowly scoped slices:
+    The last inventory cells are complete:
     [#140](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/issues/140)
-    (authentication-gated room admission),
+    gates the five directed room operations on server-confirmed
+    authentication with the new `SignalFishError::NotAuthenticated` refusal
+    in both drivers,
     [#141](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/issues/141)
-    (bounded terminal disconnect delivery), and
+    bounds async terminal disconnect delivery by `shutdown_timeout` so a
+    wedged consumer can no longer leak the transport loop or park reliable
+    senders forever while keeping the at-most-one-in-flight bound honest for
+    multi-event frames, and
     [#142](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/issues/142)
-    (cancellation-safety pins and dequeue-failure fence release).
+    pins reliable-send cancellation safety and releases operation fences when
+    dequeue-time serialization fails. With these landed, the issue-#126
+    audit's correctness slices are finished; the remaining milestone work is
+    the re-run of established unsafe-inventory, Miri, fuzz, dependency, and
+    no-panic gates plus measured profiling against the 28-cell laboratory.
 4. Re-run established unsafe-inventory, Miri, fuzz, dependency, and no-panic
    gates. Evaluate focused Loom models and additional sanitizer or lint coverage
    only where target support and owned boundaries make them applicable; promote

--- a/docs/client.md
+++ b/docs/client.md
@@ -646,16 +646,19 @@ connection continues with the legacy Server 0.7 wire behavior. Operations
 admitted before the first `ProtocolInfo` also remain legacy for their complete
 request/response lifetime, even if negotiation finishes while one is pending.
 
-Room command admission is role-specific:
+Room command admission is role-specific, and the five directed room operations
+additionally require server-confirmed authentication:
 
 | Local state | Allowed room operations |
 |---|---|
-| Outside a room | `join_room`, `join_as_spectator`, or `reconnect` |
+| Unauthenticated connection | None of them — they return `NotAuthenticated` (wait for the `Authenticated` event) |
+| Authenticated, outside a room | `join_room`, `join_as_spectator`, or `reconnect` |
 | `RoomRole::Player` | leave, game-data, readiness/game-start, authority, connection-info, signaling, and transport-status operations |
 | `RoomRole::Spectator` | `leave_spectator` |
 | Any nonterminal connection | `ping` |
 
 Wrong-state errors are deterministic: `NotConnected` wins first, then
+`NotAuthenticated` for the five directed room operations, then
 `RoomOperationPending`, membership/role and authority errors, protocol/format
 or session-plan errors, and finally `SendBufferFull` at queue admission.
 

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -30,6 +30,7 @@ exhaustive public enum:
 | `TokenBinding` | `TokenBindingFailure` | Native WebSocket token-binding negotiation, challenge validation, key derivation, canonicalization, encoding, or sequence handling failed. Reasons are typed and contain no key, nonce, proof, signature, fingerprint, URL credential, or payload material. See [WebSocket Token Binding](token-binding.md). |
 | `Serialization` | `serde_json::Error` | Failed to serialize or deserialize a protocol message. Implements `From<serde_json::Error>`. |
 | `NotConnected` | — | Attempted an operation requiring an active connection but the client is not connected. |
+| `NotAuthenticated` | — | Attempted a directed room operation (`join_room`, `leave_room`, `reconnect`, `join_as_spectator`, or `leave_spectator`) before the server confirmed authentication. The command was **not** queued; retry once the `Authenticated` event arrives. Non-room commands keep their pre-authentication behavior. |
 | `SendBufferFull` | `capacity: usize` | The bounded outgoing command queue is full — the caller is producing messages faster than the transport can drain them. The message was refused, **not** queued; nothing is silently dropped. See [Handling `SendBufferFull`](#handling-sendbufferfull). |
 | `NotInRoom` | — | Attempted a room operation but the client is not in a room. |
 | `AlreadyInRoom` | — | Attempted to join as a player/spectator or reconnect while already in a room. |
@@ -44,9 +45,10 @@ exhaustive public enum:
 | `Timeout` | — | An operation timed out. |
 | `Io` | `std::io::Error` | An I/O error occurred. Implements `From<std::io::Error>`. |
 
-Local validation has stable precedence: connection state, an admitted pending
-room transition, membership/role, authority, protocol version, format/session
-plan, and then bounded-queue capacity. Invalid state therefore does not consume
+Local validation has stable precedence: connection state, server-confirmed
+authentication for directed room operations, an admitted pending room
+transition, membership/role, authority, protocol version, format/session plan,
+and then bounded-queue capacity. Invalid state therefore does not consume
 queue capacity and is not hidden by `SendBufferFull`.
 
 ### Handling errors from client methods

--- a/src/client.rs
+++ b/src/client.rs
@@ -18,10 +18,12 @@
 //!   only be missed when the loop stops delivering entirely: the receiver was
 //!   dropped, the client handle was dropped without calling
 //!   [`shutdown`](SignalFishClient::shutdown) (which aborts immediately), or
-//!   `shutdown` was requested — a shutdown abandons at most the one event
-//!   delivery it interrupted, closes the transport gracefully, and delivers
-//!   the terminal `Disconnected` best-effort (a receiver that outlives the
-//!   loop also observes the event channel closing).
+//!   delivery was preempted — `shutdown`, or a terminal disconnect facing a
+//!   consumer that never drains, abandon at most the one event delivery they
+//!   interrupt (remaining batch events get one nonblocking attempt), close
+//!   the transport gracefully under [`shutdown_timeout`](SignalFishConfig::shutdown_timeout),
+//!   and deliver the terminal `Disconnected` best-effort (a receiver that
+//!   outlives the loop also observes the event channel closing).
 //! - **Commands** go through a bounded queue and queue admission is never
 //!   silent: the synchronous send methods fail fast with
 //!   [`SignalFishError::SendBufferFull`] when it is full, and the
@@ -219,8 +221,11 @@ pub struct SignalFishConfig {
     /// the consumer gets before that backpressure kicks in. An event can only
     /// be missed when delivery stops entirely: the receiver is dropped, the
     /// client handle is dropped without calling [`SignalFishClient::shutdown`],
-    /// or on `shutdown` — which abandons at most one in-flight event and
-    /// delivers the terminal `Disconnected` best-effort.
+    /// or delivery was preempted — by `shutdown`, or by a terminal disconnect
+    /// facing a consumer that never drains, which abandons at most one
+    /// in-flight event (remaining events of the same frame get one
+    /// nonblocking attempt) after [`shutdown_timeout`](SignalFishConfig::shutdown_timeout)
+    /// and delivers the terminal `Disconnected` best-effort.
     ///
     /// Defaults to **256**. Values below 1 are clamped to 1.
     pub event_channel_capacity: usize,
@@ -869,7 +874,10 @@ impl SignalFishClient {
     /// remains pending), the transport is aborted and the loop normally
     /// returns. A later watchdog cancels the task if it still does not stop.
     /// Task cancellation and handle drop also invoke the transport's required
-    /// abort fallback. After shutdown completes, the event
+    /// abort fallback. The same budget bounds a terminal disconnect when
+    /// `shutdown` is never called: a consumer that wedges permanently cannot
+    /// keep the loop (and every waiting reliable sender) alive past it.
+    /// After shutdown completes, the event
     /// receiver yields the remaining buffered events and then `None` — treat
     /// the channel closing as the authoritative end-of-stream signal.
     pub async fn shutdown(&mut self) {
@@ -915,8 +923,10 @@ impl SignalFishClient {
     ///
     /// # Errors
     ///
-    /// Returns [`SignalFishError::AlreadyInRoom`] when membership already
-    /// exists, [`SignalFishError::RoomOperationPending`] during another room
+    /// Returns [`SignalFishError::NotAuthenticated`] before the server
+    /// confirms authentication, [`SignalFishError::AlreadyInRoom`] when
+    /// membership already exists,
+    /// [`SignalFishError::RoomOperationPending`] during another room
     /// transition, [`SignalFishError::NotConnected`] if the transport has closed,
     /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
     /// is full (the message is **not** queued; nothing is silently dropped).
@@ -928,7 +938,8 @@ impl SignalFishClient {
     ///
     /// # Errors
     ///
-    /// Returns [`SignalFishError::NotInRoom`] outside a room,
+    /// Returns [`SignalFishError::NotAuthenticated`] before the server
+    /// confirms authentication, [`SignalFishError::NotInRoom`] outside a room,
     /// [`SignalFishError::WrongRoomRole`] as a spectator,
     /// [`SignalFishError::RoomOperationPending`] during another room transition,
     /// [`SignalFishError::NotConnected`] if the transport has closed,
@@ -994,6 +1005,11 @@ impl SignalFishClient {
     /// task rather than strictly sequentially. (Do **not** race this send
     /// against the event receiver in a `tokio::select!`: if the event arm
     /// wins, the cancelled send future discards the payload.)
+    ///
+    /// Apart from that racing pattern this method is cancel-safe: dropping
+    /// the returned future while it waits for queue capacity neither queues
+    /// the command nor mutates any state, and the operation is admitted at
+    /// most once per awaited completion.
     ///
     /// # Errors
     ///
@@ -1093,8 +1109,10 @@ impl SignalFishClient {
     ///
     /// # Errors
     ///
-    /// Returns [`SignalFishError::AlreadyInRoom`] when membership already
-    /// exists, [`SignalFishError::RoomOperationPending`] during another room
+    /// Returns [`SignalFishError::NotAuthenticated`] before the server
+    /// confirms authentication, [`SignalFishError::AlreadyInRoom`] when
+    /// membership already exists,
+    /// [`SignalFishError::RoomOperationPending`] during another room
     /// transition, [`SignalFishError::NotConnected`] if the transport has closed,
     /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
     /// is full (the message is **not** queued; nothing is silently dropped).
@@ -1111,8 +1129,10 @@ impl SignalFishClient {
     ///
     /// # Errors
     ///
-    /// Returns [`SignalFishError::AlreadyInRoom`] when membership already
-    /// exists, [`SignalFishError::RoomOperationPending`] during another room
+    /// Returns [`SignalFishError::NotAuthenticated`] before the server
+    /// confirms authentication, [`SignalFishError::AlreadyInRoom`] when
+    /// membership already exists,
+    /// [`SignalFishError::RoomOperationPending`] during another room
     /// transition, [`SignalFishError::NotConnected`] if the transport has closed,
     /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
     /// is full (the message is **not** queued; nothing is silently dropped).
@@ -1133,7 +1153,8 @@ impl SignalFishClient {
     ///
     /// # Errors
     ///
-    /// Returns [`SignalFishError::NotInRoom`] outside a room,
+    /// Returns [`SignalFishError::NotAuthenticated`] before the server
+    /// confirms authentication, [`SignalFishError::NotInRoom`] outside a room,
     /// [`SignalFishError::WrongRoomRole`] as a player,
     /// [`SignalFishError::RoomOperationPending`] during another room transition,
     /// [`SignalFishError::NotConnected`] if the transport has closed,
@@ -1802,22 +1823,73 @@ async fn emit_core_disconnected_or_shutdown(
     reason: Option<String>,
     shutdown_timeout: Duration,
 ) {
+    // Peer-close delivery is bounded by the same budget as graceful
+    // termination: a wedged consumer must not leak the task holding the
+    // command receiver, which would park every waiting reliable sender
+    // forever. On expiry the terminal event falls back to a nonblocking
+    // attempt before the loop terminates.
+    // A timeout so large that its deadline cannot be represented yields
+    // `None`, which restores the historical unbounded wait — matching the
+    // documented behavior of an effectively-never-expiring budget.
+    let deadline = tokio::time::Instant::now().checked_add(shutdown_timeout);
     let event = lock_core(state).disconnect(reason);
     let deliver_event = async {
-        tokio::select! {
-            biased;
-            result = event_tx.send(event.clone()) => {
-                if result.is_err() {
-                    debug!("event channel closed, receiver dropped");
-                }
-            }
-            _ = &mut *shutdown_rx => {
-                let _ = event_tx.try_send(event);
-            }
+        if !emit_terminal_event(event_tx, shutdown_rx, deadline, event.clone()).await {
+            let _ = event_tx.try_send(event);
         }
     };
-    let close = finish_send_and_close_bounded(transport, pending_send, state, shutdown_timeout);
+    let close = finish_send_and_close_bounded(
+        transport,
+        pending_send,
+        state,
+        remaining_shutdown_budget(shutdown_timeout, deadline),
+    );
     let ((), ()) = tokio::join!(deliver_event, close);
+}
+
+/// The time left in a shutdown budget whose deadline was computed earlier.
+#[cfg(feature = "tokio-runtime")]
+fn remaining_shutdown_budget(
+    timeout: Duration,
+    deadline: Option<tokio::time::Instant>,
+) -> Duration {
+    deadline.map_or(timeout, |deadline| {
+        deadline.saturating_duration_since(tokio::time::Instant::now())
+    })
+}
+
+/// Deliver a frame's events, racing each wait against shutdown (and an
+/// optional terminal deadline).
+///
+/// Returns `true` when every event was handed to the channel. When a wait is
+/// preempted mid-batch, the remaining events are attempted through the
+/// nonblocking fallback before being abandoned, so a multi-event frame loses
+/// nothing that could still fit instead of everything after the interrupted
+/// delivery.
+#[cfg(feature = "tokio-runtime")]
+async fn emit_event_batch(
+    event_tx: &mpsc::Sender<SignalFishEvent>,
+    shutdown_rx: &mut tokio::sync::oneshot::Receiver<()>,
+    deadline: Option<tokio::time::Instant>,
+    events: Vec<SignalFishEvent>,
+) -> bool {
+    let mut iter = events.into_iter();
+    for event in iter.by_ref() {
+        let delivered = match deadline {
+            Some(_) => emit_terminal_event(event_tx, shutdown_rx, deadline, event).await,
+            None => !matches!(
+                emit_event_or_shutdown(event_tx, shutdown_rx, event).await,
+                EmitOutcome::ShutdownRequested
+            ),
+        };
+        if !delivered {
+            for remaining in iter {
+                let _ = event_tx.try_send(remaining);
+            }
+            return false;
+        }
+    }
+    true
 }
 
 #[cfg(feature = "tokio-runtime")]
@@ -2007,22 +2079,19 @@ async fn finish_send_failure(
 
         let outcome = lock_core(state).process_frame(frame);
         let protocol_stop = outcome.disconnect;
-        for event in outcome.events {
-            if !emit_terminal_event(event_tx, shutdown_rx, deadline, event).await {
-                delivery_preempted = true;
-                break;
-            }
+        delivery_preempted =
+            !emit_event_batch(event_tx, shutdown_rx, deadline, outcome.events).await;
+        if delivery_preempted {
+            debug!("terminal event delivery was preempted mid-batch after send failure");
+            break;
         }
-        if delivery_preempted || protocol_stop || budget_reached {
+        if protocol_stop || budget_reached {
             break;
         }
     }
 
     let reason = peer_close_reason(transport).or_else(|| Some(error.to_string()));
     let disconnected = lock_core(state).disconnect(reason);
-    let remaining = deadline.map_or(timeout, |deadline| {
-        deadline.saturating_duration_since(tokio::time::Instant::now())
-    });
     let deliver_disconnected = async {
         if delivery_preempted
             || !emit_terminal_event(event_tx, shutdown_rx, deadline, disconnected.clone()).await
@@ -2030,7 +2099,12 @@ async fn finish_send_failure(
             let _ = event_tx.try_send(disconnected);
         }
     };
-    let close = finish_send_and_close_bounded(transport, pending_send, state, remaining);
+    let close = finish_send_and_close_bounded(
+        transport,
+        pending_send,
+        state,
+        remaining_shutdown_budget(timeout, deadline),
+    );
     let ((), ()) = tokio::join!(deliver_disconnected, close);
 }
 
@@ -2095,6 +2169,7 @@ async fn transport_loop(
                         ),
                         Err(error) => {
                             error!("failed to serialize ClientMessage: {error}");
+                            lock_core(&state).dequeue_serialization_failed(&message);
                             (None, false)
                         }
                     },
@@ -2185,17 +2260,10 @@ async fn transport_loop(
                     TransportIo::Received(Some(Ok(frame))) => {
                         let outcome = lock_core(&state).process_frame(frame);
                         let disconnect = outcome.disconnect;
-                        let mut shutdown_requested = false;
-                        for event in outcome.events {
-                            if matches!(
-                                emit_event_or_shutdown(&event_tx, &mut shutdown_rx, event).await,
-                                EmitOutcome::ShutdownRequested
-                            ) {
-                                shutdown_requested = true;
-                                break;
-                            }
-                        }
-                        if shutdown_requested {
+                        let delivered =
+                            emit_event_batch(&event_tx, &mut shutdown_rx, None, outcome.events)
+                                .await;
+                        if !delivered {
                             finish_core_shutdown(
                                 &mut transport,
                                 &mut pending_send,
@@ -2269,7 +2337,9 @@ enum EmitOutcome {
 /// lets shutdown win. On [`EmitOutcome::ShutdownRequested`] exactly the one
 /// in-flight event is abandoned — the caller must then run
 /// [`finish_core_shutdown`] and exit the loop **without polling `shutdown_rx`
-/// again** (a completed `oneshot::Receiver` panics if re-polled).
+/// again** (a completed `oneshot::Receiver` panics if re-polled). Batch
+/// callers route through [`emit_event_batch`], which attempts the nonblocking
+/// fallback for the batch's remaining events before abandoning them.
 #[cfg(feature = "tokio-runtime")]
 async fn emit_event_or_shutdown(
     event_tx: &mpsc::Sender<SignalFishEvent>,
@@ -2324,57 +2394,167 @@ mod tests {
     // ── Mock transport ──────────────────────────────────────────────
 
     /// A mock transport that records sent messages and replays scripted responses.
+    type SharedIncoming =
+        Arc<StdMutex<VecDeque<Option<std::result::Result<String, SignalFishError>>>>>;
+
+    /// Handles for steering a running [`MockTransport`] from a test.
+    struct IncomingControls {
+        incoming: SharedIncoming,
+        waker: Arc<StdMutex<Option<Waker>>>,
+    }
+
+    impl IncomingControls {
+        fn close_peer(&self) {
+            self.incoming.lock().unwrap().push_back(None);
+            if let Some(waker) = self.waker.lock().unwrap().take() {
+                waker.wake();
+            }
+        }
+    }
+
     struct MockTransport {
         /// Messages that `poll_recv` will yield in order.
-        incoming: VecDeque<Option<std::result::Result<String, SignalFishError>>>,
+        incoming: SharedIncoming,
         /// Recorded outgoing messages.
         sent: Arc<StdMutex<Vec<String>>>,
         /// Whether `poll_close` was called.
         closed: Arc<AtomicBool>,
         delivered_room_responses: [usize; 5],
+        /// Waker registered whenever `poll_recv` has nothing scripted.
+        recv_waker: Arc<StdMutex<Option<Waker>>>,
+        /// When present, outbound sends block until these permits are
+        /// available, keeping queued commands stranded in the client.
+        send_gate: Option<Arc<tokio::sync::Semaphore>>,
+        held_frame: Option<TransportFrame>,
+        permit_wait:
+            Option<Pin<Box<dyn Future<Output = tokio::sync::OwnedSemaphorePermit> + Send>>>,
+        /// Count of outbound frames the gate has taken ownership of.
+        frames_taken: Arc<std::sync::atomic::AtomicUsize>,
     }
 
     impl MockTransport {
         fn new(
             incoming: Vec<Option<std::result::Result<String, SignalFishError>>>,
         ) -> (Self, Arc<StdMutex<Vec<String>>>, Arc<AtomicBool>) {
+            let (transport, sent, closed, _controls) = Self::new_shared(incoming);
+            (transport, sent, closed)
+        }
+
+        #[allow(clippy::type_complexity)]
+        fn new_shared(
+            incoming: Vec<Option<std::result::Result<String, SignalFishError>>>,
+        ) -> (
+            Self,
+            Arc<StdMutex<Vec<String>>>,
+            Arc<AtomicBool>,
+            IncomingControls,
+        ) {
             let sent = Arc::new(StdMutex::new(Vec::new()));
             let closed = Arc::new(AtomicBool::new(false));
+            let incoming = Arc::new(StdMutex::new(VecDeque::from(incoming)));
+            let recv_waker = Arc::new(StdMutex::new(None));
             let transport = Self {
-                incoming: VecDeque::from(incoming),
+                incoming: Arc::clone(&incoming),
                 sent: Arc::clone(&sent),
                 closed: Arc::clone(&closed),
                 delivered_room_responses: [0; 5],
+                recv_waker: Arc::clone(&recv_waker),
+                send_gate: None,
+                held_frame: None,
+                permit_wait: None,
+                frames_taken: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             };
-            (transport, sent, closed)
+            (
+                transport,
+                sent,
+                closed,
+                IncomingControls {
+                    incoming,
+                    waker: recv_waker,
+                },
+            )
+        }
+
+        /// A mock whose outbound sends block on a semaphore after the given
+        /// number of initial permits are consumed.
+        #[allow(clippy::type_complexity)]
+        fn new_send_gated(
+            incoming: Vec<Option<std::result::Result<String, SignalFishError>>>,
+            initial_permits: usize,
+        ) -> (
+            Self,
+            Arc<StdMutex<Vec<String>>>,
+            Arc<AtomicBool>,
+            IncomingControls,
+            Arc<tokio::sync::Semaphore>,
+            Arc<std::sync::atomic::AtomicUsize>,
+        ) {
+            let (mut transport, sent, closed, controls) = Self::new_shared(incoming);
+            let gate = Arc::new(tokio::sync::Semaphore::new(initial_permits));
+            transport.send_gate = Some(Arc::clone(&gate));
+            let frames_taken = Arc::clone(&transport.frames_taken);
+            (transport, sent, closed, controls, gate, frames_taken)
         }
     }
 
     impl Transport for MockTransport {
-        fn abort(&mut self) {}
+        fn abort(&mut self) {
+            // Aborting is teardown too: tests observe either graceful close
+            // or abort through the same flag.
+            self.closed.store(true, Ordering::Relaxed);
+            self.held_frame = None;
+            self.permit_wait = None;
+        }
 
         fn poll_send(
             &mut self,
-            _cx: &mut Context<'_>,
+            cx: &mut Context<'_>,
             frame: &mut Option<TransportFrame>,
         ) -> Poll<std::result::Result<(), SignalFishError>> {
-            match frame.take() {
-                Some(TransportFrame::Text(message)) => {
-                    self.sent.lock().unwrap().push(message);
-                    Poll::Ready(Ok(()))
-                }
-                Some(TransportFrame::Binary(_)) => Poll::Ready(Err(
-                    SignalFishError::TransportSend("mock expected a text frame".into()),
-                )),
-                None => Poll::Ready(Ok(())),
+            let Some(gate) = self.send_gate.as_ref() else {
+                return match frame.take() {
+                    Some(TransportFrame::Text(message)) => {
+                        self.sent.lock().unwrap().push(message);
+                        Poll::Ready(Ok(()))
+                    }
+                    Some(TransportFrame::Binary(_)) => Poll::Ready(Err(
+                        SignalFishError::TransportSend("mock expected a text frame".into()),
+                    )),
+                    None => Poll::Ready(Ok(())),
+                };
+            };
+            if self.held_frame.is_none() {
+                let Some(accepted) = frame.take() else {
+                    return Poll::Ready(Ok(()));
+                };
+                self.held_frame = Some(accepted);
+                self.frames_taken.fetch_add(1, Ordering::Release);
+                let gate = Arc::clone(gate);
+                self.permit_wait = Some(Box::pin(async move {
+                    gate.acquire_owned().await.expect("send gate never closed")
+                }));
             }
+            let Some(permit_wait) = self.permit_wait.as_mut() else {
+                return Poll::Ready(Err(SignalFishError::TransportClosed));
+            };
+            let permit = match permit_wait.as_mut().poll(cx) {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(permit) => permit,
+            };
+            // Consume the permit permanently so later sends stay blocked.
+            permit.forget();
+            self.permit_wait = None;
+            if let Some(TransportFrame::Text(message)) = self.held_frame.take() {
+                self.sent.lock().unwrap().push(message);
+            }
+            Poll::Ready(Ok(()))
         }
 
         fn poll_recv(
             &mut self,
-            _cx: &mut Context<'_>,
+            cx: &mut Context<'_>,
         ) -> Poll<Option<std::result::Result<TransportFrame, SignalFishError>>> {
-            let response_kind = self.incoming.front().and_then(|item| {
+            let response_kind = self.incoming.lock().unwrap().front().and_then(|item| {
                 let Some(Ok(json)) = item else {
                     return None;
                 };
@@ -2412,10 +2592,11 @@ mod tests {
                     })
                     .count();
                 if sent_count <= self.delivered_room_responses[kind] {
+                    *self.recv_waker.lock().unwrap() = Some(cx.waker().clone());
                     return Poll::Pending;
                 }
             }
-            if let Some(item) = self.incoming.pop_front() {
+            if let Some(item) = self.incoming.lock().unwrap().pop_front() {
                 if let Some(kind) = response_kind {
                     self.delivered_room_responses[kind] += 1;
                 }
@@ -2423,9 +2604,10 @@ mod tests {
                 // `Some(result)` delivers the scripted message or error.
                 Poll::Ready(item.map(|result| result.map(TransportFrame::Text)))
             } else {
-                // All scripted messages have been delivered. No waker is
-                // registered, preserving the old never-completing recv until
-                // shutdown aborts the transport loop.
+                // All scripted messages have been delivered. Register the
+                // waker so tests can push further frames (or a peer close)
+                // into the running queue.
+                *self.recv_waker.lock().unwrap() = Some(cx.waker().clone());
                 Poll::Pending
             }
         }
@@ -4185,6 +4367,77 @@ mod tests {
         assert_reliable_game_data_rejected_after_room_change(false, true).await;
     }
 
+    /// Pins the cancellation contract of the waiting sends: dropping a future
+    /// parked on queue capacity leaves no state mutation, no statistics
+    /// change, and no leaked queue permit, so an identical command still
+    /// completes afterwards.
+    #[tokio::test]
+    async fn dropping_a_parked_reliable_send_leaves_no_trace() {
+        let (transport, entered_send, permits, sent) = GatedSendTransport::new(0);
+        let config = SignalFishConfig::new("mb_test").with_command_channel_capacity(1);
+        let (mut client, mut events) = SignalFishClient::start(transport, config);
+
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Connected)
+        ));
+        wait_until(|| entered_send.load(Ordering::Acquire)).await;
+        prime_player_room(&client);
+
+        client
+            .send_game_data(serde_json::json!({ "fills": "queue" }))
+            .expect("capacity-1 queue should accept one filler command");
+        let client = Arc::new(client);
+        let sender = Arc::clone(&client);
+        let mut parked = Box::pin(async move {
+            sender
+                .send_game_data_reliable(serde_json::json!({ "cancelled": true }))
+                .await
+        });
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), parked.as_mut())
+                .await
+                .is_err(),
+            "the reliable send should be parked on queue capacity"
+        );
+
+        // Drop mid-wait: nothing may change.
+        let stats_before = client.stats();
+        let snapshot_before = client.snapshot();
+        drop(parked);
+        assert_eq!(client.stats(), stats_before, "stats must not move");
+        assert_eq!(client.snapshot(), snapshot_before, "snapshot must not move");
+        assert_eq!(client.send_capacity(), 0, "the filler still owns the slot");
+
+        // The same command still works once capacity is available again.
+        permits.add_permits(16);
+        wait_for_sent_len(&sent, 2).await;
+        assert_eq!(
+            client.snapshot(),
+            snapshot_before,
+            "draining the filler must not disturb membership state"
+        );
+        client
+            .send_game_data_reliable(serde_json::json!({ "identical": true }))
+            .await
+            .expect("an identical reliable send must complete after cancellation");
+        wait_for_sent_len(&sent, 3).await;
+        {
+            let payloads = sent.lock().unwrap();
+            assert!(
+                !payloads.iter().any(|json| json.contains("\"cancelled\"")),
+                "the cancelled payload must not reach the wire: {payloads:?}"
+            );
+            assert!(
+                payloads.iter().any(|json| json.contains("\"identical\"")),
+                "the identical payload must reach the wire: {payloads:?}"
+            );
+        }
+
+        let mut client = Arc::into_inner(client).expect("all client clones should be dropped");
+        client.shutdown().await;
+    }
+
     #[tokio::test]
     async fn reliable_binary_game_data_does_not_cross_room_membership() {
         assert_reliable_game_data_rejected_after_room_change(true, true).await;
@@ -5464,6 +5717,49 @@ mod tests {
         client.shutdown().await;
     }
 
+    #[tokio::test]
+    async fn room_operations_are_refused_before_authentication_completes() {
+        // The server never confirms authentication. A caller that skips the
+        // documented wait for `Authenticated` must get an immediate typed
+        // refusal instead of arming an operation fence that the inbound
+        // lifecycle gates would never release.
+        let (transport, sent, _closed) = MockTransport::new(vec![]);
+        let config = SignalFishConfig::new("mb_test");
+        let (mut client, mut events) = SignalFishClient::start(transport, config);
+        let _ = events.recv().await; // Connected
+
+        let result = client.join_room(JoinRoomParams::new("test-game", "local"));
+        assert!(
+            matches!(result, Err(SignalFishError::NotAuthenticated)),
+            "expected NotAuthenticated, got {result:?}"
+        );
+        assert!(!client.is_authenticated());
+        assert_eq!(
+            client.send_capacity(),
+            client.max_send_capacity(),
+            "a refused room operation must not consume queue capacity"
+        );
+
+        // The fence stayed unarmed: once authentication completes, the same
+        // operation is admitted immediately.
+        {
+            let mut core = lock_core(&client.state);
+            let _ = core.process_frame(TransportFrame::Text(authenticated_json()));
+        }
+        assert!(client.is_authenticated());
+        client
+            .join_room(JoinRoomParams::new("test-game", "local"))
+            .expect("join must be admitted once authenticated");
+
+        // Exactly two commands reached the wire: Authenticate and JoinRoom.
+        wait_for_sent_len(&sent, 2).await;
+        let join_json = sent.lock().unwrap()[1].clone();
+        let join: serde_json::Value = serde_json::from_str(&join_json).unwrap();
+        assert_eq!(join["type"], "JoinRoom");
+
+        client.shutdown().await;
+    }
+
     /// Validates the documented best-effort delivery guarantee: deadline
     /// abandonment does not make the terminal `Disconnected` event mandatory.
     #[tokio::test]
@@ -5534,5 +5830,221 @@ mod tests {
         assert!(client.current_room_id().await.is_none());
         assert!(client.current_room_code().await.is_none());
         assert!(client.current_player_id().await.is_none());
+    }
+
+    // ── Bounded terminal delivery ───────────────────────────────────
+
+    /// A consumer that never drains must not keep the transport loop (and
+    /// every sender parked on the command queue) alive past the configured
+    /// shutdown budget when the peer closes the connection without any
+    /// `shutdown()` call.
+    #[tokio::test]
+    async fn peer_close_with_wedged_consumer_terminates_loop_and_releases_parked_senders() {
+        // Two permits let Authenticate and JoinRoom reach the wire so the
+        // gated room baseline is released; every later send stalls inside the
+        // transport while the command queue backs up behind it.
+        let (transport, _sent, closed, controls, _permits, frames_taken) =
+            MockTransport::new_send_gated(
+                vec![
+                    Some(Ok(authenticated_json())),
+                    Some(Ok(protocol_info_v2_json())),
+                    Some(Ok(room_joined_json())),
+                ],
+                2,
+            );
+        let config = SignalFishConfig::new("mb_test")
+            .with_event_channel_capacity(4)
+            .with_command_channel_capacity(1)
+            .with_shutdown_timeout(std::time::Duration::from_millis(100));
+        let (mut client, mut events) = SignalFishClient::start(transport, config);
+
+        // Reach membership without draining events: Connected..RoomJoined
+        // then exactly fill the capacity-4 channel, so the terminal
+        // Disconnected delivery wedges against a permanently full channel.
+        let give_up = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
+        while !client.is_authenticated() {
+            assert!(
+                tokio::time::Instant::now() < give_up,
+                "the scripted handshake never authenticated"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+        }
+        client
+            .join_room(JoinRoomParams::new("test-game", "local"))
+            .expect("join must be admitted once authenticated");
+        while client.current_room_id().await.is_none() {
+            assert!(
+                tokio::time::Instant::now() < give_up,
+                "the scripted room baseline never landed"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+        }
+
+        // Strand one command inside the stalled transport, fill the single
+        // command queue slot behind it, then park a reliable sender on
+        // reserve.
+        client
+            .ping()
+            .expect("the first ping is taken by the stalled transport");
+        // Authenticate + JoinRoom + our first ping: three gated takes.
+        wait_until(|| frames_taken.load(Ordering::Acquire) >= 3).await;
+        client
+            .ping()
+            .expect("one command fits the capacity-1 queue");
+        let client = Arc::new(client);
+        let sender = Arc::clone(&client);
+        let mut parked = tokio::spawn(async move {
+            sender
+                .send_game_data_reliable(serde_json::json!({ "late": true }))
+                .await
+        });
+        match tokio::time::timeout(std::time::Duration::from_millis(50), &mut parked).await {
+            Err(_) => {}
+            Ok(outcome) => panic!(
+                "reliable send finished early: {outcome:?} (cap={}, role={:?})",
+                client.send_capacity(),
+                client.room_role(),
+            ),
+        }
+
+        // The peer closes now. Connected..RoomJoined hold every event slot,
+        // so the terminal Disconnected delivery also wedges until its budget
+        // expires while the loop stops servicing the command queue entirely.
+        controls.close_peer();
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        // The budget expires on the wedged Disconnected delivery; loop exit
+        // drops the command receiver and resolves the parked reserve.
+        let result = tokio::time::timeout(std::time::Duration::from_secs(2), parked)
+            .await
+            .expect("loop termination must release parked reliable senders")
+            .expect("reliable sender task should not panic");
+        assert!(
+            matches!(result, Err(SignalFishError::NotConnected)),
+            "a reliable send interrupted by terminal close must fail cleanly: {result:?}"
+        );
+        assert!(
+            closed.load(Ordering::Relaxed),
+            "peer-close teardown must close or abort the transport"
+        );
+        {
+            let client = Arc::clone(&client);
+            assert!(!client.is_connected());
+        }
+
+        // Exactly the pre-close events were delivered, in order, and the
+        // loop's exit closes the stream.
+        let expected = ["Connected", "Authenticated", "ProtocolInfo", "RoomJoined"];
+        let mut observed = Vec::new();
+        while let Ok(Some(event)) =
+            tokio::time::timeout(std::time::Duration::from_millis(200), events.recv()).await
+        {
+            observed.push(format!("{event:?}"));
+            if observed.len() == expected.len() {
+                break;
+            }
+        }
+        let names: Vec<String> = observed
+            .iter()
+            .map(|debug| {
+                debug
+                    .split(['{', '('])
+                    .next()
+                    .unwrap_or_default()
+                    .to_owned()
+            })
+            .collect();
+        assert_eq!(names, expected, "wedged delivery must preserve order");
+    }
+
+    /// A receive error wedges terminal delivery exactly like a clean close:
+    /// with no `shutdown()` and an uncompletable `poll_close`, teardown must
+    /// come from the budget-expiry abort, never hang the loop.
+    #[tokio::test]
+    async fn terminal_receive_error_aborts_only_after_the_shutdown_budget() {
+        // Connected and Authenticated fill the capacity-2 channel, so the
+        // terminal Disconnected delivery wedges with no `shutdown()` call.
+        // The transport's `poll_close` never completes, so graceful close is
+        // impossible: teardown can only come from the budget expiry aborting
+        // the transport. A regression that restores unbounded delivery keeps
+        // this spin alive forever instead of passing vacuously.
+        let (transport, _close_called, abort_called, _dropped) =
+            HangingCloseTransport::with_incoming(vec![
+                Some(Ok(authenticated_json())),
+                Some(Err(SignalFishError::TransportReceive(
+                    "network failure".into(),
+                ))),
+            ]);
+        let config = SignalFishConfig::new("mb_test")
+            .with_event_channel_capacity(2)
+            .with_shutdown_timeout(std::time::Duration::from_millis(100));
+        let (client, mut events) = SignalFishClient::start(transport, config);
+
+        let started = std::time::Instant::now();
+        while !abort_called.load(Ordering::Acquire) {
+            assert!(
+                started.elapsed() < std::time::Duration::from_secs(2),
+                "the wedged terminal delivery must abort at its budget without shutdown()"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+        assert!(!client.is_connected());
+
+        // Loop exit drops the sender: draining surfaces the buffered prefix,
+        // then closes the stream authoritatively.
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Connected)
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Authenticated { .. })
+        ));
+        let closed_stream =
+            tokio::time::timeout(std::time::Duration::from_millis(500), events.recv())
+                .await
+                .expect("the event stream must end promptly after teardown");
+        assert!(
+            closed_stream.is_none(),
+            "unexpected extra events after abort: {closed_stream:?}"
+        );
+    }
+
+    /// When a batch delivery is preempted, the remaining batch events get one
+    /// nonblocking attempt instead of being discarded sight unseen.
+    #[tokio::test]
+    async fn expired_budget_preempts_blocked_batch_delivers_without_corruption() {
+        let (tx, mut rx) = mpsc::channel(4);
+        let (_shutdown_tx, mut shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+
+        // A budget that expired before the call makes every blocked delivery
+        // deterministic. The channel starts full, so both batch events are
+        // preempted instead of delivered or queued.
+        for _ in 0..4 {
+            tx.try_send(SignalFishEvent::Pong).expect("filler fits");
+        }
+        let stale_deadline = tokio::time::Instant::now();
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
+        let batch = vec![SignalFishEvent::Connected, SignalFishEvent::Connected];
+        let delivered = emit_event_batch(&tx, &mut shutdown_rx, Some(stale_deadline), batch).await;
+        assert!(!delivered, "an expired budget must report preemption");
+
+        drop(tx);
+        let mut observed = Vec::new();
+        while let Some(event) = rx.recv().await {
+            observed.push(event);
+        }
+        assert_eq!(
+            observed.len(),
+            4,
+            "preemption must not corrupt buffered events: {observed:?}"
+        );
+        assert!(
+            observed
+                .iter()
+                .all(|event| matches!(event, SignalFishEvent::Pong)),
+            "only the original buffered events remain: {observed:?}"
+        );
     }
 }

--- a/src/client_core.rs
+++ b/src/client_core.rs
@@ -344,6 +344,22 @@ impl ClientCore {
         if !self.is_connected() {
             return Err(crate::SignalFishError::NotConnected);
         }
+        if matches!(
+            operation,
+            ClientOperation::JoinRoom(_)
+                | ClientOperation::LeaveRoom
+                | ClientOperation::Reconnect(..)
+                | ClientOperation::JoinAsSpectator(..)
+                | ClientOperation::LeaveSpectator
+        ) && !self.snapshot.authenticated
+        {
+            // The inbound lifecycle gates require `authenticated` for every
+            // room response, so admitting an outbound room operation before
+            // authentication would arm its fence against responses the SDK
+            // itself classifies as violations — poisoning every later room
+            // operation with `RoomOperationPending` until teardown.
+            return Err(crate::SignalFishError::NotAuthenticated);
+        }
         if self.pending_room_operation.is_some() && !matches!(operation, ClientOperation::Ping) {
             return Err(crate::SignalFishError::RoomOperationPending);
         }
@@ -935,6 +951,36 @@ impl ClientCore {
             self.pending_reconnects.pop_front();
         }
         self.pending_room_operation = None;
+    }
+
+    /// Release the operation fence when a command that armed it at queue
+    /// admission fails to serialize at dequeue time.
+    ///
+    /// Unreachable while every `ClientMessage` field serializes infallibly,
+    /// but one fallible field away from a permanent `RoomOperationPending` in
+    /// both drivers, so the fence is released instead of asserted away.
+    pub(crate) fn dequeue_serialization_failed(&mut self, message: &ClientMessage) {
+        let kind = match message {
+            ClientMessage::JoinRoom { .. } => PendingRoomOperation::JoinPlayer,
+            ClientMessage::LeaveRoom => PendingRoomOperation::LeavePlayer,
+            ClientMessage::Reconnect { .. } => PendingRoomOperation::ReconnectPlayer,
+            ClientMessage::JoinAsSpectator { .. } => PendingRoomOperation::JoinSpectator,
+            ClientMessage::LeaveSpectator => PendingRoomOperation::LeaveSpectator,
+            _ => return,
+        };
+        if self
+            .pending_room_operation
+            .as_ref()
+            .is_some_and(|pending| pending.kind == kind)
+        {
+            if kind == PendingRoomOperation::ReconnectPlayer {
+                self.pending_reconnects.pop_front();
+            }
+            self.pending_room_operation = None;
+            tracing::warn!(
+                "dequeued room operation failed to serialize; released its admission fence"
+            );
+        }
     }
 
     fn process_binary(&mut self, bytes: Vec<u8>) -> FrameOutcome {
@@ -3188,10 +3234,17 @@ mod tests {
     #[test]
     fn operation_membership_matrix_is_exhaustive_and_role_specific() {
         for (name, operation, outside, player, spectator) in operation_matrix() {
-            let outside_core = ClientCore::new(
+            let mut outside_core = ClientCore::new(
                 Some(GameDataEncoding::Json),
                 ProtocolViolationPolicy::Observe,
                 true,
+            );
+            assert_eq!(process(&mut outside_core, authenticated()).events.len(), 1);
+            assert_eq!(
+                process(&mut outside_core, protocol_info(Some(3)))
+                    .events
+                    .len(),
+                1
             );
             assert_eq!(
                 membership_error(outside_core.validate(&operation)),
@@ -3213,6 +3266,78 @@ mod tests {
                 "{name}"
             );
         }
+    }
+
+    #[test]
+    fn unauthenticated_core_rejects_fencing_room_operations_before_admission() {
+        let fencing_operations = [
+            (
+                "join room",
+                ClientOperation::JoinRoom(JoinRoomParams::new("game", "local")),
+            ),
+            ("leave room", ClientOperation::LeaveRoom),
+            (
+                "reconnect",
+                ClientOperation::Reconnect(
+                    PlayerId::from_u128(LOCAL),
+                    RoomId::from_u128(10),
+                    "token".into(),
+                ),
+            ),
+            (
+                "join spectator",
+                ClientOperation::JoinAsSpectator("game".into(), "ROOM".into(), "viewer".into()),
+            ),
+            ("leave spectator", ClientOperation::LeaveSpectator),
+        ];
+        for (name, operation) in fencing_operations {
+            let mut core = ClientCore::new(
+                Some(GameDataEncoding::Json),
+                ProtocolViolationPolicy::Observe,
+                true,
+            );
+            assert!(
+                matches!(
+                    core.validate(&operation),
+                    Err(crate::SignalFishError::NotAuthenticated)
+                ),
+                "{name} must be refused before authentication"
+            );
+            assert_eq!(
+                core.pending_room_operation, None,
+                "{name} must not arm its admission fence while unauthenticated"
+            );
+
+            assert_eq!(process(&mut core, authenticated()).events.len(), 1);
+            if matches!(
+                operation,
+                ClientOperation::JoinRoom(_)
+                    | ClientOperation::Reconnect(..)
+                    | ClientOperation::JoinAsSpectator(..)
+            ) {
+                core.validate(&operation).unwrap_or_else(|error| {
+                    panic!("{name} must validate after authentication: {error:?}")
+                });
+            }
+        }
+
+        let core = ClientCore::new(
+            Some(GameDataEncoding::Json),
+            ProtocolViolationPolicy::Observe,
+            true,
+        );
+        core.validate(&ClientOperation::Ping)
+            .expect("ping remains valid before authentication");
+        assert!(
+            matches!(
+                core.validate(&ClientOperation::GameData(
+                    serde_json::json!({"value": 1}),
+                    GameDataDelivery::Reliable,
+                )),
+                Err(crate::SignalFishError::NotInRoom)
+            ),
+            "non-fencing operations keep their existing pre-authentication behavior"
+        );
     }
 
     #[test]
@@ -5051,5 +5176,89 @@ mod tests {
             outcome.events.as_slice(),
             [SignalFishEvent::AuthorityResponse { granted: false, .. }]
         ));
+    }
+
+    #[test]
+    fn dequeue_serialization_failure_releases_only_the_matching_fence() {
+        let cases: [(&str, ClientOperation, ClientMessage); 5] = [
+            (
+                "join",
+                ClientOperation::JoinRoom(JoinRoomParams::new("game", "local")),
+                ClientMessage::JoinRoom {
+                    game_name: "game".into(),
+                    player_name: "local".into(),
+                    room_code: None,
+                    max_players: None,
+                    supports_authority: None,
+                    relay_transport: None,
+                },
+            ),
+            (
+                "leave",
+                ClientOperation::LeaveRoom,
+                ClientMessage::LeaveRoom,
+            ),
+            (
+                "reconnect",
+                ClientOperation::Reconnect(
+                    PlayerId::from_u128(LOCAL),
+                    RoomId::from_u128(10),
+                    "token".into(),
+                ),
+                ClientMessage::Reconnect {
+                    player_id: PlayerId::from_u128(LOCAL),
+                    room_id: RoomId::from_u128(10),
+                    auth_token: "token".into(),
+                },
+            ),
+            (
+                "spectator join",
+                ClientOperation::JoinAsSpectator("game".into(), "ROOM".into(), "viewer".into()),
+                ClientMessage::JoinAsSpectator {
+                    game_name: "game".into(),
+                    room_code: "ROOM".into(),
+                    spectator_name: "viewer".into(),
+                },
+            ),
+            (
+                "spectator leave",
+                ClientOperation::LeaveSpectator,
+                ClientMessage::LeaveSpectator,
+            ),
+        ];
+
+        for (name, operation, message) in cases {
+            let mut core = ClientCore::new(
+                Some(GameDataEncoding::Json),
+                ProtocolViolationPolicy::Observe,
+                true,
+            );
+            core.record_admission(ClientCore::admission_for(&operation));
+            assert!(
+                core.pending_room_operation.is_some(),
+                "{name}: admission must arm the fence"
+            );
+            if matches!(operation, ClientOperation::Reconnect(..)) {
+                assert_eq!(core.pending_reconnects.len(), 1);
+            }
+
+            core.dequeue_serialization_failed(&message);
+            assert!(
+                core.pending_room_operation.is_none(),
+                "{name}: dequeue failure must release the fence"
+            );
+            assert!(
+                core.pending_reconnects.is_empty(),
+                "{name}: reconnect bookkeeping must be released with the fence"
+            );
+            // A mismatched message kind must never release someone else's
+            // fence.
+            core.record_admission(ClientCore::admission_for(&operation));
+            core.dequeue_serialization_failed(&ClientMessage::Ping);
+            assert!(
+                core.pending_room_operation.is_some(),
+                "{name}: an unrelated message must not release the fence"
+            );
+        }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -114,6 +114,24 @@ pub enum SignalFishError {
         capacity: usize,
     },
 
+    /// Attempted a directed room operation before the server confirmed
+    /// authentication.
+    ///
+    /// The five admission-fencing operations
+    /// ([`join_room`](crate::SignalFishClient::join_room),
+    /// [`leave_room`](crate::SignalFishClient::leave_room),
+    /// [`reconnect`](crate::SignalFishClient::reconnect),
+    /// [`join_as_spectator`](crate::SignalFishClient::join_as_spectator), and
+    /// [`leave_spectator`](crate::SignalFishClient::leave_spectator)) require
+    /// the server's `Authenticated` confirmation first. The command was
+    /// **not** queued: retry once
+    /// [`SignalFishEvent::Authenticated`](crate::SignalFishEvent::Authenticated)
+    /// arrives.
+    #[error(
+        "not yet authenticated: wait for SignalFishEvent::Authenticated before room operations"
+    )]
+    NotAuthenticated,
+
     /// Attempted a room operation but the client is not in a room.
     #[error("not in a room")]
     NotInRoom,

--- a/src/polling_client.rs
+++ b/src/polling_client.rs
@@ -449,8 +449,10 @@ impl<T: Transport> SignalFishPollingClient<T> {
     ///
     /// # Errors
     ///
-    /// Returns [`SignalFishError::AlreadyInRoom`] when membership already
-    /// exists, [`SignalFishError::RoomOperationPending`] during another room
+    /// Returns [`SignalFishError::NotAuthenticated`] before the server
+    /// confirms authentication, [`SignalFishError::AlreadyInRoom`] when
+    /// membership already exists,
+    /// [`SignalFishError::RoomOperationPending`] during another room
     /// transition, [`SignalFishError::NotConnected`] if the transport has closed,
     /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
     /// is full (the message is **not** queued; nothing is silently dropped).
@@ -462,7 +464,8 @@ impl<T: Transport> SignalFishPollingClient<T> {
     ///
     /// # Errors
     ///
-    /// Returns [`SignalFishError::NotInRoom`] outside a room,
+    /// Returns [`SignalFishError::NotAuthenticated`] before the server
+    /// confirms authentication, [`SignalFishError::NotInRoom`] outside a room,
     /// [`SignalFishError::WrongRoomRole`] as a spectator,
     /// [`SignalFishError::RoomOperationPending`] during another room transition,
     /// [`SignalFishError::NotConnected`] if the transport has closed,
@@ -562,8 +565,10 @@ impl<T: Transport> SignalFishPollingClient<T> {
     ///
     /// # Errors
     ///
-    /// Returns [`SignalFishError::AlreadyInRoom`] when membership already
-    /// exists, [`SignalFishError::RoomOperationPending`] during another room
+    /// Returns [`SignalFishError::NotAuthenticated`] before the server
+    /// confirms authentication, [`SignalFishError::AlreadyInRoom`] when
+    /// membership already exists,
+    /// [`SignalFishError::RoomOperationPending`] during another room
     /// transition, [`SignalFishError::NotConnected`] if the transport has closed,
     /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
     /// is full (the message is **not** queued; nothing is silently dropped).
@@ -580,8 +585,10 @@ impl<T: Transport> SignalFishPollingClient<T> {
     ///
     /// # Errors
     ///
-    /// Returns [`SignalFishError::AlreadyInRoom`] when membership already
-    /// exists, [`SignalFishError::RoomOperationPending`] during another room
+    /// Returns [`SignalFishError::NotAuthenticated`] before the server
+    /// confirms authentication, [`SignalFishError::AlreadyInRoom`] when
+    /// membership already exists,
+    /// [`SignalFishError::RoomOperationPending`] during another room
     /// transition, [`SignalFishError::NotConnected`] if the transport has closed,
     /// or [`SignalFishError::SendBufferFull`] if the outgoing command queue
     /// is full (the message is **not** queued; nothing is silently dropped).
@@ -602,7 +609,8 @@ impl<T: Transport> SignalFishPollingClient<T> {
     ///
     /// # Errors
     ///
-    /// Returns [`SignalFishError::NotInRoom`] outside a room,
+    /// Returns [`SignalFishError::NotAuthenticated`] before the server
+    /// confirms authentication, [`SignalFishError::NotInRoom`] outside a room,
     /// [`SignalFishError::WrongRoomRole`] as a player,
     /// [`SignalFishError::RoomOperationPending`] during another room transition,
     /// [`SignalFishError::NotConnected`] if the transport has closed,
@@ -1022,9 +1030,11 @@ impl<T: Transport> SignalFishPollingClient<T> {
                 self.pending_frame_enqueued_at = Some(queued.enqueued_at);
                 match queued.command {
                     PollingCommand::Message(message) => {
-                        let Some(json) =
-                            self.finish_serialization_at(serialize_client_message(&message), now)
-                        else {
+                        let Some(json) = self.finish_serialization_at(
+                            serialize_client_message(&message),
+                            &message,
+                            now,
+                        ) else {
                             continue;
                         };
                         self.pending_frame_is_game_data =
@@ -1293,12 +1303,14 @@ impl<T: Transport> SignalFishPollingClient<T> {
     fn finish_serialization_at(
         &mut self,
         result: serde_json::Result<String>,
+        message: &ClientMessage,
         now: Instant,
     ) -> Option<String> {
         match result {
             Ok(json) => Some(json),
             Err(error) => {
                 error!(%error, "failed to serialize ClientMessage");
+                self.core.dequeue_serialization_failed(message);
                 self.record_serialization_failure_at(now);
                 None
             }
@@ -2894,16 +2906,19 @@ mod tests {
 
     #[test]
     fn join_room_queues_command() {
-        let transport = MockTransport::new();
+        let transport = MockTransport::new()
+            .with_incoming(vec![Some(Ok(authenticated_json_str().to_string()))]);
         let mut client = SignalFishPollingClient::new(transport, default_config());
 
-        // First poll to send the authenticate message and emit Connected.
+        // First poll sends Authenticate, emits Connected, and consumes
+        // Authenticated.
         client.poll();
+        assert!(client.is_authenticated());
 
         // Now join a room.
         client
             .join_room(JoinRoomParams::new("test-game", "Alice"))
-            .expect("join_room must succeed on connected client");
+            .expect("join_room must succeed on an authenticated client");
 
         // Poll again to flush the join_room command.
         client.poll();
@@ -2919,6 +2934,51 @@ mod tests {
         assert_eq!(sent_json["type"], "JoinRoom");
         assert_eq!(sent_json["data"]["game_name"], "test-game");
         assert_eq!(sent_json["data"]["player_name"], "Alice");
+    }
+
+    #[test]
+    fn room_operations_are_refused_before_authentication_completes() {
+        // The server never confirms authentication. A caller that skips the
+        // documented wait for `Authenticated` must get an immediate typed
+        // refusal instead of arming an operation fence that the inbound
+        // lifecycle gates would never release.
+        let transport = MockTransport::new();
+        let mut client = SignalFishPollingClient::new(transport, default_config());
+        client.poll(); // Connected + Authenticate flushed
+
+        let result = client.join_room(JoinRoomParams::new("test-game", "Alice"));
+        assert!(
+            matches!(result, Err(SignalFishError::NotAuthenticated)),
+            "expected NotAuthenticated, got {result:?}"
+        );
+        assert!(!client.is_authenticated());
+        assert_eq!(
+            client.send_capacity(),
+            client.max_send_capacity(),
+            "a refused room operation must not consume queue capacity"
+        );
+
+        // The fence stayed unarmed: once authentication completes, the same
+        // operation is admitted immediately.
+        client
+            .transport
+            .incoming
+            .push_back(Some(Ok(TransportFrame::Text(
+                authenticated_json_str().to_string(),
+            ))));
+        let _ = client.poll();
+        assert!(client.is_authenticated());
+        client
+            .join_room(JoinRoomParams::new("test-game", "Alice"))
+            .expect("join_room must be admitted once authenticated");
+        client.poll();
+        let last_sent = client
+            .transport
+            .sent
+            .last()
+            .expect("transport must have at least one sent message");
+        let sent_json: serde_json::Value = serde_json::from_str(last_sent).unwrap();
+        assert_eq!(sent_json["type"], "JoinRoom");
     }
 
     #[test]
@@ -3844,7 +3904,8 @@ mod tests {
 
     #[test]
     fn reconnect_queues_command() {
-        let transport = MockTransport::new();
+        let transport = MockTransport::new()
+            .with_incoming(vec![Some(Ok(authenticated_json_str().to_string()))]);
         let mut client = SignalFishPollingClient::new(transport, default_config());
         client.poll(); // flush auth
 
@@ -3852,7 +3913,7 @@ mod tests {
         let room_id = uuid::Uuid::from_u128(2);
         client
             .reconnect(player_id, room_id, "token123".into())
-            .expect("reconnect must succeed on connected client");
+            .expect("reconnect must succeed on authenticated client");
         client.poll();
 
         let last_sent = client
@@ -3870,13 +3931,14 @@ mod tests {
 
     #[test]
     fn join_as_spectator_queues_command() {
-        let transport = MockTransport::new();
+        let transport = MockTransport::new()
+            .with_incoming(vec![Some(Ok(authenticated_json_str().to_string()))]);
         let mut client = SignalFishPollingClient::new(transport, default_config());
         client.poll(); // flush auth
 
         client
             .join_as_spectator("my-game".into(), "ROOM1".into(), "Spectator1".into())
-            .expect("join_as_spectator must succeed on connected client");
+            .expect("join_as_spectator must succeed on authenticated client");
         client.poll();
 
         let last_sent = client
@@ -3937,7 +3999,8 @@ mod tests {
 
     #[test]
     fn join_room_with_all_options_queues_command() {
-        let transport = MockTransport::new();
+        let transport = MockTransport::new()
+            .with_incoming(vec![Some(Ok(authenticated_json_str().to_string()))]);
         let mut client = SignalFishPollingClient::new(transport, default_config());
         client.poll(); // flush auth
 
@@ -3948,7 +4011,7 @@ mod tests {
             .with_room_code("CUSTOM1");
         client
             .join_room(params)
-            .expect("join_room must succeed on connected client");
+            .expect("join_room must succeed on authenticated client");
         client.poll();
 
         let last_sent = client
@@ -4855,7 +4918,11 @@ mod tests {
         let serialization_error = serde_json::from_str::<serde_json::Value>("{")
             .expect_err("the injected malformed JSON should fail");
         assert!(client
-            .finish_serialization_at(Err(serialization_error), base + Duration::from_millis(20),)
+            .finish_serialization_at(
+                Err(serialization_error),
+                &ClientMessage::Ping,
+                base + Duration::from_millis(20),
+            )
             .is_none());
 
         let age = client.queue_age_stats();

--- a/src/webrtc.rs
+++ b/src/webrtc.rs
@@ -1149,6 +1149,7 @@ mod tests {
                 serde_json::from_str::<ServerMessage>(json).ok()
             });
             let expected_command = match terminal_response {
+                Some(ServerMessage::RoomJoined(_)) => Some("JoinRoom"),
                 Some(ServerMessage::Reconnected(_) | ServerMessage::ReconnectionFailed { .. }) => {
                     Some("Reconnect")
                 }
@@ -1161,10 +1162,12 @@ mod tests {
                         |message| {
                             matches!(
                                 (expected, message),
-                                (
-                                    "Reconnect",
-                                    crate::protocol::ClientMessage::Reconnect { .. }
-                                ) | ("LeaveRoom", crate::protocol::ClientMessage::LeaveRoom)
+                                ("JoinRoom", crate::protocol::ClientMessage::JoinRoom { .. })
+                                    | (
+                                        "Reconnect",
+                                        crate::protocol::ClientMessage::Reconnect { .. }
+                                    )
+                                    | ("LeaveRoom", crate::protocol::ClientMessage::LeaveRoom)
                             )
                         },
                     )
@@ -1447,11 +1450,34 @@ mod tests {
         }
     }
 
-    fn start_in_scripted_room(
+    /// Drain scripted signaling events until the controller observes the
+    /// server's `Authenticated` confirmation.
+    async fn wait_for_authenticated(mesh: &mut MeshController<SharedDriver>) {
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            while let Some(event) = mesh.recv().await {
+                if matches!(
+                    event,
+                    MeshEvent::Signaling(boxed)
+                        if matches!(*boxed, SignalFishEvent::Authenticated { .. })
+                ) {
+                    return;
+                }
+            }
+            panic!("scripted handshake ended before Authenticated");
+        })
+        .await
+        .expect("scripted handshake never reached Authenticated");
+    }
+
+    async fn start_in_scripted_room(
         transport: MockTransport,
         driver: SharedDriver,
     ) -> MeshController<SharedDriver> {
         let mut mesh = MeshController::start(transport, SignalFishConfig::new("app"), driver);
+        // Consume the scripted handshake so the directed room operation
+        // observes an authenticated connection; the mock keeps every room
+        // response gated behind the matching outgoing command.
+        wait_for_authenticated(&mut mesh).await;
         mesh.join_room(crate::client::JoinRoomParams::new("test", "local"))
             .expect("scripted room response must follow an admitted join");
         mesh
@@ -1893,7 +1919,7 @@ mod tests {
                 serde_json::json!({ "Answer": "remote" }),
             ))),
         ]);
-        let mut mesh = start_in_scripted_room(transport, driver.clone());
+        let mut mesh = start_in_scripted_room(transport, driver.clone()).await;
 
         let connected = tokio::time::timeout(
             std::time::Duration::from_secs(2),
@@ -1963,7 +1989,7 @@ mod tests {
                 serde_json::json!({ "Offer": "remote-offer" }),
             ))),
         ]);
-        let mut mesh = start_in_scripted_room(transport, driver.clone());
+        let mut mesh = start_in_scripted_room(transport, driver.clone()).await;
 
         let connected = tokio::time::timeout(
             std::time::Duration::from_secs(2),
@@ -2008,7 +2034,7 @@ mod tests {
             Some(Ok(session_plan(peer, false))),
             Some(Ok(player_left)),
         ]);
-        let mut mesh = start_in_scripted_room(transport, driver.clone());
+        let mut mesh = start_in_scripted_room(transport, driver.clone()).await;
 
         for _ in 0..8 {
             let _ = tokio::time::timeout(std::time::Duration::from_millis(100), mesh.recv()).await;
@@ -2029,7 +2055,7 @@ mod tests {
             Some(Ok(protocol_info_v3())),
             Some(Ok(session_plan(peer, false))),
         ]);
-        let mut mesh = start_in_scripted_room(transport, driver.clone());
+        let mut mesh = start_in_scripted_room(transport, driver.clone()).await;
         assert!(
             pump_until(&mut mesh, &driver, |calls| calls
                 .contains(&DriverCall::Connect(peer, false)))
@@ -2063,7 +2089,7 @@ mod tests {
             Some(Ok(protocol_info_v3())),
             Some(Ok(session_plan(uuid(1), false))),
         ]);
-        let mut mesh = start_in_scripted_room(transport, driver.clone());
+        let mut mesh = start_in_scripted_room(transport, driver.clone()).await;
         mesh.send_to(peer, &[9, 9]);
         assert!(driver.calls().contains(&DriverCall::Send(peer, vec![9, 9])));
         mesh.shutdown().await;
@@ -2096,7 +2122,7 @@ mod tests {
             Some(Ok(session_plan(peer, true))),
             Some(Ok(signal_from(peer, serde_json::json!({ "Answer": "r" })))),
         ]);
-        let mut mesh = start_in_scripted_room(transport, driver.clone());
+        let mut mesh = start_in_scripted_room(transport, driver.clone()).await;
 
         // Drive the handshake to PeerConnected.
         tokio::time::timeout(
@@ -2145,7 +2171,7 @@ mod tests {
             Some(Ok(session_plan_multi(&[], &[]))),
             Some(Ok(new_peer)),
         ]);
-        let mut mesh = start_in_scripted_room(transport, driver.clone());
+        let mut mesh = start_in_scripted_room(transport, driver.clone()).await;
         for _ in 0..6 {
             let _ = tokio::time::timeout(std::time::Duration::from_millis(100), mesh.recv()).await;
             if driver.calls().contains(&DriverCall::Connect(peer, true)) {
@@ -2167,7 +2193,7 @@ mod tests {
             Some(Ok(session_plan(peer, false))),
             Some(Ok(room_left)),
         ]);
-        let mut mesh = start_in_scripted_room(transport, driver.clone());
+        let mut mesh = start_in_scripted_room(transport, driver.clone()).await;
         assert!(
             pump_until(&mut mesh, &driver, |calls| calls
                 .contains(&DriverCall::Connect(peer, false)))
@@ -2198,7 +2224,7 @@ mod tests {
             Some(Ok(protocol_info_v3())),
             Some(Ok(room_joined.to_string())),
         ]);
-        let mut mesh = start_in_scripted_room(transport, driver.clone());
+        let mut mesh = start_in_scripted_room(transport, driver.clone()).await;
         for _ in 0..6 {
             let _ = tokio::time::timeout(std::time::Duration::from_millis(100), mesh.recv()).await;
             if driver
@@ -2231,7 +2257,7 @@ mod tests {
             Some(Ok(session_plan(peer, true))),
             Some(Ok(signal_from(peer, serde_json::json!({ "Answer": "r" })))),
         ]);
-        let mut mesh = start_in_scripted_room(transport, driver.clone());
+        let mut mesh = start_in_scripted_room(transport, driver.clone()).await;
 
         // Drive the handshake to an open channel (reports TransportStatus(true)).
         tokio::time::timeout(
@@ -2274,7 +2300,7 @@ mod tests {
             Some(Ok(protocol_info_v3())),
             Some(Ok(session_plan_multi(&[(a, false), (b, false)], &[]))),
         ]);
-        let mut mesh = start_in_scripted_room(transport, driver.clone());
+        let mut mesh = start_in_scripted_room(transport, driver.clone()).await;
         pump_until(&mut mesh, &driver, |c| {
             c.contains(&DriverCall::Connect(a, false)) && c.contains(&DriverCall::Connect(b, false))
         })
@@ -2343,7 +2369,7 @@ mod tests {
                 &["stun:2"],
             ))),
         ]);
-        let mut mesh = start_in_scripted_room(transport, driver.clone());
+        let mut mesh = start_in_scripted_room(transport, driver.clone()).await;
         pump_until(&mut mesh, &driver, |c2| {
             c2.contains(&DriverCall::Connect(c, true))
         })
@@ -2397,7 +2423,7 @@ mod tests {
             Some(Ok(session_plan_with_generation(peer, false, first))),
             Some(Ok(session_plan_with_generation(peer, false, second))),
         ]);
-        let mut mesh = start_in_scripted_room(transport, driver.clone());
+        let mut mesh = start_in_scripted_room(transport, driver.clone()).await;
 
         assert!(
             pump_until(&mut mesh, &driver, |calls| calls
@@ -2428,7 +2454,7 @@ mod tests {
             Some(Ok(session_plan_with_generation(peer, false, first))),
             Some(Ok(session_plan_with_generation(peer, false, second))),
         ]);
-        let mut mesh = start_in_scripted_room(transport, driver.clone());
+        let mut mesh = start_in_scripted_room(transport, driver.clone()).await;
         assert!(
             pump_until(&mut mesh, &driver, |calls| calls
                 .contains(&DriverCall::ConnectGeneration(peer, Some(second))))
@@ -2473,7 +2499,7 @@ mod tests {
             Some(Ok(session_plan_with_generation(peer, true, first))),
             Some(Ok(session_plan_with_generation(peer, true, second))),
         ]);
-        let mut mesh = start_in_scripted_room(transport, driver.clone());
+        let mut mesh = start_in_scripted_room(transport, driver.clone()).await;
 
         loop {
             if matches!(
@@ -2534,7 +2560,7 @@ mod tests {
                 serde_json::json!({ "Offer": "unplanned" }),
             ))),
         ]);
-        let mut mesh = start_in_scripted_room(transport, driver.clone());
+        let mut mesh = start_in_scripted_room(transport, driver.clone()).await;
         drain(&mut mesh, 8).await;
         assert!(!driver
             .calls()
@@ -2563,7 +2589,7 @@ mod tests {
                 })
                 .unwrap())),
             ]);
-            let mut mesh = start_in_scripted_room(transport, driver.clone());
+            let mut mesh = start_in_scripted_room(transport, driver.clone()).await;
             drain(&mut mesh, 10).await;
             let calls = driver.calls();
             assert!(calls.contains(&DriverCall::Disconnect(old_peer)));
@@ -2608,7 +2634,7 @@ mod tests {
             Some(Ok(session_plan_multi(&[(p, true)], &["stun:a"]))),
             Some(Ok(new_peer_msg(p, true))),
         ]);
-        let mut mesh = start_in_scripted_room(transport, driver.clone());
+        let mut mesh = start_in_scripted_room(transport, driver.clone()).await;
         drain(&mut mesh, 12).await;
         assert_eq!(
             count_calls(
@@ -2637,7 +2663,7 @@ mod tests {
             Some(Ok(new_peer_msg(p, true))),
             Some(Ok(new_peer_msg(p, true))),
         ]);
-        let mut mesh = start_in_scripted_room(transport, driver.clone());
+        let mut mesh = start_in_scripted_room(transport, driver.clone()).await;
         drain(&mut mesh, 12).await;
         assert_eq!(
             count_calls(
@@ -2675,7 +2701,7 @@ mod tests {
             Some(Ok(session_plan(p, false))),
             Some(Ok(session_plan(p, true))),
         ]);
-        let mut mesh = start_in_scripted_room(transport, driver.clone());
+        let mut mesh = start_in_scripted_room(transport, driver.clone()).await;
         let flipped = pump_until(&mut mesh, &driver, |c| {
             c.contains(&DriverCall::Connect(p, true))
         })
@@ -2723,7 +2749,7 @@ mod tests {
             Some(Ok(new_peer_msg(p, false))),
             Some(Ok(new_peer_msg(p, true))),
         ]);
-        let mut mesh = start_in_scripted_room(transport, driver.clone());
+        let mut mesh = start_in_scripted_room(transport, driver.clone()).await;
         let flipped = pump_until(&mut mesh, &driver, |c| {
             c.contains(&DriverCall::Connect(p, true))
         })
@@ -2759,7 +2785,7 @@ mod tests {
             Some(Ok(session_plan(p, true))),
             Some(Ok(signal_from(p, serde_json::json!({ "Answer": "r" })))),
         ]);
-        let mut mesh = start_in_scripted_room(transport, driver.clone());
+        let mut mesh = start_in_scripted_room(transport, driver.clone()).await;
 
         // Drive the handshake to an open channel (reports TransportStatus(true)).
         tokio::time::timeout(
@@ -2823,7 +2849,7 @@ mod tests {
                 &["stun:2"],
             ))),
         ]);
-        let mut mesh = start_in_scripted_room(transport, driver.clone());
+        let mut mesh = start_in_scripted_room(transport, driver.clone()).await;
         pump_until(&mut mesh, &driver, |calls| {
             calls.contains(&DriverCall::Connect(c, false))
         })
@@ -2888,7 +2914,7 @@ mod tests {
             Some(Ok(signal_from(p, serde_json::json!({ "Bogus": "x" })))),
             Some(Ok(signal_from(p, serde_json::json!({ "Offer": "ok" })))),
         ]);
-        let mut mesh = start_in_scripted_room(transport, driver.clone());
+        let mut mesh = start_in_scripted_room(transport, driver.clone()).await;
         pump_until(&mut mesh, &driver, |c| {
             c.contains(&DriverCall::OnSignal(p, PeerSignal::Offer("ok".into())))
         })
@@ -2916,7 +2942,7 @@ mod tests {
             Some(Ok(session_plan_multi(&[(p, false)], &["stun:real"]))),
             Some(Ok(session_plan_multi(&[(p, false), (q, false)], &[]))),
         ]);
-        let mut mesh = start_in_scripted_room(transport, driver.clone());
+        let mut mesh = start_in_scripted_room(transport, driver.clone()).await;
         pump_until(&mut mesh, &driver, |c| {
             c.contains(&DriverCall::Connect(q, false))
         })
@@ -2948,7 +2974,7 @@ mod tests {
             Some(Ok(new_peer_msg(p, true))),
             Some(Ok(session_plan_multi(&[(q, true)], &["stun:a"]))),
         ]);
-        let mut mesh = start_in_scripted_room(transport, driver.clone());
+        let mut mesh = start_in_scripted_room(transport, driver.clone()).await;
         let ok = pump_until(&mut mesh, &driver, |c| {
             c.contains(&DriverCall::Connect(q, true))
         })
@@ -3001,9 +3027,10 @@ mod tests {
         ]);
         let mut mesh =
             MeshController::start(transport, SignalFishConfig::new("app"), driver.clone());
+        wait_for_authenticated(&mut mesh).await;
         mesh.client_mut()
             .reconnect(uuid(0), uuid(0), "submitted-token".into())
-            .unwrap();
+            .expect("reconnect must be admitted once authenticated");
         let ok = pump_until(&mut mesh, &driver, |c| {
             c.contains(&DriverCall::Connect(a, true)) && c.contains(&DriverCall::Connect(b, false))
         })
@@ -3097,6 +3124,7 @@ mod tests {
             Some(Ok(session_plan(uuid(1), false))),
         ]);
         let mut mesh = start_in_scripted_room(transport, driver.clone())
+            .await
             .with_pump_interval(std::time::Duration::from_secs(30));
 
         // Drain the initial signaling events so the next recv() genuinely parks.

--- a/tests/client_tests.rs
+++ b/tests/client_tests.rs
@@ -47,11 +47,11 @@ use common::{
 /// Start a client with the given scripted server responses. The first item
 /// is typically `authenticated_json()` so the auth handshake succeeds.
 #[allow(clippy::type_complexity)]
-fn start_client(incoming: Vec<Option<Result<String, SignalFishError>>>) -> StartedClient {
-    start_client_with_config(incoming, SignalFishConfig::new("mb_test_integration"))
+async fn start_client(incoming: Vec<Option<Result<String, SignalFishError>>>) -> StartedClient {
+    start_client_with_config(incoming, SignalFishConfig::new("mb_test_integration")).await
 }
 
-fn start_client_with_config(
+async fn start_client_with_config(
     incoming: Vec<Option<Result<String, SignalFishError>>>,
     config: SignalFishConfig,
 ) -> StartedClient {
@@ -67,6 +67,11 @@ fn start_client_with_config(
     });
     let (transport, sent, closed) = MockTransport::new(incoming);
     let (mut client, events) = SignalFishClient::start(transport, config);
+    // Scripted room responses are gated behind matching outbound commands, so
+    // mirror documented usage and wait for authentication before admitting.
+    if scripted_room_operation.is_some() {
+        common::wait_for_authentication(&client).await;
+    }
     match scripted_room_operation {
         Some(false) => client
             .join_room(JoinRoomParams::new("test-game", "Alice"))
@@ -193,12 +198,14 @@ fn v2_room_baseline_json(peer: uuid::Uuid) -> String {
 /// Transport that can script incoming messages but hangs forever in `close()`.
 struct HangingCloseTransport {
     incoming: VecDeque<Option<Result<String, SignalFishError>>>,
+    sent_join_room: bool,
 }
 
 impl HangingCloseTransport {
     fn new(incoming: Vec<Option<Result<String, SignalFishError>>>) -> Self {
         Self {
             incoming: VecDeque::from(incoming),
+            sent_join_room: false,
         }
     }
 }
@@ -211,6 +218,13 @@ impl Transport for HangingCloseTransport {
         _cx: &mut std::task::Context<'_>,
         frame: &mut Option<TransportFrame>,
     ) -> std::task::Poll<Result<(), SignalFishError>> {
+        if let Some(TransportFrame::Text(message)) = frame.as_ref() {
+            if serde_json::from_str::<ClientMessage>(message)
+                .is_ok_and(|message| matches!(message, ClientMessage::JoinRoom { .. }))
+            {
+                self.sent_join_room = true;
+            }
+        }
         frame.take();
         std::task::Poll::Ready(Ok(()))
     }
@@ -219,6 +233,16 @@ impl Transport for HangingCloseTransport {
         &mut self,
         _cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Option<Result<TransportFrame, SignalFishError>>> {
+        if !self.sent_join_room {
+            let front_is_room_joined = match self.incoming.front() {
+                Some(Some(Ok(json))) => serde_json::from_str::<ServerMessage>(json)
+                    .is_ok_and(|message| matches!(message, ServerMessage::RoomJoined(_))),
+                _ => false,
+            };
+            if front_is_room_joined {
+                return std::task::Poll::Pending;
+            }
+        }
         if let Some(item) = self.incoming.pop_front() {
             std::task::Poll::Ready(item.map(|result| result.map(TransportFrame::Text)))
         } else {
@@ -241,7 +265,7 @@ impl Transport for HangingCloseTransport {
 #[tokio::test]
 async fn auth_flow_connected_then_authenticated() {
     let (mut client, mut events, sent, _closed) =
-        start_client(vec![Some(Ok(authenticated_json()))]);
+        start_client(vec![Some(Ok(authenticated_json()))]).await;
 
     // First event: Connected (synthetic).
     let ev = events.recv().await.expect("event");
@@ -291,7 +315,8 @@ async fn room_join_leave_rejoin_flow() {
         Some(Ok(room_joined_json())),
         Some(Ok(room_left_json())),
         Some(Ok(room_joined_json())),
-    ]);
+    ])
+    .await;
 
     drain_until_authenticated(&mut events).await;
     drain_until_protocol_info(&mut events).await;
@@ -336,7 +361,8 @@ async fn reconnection_flow_updates_state() {
         Some(Ok(authenticated_json())),
         Some(Ok(protocol_info_json(None))),
         Some(Ok(reconnected_json())),
-    ]);
+    ])
+    .await;
 
     drain_until_authenticated(&mut events).await;
     drain_until_protocol_info(&mut events).await;
@@ -398,7 +424,8 @@ async fn spectator_join_and_leave_flow() {
         Some(Ok(protocol_info_json(None))),
         Some(Ok(spectator_joined_json())),
         Some(Ok(spectator_left_json())),
-    ]);
+    ])
+    .await;
 
     drain_until_authenticated(&mut events).await;
     drain_until_protocol_info(&mut events).await;
@@ -440,7 +467,8 @@ async fn spectator_join_and_leave_flow() {
 async fn authority_request_granted() {
     let (mut client, mut events, sent, _closed) = start_client(player_room_script([Some(Ok(
         authority_response_json(true, None),
-    ))]));
+    ))]))
+    .await;
 
     drain_player_room(&mut events).await;
 
@@ -486,7 +514,8 @@ async fn authority_request_granted() {
 async fn authority_request_denied() {
     let (mut client, mut events, _sent, _closed) = start_client(player_room_script([Some(Ok(
         authority_response_json(false, Some("not allowed")),
-    ))]));
+    ))]))
+    .await;
 
     drain_player_room(&mut events).await;
 
@@ -512,7 +541,7 @@ async fn authority_request_denied() {
 
 #[tokio::test]
 async fn provide_connection_info_sends_correct_message() {
-    let (mut client, mut events, sent, _closed) = start_client(player_room_script([]));
+    let (mut client, mut events, sent, _closed) = start_client(player_room_script([])).await;
 
     drain_player_room(&mut events).await;
 
@@ -558,7 +587,7 @@ async fn provide_connection_info_sends_correct_message() {
 
 #[tokio::test]
 async fn provide_relay_connection_info() {
-    let (mut client, mut events, sent, _closed) = start_client(player_room_script([]));
+    let (mut client, mut events, sent, _closed) = start_client(player_room_script([])).await;
 
     drain_player_room(&mut events).await;
 
@@ -616,7 +645,7 @@ async fn provide_relay_connection_info() {
 #[tokio::test]
 async fn join_as_spectator_sends_correct_message() {
     let (mut client, mut events, sent, _closed) =
-        start_client(vec![Some(Ok(authenticated_json()))]);
+        start_client(vec![Some(Ok(authenticated_json()))]).await;
 
     drain_until_authenticated(&mut events).await;
 
@@ -656,7 +685,8 @@ async fn leave_spectator_sends_correct_message() {
         Some(Ok(authenticated_json())),
         Some(Ok(protocol_info_json(None))),
         Some(Ok(spectator_joined_json())),
-    ]);
+    ])
+    .await;
 
     drain_until_authenticated(&mut events).await;
     drain_until_protocol_info(&mut events).await;
@@ -694,7 +724,8 @@ async fn server_error_event_received() {
             "something went wrong",
             Some(ErrorCode::InternalError),
         ))),
-    ]);
+    ])
+    .await;
 
     drain_until_authenticated(&mut events).await;
 
@@ -718,7 +749,8 @@ async fn server_error_event_without_error_code() {
     let (mut client, mut events, _sent, _closed) = start_client(vec![
         Some(Ok(authenticated_json())),
         Some(Ok(error_json("generic error", None))),
-    ]);
+    ])
+    .await;
 
     drain_until_authenticated(&mut events).await;
 
@@ -744,7 +776,7 @@ async fn server_error_event_without_error_code() {
 #[tokio::test]
 async fn disconnect_on_transport_close() {
     let (mut client, mut events, _sent, _closed) =
-        start_client(vec![Some(Ok(authenticated_json())), None]);
+        start_client(vec![Some(Ok(authenticated_json())), None]).await;
 
     drain_until_authenticated(&mut events).await;
 
@@ -759,7 +791,8 @@ async fn disconnect_on_transport_close() {
 async fn disconnect_on_transport_error() {
     let (mut client, mut events, _sent, _closed) = start_client(vec![Some(Err(
         SignalFishError::TransportReceive("network failure".into()),
-    ))]);
+    ))])
+    .await;
 
     // Connected might still be emitted before the error is processed.
     let ev = events.recv().await.expect("event");
@@ -780,7 +813,7 @@ async fn disconnect_on_transport_error() {
 #[tokio::test]
 async fn operations_fail_after_disconnect() {
     let (mut client, mut events, _sent, _closed) =
-        start_client(vec![Some(Ok(authenticated_json())), None]);
+        start_client(vec![Some(Ok(authenticated_json())), None]).await;
 
     drain_until_authenticated(&mut events).await;
 
@@ -809,7 +842,8 @@ async fn game_data_event_received() {
         Some(Ok(protocol_info_json(None))),
         Some(Ok(v2_room_baseline_json(player))),
         Some(Ok(game_data_json(player, data.clone()))),
-    ]);
+    ])
+    .await;
 
     drain_until_authenticated(&mut events).await;
     drain_until_protocol_info(&mut events).await;
@@ -864,6 +898,7 @@ async fn game_data_binary_event_received() {
     let mut config = SignalFishConfig::new("mb_test_integration").enable_v3();
     config.game_data_format = Some(GameDataEncoding::MessagePack);
     let (mut client, mut events) = SignalFishClient::start(transport, config);
+    common::wait_for_authentication(&client).await;
     client
         .join_room(JoinRoomParams::new("test", "Local"))
         .expect("binary room fixture must follow an admitted join");
@@ -918,6 +953,7 @@ async fn v2_message_pack_binary_event_received() {
     let mut config = SignalFishConfig::new("mb_test_integration");
     config.game_data_format = Some(GameDataEncoding::MessagePack);
     let (mut client, mut events) = SignalFishClient::start(transport, config);
+    common::wait_for_authentication(&client).await;
     client
         .join_room(JoinRoomParams::new("test", "Local"))
         .expect("binary room fixture must follow an admitted join");
@@ -1019,6 +1055,7 @@ async fn async_observe_advances_valid_wrong_representation_sequence() {
         .enable_v3()
         .with_protocol_violation_policy(signal_fish_client::ProtocolViolationPolicy::Observe);
     let (mut client, mut events) = SignalFishClient::start(transport, config);
+    common::wait_for_authentication(&client).await;
     client
         .join_room(JoinRoomParams::new("test", "Local"))
         .expect("binary room fixture must follow an admitted join");
@@ -1052,7 +1089,7 @@ async fn async_observe_advances_valid_wrong_representation_sequence() {
 
 #[tokio::test]
 async fn send_game_data_produces_correct_json() {
-    let (mut client, mut events, sent, _closed) = start_client(player_room_script([]));
+    let (mut client, mut events, sent, _closed) = start_client(player_room_script([])).await;
 
     drain_player_room(&mut events).await;
 
@@ -1092,7 +1129,7 @@ async fn send_game_data_produces_correct_json() {
 
 #[tokio::test]
 async fn set_ready_sends_player_ready_message() {
-    let (mut client, mut events, sent, _closed) = start_client(player_room_script([]));
+    let (mut client, mut events, sent, _closed) = start_client(player_room_script([])).await;
 
     drain_player_room(&mut events).await;
 
@@ -1119,7 +1156,8 @@ async fn ping_and_pong_flow() {
         Some(Ok(authenticated_json())),
         Some(Ok(protocol_info_json(None))),
         Some(Ok(pong_json())),
-    ]);
+    ])
+    .await;
 
     drain_until_authenticated(&mut events).await;
     drain_until_protocol_info(&mut events).await;
@@ -1150,7 +1188,7 @@ async fn ping_and_pong_flow() {
 #[tokio::test]
 async fn join_room_with_all_options_sends_correct_message() {
     let (mut client, mut events, sent, _closed) =
-        start_client(vec![Some(Ok(authenticated_json()))]);
+        start_client(vec![Some(Ok(authenticated_json()))]).await;
 
     drain_until_authenticated(&mut events).await;
 
@@ -1207,7 +1245,7 @@ async fn join_room_with_all_options_sends_correct_message() {
 
 #[tokio::test]
 async fn multiple_sequential_operations() {
-    let (mut client, mut events, sent, _closed) = start_client(player_room_script([]));
+    let (mut client, mut events, sent, _closed) = start_client(player_room_script([])).await;
     drain_player_room(&mut events).await;
 
     // Send game data.
@@ -1248,7 +1286,8 @@ async fn player_joined_event_received() {
         Some(Ok(protocol_info_json(None))),
         Some(Ok(room_joined_json())),
         Some(Ok(common::player_joined_json("Bob", new_player))),
-    ]);
+    ])
+    .await;
 
     drain_until_authenticated(&mut events).await;
     drain_until_protocol_info(&mut events).await;
@@ -1274,7 +1313,8 @@ async fn player_left_event_received() {
         Some(Ok(protocol_info_json(None))),
         Some(Ok(v2_room_baseline_json(left_player))),
         Some(Ok(player_left_json(left_player))),
-    ]);
+    ])
+    .await;
 
     drain_until_authenticated(&mut events).await;
     drain_until_protocol_info(&mut events).await;
@@ -1316,7 +1356,8 @@ async fn lobby_state_changed_event() {
         Some(Ok(protocol_info_json(None))),
         Some(Ok(room_joined_json())),
         Some(Ok(lobby_json)),
-    ]);
+    ])
+    .await;
 
     drain_until_authenticated(&mut events).await;
     drain_until_protocol_info(&mut events).await;
@@ -1365,7 +1406,8 @@ async fn game_starting_event() {
         Some(Ok(protocol_info_json(None))),
         Some(Ok(v2_room_baseline_json(uuid::Uuid::from_u128(10)))),
         Some(Ok(gs_json)),
-    ]);
+    ])
+    .await;
 
     drain_until_authenticated(&mut events).await;
     drain_until_protocol_info(&mut events).await;
@@ -1403,7 +1445,8 @@ async fn authority_changed_event() {
         Some(Ok(protocol_info_json(None))),
         Some(Ok(v2_room_baseline_json(auth_player))),
         Some(Ok(ac_json)),
-    ]);
+    ])
+    .await;
 
     drain_until_authenticated(&mut events).await;
     drain_until_protocol_info(&mut events).await;
@@ -1449,7 +1492,8 @@ async fn new_spectator_joined_event() {
         Some(Ok(protocol_info_json(None))),
         Some(Ok(room_joined_json())),
         Some(Ok(nsj_json)),
-    ]);
+    ])
+    .await;
 
     drain_until_authenticated(&mut events).await;
     drain_until_protocol_info(&mut events).await;
@@ -1489,7 +1533,8 @@ async fn spectator_disconnected_event() {
         Some(Ok(protocol_info_json(None))),
         Some(Ok(room_joined_json())),
         Some(Ok(sd_json)),
-    ]);
+    ])
+    .await;
 
     drain_until_authenticated(&mut events).await;
     drain_until_protocol_info(&mut events).await;
@@ -1533,7 +1578,8 @@ async fn reconnection_failed_event() {
         Some(Ok(authenticated_json())),
         Some(Ok(protocol_info_json(None))),
         Some(Ok(rf_json)),
-    ]);
+    ])
+    .await;
 
     drain_until_authenticated(&mut events).await;
     drain_until_protocol_info(&mut events).await;
@@ -1569,7 +1615,8 @@ async fn player_reconnected_event() {
         Some(Ok(protocol_info_json(None))),
         Some(Ok(v2_room_baseline_json(uuid::Uuid::from_u128(700)))),
         Some(Ok(pr_json)),
-    ]);
+    ])
+    .await;
 
     drain_until_authenticated(&mut events).await;
     drain_until_protocol_info(&mut events).await;
@@ -1601,7 +1648,7 @@ async fn authentication_error_event() {
     })
     .expect("serialize");
 
-    let (mut client, mut events, _sent, _closed) = start_client(vec![Some(Ok(ae_json))]);
+    let (mut client, mut events, _sent, _closed) = start_client(vec![Some(Ok(ae_json))]).await;
 
     // Connected is first.
     let ev = events.recv().await.expect("event");
@@ -1634,7 +1681,8 @@ async fn room_join_failed_event() {
         Some(Ok(authenticated_json())),
         Some(Ok(protocol_info_json(None))),
         Some(Ok(rjf_json)),
-    ]);
+    ])
+    .await;
 
     drain_until_authenticated(&mut events).await;
     drain_until_protocol_info(&mut events).await;
@@ -1662,7 +1710,8 @@ async fn spectator_join_failed_event() {
         Some(Ok(authenticated_json())),
         Some(Ok(protocol_info_json(None))),
         Some(Ok(sjf_json)),
-    ]);
+    ])
+    .await;
 
     drain_until_authenticated(&mut events).await;
     drain_until_protocol_info(&mut events).await;
@@ -1704,7 +1753,7 @@ async fn protocol_info_event() {
     .expect("serialize");
 
     let (mut client, mut events, _sent, _closed) =
-        start_client(vec![Some(Ok(authenticated_json())), Some(Ok(pi_json))]);
+        start_client(vec![Some(Ok(authenticated_json())), Some(Ok(pi_json))]).await;
 
     drain_until_authenticated(&mut events).await;
 
@@ -1726,7 +1775,7 @@ async fn protocol_info_event() {
 #[tokio::test]
 async fn shutdown_closes_transport() {
     let (mut client, mut events, _sent, closed) =
-        start_client(vec![Some(Ok(authenticated_json()))]);
+        start_client(vec![Some(Ok(authenticated_json()))]).await;
 
     drain_until_authenticated(&mut events).await;
 
@@ -1749,6 +1798,7 @@ async fn shutdown_timeout_clears_state_even_when_disconnected_event_is_skipped()
     let config = SignalFishConfig::new("mb_test_integration")
         .with_shutdown_timeout(std::time::Duration::from_millis(1));
     let (mut client, mut events) = SignalFishClient::start(transport, config);
+    common::wait_for_authentication(&client).await;
     client
         .join_room(JoinRoomParams::new("test-game", "Alice"))
         .expect("room fixture must follow an admitted join");
@@ -1774,7 +1824,7 @@ async fn shutdown_timeout_clears_state_even_when_disconnected_event_is_skipped()
 
 #[tokio::test]
 async fn leave_room_sends_leave_room_message() {
-    let (mut client, mut events, sent, _closed) = start_client(player_room_script([]));
+    let (mut client, mut events, sent, _closed) = start_client(player_room_script([])).await;
 
     drain_player_room(&mut events).await;
 
@@ -1809,7 +1859,8 @@ async fn malformed_json_emits_decode_failed_then_next_message_arrives() {
         Some(Ok(protocol_info_json(None))),
         Some(Ok("{{not valid json at all!!!".into())),
         Some(Ok(pong_json())),
-    ]);
+    ])
+    .await;
 
     drain_until_authenticated(&mut events).await;
     drain_until_protocol_info(&mut events).await;
@@ -1858,7 +1909,8 @@ async fn unknown_error_code_string_surfaces_decode_failed_not_silent_drop() {
         Some(Ok(protocol_info_json(None))),
         Some(Ok(unknown_code_frame.to_string())),
         Some(Ok(pong_json())),
-    ]);
+    ])
+    .await;
 
     drain_until_authenticated(&mut events).await;
     drain_until_protocol_info(&mut events).await;
@@ -1905,7 +1957,8 @@ async fn decode_failed_raw_prefix_is_capped_on_utf8_boundary() {
     let (mut client, mut events, _sent, _closed) = start_client(vec![
         Some(Ok(authenticated_json())),
         Some(Ok(garbage.clone())),
-    ]);
+    ])
+    .await;
     drain_until_authenticated(&mut events).await;
 
     let ev = events.recv().await.expect("DecodeFailed for garbage");
@@ -1941,7 +1994,8 @@ async fn disconnected_carries_last_server_error_after_server_close() {
             Some(ErrorCode::SlowConsumer),
         ))),
         None, // server closes
-    ]);
+    ])
+    .await;
 
     drain_until_authenticated(&mut events).await;
 
@@ -1964,7 +2018,7 @@ async fn disconnected_carries_last_server_error_after_server_close() {
 #[tokio::test]
 async fn disconnected_last_server_error_is_none_without_prior_error() {
     let (_client, mut events, _sent, _closed) =
-        start_client(vec![Some(Ok(authenticated_json())), None]);
+        start_client(vec![Some(Ok(authenticated_json())), None]).await;
 
     drain_until_authenticated(&mut events).await;
 
@@ -2123,7 +2177,8 @@ async fn player_joined_with_connection_info_direct() {
         Some(Ok(protocol_info_json(None))),
         Some(Ok(room_joined_json())),
         Some(Ok(pj_json)),
-    ]);
+    ])
+    .await;
 
     drain_until_authenticated(&mut events).await;
     drain_until_protocol_info(&mut events).await;
@@ -2186,7 +2241,7 @@ fn sent_messages(sent: &std::sync::Arc<std::sync::Mutex<Vec<String>>>) -> Vec<Cl
 
 #[tokio::test]
 async fn start_game_sends_start_game_message() {
-    let (mut client, mut events, sent, _closed) = start_client(player_room_script([]));
+    let (mut client, mut events, sent, _closed) = start_client(player_room_script([])).await;
     drain_player_room(&mut events).await;
 
     client.start_game().expect("start_game");
@@ -2201,7 +2256,7 @@ async fn start_game_sends_start_game_message() {
 #[tokio::test]
 async fn start_game_available_on_relay_floor() {
     // start_game is the universal v2 change — NOT gated behind v3 negotiation.
-    let (mut client, mut events, sent, _closed) = start_client(player_room_script([]));
+    let (mut client, mut events, sent, _closed) = start_client(player_room_script([])).await;
     drain_player_room(&mut events).await;
     assert!(client.negotiated_protocol_version().is_none());
 
@@ -2218,7 +2273,7 @@ async fn start_game_available_on_relay_floor() {
 #[tokio::test]
 async fn send_signal_outside_room_returns_not_in_room_before_protocol_guard() {
     let (mut client, mut events, sent, _closed) =
-        start_client(vec![Some(Ok(authenticated_json()))]);
+        start_client(vec![Some(Ok(authenticated_json()))]).await;
     drain_until_authenticated(&mut events).await;
 
     // Player membership is checked before protocol negotiation.
@@ -2248,7 +2303,8 @@ async fn send_signal_after_v3_negotiation_is_sent() {
         Some(Ok(protocol_info_json(Some(3)))),
         Some(Ok(v3_room_baseline_json(peer))),
         Some(Ok(session_plan_json(peer, true))),
-    ]);
+    ])
+    .await;
     drain_until_authenticated(&mut events).await;
     drain_until_protocol_info(&mut events).await;
     while !matches!(
@@ -2284,7 +2340,8 @@ async fn send_signal_after_v3_but_before_plan_fails_locally() {
         Some(Ok(authenticated_json())),
         Some(Ok(protocol_info_json(Some(3)))),
         Some(Ok(v3_room_baseline_json(uuid::Uuid::from_u128(2)))),
-    ]);
+    ])
+    .await;
     drain_until_authenticated(&mut events).await;
     drain_until_protocol_info(&mut events).await;
     assert!(matches!(
@@ -2315,7 +2372,8 @@ async fn generation_bound_typed_and_raw_signals_refuse_stale_plan() {
         Some(Ok(v3_room_baseline_json(peer))),
         Some(Ok(session_plan_json(peer, true))),
         Some(Ok(replacement)),
-    ]);
+    ])
+    .await;
     tokio::time::timeout(std::time::Duration::from_secs(5), async {
         while client.snapshot().session_generation != Some(second) {
             tokio::task::yield_now().await;
@@ -2372,7 +2430,8 @@ async fn stale_and_preplan_signals_are_suppressed() {
             peer,
             serde_json::json!({ "Offer": "current" }),
         ))),
-    ]);
+    ])
+    .await;
 
     let mut received = Vec::new();
     while received.is_empty() {
@@ -2395,7 +2454,8 @@ async fn legacy_generationless_plan_keeps_generationless_signal_wire() {
         Some(Ok(protocol_info_json(Some(3)))),
         Some(Ok(v3_room_baseline_json(peer))),
         Some(Ok(legacy_plan.into())),
-    ]);
+    ])
+    .await;
     while !matches!(
         events.recv().await.expect("SessionPlan event"),
         SignalFishEvent::SessionPlan {
@@ -2426,7 +2486,8 @@ async fn report_transport_status_after_v3_is_sent() {
         Some(Ok(authenticated_json())),
         Some(Ok(protocol_info_json(Some(3)))),
         Some(Ok(v3_room_baseline_json(uuid::Uuid::from_u128(2)))),
-    ]);
+    ])
+    .await;
     drain_until_authenticated(&mut events).await;
     drain_until_protocol_info(&mut events).await;
     assert!(matches!(
@@ -2459,7 +2520,8 @@ async fn v2_protocol_info_keeps_relay_floor_guard() {
         Some(Ok(authenticated_json())),
         Some(Ok(protocol_info_json(None))),
         Some(Ok(v2_room_baseline_json(uuid::Uuid::from_u128(2)))),
-    ]);
+    ])
+    .await;
     drain_until_authenticated(&mut events).await;
     drain_until_protocol_info(&mut events).await;
     assert!(matches!(
@@ -2486,7 +2548,8 @@ async fn v3_session_plan_and_signal_events_are_emitted() {
             peer,
             serde_json::json!({ "Offer": "remote-sdp" }),
         ))),
-    ]);
+    ])
+    .await;
     drain_until_authenticated(&mut events).await;
 
     let mut saw_plan = false;
@@ -2532,7 +2595,8 @@ async fn new_peer_and_peer_transport_status_events_are_emitted() {
         Some(Ok(session_plan_json(peer, true))),
         Some(Ok(new_peer_json(peer, true))),
         Some(Ok(peer_transport_status_json(peer, true))),
-    ]);
+    ])
+    .await;
     drain_until_authenticated(&mut events).await;
 
     let mut saw_new_peer = false;
@@ -2573,7 +2637,8 @@ async fn unknown_server_message_type_surfaces_decode_failed_then_next_arrives() 
         Some(Ok(protocol_info_json(None))),
         Some(Ok(r#"{"type":"SomeFutureV4Message","data":{}}"#.to_string())),
         Some(Ok(pong_json())),
-    ]);
+    ])
+    .await;
     drain_until_authenticated(&mut events).await;
     drain_until_protocol_info(&mut events).await;
     let ev = events.recv().await.expect("event after unknown type");
@@ -2593,7 +2658,7 @@ async fn unknown_server_message_type_surfaces_decode_failed_then_next_arrives() 
 async fn send_signal_before_authentication_is_not_in_room() {
     // Command queuing remains available before authentication, but a
     // player-only operation still requires confirmed membership.
-    let (mut client, _events, sent, _closed) = start_client(vec![]);
+    let (mut client, _events, sent, _closed) = start_client(vec![]).await;
 
     let err = client
         .send_offer(uuid::Uuid::from_u128(2), "sdp")
@@ -2615,7 +2680,8 @@ async fn negotiated_version_resets_on_disconnect() {
         Some(Ok(authenticated_json())),
         Some(Ok(protocol_info_json(Some(3)))),
         None, // clean close
-    ]);
+    ])
+    .await;
     drain_until_authenticated(&mut events).await;
 
     // Drain until the transport closes (clear_session_state runs before the
@@ -2643,14 +2709,16 @@ async fn reconnect_receives_fresh_authoritative_session_plan() {
             Some(Ok(session_plan_json(peer, true))),
         ],
         SignalFishConfig::new("mb_test_integration").enable_mesh(),
-    );
+    )
+    .await;
+    common::wait_for_authentication(&client).await;
     client
         .reconnect(
             uuid::Uuid::from_u128(200),
             uuid::Uuid::from_u128(100),
             "submitted-token".into(),
         )
-        .expect("reconnect must queue");
+        .expect("authenticated reconnect must queue");
     drain_until_authenticated(&mut events).await;
     // Reconnection establishes the finalized room baseline; the server then
     // publishes a fresh authoritative plan as a separate room-ordered frame.
@@ -2699,7 +2767,8 @@ async fn v4_negotiation_still_enables_mesh() {
             Some(Ok(session_plan_json(uuid::Uuid::from_u128(2), true))),
         ],
         SignalFishConfig::new("mb_test_integration").enable_mesh(),
-    );
+    )
+    .await;
     drain_until_authenticated(&mut events).await;
     drain_until_protocol_info(&mut events).await;
     while !matches!(
@@ -2722,7 +2791,8 @@ async fn send_answer_ice_and_raw_signal_wire_shapes() {
         Some(Ok(protocol_info_json(Some(3)))),
         Some(Ok(v3_room_baseline_json(peer))),
         Some(Ok(session_plan_json(peer, true))),
-    ]);
+    ])
+    .await;
     drain_until_authenticated(&mut events).await;
     drain_until_protocol_info(&mut events).await;
     while !matches!(

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -476,6 +476,21 @@ pub async fn wait_for_sent_len(sent: &Arc<StdMutex<Vec<String>>>, expected_len: 
     });
 }
 
+/// Wait until the async driver observes the server's `Authenticated`
+/// confirmation without consuming any events, mirroring the documented
+/// requirement to await `SignalFishEvent::Authenticated` before room
+/// operations. Room operations refuse earlier with
+/// [`SignalFishError::NotAuthenticated`].
+pub async fn wait_for_authentication(client: &signal_fish_client::SignalFishClient) {
+    tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        while !client.is_authenticated() {
+            tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+        }
+    })
+    .await
+    .expect("client must observe Authenticated before scripted room operations");
+}
+
 /// Returns the JSON for a `SessionPlan` (mesh + webrtc) naming a single peer.
 pub fn session_plan_json(peer_id: PlayerId, initiate: bool) -> String {
     serde_json::to_string(&session_plan_message(peer_id, initiate))

--- a/tests/negotiation_robustness_tests.rs
+++ b/tests/negotiation_robustness_tests.rs
@@ -21,8 +21,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex as StdMutex};
 
 use signal_fish_client::protocol::{
-    LobbyState, PlayerInfo, ReconnectedPayload, ReplayStatus, SenderWatermark, ServerMessage,
-    SessionPeer, SessionPlanPayload, Topology, TransportKind,
+    ClientMessage, LobbyState, PlayerInfo, ReconnectedPayload, ReplayStatus, SenderWatermark,
+    ServerMessage, SessionPeer, SessionPlanPayload, Topology, TransportKind,
 };
 use signal_fish_client::transport::TransportFrame;
 use signal_fish_client::{
@@ -170,15 +170,15 @@ async fn reconnect_rejects_protocol_info_without_downgrading_active_v3() {
         Some(Ok(protocol_info_json(Some(3)))), // negotiate v3
         Some(Ok(reconnected_with_missed(vec![protocol_info_msg(None)]))),
     ]);
+    drain_until_authenticated(&mut events).await;
+    drain_until_protocol_info(&mut events).await;
     client
         .reconnect(
             uuid::Uuid::from_u128(200),
             uuid::Uuid::from_u128(100),
             "submitted-token".into(),
         )
-        .expect("reconnect must queue");
-    drain_until_authenticated(&mut events).await;
-    drain_until_protocol_info(&mut events).await;
+        .expect("authenticated reconnect must queue");
     assert_eq!(client.negotiated_protocol_version(), Some(3));
 
     drain_until_violation(&mut events).await;
@@ -203,15 +203,15 @@ async fn reconnect_multiple_protocol_info_is_rejected() {
             protocol_info_msg(Some(4)),
         ]))),
     ]);
+    drain_until_authenticated(&mut events).await;
+    drain_until_protocol_info(&mut events).await;
     client
         .reconnect(
             uuid::Uuid::from_u128(200),
             uuid::Uuid::from_u128(100),
             "submitted-token".into(),
         )
-        .expect("reconnect must queue");
-    drain_until_authenticated(&mut events).await;
-    drain_until_protocol_info(&mut events).await;
+        .expect("authenticated reconnect must queue");
     drain_until_violation(&mut events).await;
 
     assert_eq!(
@@ -234,15 +234,15 @@ async fn reconnect_versioned_then_v2_keeps_version() {
             protocol_info_msg(None),
         ]))),
     ]);
+    drain_until_authenticated(&mut events).await;
+    drain_until_protocol_info(&mut events).await;
     client
         .reconnect(
             uuid::Uuid::from_u128(200),
             uuid::Uuid::from_u128(100),
             "submitted-token".into(),
         )
-        .expect("reconnect must queue");
-    drain_until_authenticated(&mut events).await;
-    drain_until_protocol_info(&mut events).await;
+        .expect("authenticated reconnect must queue");
     drain_until_violation(&mut events).await;
 
     assert_eq!(
@@ -264,15 +264,15 @@ async fn reconnect_without_protocol_info_preserves_prior_v3() {
         Some(Ok(reconnected_with_missed(vec![]))),
         Some(Ok(serde_json::to_string(&session_plan_msg()).unwrap())),
     ]);
+    drain_until_authenticated(&mut events).await;
+    drain_until_protocol_info(&mut events).await;
     client
         .reconnect(
             uuid::Uuid::from_u128(200),
             uuid::Uuid::from_u128(100),
             "submitted-token".into(),
         )
-        .expect("reconnect must queue");
-    drain_until_authenticated(&mut events).await;
-    drain_until_protocol_info(&mut events).await;
+        .expect("authenticated reconnect must queue");
     assert_eq!(client.negotiated_protocol_version(), Some(3));
 
     drain_until_reconnected(&mut events).await;
@@ -304,6 +304,7 @@ struct SendErrorTransport {
     closed: Arc<AtomicBool>,
     send_count: usize,
     error_on_send: usize,
+    sent_join_room: bool,
 }
 
 impl SendErrorTransport {
@@ -319,6 +320,7 @@ impl SendErrorTransport {
             closed: Arc::clone(&closed),
             send_count: 0,
             error_on_send,
+            sent_join_room: false,
         };
         (t, sent, closed)
     }
@@ -340,6 +342,11 @@ impl Transport for SendErrorTransport {
             let TransportFrame::Text(message) = frame else {
                 panic!("test mock expected an outbound text frame");
             };
+            if serde_json::from_str::<ClientMessage>(&message)
+                .is_ok_and(|message| matches!(message, ClientMessage::JoinRoom { .. }))
+            {
+                self.sent_join_room = true;
+            }
             self.sent.lock().unwrap().push(message);
         }
         std::task::Poll::Ready(Ok(()))
@@ -349,6 +356,17 @@ impl Transport for SendErrorTransport {
         &mut self,
         _cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Option<Result<TransportFrame, SignalFishError>>> {
+        // Room responses follow admitted joins on this fixture.
+        if !self.sent_join_room {
+            let front_is_room_joined = match self.incoming.front() {
+                Some(Some(Ok(json))) => serde_json::from_str::<ServerMessage>(json)
+                    .is_ok_and(|message| matches!(message, ServerMessage::RoomJoined(_))),
+                _ => false,
+            };
+            if front_is_room_joined {
+                return std::task::Poll::Pending;
+            }
+        }
         if let Some(item) = self.incoming.pop_front() {
             std::task::Poll::Ready(item.map(|result| result.map(TransportFrame::Text)))
         } else {
@@ -379,6 +397,7 @@ async fn send_error_midflight_disconnects_and_clears_state() {
     );
     let config = SignalFishConfig::new("mb_audit").enable_mesh();
     let (mut client, mut events) = SignalFishClient::start(transport, config);
+    common::wait_for_authentication(&client).await;
     client
         .join_room(JoinRoomParams::new("test-game", "Alice"))
         .expect("room fixture must follow an admitted join");

--- a/tests/polling_parity_tests.rs
+++ b/tests/polling_parity_tests.rs
@@ -20,6 +20,9 @@ use std::collections::VecDeque;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
+#[allow(dead_code)]
+mod common;
+
 use signal_fish_client::client::{SignalFishClient, SignalFishConfig};
 use signal_fish_client::error::SignalFishError;
 use signal_fish_client::polling_client::{
@@ -276,6 +279,7 @@ struct NeverSendMock {
     attempted: Arc<std::sync::atomic::AtomicBool>,
     allow: Arc<std::sync::atomic::AtomicBool>,
     waker: Arc<Mutex<Option<std::task::Waker>>>,
+    incoming: Arc<Mutex<VecDeque<TransportFrame>>>,
 }
 
 impl NeverSendMock {
@@ -284,6 +288,9 @@ impl NeverSendMock {
             attempted: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             allow: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             waker: Arc::new(Mutex::new(None)),
+            incoming: Arc::new(Mutex::new(VecDeque::from([TransportFrame::Text(
+                AUTH.into(),
+            )]))),
         }
     }
 
@@ -317,9 +324,15 @@ impl Transport for NeverSendMock {
 
     fn poll_recv(
         &mut self,
-        _cx: &mut std::task::Context<'_>,
+        cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Option<Result<TransportFrame, SignalFishError>>> {
-        std::task::Poll::Pending
+        match self.incoming.lock().unwrap().pop_front() {
+            Some(frame) => std::task::Poll::Ready(Some(Ok(frame))),
+            None => {
+                *self.waker.lock().unwrap() = Some(cx.waker().clone());
+                std::task::Poll::Pending
+            }
+        }
     }
 
     fn poll_close(
@@ -812,6 +825,7 @@ async fn async_membership_result(
         | MembershipPhase::SpectatorLeft
         | MembershipPhase::SpectatorRejoined => Some(InitialRoomOperation::JoinSpectator),
     };
+    common::wait_for_authentication(&client).await;
     admit_initial_room_operation(&mut client, initial);
     let mut leave_issued = false;
     let mut rejoin_issued = false;
@@ -886,6 +900,16 @@ fn polling_membership_result(phase: MembershipPhase, case: CommonCommandCase) ->
         | MembershipPhase::SpectatorLeft
         | MembershipPhase::SpectatorRejoined => Some(InitialRoomOperation::JoinSpectator),
     };
+    for _ in 0..16 {
+        if client.is_authenticated() {
+            break;
+        }
+        let _ = client.poll();
+    }
+    assert!(
+        client.is_authenticated(),
+        "polling membership fixture must authenticate before admission"
+    );
     admit_initial_room_operation(&mut client, initial);
     let _ = client.poll();
     if matches!(
@@ -1503,10 +1527,18 @@ struct TraceMock {
     sent: Arc<Mutex<Vec<TransportFrame>>>,
     required_room_commands: Arc<Mutex<RoomCommandRequirements>>,
     gate_reconnect_responses: bool,
+    /// Deliver the first `n` frames freely, then hold the trace until the
+    /// admitted room command reaches the wire. Pins admission ordering.
+    hold_until_command: Option<(usize, RoomResponseKind)>,
+    delivered_count: Arc<std::sync::atomic::AtomicUsize>,
 }
 
 impl TraceMock {
-    fn new(frames: Vec<TransportFrame>, gate_reconnect_responses: bool) -> Self {
+    fn with_join_barrier(
+        frames: Vec<TransportFrame>,
+        gate_reconnect_responses: bool,
+        hold_until_command: Option<(usize, RoomResponseKind)>,
+    ) -> Self {
         Self {
             incoming: Arc::new(Mutex::new(
                 frames
@@ -1518,6 +1550,8 @@ impl TraceMock {
             sent: Arc::new(Mutex::new(Vec::new())),
             required_room_commands: Arc::new(Mutex::new(RoomCommandRequirements::default())),
             gate_reconnect_responses,
+            hold_until_command,
+            delivered_count: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
         }
     }
 }
@@ -1540,6 +1574,23 @@ impl Transport for TraceMock {
         &mut self,
         _cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Option<Result<TransportFrame, SignalFishError>>> {
+        if let Some((delivered_freely, required_kind)) = self.hold_until_command {
+            let behind_barrier = self
+                .delivered_count
+                .load(std::sync::atomic::Ordering::Acquire)
+                >= delivered_freely;
+            if behind_barrier {
+                let command_sent = self.sent.lock().unwrap().iter().any(|frame| {
+                    let TransportFrame::Text(json) = frame else {
+                        return false;
+                    };
+                    text_matches_room_command(json, required_kind)
+                });
+                if !command_sent {
+                    return std::task::Poll::Pending;
+                }
+            }
+        }
         let response_kind = self.incoming.lock().unwrap().front().and_then(|item| {
             let Some(Ok(TransportFrame::Text(json))) = item else {
                 return None;
@@ -1570,6 +1621,10 @@ impl Transport for TraceMock {
             Some(item) => std::task::Poll::Ready(item),
             None => std::task::Poll::Pending,
         };
+        if let std::task::Poll::Ready(Some(Ok(_))) = &delivered {
+            self.delivered_count
+                .fetch_add(1, std::sync::atomic::Ordering::Release);
+        }
         if let std::task::Poll::Ready(Some(Ok(frame))) = &delivered {
             advance_frame_room_command_requirements(
                 frame,
@@ -1972,12 +2027,68 @@ async fn assert_frame_trace_parity_with_stats(
     admit_reconnect: bool,
     expected_stats: Option<ClientStats>,
 ) -> Vec<String> {
-    let make_mock = || TraceMock::new(frames.clone(), admit_reconnect);
     let initial_room_operation = initial_room_operation(&frames);
     let response_counts = room_response_counts(&frames);
+    // Wire-shape samples may omit authentication entirely; a trace that needs
+    // a scripted room operation is still driven behind a real handshake whose
+    // remainder is held until the admitted command reaches the wire.
+    let auth_frame_index = frames.iter().position(|frame| {
+        matches!(
+            frame,
+            TransportFrame::Text(json)
+                if serde_json::from_str::<ServerMessage>(json)
+                    .is_ok_and(|message| matches!(message, ServerMessage::Authenticated { .. }))
+        )
+    });
+    let needs_handshake_preamble = initial_room_operation.is_some() && auth_frame_index.is_none();
+    let preamble: Vec<TransportFrame> = if needs_handshake_preamble {
+        vec![
+            TransportFrame::Text(AUTH.to_string()),
+            TransportFrame::Text(PI_V3.to_string()),
+        ]
+    } else {
+        Vec::new()
+    };
+    let frames = preamble.into_iter().chain(frames).collect::<Vec<_>>();
+    let scripts_authentication = needs_handshake_preamble || auth_frame_index.is_some();
+    let hold_until_command = (initial_room_operation.is_some() && scripts_authentication).then({
+        move || {
+            let kind = match initial_room_operation.expect("admission checked above") {
+                InitialRoomOperation::JoinPlayer => RoomResponseKind::JoinPlayer,
+                InitialRoomOperation::JoinSpectator => RoomResponseKind::JoinSpectator,
+            };
+            if needs_handshake_preamble {
+                (2, kind)
+            } else {
+                (
+                    auth_frame_index.expect("authenticated frame index") + 1,
+                    kind,
+                )
+            }
+        }
+    });
+    let make_mock =
+        move || TraceMock::with_join_barrier(frames.clone(), admit_reconnect, hold_until_command);
 
     let async_mock = make_mock();
     let (mut async_client, mut async_rx) = SignalFishClient::start(async_mock, config.clone());
+    let mut async_events = Vec::new();
+    if scripts_authentication {
+        // Some scripted frames are intentionally undecodable wire samples, so
+        // synchronize on the Authenticated event itself rather than a snapshot
+        // that the whole trace may outlive.
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while let Some(event) = async_rx.recv().await {
+                let authenticated = matches!(event, SignalFishEvent::Authenticated { .. });
+                async_events.push(event);
+                if authenticated {
+                    break;
+                }
+            }
+        })
+        .await
+        .expect("trace should reach its scripted Authenticated response");
+    }
     admit_initial_room_operation(&mut async_client, initial_room_operation);
     if admit_reconnect {
         async_client
@@ -1988,7 +2099,6 @@ async fn assert_frame_trace_parity_with_stats(
             )
             .expect("async reconnect must queue");
     }
-    let mut async_events = Vec::new();
     let mut room_continuation = RoomTraceContinuation::default();
     tokio::time::timeout(std::time::Duration::from_secs(1), async {
         while let Some(event) = async_rx.recv().await {
@@ -2001,6 +2111,20 @@ async fn assert_frame_trace_parity_with_stats(
 
     let polling_mock = make_mock();
     let mut polling_client = SignalFishPollingClient::new(polling_mock, config);
+    let mut polling_events = Vec::new();
+    if scripts_authentication {
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while !polling_events
+                .iter()
+                .any(|event| matches!(event, SignalFishEvent::Authenticated { .. }))
+            {
+                polling_events.extend(polling_client.poll());
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("trace should reach its scripted Authenticated response");
+    }
     admit_initial_room_operation(&mut polling_client, initial_room_operation);
     if admit_reconnect {
         polling_client
@@ -2011,7 +2135,7 @@ async fn assert_frame_trace_parity_with_stats(
             )
             .expect("polling reconnect must queue");
     }
-    let mut polling_events = polling_client.poll();
+    polling_events.extend(polling_client.poll());
     drive_polling_room_continuations(&mut polling_client, &response_counts, &mut polling_events);
 
     let async_events = async_events
@@ -2154,6 +2278,23 @@ async fn assert_open_text_trace_parity_with_reconnect(
 
     let async_mock = make_mock();
     let (mut async_client, mut async_rx) = SignalFishClient::start(async_mock, config.clone());
+    let mut async_events = Vec::with_capacity(expected_events);
+    // Consume through the scripted Authenticated event before admitting; the
+    // whole trace may otherwise complete before a snapshot poll observes it.
+    tokio::time::timeout(std::time::Duration::from_secs(1), async {
+        while !async_events
+            .iter()
+            .any(|event| matches!(event, SignalFishEvent::Authenticated { .. }))
+        {
+            let event = async_rx
+                .recv()
+                .await
+                .expect("open async trace should reach its scripted authentication");
+            async_events.push(event);
+        }
+    })
+    .await
+    .expect("open async trace should authenticate");
     admit_initial_room_operation(&mut async_client, initial_room_operation);
     if admit_reconnect {
         async_client
@@ -2164,7 +2305,6 @@ async fn assert_open_text_trace_parity_with_reconnect(
             )
             .expect("async reconnect must queue");
     }
-    let mut async_events = Vec::with_capacity(expected_events);
     let mut room_continuation = RoomTraceContinuation::default();
     tokio::time::timeout(std::time::Duration::from_secs(1), async {
         while async_events.len() < expected_events {
@@ -2182,6 +2322,18 @@ async fn assert_open_text_trace_parity_with_reconnect(
 
     let polling_mock = make_mock();
     let mut polling_client = SignalFishPollingClient::new(polling_mock, config);
+    let mut polling_events = Vec::with_capacity(expected_events);
+    tokio::time::timeout(std::time::Duration::from_secs(1), async {
+        while !polling_events
+            .iter()
+            .any(|event| matches!(event, SignalFishEvent::Authenticated { .. }))
+        {
+            polling_events.extend(polling_client.poll());
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("open polling trace should authenticate");
     admit_initial_room_operation(&mut polling_client, initial_room_operation);
     if admit_reconnect {
         polling_client
@@ -2192,7 +2344,7 @@ async fn assert_open_text_trace_parity_with_reconnect(
             )
             .expect("polling reconnect must queue");
     }
-    let mut polling_events = polling_client.poll();
+    polling_events.extend(polling_client.poll());
     drive_polling_room_continuations(&mut polling_client, &response_counts, &mut polling_events);
     let polling_snapshot = polling_client.snapshot();
 
@@ -2412,15 +2564,17 @@ async fn json_fallback_is_enforced_before_outbound_transport_admission_in_both_d
     let mut config = SignalFishConfig::new("app").enable_v3();
     config.game_data_format = Some(GameDataEncoding::Rkyv);
 
-    let async_mock = SharedMock::from_msgs(
+    let async_mock = SharedMock::from_msgs_gated(
         messages
             .iter()
             .cloned()
             .map(|message| Some(Ok(message)))
             .collect(),
+        false,
     );
     let (mut async_client, mut async_events) =
         SignalFishClient::start(async_mock.clone(), config.clone());
+    common::wait_for_authentication(&async_client).await;
     admit_initial_room_operation(&mut async_client, Some(InitialRoomOperation::JoinPlayer));
     for _ in 0..=messages.len() {
         tokio::time::timeout(std::time::Duration::from_secs(1), async_events.recv())
@@ -2444,13 +2598,24 @@ async fn json_fallback_is_enforced_before_outbound_transport_admission_in_both_d
         ClientMessage::GameData { .. }
     ));
 
-    let polling_mock = SharedMock::from_msgs(
+    let polling_mock = SharedMock::from_msgs_gated(
         messages
             .into_iter()
             .map(|message| Some(Ok(message)))
             .collect(),
+        false,
     );
     let mut polling_client = SignalFishPollingClient::new(polling_mock.clone(), config);
+    for _ in 0..16 {
+        if polling_client.is_authenticated() {
+            break;
+        }
+        let _ = polling_client.poll();
+    }
+    assert!(
+        polling_client.is_authenticated(),
+        "polling fixture must authenticate before admission"
+    );
     admit_initial_room_operation(&mut polling_client, Some(InitialRoomOperation::JoinPlayer));
     let _ = polling_client.poll();
     polling_mock.sent.lock().unwrap().clear();
@@ -3813,6 +3978,7 @@ async fn every_common_command_produces_identical_physical_frames() {
         let async_sent = Arc::clone(&async_mock.sent);
         let (mut async_client, mut async_events) =
             SignalFishClient::start(async_mock, config.clone());
+        common::wait_for_authentication(&async_client).await;
         admit_initial_room_operation(&mut async_client, Some(InitialRoomOperation::JoinPlayer));
         tokio::time::timeout(std::time::Duration::from_secs(1), async {
             while !matches!(
@@ -3844,6 +4010,16 @@ async fn every_common_command_produces_identical_physical_frames() {
         let polling_mock = FrameMock::v3();
         let polling_sent = Arc::clone(&polling_mock.sent);
         let mut polling_client = SignalFishPollingClient::new(polling_mock, config);
+        for _ in 0..16 {
+            if polling_client.is_authenticated() {
+                break;
+            }
+            let _ = polling_client.poll();
+        }
+        assert!(
+            polling_client.is_authenticated(),
+            "polling fixture must authenticate before admission"
+        );
         admit_initial_room_operation(&mut polling_client, Some(InitialRoomOperation::JoinPlayer));
         let _ = polling_client.poll();
         polling_sent.lock().unwrap().clear();
@@ -3880,6 +4056,7 @@ async fn unauthorized_outbound_signals_fail_without_wire_output_in_both_drivers(
     let async_mock = FrameMock::v3();
     let async_sent = Arc::clone(&async_mock.sent);
     let (mut async_client, mut async_events) = SignalFishClient::start(async_mock, config.clone());
+    common::wait_for_authentication(&async_client).await;
     admit_initial_room_operation(&mut async_client, Some(InitialRoomOperation::JoinPlayer));
     tokio::time::timeout(std::time::Duration::from_secs(1), async {
         while !matches!(
@@ -3916,6 +4093,16 @@ async fn unauthorized_outbound_signals_fail_without_wire_output_in_both_drivers(
     let polling_mock = FrameMock::v3();
     let polling_sent = Arc::clone(&polling_mock.sent);
     let mut polling_client = SignalFishPollingClient::new(polling_mock, config);
+    for _ in 0..16 {
+        if polling_client.is_authenticated() {
+            break;
+        }
+        let _ = polling_client.poll();
+    }
+    assert!(
+        polling_client.is_authenticated(),
+        "polling fixture must authenticate before admission"
+    );
     admit_initial_room_operation(&mut polling_client, Some(InitialRoomOperation::JoinPlayer));
     let _ = polling_client.poll();
     polling_sent.lock().unwrap().clear();
@@ -3983,19 +4170,16 @@ async fn pending_transport_queue_capacity_and_errors_match() {
         .expect_err("polling queue must be full");
     assert_eq!(format!("{async_error:?}"), format!("{polling_error:?}"));
 
-    for case in [
-        CommonCommandCase::JoinRoom,
-        CommonCommandCase::Reconnect,
-        CommonCommandCase::JoinSpectator,
-    ] {
+    for _ in 0..3 {
+        let async_error = async_client.ping().expect_err("async queue must be full");
+        let polling_error = polling_client
+            .ping()
+            .expect_err("polling queue must be full");
         assert!(matches!(
-            case.invoke(&mut async_client),
-            Err(SignalFishError::SendBufferFull { capacity: 1 })
+            async_error,
+            SignalFishError::SendBufferFull { capacity: 1 }
         ));
-        assert!(matches!(
-            case.invoke(&mut polling_client),
-            Err(SignalFishError::SendBufferFull { capacity: 1 })
-        ));
+        assert_eq!(format!("{async_error:?}"), format!("{polling_error:?}"));
     }
 
     // A locally invalid room operation wins over queue congestion and cannot
@@ -4013,7 +4197,14 @@ async fn pending_transport_queue_capacity_and_errors_match() {
 
     async_gate.release();
     polling_gate.release();
-    let _ = polling_client.poll();
+    common::wait_for_authentication(&async_client).await;
+    for _ in 0..16 {
+        if polling_client.is_authenticated() && polling_client.send_capacity() == 1 {
+            break;
+        }
+        let _ = polling_client.poll();
+    }
+    assert!(polling_client.is_authenticated());
     tokio::time::timeout(std::time::Duration::from_secs(1), async {
         while async_client.send_capacity() == 0 {
             tokio::task::yield_now().await;
@@ -4287,6 +4478,7 @@ async fn admitted_leave_fences_following_player_commands_in_both_drivers() {
     let async_mock = FrameMock::v3();
     let async_sent = Arc::clone(&async_mock.sent);
     let (mut async_client, mut async_events) = SignalFishClient::start(async_mock, config.clone());
+    common::wait_for_authentication(&async_client).await;
     admit_initial_room_operation(&mut async_client, Some(InitialRoomOperation::JoinPlayer));
     while !matches!(
         async_events.recv().await,
@@ -4302,6 +4494,16 @@ async fn admitted_leave_fences_following_player_commands_in_both_drivers() {
     let polling_mock = FrameMock::v3();
     let polling_sent = Arc::clone(&polling_mock.sent);
     let mut polling_client = SignalFishPollingClient::new(polling_mock, config);
+    for _ in 0..16 {
+        if polling_client.is_authenticated() {
+            break;
+        }
+        let _ = polling_client.poll();
+    }
+    assert!(
+        polling_client.is_authenticated(),
+        "polling fixture must authenticate before admission"
+    );
     admit_initial_room_operation(&mut polling_client, Some(InitialRoomOperation::JoinPlayer));
     let _ = polling_client.poll();
     polling_sent.lock().unwrap().clear();
@@ -4412,15 +4614,17 @@ async fn parity_ensure_v3_relay_only_mode_after_v2_negotiation() {
         TransportFrame::Binary(_) => unreachable!("room baseline must be text"),
     };
     let messages = [AUTH.to_string(), PI_V2.to_string(), room];
-    let async_mock = SharedMock::from_msgs(
+    let async_mock = SharedMock::from_msgs_gated(
         messages
             .iter()
             .cloned()
             .map(|message| Some(Ok(message)))
             .collect(),
+        false,
     );
     let (mut client, mut events) =
         SignalFishClient::start(async_mock, SignalFishConfig::new("app"));
+    common::wait_for_authentication(&client).await;
     admit_initial_room_operation(&mut client, Some(InitialRoomOperation::JoinPlayer));
     // Drain until the v2 room baseline has been processed into client state.
     loop {
@@ -4431,13 +4635,24 @@ async fn parity_ensure_v3_relay_only_mode_after_v2_negotiation() {
     }
     let async_err = client.send_offer(peer, "sdp").unwrap_err();
 
-    let poll_mock = SharedMock::from_msgs(
+    let poll_mock = SharedMock::from_msgs_gated(
         messages
             .into_iter()
             .map(|message| Some(Ok(message)))
             .collect(),
+        false,
     );
     let mut poll_client = SignalFishPollingClient::new(poll_mock, SignalFishConfig::new("app"));
+    for _ in 0..16 {
+        if poll_client.is_authenticated() {
+            break;
+        }
+        let _ = poll_client.poll();
+    }
+    assert!(
+        poll_client.is_authenticated(),
+        "polling fixture must authenticate before admission"
+    );
     admit_initial_room_operation(&mut poll_client, Some(InitialRoomOperation::JoinPlayer));
     poll_client.poll();
     let poll_err = poll_client.send_offer(peer, "sdp").unwrap_err();
@@ -4480,6 +4695,7 @@ async fn parity_reconnect_preserves_outer_v3_negotiation() {
     let async_mock = SharedMock::new(vec![AUTH, PI_V3, &recon]);
     let (mut client, mut events) =
         SignalFishClient::start(async_mock, SignalFishConfig::new("app").enable_mesh());
+    common::wait_for_authentication(&client).await;
     client
         .reconnect(
             uuid::Uuid::from_u128(200),
@@ -4498,6 +4714,13 @@ async fn parity_reconnect_preserves_outer_v3_negotiation() {
 
     let poll_mock = SharedMock::new(vec![AUTH, PI_V3, &recon]);
     let mut poll_client = SignalFishPollingClient::new(poll_mock, SignalFishConfig::new("app"));
+    for _ in 0..16 {
+        if poll_client.is_authenticated() {
+            break;
+        }
+        let _ = poll_client.poll();
+    }
+    assert!(poll_client.is_authenticated());
     poll_client
         .reconnect(
             uuid::Uuid::from_u128(200),
@@ -4801,15 +5024,26 @@ async fn parity_selected_plan_resets_at_room_and_connection_boundaries() {
     assert!(snapshot.session_topology.is_none());
     assert!(snapshot.session_transport.is_none());
 
-    let polling_mock = SharedMock::from_msgs(
+    let polling_mock = SharedMock::from_msgs_gated(
         populated
             .iter()
             .cloned()
             .map(|message| Some(Ok(message)))
             .collect(),
+        false,
     );
     let mut polling_client =
         SignalFishPollingClient::new(polling_mock, SignalFishConfig::new("app").enable_mesh());
+    for _ in 0..16 {
+        if polling_client.is_authenticated() {
+            break;
+        }
+        let _ = polling_client.poll();
+    }
+    assert!(
+        polling_client.is_authenticated(),
+        "polling fixture must authenticate before admission"
+    );
     admit_initial_room_operation(&mut polling_client, Some(InitialRoomOperation::JoinPlayer));
     let _ = polling_client.poll();
     assert_eq!(polling_client.session_topology(), Some(Topology::Mesh));
@@ -4821,7 +5055,7 @@ async fn parity_selected_plan_resets_at_room_and_connection_boundaries() {
     assert!(polling_client.session_topology().is_none());
     assert!(polling_client.session_transport().is_none());
 
-    let async_mock = SharedMock::from_msgs(
+    let async_mock = SharedMock::from_msgs_gated(
         populated
             .into_iter()
             .map(|message| Some(Ok(message)))
@@ -4829,9 +5063,11 @@ async fn parity_selected_plan_resets_at_room_and_connection_boundaries() {
                 SignalFishError::TransportReceive("reset".into()),
             ))))
             .collect(),
+        false,
     );
     let (mut async_client, mut events) =
         SignalFishClient::start(async_mock, SignalFishConfig::new("app").enable_mesh());
+    common::wait_for_authentication(&async_client).await;
     admit_initial_room_operation(&mut async_client, Some(InitialRoomOperation::JoinPlayer));
     let mut saw_plan = false;
     loop {


### PR DESCRIPTION
Closes #140, closes #141, closes #142. Advances #126 (correctness/performance audit) to its completed correctness-slice state.

## Summary

Three remaining audit slices from session-048's research, landed as one coherent PR per the no-stacking rule. An uncommitted working tree carried a partially finished #140; it was verified, completed, and folded in.

### #140 — authentication-gated room operations (`fix!`)

`ClientCore::validate` now refuses the five admission-fencing operations (`JoinRoom`, `LeaveRoom`, `Reconnect`, `JoinAsSpectator`, `LeaveSpectator`) with the new exhaustive **`SignalFishError::NotAuthenticated`** until the server confirms authentication. Previously a caller that skipped the documented wait for `Authenticated` armed an operation fence whose responses the inbound lifecycle gates classify as violations under every policy — stranding every later room operation behind `RoomOperationPending` until teardown.

- Gate placed after connection validation, before the pending-transition check — mirroring the inbound gates exactly.
- Non-room commands keep their documented pre-auth behavior (`ping` available; game data still answers `NotInRoom`).
- Docs: all ten method doc-comments, new `docs/errors.md` table row + precedence sentence, `docs/client.md` admission table + deterministic-error ordering.
- Test sweep: migrated every fixture that relied on pre-auth admission to documented usage — shared bounded auth-wait helper, event-stream synchronization in the parity harness (vendored wire samples complete before snapshot polls can observe auth), a delivery barrier pinning trace order behind the admitted command, gated-mock conversions, send-gating support in the unit mock, and live-join reordering for reconnect flows. Positive regressions pin refusal, fence non-armament, capacity restoration, and immediate post-auth admission in both drivers.

### #141 — bounded terminal disconnect delivery

A terminal disconnect facing a consumer that never drains previously awaited event delivery with no deadline: the loop leaked holding `cmd_rx` and parked every waiting reliable sender forever.

- Peer-close delivery is now bounded by `shutdown_timeout` with the same escape/fallback machinery as the send-failure path.
- New shared `emit_event_batch` routes both multi-event emission sites through one implementation of the documented at-most-one-in-flight bound; mid-batch preemption attempts remaining batch events nonblocking instead of abandoning them sight unseen.
- Docs updated at the module boundary, event-capacity field, `shutdown()`, and helper doc-comments.

Deterministic regression tests: peer close + full channel + no shutdown terminates the loop and releases a parked reserve sender; a receive error against a never-completing `poll_close` provably aborts only at budget expiry (verified non-vacuous — a deadline regression hangs rather than passes); expired-budget batch emission reports preemption without corrupting buffered events.

### #142 — cancellation pins + dequeue-failure fence release

- `ClientCore::dequeue_serialization_failed` kind-matched-releases the operation fence (incl. `pending_reconnects`) when an admitted room command fails to serialize at dequeue, wired into both drivers; data-driven five-operation matrix test includes mismatched-kind non-release. Unreachable today, but eliminates the failure class rather than asserting it away.
- `dropping_a_parked_reliable_send_leaves_no_trace`: dropping a future parked on queue capacity moves neither stats nor snapshot, leaks no permit, never reaches the wire, and an identical command still completes. Cancel-safety sentence added beside the existing `select!`-race hazard doc.

## Verification

- `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo test --workspace --all-features` — zero failures.
- Pre-commit suite (17 checks) green on commit.
- Two adversarial sub-agent audit rounds: first found five must-fix items (stale exhaustive-error docs, stale client-doc precedence, stale `.llm/context.md` contracts, a CHANGELOG driver-scope overclaim, one vacuous budget test) plus four hygiene items — all fixed; second pass re-verified every item against code and returned SHIP with zero blocking findings.
- CHANGELOG: breaking gating entry under `Changed`, bounded terminal delivery under `Fixed`. #142 is test-only/defensive and intentionally unlisted.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking public error enum and room-admission order, plus async transport-loop teardown. Incorrect gating or timeout handling can strand room fences or leak parked senders.
> 
> **Overview**
> **Breaking:** the five directed room operations (`join_room`, `leave_room`, `reconnect`, `join_as_spectator`, `leave_spectator`) now fail immediately with `SignalFishError::NotAuthenticated` until the server confirms auth. They are not queued, so they no longer arm a fence that inbound lifecycle gates could never release (`RoomOperationPending` until teardown). Exhaustive `SignalFishError` matches must handle the new variant. Non-room commands keep existing pre-auth behavior.
> 
> **Async teardown:** peer-close / terminal receive now share `shutdown_timeout`. A wedged event consumer can no longer keep the transport loop (and parked `*_reliable` senders) alive forever. Multi-event frames use `emit_event_batch`: mid-batch preemption tries remaining events nonblocking, then exits.
> 
> **Defensive:** dequeue-time serialization failure kind-matches and releases the room-operation fence in both drivers. Docs pin that dropping a parked reliable-send future is cancel-safe (no queue/state mutation). Tests and fixtures wait for `Authenticated` before admitting room ops.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e588d07adae618d0313602d5c206dc89f0f94f7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->