### PR TITLE
Make release builds fail loudly on integer overflow

### DIFF
--- a/.llm/context.md
+++ b/.llm/context.md
@@ -83,8 +83,8 @@ risking late-callback use-after-free. Change-scoped, scheduled, and manual
 Deep Safety runs Miri protocol tests, ThreadSanitizer, three raw-byte
 JSON/MessagePack fuzz targets, and focused mutation testing; required Clippy
 and WASM gates enforce compiler safety on every PR. Every member denies
-`unwrap_used` through `indexing_slicing` (incl. `unreachable`) and the No
-Panics grep gate scans all member sources.
+`unwrap_used` through `indexing_slicing`/`unreachable`, plus `arithmetic_side_effects`; the No
+Panics grep gate scans all members; release builds enable `overflow-checks` (debug-equivalent arithmetic).
 
 Native ASan is deferred because owned unsafe is Emscripten-only; fuzz sanitizer
 instrumentation covers the parsers it drives. Blanket Clippy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Workspace release builds now enable `overflow-checks`, so integer overflow
+  aborts loudly instead of wrapping silently. Every supported configuration
+  (debug tests, release builds, fuzzing, and Miri) now validates the same
+  arithmetic semantics, and a promoted workspace-wide
+  `clippy::arithmetic_side_effects` denial keeps raw integer math on
+  server-controlled values checked/saturating/wrapping-explicit. Delivery
+  accountability gap/counter arithmetic is machine-checked accordingly;
+  observable protocol behavior and wire bytes are unchanged.
 - **Breaking:** Directed room operations are now refused before the server
   confirms authentication. `join_room`, `leave_room`, `reconnect`,
   `join_as_spectator`, and `leave_spectator` return the new

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,6 +140,11 @@ todo = "deny"
 unimplemented = "deny"
 unreachable = "deny"
 indexing_slicing = "deny"
+# Promoted from the 2026-08 runtime-invariant sweep: raw integer arithmetic
+# must be `checked_`/`saturating_`/`wrapping_`-explicit or carry a scoped,
+# documented proof, so debug/release overflow semantics cannot diverge
+# silently on hostile input. Zero unguarded findings at promotion.
+arithmetic_side_effects = "deny"
 # Stable restriction lints promoted from the 2026-08 deep-safety evaluation:
 # zero pre-existing findings across the workspace; each enforces an existing
 # written policy (no debug leftovers, no process exit from a library, no
@@ -164,3 +169,9 @@ version = "0.10.0"
 
 [workspace.dependencies]
 signal-fish-client = { version = "=0.10.0", path = ".", default-features = false }
+
+# Release builds validate under the same arithmetic semantics as every debug
+# test, fuzz, and Miri run: integer overflow aborts loudly instead of wrapping
+# silently. Bench profiles inherit this through `release`.
+[profile.release]
+overflow-checks = true

--- a/crates/signal-fish-client-godot/Cargo.toml
+++ b/crates/signal-fish-client-godot/Cargo.toml
@@ -32,6 +32,9 @@ todo = "deny"
 unimplemented = "deny"
 unreachable = "deny"
 indexing_slicing = "deny"
+# Kept in lockstep with the core crate; see its arithmetic_side_effects
+# rationale (runtime-invariant overflow discipline on hostile input).
+arithmetic_side_effects = "deny"
 # Kept in lockstep with the core crate's stable restriction lints; `unsafe_code`
 # is already forbidden here, so the unsafe-documentation lint is moot.
 dbg_macro = "deny"

--- a/crates/signal-fish-client-godot/src/lib.rs
+++ b/crates/signal-fish-client-godot/src/lib.rs
@@ -620,6 +620,13 @@ impl GodotWebSocketTransport {
     }
 }
 
+/// Exponential moving average of one eighth of each new sample.
+///
+/// The arithmetic runs in `u128`: for `u64` inputs, `7 * previous + sample`
+/// is bounded by `8 * (u64::MAX - 1) + u64::MAX`, far below `u128::MAX`, so
+/// neither the multiply-add nor the division can overflow and the only
+/// fallible step is the narrowing conversion handled by `unwrap_or`.
+#[allow(clippy::arithmetic_side_effects)]
 fn ewma_one_eighth(previous: u64, sample: u64) -> u64 {
     u64::try_from((u128::from(previous) * 7 + u128::from(sample)) / 8).unwrap_or(u64::MAX)
 }
@@ -830,7 +837,8 @@ impl Transport for GodotWebSocketTransport {
     clippy::panic,
     clippy::todo,
     clippy::unimplemented,
-    clippy::indexing_slicing
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects
 )]
 mod tests {
     use std::cell::{Cell, RefCell};

--- a/examples/custom_transport.rs
+++ b/examples/custom_transport.rs
@@ -13,6 +13,10 @@
 //! cargo run --example custom_transport
 //! ```
 
+// Demo counters and deadlines use plain arithmetic; this example is not
+// part of the panic-critical library surface.
+#![allow(clippy::arithmetic_side_effects)]
+
 use signal_fish_client::transport::TransportFrame;
 use signal_fish_client::{
     SignalFishClient, SignalFishConfig, SignalFishError, SignalFishEvent, Transport,

--- a/examples/load_lab.rs
+++ b/examples/load_lab.rs
@@ -30,6 +30,10 @@
 //! instance). Timestamps ride inside the payload, so latency is measured on
 //! one process clock: run all roles from this single binary.
 
+// Measurement harness counters/deadlines use plain arithmetic; this is a
+// standalone lab tool, not the panic-critical library surface.
+#![allow(clippy::arithmetic_side_effects)]
+
 use std::error::Error;
 use std::time::{Duration, Instant};
 

--- a/src/accountability.rs
+++ b/src/accountability.rs
@@ -506,34 +506,43 @@ impl DeliveryAccountability {
             }
             ranges.push((gap.from_seq, gap.to_seq));
         }
-        let delta = |next: u64, prior: u64| next - prior;
-        let unsupported_delta = delta(
+        // `validate_monotonic_counters` already rejected backward movement, so
+        // these subtractions are total; `checked_sub` keeps that invariant
+        // machine-checked instead of relying on the adjacent validation.
+        let delta = |next: u64, prior: u64| {
+            next.checked_sub(prior).ok_or_else(|| {
+                "delivery accountability violation: cumulative per-class counters moved backward"
+                    .to_string()
+            })
+        };
+        let reliable_unsupported = delta(
             report.per_class.reliable.unsupported_format,
             previous.reliable.unsupported_format,
-        )
-        .checked_add(delta(
+        )?;
+        let latest_unsupported = delta(
             report.per_class.latest.unsupported_format,
             previous.latest.unsupported_format,
-        ))
-        .and_then(|sum| {
-            sum.checked_add(delta(
-                report.per_class.volatile.unsupported_format,
-                previous.volatile.unsupported_format,
-            ))
-        })
-        .ok_or_else(|| {
-            "delivery accountability violation: unsupported-format delta overflowed".to_string()
-        })?;
+        )?;
+        let volatile_unsupported = delta(
+            report.per_class.volatile.unsupported_format,
+            previous.volatile.unsupported_format,
+        )?;
+        let unsupported_delta = reliable_unsupported
+            .checked_add(latest_unsupported)
+            .and_then(|sum| sum.checked_add(volatile_unsupported))
+            .ok_or_else(|| {
+                "delivery accountability violation: unsupported-format delta overflowed".to_string()
+            })?;
         let counter_deltas = [
             delta(
                 report.per_class.latest.superseded,
                 previous.latest.superseded,
-            ),
+            )?,
             delta(
                 report.per_class.latest.dropped_full,
                 previous.latest.dropped_full,
-            ),
-            delta(report.per_class.volatile.dropped, previous.volatile.dropped),
+            )?,
+            delta(report.per_class.volatile.dropped, previous.volatile.dropped)?,
             unsupported_delta,
         ];
         if counter_deltas != causal_counts {
@@ -796,7 +805,7 @@ impl DeliveryAccountability {
 
         let mut next = expected;
         let mut consumed = 0usize;
-        for gap in gaps.iter() {
+        for (index, gap) in gaps.iter().enumerate() {
             if gap.from_seq != next || gap.to_seq >= received {
                 break;
             }
@@ -806,17 +815,19 @@ impl DeliveryAccountability {
                     key.0, key.1
                 )
             })?;
-            consumed += 1;
+            consumed = index.saturating_add(1);
             if next == received {
                 break;
             }
         }
         if next != received {
+            // Sequence stamps start at 1, so the last missing sequence is
+            // `received - 1`; saturation is unreachable for validated stamps.
             return Err(format!(
                 "delivery accountability violation: prior exact reports do not cover {} epoch {} gap {expected}..={}",
                 key.0,
                 key.1,
-                received - 1
+                received.saturating_sub(1)
             ));
         }
         gaps.drain(..consumed);
@@ -842,7 +853,13 @@ impl DeliveryAccountability {
                 self.retire_departed(player_id, epoch);
                 return Ok(());
             }
-            last_seq + 1
+            // Guarded above: last_seq < terminal.final_seq, so the successor
+            // still fits; `checked_add` keeps that invariant machine-checked.
+            last_seq.checked_add(1).ok_or_else(|| {
+                format!(
+                    "delivery accountability violation: sender {player_id} sequence overflow before PlayerLeft epoch {epoch}"
+                )
+            })?
         } else {
             return Err(format!(
                 "delivery accountability violation: sender {player_id} advanced beyond its unresolved PlayerLeft epoch {}",
@@ -858,19 +875,23 @@ impl DeliveryAccountability {
             .unwrap_or(&[]);
         let mut consumed = 0usize;
         let mut covered = terminal.final_seq == 0;
-        while next <= terminal.final_seq {
-            let Some(gap) = gaps.get(consumed) else {
-                return Ok(());
-            };
+        for (index, gap) in gaps.iter().enumerate() {
+            if next > terminal.final_seq {
+                break;
+            }
             if gap.from_seq != next || gap.to_seq > terminal.final_seq {
                 return Ok(());
             }
-            consumed += 1;
+            consumed = index.saturating_add(1);
             if gap.to_seq == terminal.final_seq {
                 covered = true;
                 break;
             }
-            next = gap.to_seq + 1;
+            next = gap.to_seq.checked_add(1).ok_or_else(|| {
+                format!(
+                    "delivery accountability violation: gap range overflow for {player_id} epoch {epoch}"
+                )
+            })?;
         }
         if !covered {
             return Ok(());

--- a/src/client.rs
+++ b/src/client.rs
@@ -2511,7 +2511,8 @@ async fn emit_event_or_shutdown(
     clippy::panic,
     clippy::todo,
     clippy::unimplemented,
-    clippy::indexing_slicing
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects
 )]
 mod tests {
     use super::*;

--- a/src/event.rs
+++ b/src/event.rs
@@ -662,7 +662,7 @@ fn truncate_on_char_boundary(s: &str, max_bytes: usize) -> &str {
     }
     let mut end = max_bytes;
     while end > 0 && !s.is_char_boundary(end) {
-        end -= 1;
+        end = end.saturating_sub(1);
     }
     s.get(..end).unwrap_or_default()
 }

--- a/src/polling_client.rs
+++ b/src/polling_client.rs
@@ -1495,7 +1495,8 @@ impl<T: Transport> crate::client_api::SignalFishClientApi for SignalFishPollingC
     clippy::todo,
     clippy::unimplemented,
     clippy::indexing_slicing,
-    clippy::unreachable
+    clippy::unreachable,
+    clippy::arithmetic_side_effects
 )]
 mod tests {
     use std::collections::VecDeque;

--- a/src/token_binding.rs
+++ b/src/token_binding.rs
@@ -523,7 +523,8 @@ impl<'de> serde::de::Visitor<'de> for UniqueJsonVisitor {
     clippy::panic,
     clippy::todo,
     clippy::unimplemented,
-    clippy::indexing_slicing
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects
 )]
 mod tests {
     use super::*;

--- a/src/transports/emscripten_websocket.rs
+++ b/src/transports/emscripten_websocket.rs
@@ -582,11 +582,7 @@ extern "C" fn on_message_callback(
     if event.is_text != 0 {
         // Text message — create String from UTF-8 bytes.
         // num_bytes includes the NUL terminator for text messages.
-        let len = if event.num_bytes > 0 {
-            (event.num_bytes - 1) as usize
-        } else {
-            0
-        };
+        let len = usize::from(event.num_bytes.saturating_sub(1));
         // SAFETY: For a non-empty payload, Emscripten guarantees `event.data`
         // points to `event.num_bytes` valid bytes for this callback. `len`
         // excludes the NUL terminator. Empty payloads do not dereference data.

--- a/src/transports/emscripten_websocket.rs
+++ b/src/transports/emscripten_websocket.rs
@@ -582,7 +582,7 @@ extern "C" fn on_message_callback(
     if event.is_text != 0 {
         // Text message — create String from UTF-8 bytes.
         // num_bytes includes the NUL terminator for text messages.
-        let len = usize::from(event.num_bytes.saturating_sub(1));
+        let len = event.num_bytes.saturating_sub(1) as usize;
         // SAFETY: For a non-empty payload, Emscripten guarantees `event.data`
         // points to `event.num_bytes` valid bytes for this callback. `len`
         // excludes the NUL terminator. Empty payloads do not dereference data.

--- a/src/transports/websocket.rs
+++ b/src/transports/websocket.rs
@@ -1185,18 +1185,18 @@ where
                     if !self.send_failed {
                         self.control_flush_pending = true;
                     }
-                    skipped_control_frames += 1;
+                    skipped_control_frames = skipped_control_frames.saturating_add(1);
                 }
                 Message::Pong(_) => {
                     tracing::trace!("received WebSocket pong (ignored)");
-                    skipped_control_frames += 1;
+                    skipped_control_frames = skipped_control_frames.saturating_add(1);
                 }
                 Message::Frame(_) => {
                     // This variant is never produced by the read half of the stream;
                     // it exists only for exhaustiveness against future `Message`
                     // variants. We keep the arm to satisfy exhaustiveness checks.
                     tracing::trace!("received raw WebSocket frame, skipping");
-                    skipped_control_frames += 1;
+                    skipped_control_frames = skipped_control_frames.saturating_add(1);
                 }
             }
         }

--- a/src/webrtc.rs
+++ b/src/webrtc.rs
@@ -863,7 +863,8 @@ mod controller {
     clippy::todo,
     clippy::unimplemented,
     clippy::indexing_slicing,
-    clippy::type_complexity
+    clippy::type_complexity,
+    clippy::arithmetic_side_effects
 )]
 mod tests {
     use super::*;

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -2,7 +2,8 @@
     clippy::unwrap_used,
     clippy::expect_used,
     clippy::panic,
-    clippy::indexing_slicing
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects
 )]
 //! CI configuration policy tests for Signal Fish Client.
 //!
@@ -3172,6 +3173,11 @@ mod safety_analysis_policy {
         "exit",
         "mem_forget",
         "undocumented_unsafe_blocks",
+        // Promoted by the 2026-08 runtime-invariant sweep: raw integer
+        // arithmetic must be checked/saturating/wrapping-explicit or carry a
+        // scoped proof, keeping debug/release overflow semantics aligned on
+        // hostile input. Zero unguarded production findings at promotion.
+        "arithmetic_side_effects",
     ];
 
     fn manifest(path: &str) -> toml::Value {
@@ -3610,6 +3616,7 @@ mod safety_analysis_policy {
                 "unimplemented",
                 "unreachable",
                 "indexing_slicing",
+                "arithmetic_side_effects",
             ] {
                 assert_eq!(
                     member_clippy.get(lint).and_then(toml::Value::as_str),
@@ -3627,6 +3634,18 @@ mod safety_analysis_policy {
                 "{member_manifest} must deny or forbid unsafe_code"
             );
         }
+
+        // Release builds must validate under the same arithmetic semantics as
+        // every debug test, fuzz, and Miri run: overflow aborts loudly instead
+        // of wrapping silently. Bench profiles inherit this through `release`.
+        let release = cargo["profile"]["release"]
+            .as_table()
+            .expect("Cargo.toml must define [profile.release]");
+        assert_eq!(
+            release.get("overflow-checks").and_then(toml::Value::as_bool),
+            Some(true),
+            "[profile.release] must enable overflow-checks so release arithmetic matches validated debug semantics"
+        );
     }
 
     #[test]

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -4,7 +4,8 @@
     clippy::panic,
     clippy::todo,
     clippy::unimplemented,
-    clippy::indexing_slicing
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects
 )]
 //! Shared test utilities for Signal Fish Client integration tests.
 //!

--- a/tests/negotiation_robustness_tests.rs
+++ b/tests/negotiation_robustness_tests.rs
@@ -4,6 +4,7 @@
 //! server messages). These pin behaviors that are easy to regress and would
 //! silently break mesh sessions after a network blip.
 #![cfg(feature = "tokio-runtime")]
+#![allow(clippy::arithmetic_side_effects)]
 #![allow(
     clippy::unwrap_used,
     clippy::expect_used,

--- a/tests/polling_parity_tests.rs
+++ b/tests/polling_parity_tests.rs
@@ -14,7 +14,8 @@
     clippy::indexing_slicing,
     clippy::panic,
     clippy::type_complexity,
-    clippy::unreachable
+    clippy::unreachable,
+    clippy::arithmetic_side_effects
 )]
 
 use std::collections::VecDeque;

--- a/tests/real_server_e2e.rs
+++ b/tests/real_server_e2e.rs
@@ -6,7 +6,8 @@
     clippy::todo,
     clippy::unimplemented,
     clippy::indexing_slicing,
-    clippy::unreachable
+    clippy::unreachable,
+    clippy::arithmetic_side_effects
 )]
 //! End-to-end tests against a **real** Signal Fish server.
 //!

--- a/tests/wire_golden_tests.rs
+++ b/tests/wire_golden_tests.rs
@@ -4,7 +4,8 @@
     clippy::panic,
     clippy::todo,
     clippy::unimplemented,
-    clippy::indexing_slicing
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects
 )]
 //! Golden-wire conformance tests against the Signal Fish **server's** published
 //! protocol samples (vendored under `tests/wire-samples/`).

--- a/tools/perf-lab/Cargo.toml
+++ b/tools/perf-lab/Cargo.toml
@@ -53,6 +53,9 @@ todo = "deny"
 unimplemented = "deny"
 unreachable = "deny"
 indexing_slicing = "deny"
+# Kept in lockstep with the core crate; see its arithmetic_side_effects
+# rationale (runtime-invariant overflow discipline on hostile input).
+arithmetic_side_effects = "deny"
 dbg_macro = "deny"
 exit = "deny"
 mem_forget = "deny"

--- a/tools/perf-lab/src/bin/timing.rs
+++ b/tools/perf-lab/src/bin/timing.rs
@@ -1,4 +1,6 @@
 #![forbid(unsafe_code)]
+// Measurement medians divide by a caller-checked positive operation count.
+#![allow(clippy::arithmetic_side_effects)]
 
 use std::time::Instant;
 

--- a/tools/perf-lab/src/workloads.rs
+++ b/tools/perf-lab/src/workloads.rs
@@ -1455,6 +1455,7 @@ fn reconnect_message(players: usize) -> ServerMessage {
     }))
 }
 
+#[allow(clippy::arithmetic_side_effects)] // `index` starts at 1: subtraction cannot underflow
 fn players_fixture(players: usize) -> Vec<PlayerInfo> {
     (0..players)
         .map(|index| {


### PR DESCRIPTION
## Why

Reopened #126 asked: *"we had a no-panic policy, yet bugs could panic on runtime invariants — one more paranoid sweep, what are we missing?"* The missing piece was not another manual scan but **durable enforcement**: release builds silently wrapped integer overflow while every test/fuzz/Miri run validated debug semantics, and nothing stopped raw arithmetic on hostile server values from returning.

## What changed

- **Release builds now enable `overflow-checks`** — overflow aborts loudly instead of wrapping, so all validation lanes exercise the same arithmetic semantics. (User-visible; noted in CHANGELOG.)
- **`clippy::arithmetic_side_effects` is now denied workspace-wide**, with delivery-accountability gap/counter math refactored to checked/saturating forms and provably-total math carrying scoped proofs.
- New policy assertions pin both settings in CI.

## Sweep verdict

Every audited production site was already guarded by construction (details in session log): arithmetic reachability re-derived end-to-end, sort comparators key-based only, decoders flat with guarded slicing, JSON recursion bounded, clocks saturated, casts checked at trust boundaries, config numerics clamped twice. **Zero unguarded findings — the discipline now enforces itself.**

## Verification

- Red/green: planted raw arithmetic fails clippy; release-mode underflow probe panics (exit 101) instead of wrapping; policy tests flip red when either setting regresses.
- `cargo fmt` / `clippy -D warnings` clean; full test suite green (23/23 suites).
- No-panic and test-quality gates pass; wire bytes and protocol behavior unchanged.

Closes #126

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches delivery accountability and transport edge cases on untrusted input; release builds can now panic on overflow where release previously wrapped, though semantics were already validated in debug/fuzz lanes.
> 
> **Overview**
> **Release builds now use `overflow-checks`**, so integer overflow aborts instead of wrapping silently. Debug tests, fuzz, Miri, and release therefore share the same arithmetic behavior; **CHANGELOG** calls this out as user-visible for release deployments.
> 
> **`clippy::arithmetic_side_effects` is denied** on the root crate, Godot adapter, and perf-lab, with **CI policy tests** locking both the lint and `[profile.release] overflow-checks`. Examples, perf harnesses, and test modules get scoped `#![allow]` where plain math is acceptable.
> 
> Production touch-ups are mostly **explicit checked/saturating math** on paths that handle hostile or server-driven values: delivery **accountability** gap/counter deltas and sequence advancement, WebSocket control-frame skip counting, Emscripten text payload length, UTF-8 truncation stepping, and Godot EWMA (documented `u128` proof + allow). **Wire protocol and observable behavior are unchanged**—this is enforcement and defensive arithmetic, not a protocol change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42b33dd2c17ae640dfdf50cbfb40eaa9ec7050ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->