### PR TITLE
Bump base64 from 0.22 to 0.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The optional `token-binding` dependency `base64` moved from 0.22 to 0.23.
+  The STANDARD engine API used for token-binding proofs is unchanged; only
+  the version requirement advances.
 - Workspace release builds now enable `overflow-checks`, so integer overflow
   aborts loudly instead of wrapping silently. Every supported configuration
   (debug tests, release builds, fuzzing, and Miri) now validates the same

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ thiserror = "2.0"
 tracing = "0.1"
 
 # Optional Signal Fish token-binding-v2 primitives.
-base64 = { version = "0.22", optional = true }
+base64 = { version = "0.23", optional = true }
 hkdf = { version = "0.13", optional = true }
 hmac = { version = "0.13", optional = true }
 sha2 = { version = "0.11", optional = true }


### PR DESCRIPTION
## Why

Dependabot's own PR #156 rebased onto main and came out **empty**, so the dependency bump never actually landed. This PR applies it for real.

## What changed

- `base64` requirement `0.22` → `0.23` (opt-in `token-binding` feature only).
- The STANDARD engine API used for token-binding proofs is unchanged.
- CHANGELOG entry added under `[Unreleased] › Changed`.

## Verification

Full gate green locally: fmt, clippy `-D warnings`, complete test suite including the token-binding lib suite (221 tests).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only bump on an opt-in feature with no application code or wire-format changes; risk is limited to upstream `base64` 0.23 behavior in token-binding proofs.
> 
> **Overview**
> Updates the optional **`token-binding`** dependency **`base64`** from **0.22** to **0.23** in workspace `Cargo.toml`. No Rust source changes; encoding still goes through **`general_purpose::STANDARD`** in token-binding proof paths.
> 
> Documents the version advance under **`[Unreleased] › Changed`** in **`CHANGELOG.md`**, noting the STANDARD engine API is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 465a80dd3787a99633bc38a2d089d39fc1f5964f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->