### PR TITLE
Fix mesh teardown and require server liveness tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,8 +127,8 @@ jobs:
         run: cargo test --workspace ${{ matrix.flags }}
 
   # ──────────────────────────────────────────────────────────────
-  # Pinned server compatibility E2E — generation-less 0.4, Server 0.7 mesh and
-  # reconnect behavior, and required token-binding security cases.
+  # Pinned server compatibility E2E — generation-less 0.4, Server 0.7 mesh,
+  # reconnect and liveness behavior, and required token-binding security cases.
   # ──────────────────────────────────────────────────────────────
   server-mesh-e2e:
     name: Server compatibility E2E (${{ matrix.server_version }})
@@ -148,6 +148,12 @@ jobs:
           - server_version: "0.7.0"
             server_sha256: "70c6d12ac77843038c96d374a91225825c685cbf65fd7bedfd26b08d4003af7e"
             test_name: e2e_reconnect_after_disconnect_uses_server_token
+          - server_version: "0.7.0"
+            server_sha256: "70c6d12ac77843038c96d374a91225825c685cbf65fd7bedfd26b08d4003af7e"
+            test_name: e2e_slow_consumer_eviction_is_observable
+          - server_version: "0.7.0"
+            server_sha256: "70c6d12ac77843038c96d374a91225825c685cbf65fd7bedfd26b08d4003af7e"
+            test_name: e2e_sender_ping_survives_own_game_data_flood
           - server_version: "0.7.0"
             server_sha256: "70c6d12ac77843038c96d374a91225825c685cbf65fd7bedfd26b08d4003af7e"
             test_name: e2e_server_070_required_token_binding_wss
@@ -191,6 +197,19 @@ jobs:
           set -euo pipefail
           server_bin="$(find .signal-fish-server -type f -name signal-fish-server -print -quit)"
           chmod +x "${server_bin}"
+          listed_tests="$(
+            cargo test --all-features --test real_server_e2e \
+              "${SERVER_TEST}" \
+              -- --ignored --exact --list
+          )"
+          matching_tests="$(
+            printf '%s\n' "${listed_tests}" | grep -Fxc "${SERVER_TEST}: test" || true
+          )"
+          if [ "${matching_tests}" -ne 1 ]; then
+            printf 'Expected exactly one ignored test named %s, libtest listed:\n%s\n' \
+              "${SERVER_TEST}" "${listed_tests}" >&2
+            exit 1
+          fi
           SIGNAL_FISH_SERVER_BIN="${PWD}/${server_bin}" \
             cargo test --all-features --test real_server_e2e \
               "${SERVER_TEST}" \

--- a/.llm/context.md
+++ b/.llm/context.md
@@ -81,10 +81,10 @@ checker self-tests enforce close-before-delete callback-state ownership;
 terminal deletion failure intentionally leaks the small allocation instead of
 risking late-callback use-after-free.
 
-Change-scoped, scheduled, and manual Deep Safety runs Miri protocol tests, three
-raw-byte JSON/MessagePack fuzz targets with temporary corpora, and focused
-mutation testing. It is not required because of nightly/runtime variability;
-required Clippy and WASM gates enforce compiler safety on every PR.
+Change-scoped, scheduled, and manual Deep Safety runs Miri protocol tests,
+ThreadSanitizer, three raw-byte JSON/MessagePack fuzz targets, and focused
+mutation testing. Nightly/runtime variability keeps it non-required; required
+Clippy and WASM gates enforce compiler safety on every PR.
 
 Native ASan is deferred because owned unsafe is Emscripten-only; fuzz sanitizer
 instrumentation covers the parsers it drives. Blanket Clippy
@@ -218,6 +218,8 @@ Required second argument to `SignalFishClient::start`. Only `app_id` is required
 Opt into protocol v3 relay/accountability with `.enable_v3()`. Use
 `.enable_mesh()` only with a WebRTC driver. `MeshController::start` preserves
 compatible choices while ensuring v3, WebRTC, and a Host or Mesh topology.
+Once `recv` observes signaling end, or on shutdown, the controller clears its
+view, disconnects peers, fuses receive, and prevents later driver sends.
 
 ```rust,ignore
 pub struct SignalFishConfig {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,6 +191,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed `MeshController` retaining a stale session and live peer-driver state
+  when its signaling event stream ended without room for the best-effort
+  `Disconnected` event. End-of-stream and explicit shutdown now disconnect
+  every known peer exactly once, clear the mesh view, fuse `recv`, and prevent
+  post-termination `send_to` calls from reaching the WebRTC driver.
 - Documented the Godot adapter's outbound frame bound: Godot refuses to buffer
   an outbound message once the peer's outbound buffer would overflow, so a
   single frame larger than `outbound_buffer_size` (65,535 bytes by default)

--- a/docs/mesh-guide.md
+++ b/docs/mesh-guide.md
@@ -158,6 +158,13 @@ retagged), reports `TransportStatus` on the 0↔1 connected boundary, tears
 down peers on re-election / `PlayerLeft` / `RoomLeft` / `Disconnected`, and
 surfaces a clean `MeshEvent` stream.
 
+`Disconnected` and signaling-stream closure are terminal controller boundaries.
+Before returning `MeshEvent::Signaling(Disconnected)`, or returning `None` for
+stream closure, the controller clears its session view and disconnects every
+known driver peer. It is then fused: later `recv()` calls return `None` without
+polling the driver, and `send_to` ignores data. Explicit `shutdown()` performs
+the same peer cleanup before gracefully stopping the signaling client.
+
 When integrating a driver without `MeshController`, relay its output with
 `send_signal_for_generation(peer, generation, signal)` (or the corresponding
 raw method). The client atomically refuses the send if a replacement plan has
@@ -197,11 +204,11 @@ mesh.shutdown().await;
 | API | Purpose |
 |-----|---------|
 | `MeshController::start(transport, config, driver)` | Build the controller; ensure v3, WebRTC, and a P2P topology while preserving compatible custom choices. |
-| `recv().await -> Option<MeshEvent>` | Drive the handshake and yield the next high-level event. `None` once the transport closes. |
-| `send_to(peer, &[u8])` | Send application bytes to a peer over its data channel. |
+| `recv().await -> Option<MeshEvent>` | Drive the handshake and yield the next high-level event. A returned `Disconnected` has already cleared the session and disconnected known peers; after it or stream closure, the controller is fused and returns `None` without polling the driver. |
+| `send_to(peer, &[u8])` | Send application bytes to a peer over its data channel; ignored after the controller becomes terminal. |
 | `with_pump_interval(Duration)` | Tune the periodic driver pump (default 20 ms). |
 | `join_room` / `set_ready` / `start_game` / `leave_room` / `client()` | Room-lifecycle delegations to the inner client. |
-| `shutdown().await` | Gracefully stop the controller and its client. |
+| `shutdown().await` | Disconnect every known driver peer, then gracefully stop the signaling client. |
 
 `MeshEvent` has four variants: `Signaling(Box<SignalFishEvent>)` (every
 underlying event, passed through verbatim), `PeerConnected(PlayerId)`,

--- a/src/webrtc.rs
+++ b/src/webrtc.rs
@@ -281,6 +281,9 @@ mod controller {
         /// reconnect/replan before this controller consumes its queued event;
         /// a revision mismatch therefore fences driver output first.
         observed_session_plan_revision: u64,
+        /// Sticky authoritative end-of-stream state. Once terminal, driver
+        /// output is never pumped or forwarded again.
+        terminated: bool,
     }
 
     impl<D: WebRtcDriver> MeshController<D> {
@@ -314,6 +317,7 @@ mod controller {
                 ready,
                 pending_signal: None,
                 observed_session_plan_revision: 0,
+                terminated: false,
             }
         }
 
@@ -332,12 +336,20 @@ mod controller {
         }
 
         /// Send application bytes to `peer` over its peer-to-peer data channel.
+        /// This is a no-op once the controller has entered its terminal state.
         pub fn send_to(&mut self, peer: PlayerId, data: &[u8]) {
-            self.driver.send(peer, data);
+            if !self.terminated {
+                self.driver.send(peer, data);
+            }
         }
 
         /// Receive the next high-level mesh event. Returns `None` once the
-        /// underlying transport closes.
+        /// underlying transport closes. At that boundary the controller clears
+        /// its session, disconnects every known driver peer, and becomes fused:
+        /// later calls also return `None` without pumping the driver. When this
+        /// method returns a signaling [`SignalFishEvent::Disconnected`], that
+        /// same teardown has already happened before the event reaches the
+        /// caller, and the next call returns `None`.
         ///
         /// # Cancel safety
         ///
@@ -348,6 +360,9 @@ mod controller {
         /// with `tokio::time::timeout` in a frame-budgeted game loop — never
         /// loses a signal.
         pub async fn recv(&mut self) -> Option<MeshEvent> {
+            if self.terminated {
+                return None;
+            }
             loop {
                 if self.observed_session_plan_revision != self.client.session_plan_revision() {
                     match self.events.recv().await {
@@ -355,7 +370,10 @@ mod controller {
                             self.handle_received_event(&event);
                             return Some(MeshEvent::Signaling(Box::new(event)));
                         }
-                        None => return None,
+                        None => {
+                            self.terminate();
+                            return None;
+                        }
                     }
                 }
                 // Surface any pending driver output first (relaying signals /
@@ -377,7 +395,10 @@ mod controller {
                                 self.handle_received_event(&event);
                                 return Some(MeshEvent::Signaling(Box::new(event)));
                             }
-                            None => return None,
+                            None => {
+                                self.terminate();
+                                return None;
+                            }
                         }
                     }
                     () = self.ready.notified() => {
@@ -514,13 +535,13 @@ mod controller {
                 // edge while retaining all driver cleanup.
                 SignalFishEvent::RoomLeft
                 | SignalFishEvent::SpectatorJoined { .. }
-                | SignalFishEvent::SpectatorLeft { .. }
-                | SignalFishEvent::Disconnected { .. } => {
+                | SignalFishEvent::SpectatorLeft { .. } => {
                     self.connected_peers.clear();
                     for peer in std::mem::take(&mut self.known_peers) {
                         self.disconnect_peer(peer.id);
                     }
                 }
+                SignalFishEvent::Disconnected { .. } => self.terminate(),
                 SignalFishEvent::RoomJoined { ice_servers, .. } if !ice_servers.is_empty() => {
                     self.driver.set_ice_servers(ice_servers);
                 }
@@ -554,6 +575,21 @@ mod controller {
                 self.pending_signal = None;
             }
             self.mark_disconnected(peer);
+        }
+
+        /// End the controller's data plane exactly once without emitting a
+        /// room-scoped transport-status edge after signaling has terminated.
+        fn terminate(&mut self) {
+            if self.terminated {
+                return;
+            }
+            self.terminated = true;
+            self.pending_signal = None;
+            self.connected_peers.clear();
+            self.session = MeshSession::new();
+            for peer in std::mem::take(&mut self.known_peers) {
+                self.driver.disconnect(peer.id);
+            }
         }
 
         /// Ensure the driver holds the server's current offerer role for `peer`.
@@ -809,8 +845,11 @@ mod controller {
             &mut self.client
         }
 
-        /// Gracefully shut down the controller and its client.
+        /// Disconnect every known driver peer, then gracefully shut down the
+        /// signaling client. Driver cleanup happens exactly once even if the
+        /// controller already observed a terminal signaling boundary.
         pub async fn shutdown(mut self) {
+            self.terminate();
             self.client.shutdown().await;
         }
     }
@@ -892,6 +931,7 @@ mod tests {
         OnSignalGeneration(PlayerId, Option<SessionGeneration>),
         Send(PlayerId, Vec<u8>),
         Disconnect(PlayerId),
+        Poll,
     }
 
     #[derive(Default)]
@@ -970,6 +1010,7 @@ mod tests {
             self.calls.push(DriverCall::Disconnect(peer));
         }
         fn poll(&mut self) -> Option<DriverEvent> {
+            self.calls.push(DriverCall::Poll);
             self.outputs.pop_front()
         }
     }
@@ -1040,6 +1081,39 @@ mod tests {
         incoming: VecDeque<Option<Result<String, crate::error::SignalFishError>>>,
         sent: Arc<Mutex<Vec<String>>>,
         closed: Arc<AtomicBool>,
+        recv_probe: Option<Arc<RecvProbe>>,
+    }
+
+    #[derive(Default)]
+    struct RecvProbe {
+        pong_polls: std::sync::atomic::AtomicUsize,
+        observed: tokio::sync::Notify,
+    }
+
+    impl RecvProbe {
+        fn record(&self, item: &Option<Result<String, crate::error::SignalFishError>>) {
+            if item.as_ref().is_some_and(|result| {
+                result.as_ref().is_ok_and(|json| {
+                    matches!(
+                        serde_json::from_str::<ServerMessage>(json),
+                        Ok(ServerMessage::Pong)
+                    )
+                })
+            }) {
+                self.pong_polls.fetch_add(1, Ordering::Relaxed);
+                self.observed.notify_waiters();
+            }
+        }
+
+        async fn wait_for_pong_polls(&self, expected: usize) {
+            loop {
+                let observed = self.observed.notified();
+                if self.pong_polls.load(Ordering::Relaxed) >= expected {
+                    return;
+                }
+                observed.await;
+            }
+        }
     }
 
     impl MockTransport {
@@ -1051,6 +1125,21 @@ mod tests {
 
         fn new_in_room(
             mut incoming: Vec<Option<Result<String, crate::error::SignalFishError>>>,
+        ) -> (Self, Arc<Mutex<Vec<String>>>) {
+            Self::new_in_room_impl(&mut incoming, None)
+        }
+
+        fn new_in_room_with_probe(
+            mut incoming: Vec<Option<Result<String, crate::error::SignalFishError>>>,
+        ) -> (Self, Arc<Mutex<Vec<String>>>, Arc<RecvProbe>) {
+            let probe = Arc::new(RecvProbe::default());
+            let (transport, sent) = Self::new_in_room_impl(&mut incoming, Some(Arc::clone(&probe)));
+            (transport, sent, probe)
+        }
+
+        fn new_in_room_impl(
+            incoming: &mut Vec<Option<Result<String, crate::error::SignalFishError>>>,
+            recv_probe: Option<Arc<RecvProbe>>,
         ) -> (Self, Arc<Mutex<Vec<String>>>) {
             let decoded = incoming
                 .iter()
@@ -1101,11 +1190,18 @@ mod tests {
                     .map_or(0, |index| index + 1);
                 incoming.insert(insert_at, Some(Ok(room_baseline_for(&peers))));
             }
-            Self::finish(incoming)
+            Self::finish_with_probe(std::mem::take(incoming), recv_probe)
         }
 
         fn finish(
             incoming: Vec<Option<Result<String, crate::error::SignalFishError>>>,
+        ) -> (Self, Arc<Mutex<Vec<String>>>) {
+            Self::finish_with_probe(incoming, None)
+        }
+
+        fn finish_with_probe(
+            incoming: Vec<Option<Result<String, crate::error::SignalFishError>>>,
+            recv_probe: Option<Arc<RecvProbe>>,
         ) -> (Self, Arc<Mutex<Vec<String>>>) {
             let sent = Arc::new(Mutex::new(Vec::new()));
             let closed = Arc::new(AtomicBool::new(false));
@@ -1114,6 +1210,7 @@ mod tests {
                     incoming: VecDeque::from(incoming),
                     sent: Arc::clone(&sent),
                     closed,
+                    recv_probe,
                 },
                 sent,
             )
@@ -1177,6 +1274,9 @@ mod tests {
                 return std::task::Poll::Pending;
             }
             if let Some(item) = self.incoming.pop_front() {
+                if let Some(probe) = &self.recv_probe {
+                    probe.record(&item);
+                }
                 std::task::Poll::Ready(
                     item.map(|result| result.map(crate::transport::TransportFrame::Text)),
                 )
@@ -3110,6 +3210,217 @@ mod tests {
             .contains(&DriverCall::ConnectGeneration(peer, Some(new_generation))));
         assert_eq!(mesh.session().generation(), Some(new_generation));
         mesh.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn disconnected_event_is_immediately_terminal_before_the_next_recv() {
+        let peer = uuid(54);
+        let driver = SharedDriver::default();
+        let (transport, _sent) = MockTransport::new_in_room(vec![
+            Some(Ok(authed())),
+            Some(Ok(protocol_info_v3())),
+            Some(Ok(session_plan(peer, false))),
+            None,
+        ]);
+        let mut mesh = start_in_scripted_room(transport, driver.clone()).await;
+
+        let disconnected = tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            loop {
+                let event = mesh
+                    .recv()
+                    .await
+                    .expect("Disconnected should be delivered before the scripted stream ends");
+                if matches!(
+                    event,
+                    MeshEvent::Signaling(ref event)
+                        if matches!(**event, SignalFishEvent::Disconnected { .. })
+                ) {
+                    return event;
+                }
+            }
+        })
+        .await
+        .expect("controller never surfaced the scripted Disconnected event");
+        assert!(matches!(
+            disconnected,
+            MeshEvent::Signaling(ref event)
+                if matches!(**event, SignalFishEvent::Disconnected { .. })
+        ));
+
+        // Returning Disconnected is itself the terminal boundary: callers do
+        // not need another recv() to trigger cleanup or suppress data-plane I/O.
+        assert!(mesh.session().peers().is_empty());
+        assert!(mesh.session().generation().is_none());
+        assert!(mesh.session().transport().is_none());
+        mesh.send_to(peer, b"stale-after-disconnected");
+        let polls_at_terminal = count_calls(&driver, |call| matches!(call, DriverCall::Poll));
+
+        driver.emit_and_wake(DriverEvent::Data {
+            peer,
+            generation: Some(uuid(12)),
+            data: vec![7],
+        });
+        assert!(mesh.recv().await.is_none());
+
+        let calls = driver.calls();
+        assert_eq!(
+            calls
+                .iter()
+                .filter(|call| matches!(call, DriverCall::Disconnect(id) if *id == peer))
+                .count(),
+            1,
+            "Disconnected must tear down each known peer exactly once"
+        );
+        assert_eq!(
+            count_calls(&driver, |call| matches!(call, DriverCall::Poll)),
+            polls_at_terminal,
+            "a fused controller must not poll its driver after Disconnected"
+        );
+        assert!(
+            !calls.iter().any(|call| matches!(
+                call,
+                DriverCall::Send(id, data)
+                    if *id == peer && data == b"stale-after-disconnected"
+            )),
+            "send_to must not forward data after Disconnected"
+        );
+    }
+
+    #[tokio::test]
+    async fn event_stream_end_tears_down_and_fuses_the_mesh_controller() {
+        let peer = uuid(55);
+        let driver = SharedDriver::default();
+        let pong = serde_json::to_string(&ServerMessage::Pong).unwrap();
+        let (transport, _sent, recv_probe) = MockTransport::new_in_room_with_probe(vec![
+            Some(Ok(authed())),
+            Some(Ok(protocol_info_v3())),
+            Some(Ok(session_plan(peer, false))),
+            Some(Ok(pong.clone())),
+            Some(Ok(pong)),
+        ]);
+        let config = SignalFishConfig::new("app").with_event_channel_capacity(1);
+        let mut mesh = MeshController::start(transport, config, driver.clone());
+        wait_for_authenticated(&mut mesh).await;
+        mesh.join_room(crate::client::JoinRoomParams::new("test", "local"))
+            .expect("scripted room response must follow an admitted join");
+
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            while mesh.session().peers().is_empty() {
+                assert!(
+                    mesh.recv().await.is_some(),
+                    "event stream ended before the WebRTC plan was observed"
+                );
+            }
+        })
+        .await
+        .expect("controller never observed the scripted WebRTC plan");
+
+        // Observe the transport loop polling both Pongs. On this current-thread
+        // runtime it then runs to its next pending point: the second Pong's
+        // event-channel send, blocked behind the first Pong in the capacity-one
+        // channel. Shutdown preempts that delivery, so its best-effort
+        // Disconnected cannot fit and channel closure becomes the controller's
+        // only authoritative terminal signal.
+        tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            recv_probe.wait_for_pong_polls(2),
+        )
+        .await
+        .expect("transport never polled both scripted Pong frames");
+        mesh.client_mut().shutdown().await;
+
+        let buffered = mesh.recv().await;
+        assert!(
+            matches!(
+                buffered,
+                Some(MeshEvent::Signaling(ref event)) if matches!(**event, SignalFishEvent::Pong)
+            ),
+            "the capacity-one channel should retain the first Pong, got {buffered:?}"
+        );
+
+        let first_end = mesh.recv().await.is_none();
+        let session_cleared = mesh.session().peers().is_empty()
+            && mesh.session().generation().is_none()
+            && mesh.session().transport().is_none();
+        let polls_at_terminal = count_calls(&driver, |call| matches!(call, DriverCall::Poll));
+
+        driver.emit_and_wake(DriverEvent::Data {
+            peer,
+            generation: Some(uuid(12)),
+            data: vec![7],
+        });
+        let repeated_end = mesh.recv().await.is_none();
+        mesh.send_to(peer, b"stale-after-end");
+
+        let calls = driver.calls();
+        assert!(first_end, "closed signaling stream must end mesh recv");
+        assert!(
+            session_cleared,
+            "authoritative stream end must clear the mesh view"
+        );
+        assert!(
+            repeated_end,
+            "mesh recv must remain fused after returning None"
+        );
+        assert_eq!(
+            count_calls(&driver, |call| matches!(call, DriverCall::Poll)),
+            polls_at_terminal,
+            "a fused controller must not poll its driver after stream end"
+        );
+        assert_eq!(
+            calls
+                .iter()
+                .filter(|call| matches!(call, DriverCall::Disconnect(id) if *id == peer))
+                .count(),
+            1,
+            "authoritative stream end must disconnect each known peer exactly once"
+        );
+        assert!(
+            !calls.iter().any(
+                |call| matches!(call, DriverCall::Send(id, data) if *id == peer && data == b"stale-after-end")
+            ),
+            "send_to must not forward data after authoritative stream end"
+        );
+    }
+
+    #[tokio::test]
+    async fn shutdown_disconnects_each_known_mesh_peer_once() {
+        let peers = [uuid(56), uuid(57)];
+        let driver = SharedDriver::default();
+        let (transport, _sent) = MockTransport::new_in_room(vec![
+            Some(Ok(authed())),
+            Some(Ok(protocol_info_v3())),
+            Some(Ok(session_plan_multi(
+                &[(peers[0], false), (peers[1], false)],
+                &[],
+            ))),
+        ]);
+        let mut mesh = start_in_scripted_room(transport, driver.clone()).await;
+
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            while mesh.session().peers().len() != peers.len() {
+                assert!(
+                    mesh.recv().await.is_some(),
+                    "event stream ended before the WebRTC plan was observed"
+                );
+            }
+        })
+        .await
+        .expect("controller never observed the scripted WebRTC plan");
+
+        mesh.shutdown().await;
+
+        let calls = driver.calls();
+        for peer in peers {
+            assert_eq!(
+                calls
+                    .iter()
+                    .filter(|call| matches!(call, DriverCall::Disconnect(id) if *id == peer))
+                    .count(),
+                1,
+                "shutdown must disconnect each known peer exactly once"
+            );
+        }
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -1590,15 +1590,17 @@ mod ci_workflow_policy {
     }
 
     #[test]
-    fn ci_pins_live_mesh_compatibility_seams() {
+    fn ci_pins_live_server_compatibility_seams() {
         let contents = ci_contents();
+        let server_job = extract_job_block(&contents, "server-mesh-e2e")
+            .expect("CI must contain the pinned-server compatibility job");
         let compatibility: toml::Value =
             toml::from_str(&read_project_file("tests/compatibility.toml"))
                 .expect("compatibility manifest must parse");
         let release_artifacts = compatibility["server_release_artifacts"]
             .as_table()
             .expect("server_release_artifacts must be a table");
-        for (asset, version, test_name) in [
+        let pinned_seams = [
             (
                 "signal-fish-server-v0.7.0-x86_64-unknown-linux-gnu.tar.gz",
                 "0.7.0",
@@ -1613,6 +1615,16 @@ mod ci_workflow_policy {
                 "signal-fish-server-v0.7.0-x86_64-unknown-linux-gnu.tar.gz",
                 "0.7.0",
                 "e2e_reconnect_after_disconnect_uses_server_token",
+            ),
+            (
+                "signal-fish-server-v0.7.0-x86_64-unknown-linux-gnu.tar.gz",
+                "0.7.0",
+                "e2e_slow_consumer_eviction_is_observable",
+            ),
+            (
+                "signal-fish-server-v0.7.0-x86_64-unknown-linux-gnu.tar.gz",
+                "0.7.0",
+                "e2e_sender_ping_survives_own_game_data_flood",
             ),
             (
                 "signal-fish-server-v0.7.0-x86_64-unknown-linux-gnu.tar.gz",
@@ -1644,7 +1656,8 @@ mod ci_workflow_policy {
                 "0.4.0",
                 "e2e_server_040_generationless_mesh_signal",
             ),
-        ] {
+        ];
+        for &(asset, version, test_name) in &pinned_seams {
             let digest = release_artifacts[asset]
                 .as_str()
                 .unwrap_or_else(|| panic!("{asset} release digest must be a string"));
@@ -1652,15 +1665,91 @@ mod ci_workflow_policy {
                 "- server_version: \"{version}\"\n            server_sha256: \"{digest}\"\n            test_name: {test_name}"
             );
             assert!(
-                contents.contains(&matrix_row),
+                server_job.contains(&matrix_row),
                 "CI must bind {asset} digest {digest} to {test_name} in one matrix row"
             );
         }
         let checksum_command =
             "printf '%s  %s\\n' \"${SERVER_SHA256}\" \"${asset}\" | sha256sum --check";
         assert!(
-            contents.contains(checksum_command),
+            server_job.contains(checksum_command),
             "CI must verify the matrix-bound release digest"
+        );
+
+        let matrix_rows = server_job
+            .lines()
+            .filter(|line| line.trim_start().starts_with("- server_version: "))
+            .count();
+        let matrix_test_entries: Vec<_> = server_job
+            .lines()
+            .filter_map(|line| line.trim().strip_prefix("test_name: "))
+            .collect();
+        let matrix_test_names: std::collections::BTreeSet<_> =
+            matrix_test_entries.iter().copied().collect();
+        let pinned_test_names: std::collections::BTreeSet<_> = pinned_seams
+            .iter()
+            .map(|(_, _, test_name)| *test_name)
+            .collect();
+        assert_eq!(
+            matrix_test_entries.len(),
+            matrix_test_names.len(),
+            "the pinned-server matrix must not run the same test more than once"
+        );
+        assert_eq!(
+            pinned_seams.len(),
+            pinned_test_names.len(),
+            "the audited pinned-server inventory must contain unique test names"
+        );
+        assert_eq!(
+            matrix_rows,
+            pinned_seams.len(),
+            "the pinned-server matrix must have exactly one row per audited compatibility test"
+        );
+        assert_eq!(
+            matrix_test_entries.len(),
+            matrix_rows,
+            "every pinned-server matrix row must name exactly one test"
+        );
+        assert_eq!(
+            matrix_test_names, pinned_test_names,
+            "the pinned-server matrix must contain exactly the audited compatibility tests"
+        );
+
+        // Tie the complete ignored-test inventory to the matrix without trying
+        // to parse arbitrary Rust syntax: every audited name must be an ignored
+        // async test, names must be unique, and the number of ignored attributes
+        // must equal the number of matrix entries.
+        let e2e_source = read_project_file("tests/real_server_e2e.rs");
+        let ignored_attributes = e2e_source
+            .lines()
+            .filter(|line| line.trim_start().starts_with("#[ignore"))
+            .count();
+        assert_eq!(
+            ignored_attributes,
+            pinned_test_names.len(),
+            "every ignored real-server E2E must have one pinned-server matrix entry"
+        );
+        for test_name in &pinned_test_names {
+            let declaration = format!("async fn {test_name}()");
+            let declaration_offset = e2e_source
+                .find(&declaration)
+                .unwrap_or_else(|| panic!("{test_name} must remain an async real-server test"));
+            let preceding_line = e2e_source[..declaration_offset]
+                .lines()
+                .rev()
+                .find(|line| !line.trim().is_empty())
+                .expect("an E2E test declaration must have attributes");
+            assert!(
+                preceding_line.trim_start().starts_with("#[ignore"),
+                "{test_name} must remain ignored by offline cargo test runs"
+            );
+        }
+
+        assert!(
+            server_job.contains("-- --ignored --exact --list")
+                && server_job.contains("grep -Fxc \"${SERVER_TEST}: test\"")
+                && server_job.contains("if [ \"${matching_tests}\" -ne 1 ]; then"),
+            "the pinned-server job must fail closed unless libtest lists exactly one requested ignored test"
         );
     }
 

--- a/tests/real_server_e2e.rs
+++ b/tests/real_server_e2e.rs
@@ -1635,14 +1635,25 @@ async fn e2e_sender_ping_survives_own_game_data_flood() {
     .await;
 
     // Flood (room of one: relay fan-out is empty, but the inbound path and
-    // parse work are real) while pinging once per 250ms.
+    // parse work are real). Each synchronous burst puts a substantial batch in
+    // the client command queue ahead of its Ping without yielding to the
+    // transport task, so the measured Pong proves ordered control-plane
+    // progress behind real bulk traffic rather than after a pre-ping quiet
+    // interval.
+    const PING_ROUNDS: u32 = 8;
+    const BURST_FRAMES: u32 = 512;
     let payload = serde_json::json!({ "pad": "y".repeat(512) });
     let mut pongs = 0u32;
+    let mut accepted_game_data = 0u32;
     let mut worst_rtt = Duration::ZERO;
-    for _ in 0..8 {
-        let _ = a.send_game_data(payload.clone());
-        a.ping().expect("queue ping");
+    for _ in 0..PING_ROUNDS {
+        for _ in 0..BURST_FRAMES {
+            a.send_game_data(payload.clone())
+                .expect("the bounded pre-ping flood must be admitted");
+            accepted_game_data += 1;
+        }
         let sent_at = Instant::now();
+        a.ping().expect("queue ping");
         wait_for_event(&mut a_events, "Pong", Duration::from_secs(3), |e| {
             matches!(e, SignalFishEvent::Pong)
         })
@@ -1650,13 +1661,17 @@ async fn e2e_sender_ping_survives_own_game_data_flood() {
         let rtt = sent_at.elapsed();
         worst_rtt = worst_rtt.max(rtt);
         pongs += 1;
-        for _ in 0..50 {
-            let _ = a.send_game_data(payload.clone());
-        }
-        tokio::time::sleep(Duration::from_millis(250)).await;
     }
-    println!("E4 SMOKE DATA: {pongs} pongs, worst sender-side RTT {worst_rtt:?}");
-    assert_eq!(pongs, 8);
+    println!(
+        "E4 SMOKE DATA: {accepted_game_data} accepted GameData frames, \
+         {pongs} pongs, worst sender-side RTT {worst_rtt:?}"
+    );
+    assert_eq!(
+        accepted_game_data,
+        PING_ROUNDS * BURST_FRAMES,
+        "every substantial pre-ping flood batch must be accepted"
+    );
+    assert_eq!(pongs, PING_ROUNDS);
     assert!(
         worst_rtt < Duration::from_secs(2),
         "sender-side Pong RTT should stay low during its own flood; got {worst_rtt:?}"


### PR DESCRIPTION
## Why

A signaling stream can close without room for its best-effort `Disconnected` event. `MeshController` then retained stale session/peer state and could keep forwarding data. Two existing Server 0.7 liveness regressions also were not part of required CI.

## What

- make mesh termination idempotently clear the session, disconnect known peers, fuse receive, and ignore later sends
- cover explicit disconnect, channel closure under backpressure, and explicit shutdown
- require all 11 ignored real-server tests in the checksum-pinned server matrix, with fail-closed exact selection
- strengthen the sender-flood smoke to admit 4,096 frames ahead of its Pings

## Tests

- mandatory workspace fmt, Clippy, and all-feature tests
- 17 pre-commit and 6 pre-push checks
- exact Server 0.7.0 slow-consumer and sender-flood tests on ARM64
- two adversarial review rounds with zero remaining findings

Refs #126