### PR TITLE
Paranoid sweep: departed-host fix, dead code, contract docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -202,6 +202,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed `MeshSession` continuing to report a departed host through `host()`
+  and `direct_endpoint()` until the next plan arrived. A host's `PlayerLeft`
+  now clears both immediately, matching the shared core's authority handling,
+  so consumers cannot dial a dead endpoint in the re-planning gap; the
+  replacement `SessionPlan` owns host re-election.
 - Fixed `MeshController` retaining a stale session and live peer-driver state
   when its signaling event stream ended without room for the best-effort
   `Disconnected` event. End-of-stream and explicit shutdown now disconnect

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -207,6 +207,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   now clears both immediately, matching the shared core's authority handling,
   so consumers cannot dial a dead endpoint in the re-planning gap; the
   replacement `SessionPlan` owns host re-election.
+- Documented two driver-contract boundaries that previously lived only in the
+  code: the polling client's post-send-failure ready-frame drain is bounded by
+  the configured receive budget against the standard 64 frames / 64 KiB — at
+  most `min(receive_frames, 64)` complete frames, stopping at the first frame
+  that reaches the byte bound — so frame-budgeted callers never see teardown
+  work beyond their per-poll frame bound (the async driver always drains the
+  standard budget), and the WebSocket transport's retryable `WriteBufferFull`
+  refusals apply to direct `Transport` operation while the built-in drivers
+  map any send error, including a restored refusal, to a terminal disconnect.
 - Fixed `MeshController` retaining a stale session and live peer-driver state
   when its signaling event stream ended without room for the best-effort
   `Disconnected` event. End-of-stream and explicit shutdown now disconnect

--- a/src/client_core.rs
+++ b/src/client_core.rs
@@ -788,14 +788,13 @@ impl ClientCore {
             return outcome;
         }
 
-        let duplicate_protocol_info =
-            matches!(server_msg, ServerMessage::ProtocolInfo(_)) && self.protocol_info_seen;
+        // `validate_inbound_message` rejects any second `ProtocolInfo` before
+        // this point, so the accountability swap below always runs on the one
+        // permitted negotiation frame.
         if let ServerMessage::ProtocolInfo(payload) = &server_msg {
-            if !duplicate_protocol_info {
-                self.accountability = DeliveryAccountability::new(
-                    payload.protocol_version.is_some_and(|version| version >= 3),
-                );
-            }
+            self.accountability = DeliveryAccountability::new(
+                payload.protocol_version.is_some_and(|version| version >= 3),
+            );
         }
 
         let authoritative_baseline = matches!(
@@ -805,18 +804,12 @@ impl ClientCore {
                 | ServerMessage::Reconnected(_)
         );
         let effective_game_data_format = self.effective_game_data_format().unwrap_or_default();
-        let validation = if duplicate_protocol_info {
-            self.accountability
-                .observe_server_message(false)
-                .map(|()| GameDataDisposition::Apply)
-        } else {
-            accountability::validate_server_frame(
-                &mut self.accountability,
-                &server_msg,
-                effective_game_data_format,
-                false,
-            )
-        };
+        let validation = accountability::validate_server_frame(
+            &mut self.accountability,
+            &server_msg,
+            effective_game_data_format,
+            false,
+        );
 
         let (disposition, validation_failed) = match validation {
             Ok(disposition) => {
@@ -857,9 +850,6 @@ impl ClientCore {
             && (authoritative_baseline
                 || self.violation_policy == ProtocolViolationPolicy::Quarantine)
         {
-            return outcome;
-        }
-        if duplicate_protocol_info {
             return outcome;
         }
         if let ServerMessage::Signal {

--- a/src/mesh.rs
+++ b/src/mesh.rs
@@ -158,7 +158,16 @@ impl MeshSession {
             SignalFishEvent::PlayerLeft { player_id, .. } => {
                 let before = self.peers.len();
                 self.peers.retain(|p| p.player_id != *player_id);
-                self.peers.len() != before
+                let host_departed = self.host == Some(*player_id);
+                if host_departed {
+                    // The server elects and replans a replacement host on
+                    // departure, but the next SessionPlan owns that decision.
+                    // Until it lands, a departed host must not stay reachable
+                    // through host()/direct_endpoint().
+                    self.host = None;
+                    self.direct_endpoint = None;
+                }
+                self.peers.len() != before || host_departed
             }
             // ICE pre-gather: seed the ICE servers during the lobby wait. Do not
             // create peers here — a relay-floor room may never produce a plan.
@@ -707,6 +716,51 @@ mod tests {
             epoch: None,
             final_seq: None,
         }));
+    }
+
+    #[test]
+    fn player_left_clears_departed_host_and_endpoint() {
+        let mut s = MeshSession::new();
+        s.apply(&SignalFishEvent::SessionPlan {
+            generation: None,
+            topology: Topology::Host,
+            transport: TransportKind::Direct,
+            host: Some(uuid(1)),
+            direct_endpoint: Some(DirectEndpoint {
+                host: "203.0.113.8".into(),
+                port: 7000,
+            }),
+            peers: vec![],
+            ice_servers: vec![],
+            fallback: TransportKind::Relay,
+        });
+        // A departed host must not stay reachable through host() or
+        // direct_endpoint(); the replacement SessionPlan owns re-election.
+        // The plan carries no peer rows, so `true` here reports exactly the
+        // host/endpoint view change.
+        assert!(s.apply(&SignalFishEvent::PlayerLeft {
+            player_id: uuid(1),
+            epoch: None,
+            final_seq: None,
+        }));
+        assert!(s.host().is_none());
+        assert!(s.direct_endpoint().is_none());
+        assert!(s.peers().is_empty());
+
+        // A non-host departure leaves the elected host untouched.
+        s.apply(&plan(
+            Topology::Host,
+            Some(uuid(3)),
+            vec![peer(3, false), peer(4, false)],
+            vec![],
+        ));
+        assert_eq!(s.host(), Some(uuid(3)));
+        assert!(s.apply(&SignalFishEvent::PlayerLeft {
+            player_id: uuid(4),
+            epoch: None,
+            final_seq: None,
+        }));
+        assert_eq!(s.host(), Some(uuid(3)));
     }
 
     #[test]

--- a/src/polling_client.rs
+++ b/src/polling_client.rs
@@ -45,6 +45,14 @@ const DEFAULT_POLL_FRAMES: usize = DEFAULT_DRIVER_WORK_FRAMES;
 const DEFAULT_POLL_BYTES: usize = DEFAULT_DRIVER_WORK_BYTES;
 
 /// Maximum send and receive work performed by one [`poll`](SignalFishPollingClient::poll).
+///
+/// These bounds also cap the bounded ready-frame drain that follows a terminal
+/// send failure inside the same poll: that drain processes at most
+/// `min(receive_frames, 64)` complete frames and stops at the first frame
+/// that reaches `min(receive_bytes, 64 KiB)`, so a frame-budgeted caller
+/// never sees teardown work beyond its configured per-poll frame bound. The
+/// async driver has no budget knob and always uses the 64-frame / 64-KiB
+/// standard drain.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PollingWorkBudget {
     /// Maximum outbound ownership transfers per poll.
@@ -1108,6 +1116,11 @@ impl<T: Transport> SignalFishPollingClient<T> {
         started_at: Instant,
         terminal_now: &mut impl FnMut() -> Instant,
     ) {
+        // The configured receive budget caps this teardown drain so a
+        // frame-budgeted caller never exceeds its per-poll frame bound (the
+        // byte-crossing frame itself is processed); the async driver, which
+        // has no budget knob, always drains the standard 64 frames / 64 KiB
+        // here.
         let standard = ReadyFrameDrainBudget::standard();
         let budget = ReadyFrameDrainBudget::new(
             self.options.work_budget.receive_frames.min(standard.frames),

--- a/src/protocol/binary.rs
+++ b/src/protocol/binary.rs
@@ -104,7 +104,9 @@ pub fn decode_v2_binary_game_data(wire: &[u8]) -> Result<V2BinaryGameDataFrame, 
 ///
 /// Unlike a derived Serde decoder, this validates the physical MessagePack
 /// representation: a map with string keys, binary UUID/payload fields, string
-/// encoding token, integer delivery stamps, and no trailing value.
+/// encoding token, integer delivery stamps, and no trailing value. Type-level
+/// shape is enforced, not minimal-length encoding: integer markers may use any
+/// width that carries the value, and map headers may use any size prefix.
 pub fn decode_v3_binary_game_data(wire: &[u8]) -> Result<V3BinaryGameDataFrame, String> {
     let mut remaining = wire;
     let field_count = read_map_len(&mut remaining)

--- a/src/token_binding.rs
+++ b/src/token_binding.rs
@@ -680,6 +680,26 @@ mod tests {
         }
     }
 
+    /// Object keys are ordered by UTF-16 code units (JCS order), matching the
+    /// server's canonicalizer byte-for-byte. UTF-8 byte order disagrees for
+    /// keys above U+E000 versus astral keys; this pin fails if the sort is
+    /// ever "simplified" to plain string ordering.
+    #[test]
+    fn canonical_json_orders_object_keys_by_utf16_code_units() {
+        let value = serde_json::from_str::<serde_json::Value>(r#"{"":1,"😀":2,"a":3}"#)
+            .expect("ordering fixture must parse");
+        let canonical = canonical_json(&value).expect("ordering fixture must canonicalize");
+        assert_eq!(
+            std::str::from_utf8(&canonical).expect("canonical output is UTF-8"),
+            r#"{"a":3,"😀":2,"":1}"#,
+        );
+        // serde_json's BTreeMap wire order genuinely differs, which is why
+        // proofs are computed over the canonical bytes rather than a
+        // re-serialization of the parsed map.
+        let wire_order = serde_json::to_string(&value).expect("re-serialization");
+        assert_ne!(wire_order, std::str::from_utf8(&canonical).unwrap());
+    }
+
     #[test]
     fn server_070_fingerprint_goldens_bind_json_and_binary_proofs() {
         let vectors = golden_vectors();

--- a/src/transports/websocket.rs
+++ b/src/transports/websocket.rs
@@ -514,7 +514,10 @@ impl WebSocketConnectOptions {
 /// still return already-buffered frames; the first backend `Pending`, receive
 /// failure, EOF, close, or abort then fully fuses the transport. Pre-acceptance
 /// token-binding errors and `WriteBufferFull` with exact frame restoration are
-/// retryable refusals instead.
+/// retryable refusals instead — for direct [`Transport`] operation. The
+/// built-in client drivers choose fail-fast semantics and map any send error,
+/// including a restored `WriteBufferFull`, to a terminal disconnect that drops
+/// the connection and its retained frame.
 pub struct WebSocketTransport {
     state: WebSocketState<WsStream>,
 }

--- a/tests/client_tests.rs
+++ b/tests/client_tests.rs
@@ -38,7 +38,9 @@ use common::{
     game_data_json, new_peer_json, peer_transport_status_json, player_left_json, pong_json,
     protocol_info_json, reconnected_json, room_joined_json, room_left_json, session_plan_json,
     signal_json, spectator_joined_json, spectator_left_json, wait_for_sent_len, MockTransport,
+    RecordingCloseTransport,
 };
+use std::time::Duration;
 
 // ════════════════════════════════════════════════════════════════════
 // Helper: start a mock client with scripted responses
@@ -261,6 +263,45 @@ impl Transport for HangingCloseTransport {
 // ════════════════════════════════════════════════════════════════════
 // Auth flow lifecycle
 // ════════════════════════════════════════════════════════════════════
+
+/// A zero `shutdown_timeout` must collapse the teardown deadline to "now":
+/// the loop aborts the transport instead of attempting a graceful close that
+/// can never complete, and the farewell still reaches an idle consumer.
+#[tokio::test]
+async fn zero_shutdown_timeout_aborts_without_attempting_close() {
+    let transport = RecordingCloseTransport::default();
+    let config = SignalFishConfig::new("mb_test_integration").with_shutdown_timeout(Duration::ZERO);
+    let (mut client, mut events) = SignalFishClient::start(transport.clone(), config);
+
+    client.shutdown().await;
+
+    assert_eq!(
+        transport
+            .close_calls
+            .load(std::sync::atomic::Ordering::Relaxed),
+        0,
+        "a zero deadline must not attempt the graceful close handshake"
+    );
+    assert_eq!(
+        transport
+            .abort_calls
+            .load(std::sync::atomic::Ordering::Relaxed),
+        1,
+        "a zero deadline must fall back to abort exactly once"
+    );
+    // The synthetic Connected event may or may not precede the farewell
+    // depending on loop scheduling; the farewell must reach an idle consumer.
+    loop {
+        match events.recv().await {
+            Some(SignalFishEvent::Connected) => continue,
+            other => assert!(
+                matches!(other, Some(SignalFishEvent::Disconnected { .. })),
+                "expected Disconnected, got {other:?}"
+            ),
+        }
+        break;
+    }
+}
 
 #[tokio::test]
 async fn auth_flow_connected_then_authenticated() {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -13,7 +13,7 @@
 //! constructing common server response JSON strings.
 
 use std::collections::VecDeque;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex as StdMutex};
 
 use signal_fish_client::protocol::SpectatorJoinedPayload;
@@ -544,4 +544,45 @@ pub fn peer_transport_status_json(peer_id: PlayerId, connected: bool) -> String 
         connected,
     })
     .expect("peer_transport_status_json serialization")
+}
+
+/// Transport whose graceful close never completes, with per-path call
+/// counters so tests can pin abort-vs-close teardown decisions.
+#[derive(Clone, Default)]
+pub struct RecordingCloseTransport {
+    /// Times the driver attempted the graceful `poll_close` handshake.
+    pub close_calls: Arc<AtomicUsize>,
+    /// Times the driver invoked the abort fallback.
+    pub abort_calls: Arc<AtomicUsize>,
+}
+
+impl Transport for RecordingCloseTransport {
+    fn abort(&mut self) {
+        self.abort_calls.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn poll_send(
+        &mut self,
+        _cx: &mut std::task::Context<'_>,
+        frame: &mut Option<TransportFrame>,
+    ) -> std::task::Poll<Result<(), SignalFishError>> {
+        // Accept ownership and drop; teardown decisions are what is pinned.
+        let _accepted = frame.take();
+        std::task::Poll::Ready(Ok(()))
+    }
+
+    fn poll_recv(
+        &mut self,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Result<TransportFrame, SignalFishError>>> {
+        std::task::Poll::Pending
+    }
+
+    fn poll_close(
+        &mut self,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), SignalFishError>> {
+        self.close_calls.fetch_add(1, Ordering::Relaxed);
+        std::task::Poll::Pending
+    }
 }


### PR DESCRIPTION
Answers #126's latest paranoid-sweep ask: are we fully correct and optimal under all scenarios?

**Why:** five parallel audits covered wire/serde edges, the client lifecycle matrix, both drivers, transports/token-binding, mesh/Godot, and performance. Every candidate finding was verified against the pinned server source (`d5b3135`) before changing anything — that verification disproved two plausible findings and prevented regressions.

## What changed

- **MeshSession:** a departing host is dropped from `host()` and `direct_endpoint()` immediately, matching the shared core's authority handling. The replacement plan owns re-election; consumers can no longer act on a dead endpoint in the re-planning gap.
- **ClientCore:** removed provably-unreachable duplicate-`ProtocolInfo` handling (rejection already happens at validation) — kills a latent reorder hazard.
- **Docs:** exact polling teardown-drain bound (`min(receive_frames, 64)` complete frames vs the async standard drain), WebSocket retryable-refusal-vs-driver-fail-fast layering, and decoder wording (type-level shape, not minimal encoding).
- **New pins:** async zero-`shutdown_timeout` aborts without attempting close; token-binding canonical key ordering (UTF-16, byte-identical to the server).

## Verified safe, unchanged

- `PlayerReconnected` without roster containment **matches server behavior**: disconnects broadcast `PlayerLeft`, reconnects name removed players. Containment would break legitimate reconnects; phantom baselines are equally reachable via trusted `PlayerJoined`.
- Tungstenite 0.30 queues no close reply on capacity errors, so there is nothing being dropped on recv-error teardown.
- Hot paths stay allocation-neutral per the pinned ledgers (base64 0.23 and #155 are hot-path-neutral).

## Checks

Local mandatory workflow green (976 tests); adversarial review loop converged to zero findings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted mesh visibility fix, dead-code removal in inbound handling, and documentation plus regression tests; no auth, payment, or broad API changes.
> 
> **Overview**
> **MeshSession** now clears **`host()`** and **`direct_endpoint()`** as soon as the elected host **`PlayerLeft`**, so callers cannot dial a stale direct endpoint before the replacement **`SessionPlan`** arrives; non-host departures are unchanged.
> 
> **ClientCore** drops the duplicate-**`ProtocolInfo`** branch and always runs normal accountability validation, because **`validate_inbound_message`** already rejects a second negotiation frame.
> 
> Documentation and changelog spell out driver/transport contracts: polling post-send-failure ready-frame drain is capped by **`min(receive_frames, 64)`** (and the byte budget) versus the async driver’s fixed 64/64 KiB drain; **`WriteBufferFull`** stays retryable on raw **`Transport`** while built-in drivers treat any send error as terminal; v3 binary decode docs clarify type-level MessagePack shape, not minimal encoding.
> 
> **Tests:** **`MeshSession`** host-clearing behavior, async **`shutdown_timeout(Duration::ZERO)`** aborts without **`poll_close`**, and token-binding canonical JSON key order matches server UTF-16 (JCS) ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 638725155d0ef6338cd9ebf88052a99283527ede. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->