### PR TITLE
Simplify terminal farewells; document the Godot outbound frame bound

### DIFF
--- a/.llm/context.md
+++ b/.llm/context.md
@@ -174,7 +174,7 @@ fresh nonce, derived key, and sequence space; replay/reordering/tamper fails.
 The lockstep `signal-fish-client-godot` adapter defaults to adaptive outbound admission: a 50 ms latency target with a
 4 KiB floor, 32 KiB ceiling, and a further native-capacity clamp. A successful Godot send
 transfers ownership immediately; browser buffering is observed separately.
-SDK-created Godot peers set an 8 MiB inbound buffer before connecting, which may reserve roughly 16 MiB in Godot; `from_peer` preserves caller settings. The
+SDK-created Godot peers set an 8 MiB inbound buffer before connecting, which may reserve roughly 16 MiB in Godot; `from_peer` preserves caller settings. Outbound keeps Godot's legacy 65,535-byte default: a single frame over that size on native (at or above it on web) parks as `Pending`, growing only capacity diagnostics. The
 blocking workflow covers official native/web Godot 4.5, requires a valid frame
 over the legacy 65,535-byte default, and runs clean, seeded-netem impaired, and
 3,600-frame soak jobs on Server 0.7 plus a clean Server 0.4 gate. It checksum-verifies and builds iproute2
@@ -302,8 +302,9 @@ Decoded game-data receipt counts before suppression; counters are diagnostic bou
 `SignalFishPollingClient` shares the classified/binary sends, queue bound,
 capacity accessors, `stats()`, and coherent `snapshot()`. Its default per-poll
 work budget is 64 frames/64 KiB in each direction, and its default close policy
-abandons client-owned queued work. Adaptive backpressure and flush-on-close are
-explicit opt-ins. Use `polling_stats()` for scheduling/queue diagnostics and
+abandons client-owned queued work. Flush-on-close is an explicit opt-in;
+adaptive outbound admission lives on the Godot transport options, not the
+polling client. Use `polling_stats()` for scheduling/queue diagnostics and
 `queue_age_stats()` for sampled current/peak age of client-owned work; reset the
 age peak after authentication/setup when measuring gameplay. Backend acceptance
 ends queue age but is not peer delivery. Use `transport_diagnostics()` for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,6 +191,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Documented the Godot adapter's outbound frame bound: Godot refuses to buffer
+  an outbound message once the peer's outbound buffer would overflow, so a
+  single frame larger than `outbound_buffer_size` (65,535 bytes by default)
+  parks as `Pending` on native builds — at or above it on web exports — with
+  only capacity diagnostics growing. SDK-created peers keep that legacy
+  outbound default and raise only the inbound buffer; the crate guide now
+  explains how to admit larger frames with `from_peer`.
 - Hardened async-driver terminal teardown: observing the shutdown signal is
   now tracked explicitly by a sticky wrapper instead of being inferred from
   event-delivery outcomes, so no future call-site change can re-poll the

--- a/crates/signal-fish-client-godot/src/lib.rs
+++ b/crates/signal-fish-client-godot/src/lib.rs
@@ -10,6 +10,17 @@
 //! godot-rust 0.4.5 through 0.5.x, and requires Rust 1.94. Applications should
 //! select one exact `godot` version in that range so their `Gd<WebSocketPeer>`
 //! has the same type identity as the adapter's public API.
+//!
+//! # Outbound frame bound
+//!
+//! Godot refuses to buffer an outbound message once the peer's outbound
+//! buffer would overflow, so a single frame larger than `outbound_buffer_size`
+//! (65,535 bytes by default) is never admitted on native builds — and one at
+//! or above that size on web exports. Such a frame parks as `Pending`,
+//! growing only the capacity diagnostics. SDK-created peers keep that legacy
+//! outbound default and raise only the inbound buffer; keep game payloads
+//! under ~64 KiB, or construct your own peer with a raised outbound buffer
+//! and wrap it with [`GodotWebSocketTransport::from_peer`].
 
 use std::fmt;
 use std::task::{Context, Poll};
@@ -358,8 +369,10 @@ impl GodotWebSocketTransport {
     /// The connection handshake advances when the transport is polled. For web
     /// exports, use `wss://` when the exported page is served over HTTPS. The
     /// SDK-created peer uses an 8 MiB Godot inbound buffer so valid aggregated
-    /// server messages are not constrained by Godot's much smaller default.
-    /// Use [`Self::from_peer`] when the application must choose another size.
+    /// server messages are not constrained by Godot's much smaller default,
+    /// while the outbound buffer keeps Godot's own default — see the crate
+    /// docs for how that bounds a single admitted frame. Use
+    /// [`Self::from_peer`] when the application must choose either size.
     ///
     /// # Errors
     ///

--- a/src/client.rs
+++ b/src/client.rs
@@ -2077,7 +2077,6 @@ async fn finish_send_failure(
 ) {
     let deadline = tokio::time::Instant::now().checked_add(timeout);
     let mut drain = ReadyFrameDrain::new(None, ReadyFrameDrainBudget::standard());
-    let mut delivery_preempted = false;
     loop {
         let polled = std::future::poll_fn(|cx| {
             std::task::Poll::Ready(drain.poll_next(
@@ -2107,8 +2106,7 @@ async fn finish_send_failure(
 
         let outcome = lock_core(state).process_frame(frame);
         let protocol_stop = outcome.disconnect;
-        delivery_preempted = !emit_event_batch(event_tx, shutdown, deadline, outcome.events).await;
-        if delivery_preempted {
+        if !emit_event_batch(event_tx, shutdown, deadline, outcome.events).await {
             debug!("terminal event delivery was preempted mid-batch after send failure");
             break;
         }
@@ -2119,10 +2117,11 @@ async fn finish_send_failure(
 
     let reason = peer_close_reason(transport).or_else(|| Some(error.to_string()));
     let disconnected = lock_core(state).disconnect(reason);
+    // A preempted batch means the sticky signal was observed or the shared
+    // deadline has passed, so this bounded wait always collapses within one
+    // poll instead of parking beside the already-spent budget.
     let deliver_disconnected = async {
-        if delivery_preempted
-            || !emit_terminal_event(event_tx, shutdown, deadline, disconnected.clone()).await
-        {
+        if !emit_terminal_event(event_tx, shutdown, deadline, disconnected.clone()).await {
             let _ = event_tx.try_send(disconnected);
         }
     };
@@ -2317,11 +2316,12 @@ async fn transport_loop(
                             break;
                         }
                         if let Some(teardown) = violation_teardown {
-                            // If the batch was preempted, the shutdown signal
-                            // may already have been observed (its tracking is
-                            // sticky), so the farewell skips the bounded wait
-                            // and takes the nonblocking attempt — exactly
-                            // like the send-failure teardown.
+                            // A preempted batch means the sticky shutdown
+                            // signal was observed or the shared deadline has
+                            // passed, so the farewell's bounded wait always
+                            // collapses within one poll — exactly like the
+                            // send-failure teardown — and never parks beside
+                            // the already-spent budget.
                             let TerminalTeardown {
                                 reason,
                                 deadline,
@@ -2329,14 +2329,13 @@ async fn transport_loop(
                             } = teardown;
                             let event = lock_core(&state).disconnect(reason);
                             let deliver_farewell = async {
-                                if !delivered
-                                    || !emit_terminal_event(
-                                        &event_tx,
-                                        &mut shutdown,
-                                        deadline,
-                                        event.clone(),
-                                    )
-                                    .await
+                                if !emit_terminal_event(
+                                    &event_tx,
+                                    &mut shutdown,
+                                    deadline,
+                                    event.clone(),
+                                )
+                                .await
                                 {
                                     let _ = event_tx.try_send(event);
                                 }


### PR DESCRIPTION
## Why

Two small cleanups from a fresh adversarial audit sweep (three parallel auditors over async teardown, cross-driver parity, and transports):

- After #150 made shutdown-signal tracking sticky, terminal teardown no longer needs its conservative special case: when an event batch delivery is preempted, the farewell `Disconnected` event skipped its bounded wait and fell back to a nonblocking send. A preempted batch already proves the sticky signal was observed or the shared deadline has passed, so that wait always resolves within one poll — the skip is pure complexity.
- The Godot adapter never told users that Godot itself bounds each outbound frame by the peer's outbound buffer: a frame larger than `outbound_buffer_size` (65,535 bytes by default) parks as `Pending` on native builds (at or above it on web exports), growing only capacity diagnostics. SDK-created peers raise only the inbound buffer, so large payloads silently stall.

## What

- Send-failure and policy-disconnect farewells now uniformly go through `emit_terminal_event`. Zero observable behavior change; every documented budget and event-delivery contract holds, and all pinned red/green tests pass unchanged.
- Crate docs for the adapter gain an "Outbound frame bound" section explaining the limit and how to admit larger frames with `from_peer`; CHANGELOG records it.
- `.llm/context.md`: corrects where adaptive outbound admission lives (Godot transport options, not the polling client).

## Validation

- `cargo fmt && cargo clippy --workspace --all-targets --all-features -- -D warnings && cargo test --workspace --all-features` green
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features` clean
- Equivalence reviewed across eight interleavings; two adversarial review rounds, final verdict SHIP

Refs #126.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches async-driver terminal teardown (send-failure and policy-disconnect farewells). Intended as a no-op simplification after sticky shutdown tracking, but teardown remains a high-sensitivity path if the assumption is wrong.
> 
> **Overview**
> Documents that Godot itself refuses a single outbound frame larger than the peer's `outbound_buffer_size` (legacy 65,535-byte default on SDK-created peers). Such a frame parks as `Pending` (native: strictly over the bound; web: at or above it) and only capacity diagnostics grow. Crate rustdoc, `connect` docs, CHANGELOG, and project context now tell callers to keep payloads under ~64 KiB or wrap a raised-buffer peer with `from_peer`.
> 
> Separately, send-failure and policy-disconnect farewells always go through `emit_terminal_event`. After sticky shutdown tracking, a preempted batch already means the signal was observed or the shared deadline passed, so the old skip-the-wait special case was unused complexity. Documented budgets and event-delivery contracts are unchanged.
> 
> Also corrects context: adaptive outbound admission lives on Godot transport options, not the polling client.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6299326ecc6d14c535e4e834f296f56cfe1ec443. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->