### PR TITLE
fix: stop Disconnect-policy teardowns from hanging past shutdown_timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,6 +191,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed a `ProtocolViolationPolicy::Disconnect` teardown hanging past
+  [`shutdown_timeout`](SignalFishConfig::shutdown_timeout) when the violating
+  frame's event batch meets a consumer that stopped draining and `shutdown`
+  is never called. The policy-disconnect batch now shares one shutdown budget
+  with the farewell delivery and transport close — the same bound the
+  send-failure teardown already applies — so the loop terminates and every
+  sender parked on the command queue resolves. The polling client was never
+  affected.
+- Corrected documentation drift found in review: `send_game_data_reliable`'s
+  documented error surface now matches its membership checks, the concepts
+  guide lists all four synthetic events including `ProtocolViolation`, the
+  errors guide states where `Timeout` originates, the reconnection events
+  describe all three `ReplayStatus` variants, and the client guide gains a
+  consolidated end-to-end reconnect recovery policy with per-error-code
+  fallbacks.
 - Fixed a terminal disconnect wedging the async transport loop forever when
   the event consumer stops draining and `shutdown` is never called. Terminal
   delivery is now bounded by [`shutdown_timeout`](SignalFishConfig::shutdown_timeout):

--- a/docs/client.md
+++ b/docs/client.md
@@ -358,8 +358,9 @@ The backpressure-aware counterpart to [`send_game_data`](#send_game_data):
 instead of failing fast with `SendBufferFull`, it pauses until the transport
 drains a slot, pacing the caller to actual transport throughput. This is the
 recommended way to stream high-rate payloads (rollback input packets, state
-sync) without guessing at sleep durations. It only errors with
-`NotConnected` when the transport has closed.
+sync) without guessing at sleep durations. It returns the same membership
+errors as [`send_game_data`](#send_game_data) — checked synchronously before
+it waits — plus `NotConnected` if the transport closes while waiting.
 
 !!! warning "Keep draining events"
     The command queue only drains while the transport loop runs, and the
@@ -546,6 +547,30 @@ Reconnect is also a hard session-plan boundary. The old generation and peer
 set are fenced immediately, and Server 0.7 follows `Reconnected` with a fresh
 live `SessionPlan` for a finalized room. `ProtocolInfo`, `SessionPlan`, signals,
 and game data are not legal `missed_events` replay entries.
+
+##### End-to-end recovery policy
+
+The reconnect flow spans a disconnect and a fresh connection, so it is worth
+writing down as one procedure:
+
+1. **Persist after every `RoomJoined` / `Reconnected`:** `player_id`, `room_id`,
+   and `snapshot().reconnection_token` (a connection secret — never log it).
+2. **On an unexpected `Disconnected`:** build a fresh transport and client,
+   then wait for `Authenticated` before recovering (directed room operations
+   refuse until the server confirms authentication).
+3. **Call `reconnect(player_id, room_id, token)`** with the persisted triple.
+4. **On `Reconnected`:** fold `missed_events` into your game state, adopt the
+   fresh live `SessionPlan` that follows, and persist the rotated
+   `reconnection_token` from the new snapshot.
+5. **On `ReconnectionFailed`:** decide by `error_code`:
+   - `ReconnectionExpired` or `ReconnectionTokenInvalid` — the server no
+     longer knows this session: fall back to a normal `join_room`.
+   - `PlayerAlreadyConnected` — another live connection still holds the seat;
+     wait for it to exit (or drop it) before retrying.
+   - Anything else — retry with backoff while the room is worth rejoining.
+
+Peers stay fenced against your signals until the post-reconnect
+`SessionPlan` arrives, so gate mesh/relay work on it as on a first join.
 
 ---
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -205,7 +205,7 @@ an event channel.
 
 ### Synthetic vs. Server Events
 
-Most events correspond 1:1 to a server message. Three **synthetic** events
+Most events correspond 1:1 to a server message. Four **synthetic** events
 are generated locally by the transport layer:
 
 | Event | Origin |
@@ -213,6 +213,7 @@ are generated locally by the transport layer:
 | `SignalFishEvent::Connected` | Emitted when the transport opens, before any server message. |
 | `SignalFishEvent::Disconnected { reason, .. }` | Emitted when the transport closes or errors. Last event (best-effort). |
 | `SignalFishEvent::DecodeFailed { .. }` | Emitted when an inbound frame fails to decode; the connection stays open. See [Events](events.md#decodefailed). |
+| `SignalFishEvent::ProtocolViolation { .. }` | Emitted when a decoded frame contradicts negotiated protocol state; your configured `protocol_violation_policy` decides what happens next. See [Events](events.md#decodefailed). |
 
 !!! note "Lossless delivery with backpressure"
     Events are **never dropped on overflow**. The event channel has a default capacity of

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -42,7 +42,7 @@ exhaustive public enum:
 | `SessionPlanUnavailable` | — | No authoritative WebRTC plan currently authorizes the signal: no plan has arrived, or the target is self, unknown, departed, or absent from the replace-on-plan peer set/current room roster. The set may be extended by a valid compatibility `NewPeer`; the frame is refused locally. |
 | `StaleSessionGeneration` | `attempted: Option<SessionGeneration>`, `current: Option<SessionGeneration>` | A generation-bound driver signal was produced after its session plan had been replaced. The client refuses it rather than relabeling stale signaling. |
 | `BinaryFormatNotNegotiated` | — | A binary send was attempted after negotiation resolved to JSON. Request `MessagePack` and confirm `effective_game_data_format() == Some(MessagePack)`; unsupported requests resolve to JSON and are refused before transport admission. Before `ProtocolInfo`, v3-only sends return `ProtocolUnsupported` instead. |
-| `Timeout` | — | An operation timed out. |
+| `Timeout` | — | The WebSocket handshake did not complete within its deadline. Only `WebSocketTransport::connect_with_timeout` emits this variant, when the connection is not established within the duration it is given. |
 | `Io` | `std::io::Error` | An I/O error occurred. Implements `From<std::io::Error>`. |
 
 Local validation has stable precedence: connection state, server-confirmed

--- a/docs/events.md
+++ b/docs/events.md
@@ -518,8 +518,8 @@ Carries the same room-state fields as `RoomJoined` plus:
 | Field | Type | Description |
 |-------|------|-------------|
 | `missed_events` | `Vec<SignalFishEvent>` | Events that occurred while the client was disconnected. |
-| `replay` | `Option<ReplayStatus>` | Whether the replayed control-event suffix is complete or truncated. |
-| `sender_watermarks` | `Vec<SenderWatermark>` | Authoritative per-sender epoch/sequence baselines for resumed delivery. |
+| `replay` | `Option<ReplayStatus>` | Completeness of the replayed control-event suffix: `Complete` (nothing was lost), `Truncated` (some history was dropped — reconcile from `sender_watermarks` and your own game state), or `Unavailable` (the server could not replay — do not rely on `missed_events`). `None` means the connected server predates replay reporting (pre-v3 negotiation). |
+| `sender_watermarks` | `Vec<SenderWatermark>` | Authoritative per-sender epoch/sequence baselines for resumed delivery. The SDK validates them against its accountability state; they also let you judge which remote inputs your simulation already applied before the gap. |
 | `ice_servers` | `Vec<IceServer>` | Protocol-v3 STUN/TURN servers for early candidate gathering. |
 | `reconnection_token` | `Option<String>` | Fresh secret replacing the consumed token; also stored in `ClientSnapshot`. |
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -1820,18 +1820,18 @@ async fn emit_core_disconnected_or_shutdown(
     event_tx: &mpsc::Sender<SignalFishEvent>,
     shutdown_rx: &mut tokio::sync::oneshot::Receiver<()>,
     state: &Arc<Mutex<ClientCore>>,
-    reason: Option<String>,
-    shutdown_timeout: Duration,
+    teardown: TerminalTeardown,
 ) {
     // Peer-close delivery is bounded by the same budget as graceful
     // termination: a wedged consumer must not leak the task holding the
     // command receiver, which would park every waiting reliable sender
     // forever. On expiry the terminal event falls back to a nonblocking
     // attempt before the loop terminates.
-    // A timeout so large that its deadline cannot be represented yields
-    // `None`, which restores the historical unbounded wait — matching the
-    // documented behavior of an effectively-never-expiring budget.
-    let deadline = tokio::time::Instant::now().checked_add(shutdown_timeout);
+    let TerminalTeardown {
+        reason,
+        deadline,
+        timeout,
+    } = teardown;
     let event = lock_core(state).disconnect(reason);
     let deliver_event = async {
         if !emit_terminal_event(event_tx, shutdown_rx, deadline, event.clone()).await {
@@ -1842,9 +1842,37 @@ async fn emit_core_disconnected_or_shutdown(
         transport,
         pending_send,
         state,
-        remaining_shutdown_budget(shutdown_timeout, deadline),
+        remaining_shutdown_budget(timeout, deadline),
     );
     let ((), ()) = tokio::join!(deliver_event, close);
+}
+
+/// One terminal disconnect's attribution and shared shutdown budget: every
+/// delivery of the teardown races the same deadline so a wedged consumer
+/// cannot keep the loop alive past the configured total.
+#[cfg(feature = "tokio-runtime")]
+struct TerminalTeardown {
+    /// Attribution for the core-computed farewell event.
+    reason: Option<String>,
+    /// The configured budget total, kept so the close window can be derived
+    /// from what is actually left at use time instead of freezing it before
+    /// earlier deliveries consume their share.
+    timeout: Duration,
+    /// Shared budget start for every delivery of this teardown. `None` only
+    /// when the configured timeout is too large to represent its deadline,
+    /// which restores the documented effectively-never-expiring wait.
+    deadline: Option<tokio::time::Instant>,
+}
+
+#[cfg(feature = "tokio-runtime")]
+impl TerminalTeardown {
+    fn starting(timeout: Duration, reason: Option<String>) -> Self {
+        Self {
+            reason,
+            timeout,
+            deadline: tokio::time::Instant::now().checked_add(timeout),
+        }
+    }
 }
 
 /// The time left in a shutdown budget whose deadline was computed earlier.
@@ -2156,8 +2184,10 @@ async fn transport_loop(
                         &event_tx,
                         &mut shutdown_rx,
                         &state,
-                        Some("client shut down".into()),
-                        shutdown_timeout,
+                        TerminalTeardown::starting(
+                            shutdown_timeout,
+                            Some("client shut down".into()),
+                        ),
                     ).await;
                     break;
                 };
@@ -2232,8 +2262,10 @@ async fn transport_loop(
                         &event_tx,
                         &mut shutdown_rx,
                         &state,
-                        Some("transport received a protocol frame before readiness".into()),
-                        shutdown_timeout,
+                        TerminalTeardown::starting(
+                            shutdown_timeout,
+                            Some("transport received a protocol frame before readiness".into()),
+                        ),
                     ).await;
                     break;
                 }
@@ -2260,10 +2292,25 @@ async fn transport_loop(
                     TransportIo::Received(Some(Ok(frame))) => {
                         let outcome = lock_core(&state).process_frame(frame);
                         let disconnect = outcome.disconnect;
-                        let delivered =
-                            emit_event_batch(&event_tx, &mut shutdown_rx, None, outcome.events)
-                                .await;
-                        if !delivered {
+                        // A policy-driven disconnect terminates the session,
+                        // so its batch shares one shutdown budget with the
+                        // farewell delivery and close: a wedged consumer
+                        // cannot park reliable senders past the budget. This
+                        // mirrors the send-failure teardown; ordinary frames
+                        // keep unbounded backpressure.
+                        let violation_teardown = disconnect.then(|| {
+                            TerminalTeardown::starting(
+                                shutdown_timeout,
+                                Some("protocol violation".into()),
+                            )
+                        });
+                        let delivered = emit_event_batch(
+                            &event_tx,
+                            &mut shutdown_rx,
+                            violation_teardown.as_ref().and_then(|t| t.deadline),
+                            outcome.events,
+                        ).await;
+                        if !delivered && !disconnect {
                             finish_core_shutdown(
                                 &mut transport,
                                 &mut pending_send,
@@ -2273,16 +2320,39 @@ async fn transport_loop(
                             ).await;
                             break;
                         }
-                        if disconnect {
-                            emit_core_disconnected_or_shutdown(
+                        if let Some(teardown) = violation_teardown {
+                            // A preempted batch may have ended because
+                            // `shutdown` fired, and a completed oneshot
+                            // receiver panics if re-polled — so any
+                            // preemption skips the bounded farewell wait and
+                            // falls back to the nonblocking attempt, exactly
+                            // like the send-failure teardown.
+                            let TerminalTeardown {
+                                reason,
+                                deadline,
+                                timeout,
+                            } = teardown;
+                            let event = lock_core(&state).disconnect(reason);
+                            let deliver_farewell = async {
+                                if !delivered
+                                    || !emit_terminal_event(
+                                        &event_tx,
+                                        &mut shutdown_rx,
+                                        deadline,
+                                        event.clone(),
+                                    )
+                                    .await
+                                {
+                                    let _ = event_tx.try_send(event);
+                                }
+                            };
+                            let close = finish_send_and_close_bounded(
                                 &mut transport,
                                 &mut pending_send,
-                                &event_tx,
-                                &mut shutdown_rx,
                                 &state,
-                        Some("protocol violation".into()),
-                                shutdown_timeout,
-                            ).await;
+                                remaining_shutdown_budget(timeout, deadline),
+                            );
+                            let ((), ()) = tokio::join!(deliver_farewell, close);
                             break;
                         }
                     }
@@ -2293,8 +2363,7 @@ async fn transport_loop(
                             &event_tx,
                             &mut shutdown_rx,
                             &state,
-                            Some(error.to_string()),
-                            shutdown_timeout,
+                            TerminalTeardown::starting(shutdown_timeout, Some(error.to_string())),
                         ).await;
                         break;
                     }
@@ -2306,8 +2375,7 @@ async fn transport_loop(
                             &event_tx,
                             &mut shutdown_rx,
                             &state,
-                            reason,
-                            shutdown_timeout,
+                            TerminalTeardown::starting(shutdown_timeout, reason),
                         ).await;
                         break;
                     }
@@ -6007,6 +6075,132 @@ mod tests {
         assert!(
             closed_stream.is_none(),
             "unexpected extra events after abort: {closed_stream:?}"
+        );
+    }
+
+    /// A policy-driven disconnect wedges on its violation batch exactly like
+    /// a peer close: with no `shutdown()` and a full channel, teardown must
+    /// come from the shared shutdown budget, never hang past it.
+    #[tokio::test]
+    async fn policy_disconnect_violation_batch_is_bounded_by_the_shutdown_budget() {
+        // Connected, Authenticated, and ProtocolInfo fill the capacity-3
+        // channel, so the violation batch that precedes the Disconnect-policy
+        // teardown wedges with no `shutdown()` call. The transport's
+        // `poll_close` never completes, so teardown can only come from the
+        // budget expiry aborting the transport. A regression that restores
+        // unbounded delivery keeps this spin alive forever instead of passing
+        // vacuously.
+        let room_left_json = serde_json::to_string(&ServerMessage::RoomLeft).unwrap();
+        let (transport, _close_called, abort_called, _dropped) =
+            HangingCloseTransport::with_incoming(vec![
+                Some(Ok(authenticated_json())),
+                Some(Ok(protocol_info_v2_json())),
+                Some(Ok(room_left_json)),
+            ]);
+        let config = SignalFishConfig::new("mb_test")
+            .with_event_channel_capacity(3)
+            .with_protocol_violation_policy(ProtocolViolationPolicy::Disconnect)
+            .with_shutdown_timeout(std::time::Duration::from_millis(200));
+        let (client, mut events) = SignalFishClient::start(transport, config);
+
+        let started = std::time::Instant::now();
+        while !abort_called.load(Ordering::Acquire) {
+            assert!(
+                started.elapsed() < std::time::Duration::from_secs(2),
+                "the wedged policy-disconnect delivery must abort at its budget without shutdown()"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+        // The batch and the close share one budget: a regression that lets
+        // the close restart a fresh window after the batch consumed it
+        // observes roughly twice the configured timeout here.
+        let elapsed = started.elapsed();
+        assert!(
+            elapsed < std::time::Duration::from_millis(300),
+            "teardown took {elapsed:?}; the batch and close must share one budget"
+        );
+        assert!(!client.is_connected());
+
+        // Loop exit drops the sender: draining surfaces the buffered prefix
+        // (the wedged violation batch and farewell were abandoned by their
+        // nonblocking fallbacks), then closes the stream authoritatively.
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Connected)
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Authenticated { .. })
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::ProtocolInfo(_))
+        ));
+        let closed_stream =
+            tokio::time::timeout(std::time::Duration::from_millis(500), events.recv())
+                .await
+                .expect("the event stream must end promptly after teardown");
+        assert!(
+            closed_stream.is_none(),
+            "unexpected extra events after abort: {closed_stream:?}"
+        );
+    }
+
+    /// `shutdown()` preempting a wedged policy-disconnect batch must not
+    /// re-poll the already-consumed shutdown signal: the farewell falls back
+    /// to a nonblocking attempt and the graceful close still runs.
+    #[tokio::test]
+    async fn shutdown_preempting_policy_disconnect_batch_skips_bounded_wait() {
+        let room_left_json = serde_json::to_string(&ServerMessage::RoomLeft).unwrap();
+        let (transport, close_called, _abort_called, _dropped) =
+            HangingCloseTransport::with_incoming(vec![
+                Some(Ok(authenticated_json())),
+                Some(Ok(protocol_info_v2_json())),
+                Some(Ok(room_left_json)),
+            ]);
+        // A long budget keeps the wedged batch blocked until the explicit
+        // `shutdown()` below preempts it; the hanging close then bounds how
+        // long `shutdown()` itself takes.
+        let config = SignalFishConfig::new("mb_test")
+            .with_event_channel_capacity(3)
+            .with_protocol_violation_policy(ProtocolViolationPolicy::Disconnect)
+            .with_shutdown_timeout(std::time::Duration::from_millis(300));
+        let (mut client, mut events) = SignalFishClient::start(transport, config);
+
+        // Let the loop wedge on the full channel before shutting down.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        tokio::time::timeout(std::time::Duration::from_secs(2), client.shutdown())
+            .await
+            .expect("shutdown must complete promptly");
+
+        // A regression that re-polled the consumed signal panicked the task
+        // before any close was attempted.
+        assert!(
+            close_called.load(Ordering::Acquire),
+            "shutdown must still attempt the graceful transport close"
+        );
+
+        // Loop exit drops the sender: draining surfaces the buffered prefix,
+        // then closes the stream authoritatively.
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Connected)
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Authenticated { .. })
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::ProtocolInfo(_))
+        ));
+        let closed_stream =
+            tokio::time::timeout(std::time::Duration::from_millis(500), events.recv())
+                .await
+                .expect("the event stream must end promptly after teardown");
+        assert!(
+            closed_stream.is_none(),
+            "unexpected extra events after shutdown: {closed_stream:?}"
         );
     }
 


### PR DESCRIPTION
## Why

With `ProtocolViolationPolicy::Disconnect`, one protocol-violating server frame plus an event consumer that stops draining could hang the client forever: the violating frame's events were delivered without any deadline, so the loop never reached its bounded teardown. The task leaked, the socket stayed open (a zombie session on the server), and every `*_reliable` sender stayed parked.

## What changed

- A policy-disconnect batch now shares **one** `shutdown_timeout` budget with the farewell delivery and transport close — the same bound the send-failure teardown already applied.
- If anything preempts that batch (budget expiry or a concurrent `shutdown()`), the farewell falls back to one nonblocking attempt instead of re-polling a consumed shutdown signal.
- Ordinary frames keep the documented unbounded backpressure; nothing changes for them.
- Docs: corrected `send_game_data_reliable`'s error surface, the synthetic-event list, `Timeout`'s origin, all three `ReplayStatus` variants, and added an end-to-end reconnect recovery policy.

## Evidence

| Check | Result |
| --- | --- |
| New red/green test | `policy_disconnect_violation_batch_is_bounded_by_the_shutdown_budget` failed on main (2.04 s hang), passes bounded (~200 ms budget, asserted < 300 ms) |
| Shutdown-preemption regression | new test pins the tokio oneshot re-poll panic; verified failing when the fix is reverted |
| Mandatory workflow | fmt + clippy `-D warnings` + 966 tests, all features — clean |
| Adversarial review | two rounds; both required findings fixed and red-checked; round 2 zero required changes |

Follow-up for a narrow pre-existing shutdown-signal race found during review: #148

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the async transport loop’s terminal teardown, which can leak the command-queue task and park reliable senders if the budget is wrong. Ordinary frames keep unbounded backpressure; polling is unchanged.
> 
> **Overview**
> **`ProtocolViolationPolicy::Disconnect` no longer hangs past `shutdown_timeout`** when the violating frame’s event batch meets a full channel and `shutdown()` is never called.
> 
> The violation batch, farewell `Disconnected`, and transport close now share one `TerminalTeardown` deadline (same bound send-failure teardown already used). If the batch is preempted by budget expiry or `shutdown()`, farewell falls back to a nonblocking send instead of re-polling a consumed oneshot. Ordinary frames keep unbounded backpressure; the polling client is unaffected.
> 
> Docs also catch up: `send_game_data_reliable` error surface, four synthetic events including `ProtocolViolation`, `Timeout` origin, all `ReplayStatus` variants, and an end-to-end reconnect recovery policy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2528c5df1a4fe2094dff74df70a8756c96d74d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->