### PR TITLE
Bound the Emscripten callback inbound queue

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -144,6 +144,25 @@ Run `cargo fetch` manually if you want strict verification.
 Cargo extension installs during image build are also best-effort. If a specific extension
 tool is missing, install it manually inside the container with `cargo install --locked <tool>`.
 
+### Rebuild Reports "removal is already in progress"
+
+VS Code can briefly race its own rebuild cleanup when Docker takes several
+seconds to remove the previous container. The Remote Containers log then ends
+before the image build with an error like:
+
+```text
+Error response from daemon: removal of container <id> is already in progress
+```
+
+This message is not a Dockerfile, mount, or lifecycle-hook failure. Wait for the
+first removal to finish, then select **Retry** or run **Dev Containers: Rebuild
+Container** once more. The repository's named Cargo and `target` volumes are not
+removed by this cleanup.
+
+If the same container ID is still listed after a minute, check its state with
+`docker ps -a` and restart Docker Desktop before retrying. Do not run concurrent
+rebuild commands for the same workspace.
+
 ### Slow Builds
 
 - The mold linker is pre-configured for faster linking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -202,6 +202,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Documented deterministic recovery from the VS Code Dev Containers rebuild
+  race where concurrent cleanup attempts report that container removal is
+  already in progress, allowing contributors to retry without deleting the
+  repository's named build caches.
 - Fixed `MeshSession` continuing to report a departed host through `host()`
   and `direct_endpoint()` until the next plan arrived. A host's `PlayerLeft`
   now clears both immediately, matching the shared core's authority handling,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Bounded the Emscripten WebSocket transport's callback-bridged inbound queue
+  at 8 MiB by default through the new
+  `EmscriptenWebSocketConnectOptions::max_inbound_queue_bytes` option and the
+  matching `connect_with_options` constructor. Callback-delivered frames that
+  exceed the bound — individually or in buffered aggregate — are refused
+  before any payload copy and fuse the transport with one terminal receive
+  error, mirroring the native transport's inbound-size policy instead of
+  growing memory without limit between game-loop polls. `None` restores the
+  previous unbounded buffering.
 - Added the negotiated outbound message-size contract to `ProtocolInfoPayload`
   as the v3-only optional field `max_outbound_message_size`, pinned to server
   commit `d5b3135fda53a2a7de69c5ea54faefa95ca9a5b9`. The negotiated value

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   at 8 MiB by default through the new
   `EmscriptenWebSocketConnectOptions::max_inbound_queue_bytes` option and the
   matching `connect_with_options` constructor. Callback-delivered frames that
-  exceed the bound — individually or in buffered aggregate — are refused
-  before any payload copy and fuse the transport with one terminal receive
-  error, mirroring the native transport's inbound-size policy instead of
-  growing memory without limit between game-loop polls. `None` restores the
-  previous unbounded buffering.
+  exceed the bound — individually, in buffered aggregate, or as a
+  zero-length-frame flood (which reserves a small minimum charge) — are
+  refused before any payload copy and fuse the transport with one terminal
+  receive error, mirroring the native transport's inbound-size policy instead
+  of growing memory without limit between game-loop polls. `None` restores
+  the previous unbounded buffering.
 - Added the negotiated outbound message-size contract to `ProtocolInfoPayload`
   as the v3-only optional field `max_outbound_message_size`, pinned to server
   commit `d5b3135fda53a2a7de69c5ea54faefa95ca9a5b9`. The negotiated value

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,4 +197,4 @@ pub use webrtc::MeshController;
 // Re-export only on the correct target (see transports/mod.rs for rationale).
 #[cfg(all(feature = "transport-websocket-emscripten", target_os = "emscripten"))]
 #[allow(deprecated)]
-pub use transports::EmscriptenWebSocketTransport;
+pub use transports::{EmscriptenWebSocketConnectOptions, EmscriptenWebSocketTransport};

--- a/src/transports/emscripten_inbound_queue.rs
+++ b/src/transports/emscripten_inbound_queue.rs
@@ -12,6 +12,24 @@
 /// native transport's 8 MiB client resource policy.
 pub(super) const DEFAULT_MAX_INBOUND_QUEUE_BYTES: usize = 8 * 1024 * 1024;
 
+/// Conservative per-frame minimum charge against the byte ledger.
+///
+/// Every admitted frame occupies queue-node and event-header storage
+/// regardless of payload length. Charging and releasing this minimum
+/// symmetrically keeps zero-length flood frames from bypassing the byte
+/// bound while never drifting from the drained amount.
+const MIN_FRAME_CHARGE_BYTES: usize = 64;
+
+/// Ledger units charged for one frame with `payload_len` content bytes,
+/// admitted and released symmetrically.
+pub(super) const fn charged_frame_bytes(payload_len: usize) -> usize {
+    if payload_len > MIN_FRAME_CHARGE_BYTES {
+        payload_len
+    } else {
+        MIN_FRAME_CHARGE_BYTES
+    }
+}
+
 /// Why [`InboundQueueBound::admit`] refused inbound input.
 ///
 /// Every hard refusal permanently fuses the queue;
@@ -80,8 +98,10 @@ impl InboundQueueBound {
         }
     }
 
-    /// Admits `frame_bytes` of inbound input, recording them against the
-    /// buffered total on success.
+    /// Admits one frame of `frame_bytes` charged units, recording them
+    /// against the buffered total on success. Callers must pass
+    /// [`charged_frame_bytes`] so empty payloads still reserve their queuing
+    /// overhead.
     ///
     /// The first over-limit input permanently fuses the queue; later calls
     /// report [`QueueRefusal::AlreadyFused`] regardless of size so callers
@@ -113,8 +133,8 @@ impl InboundQueueBound {
         Ok(())
     }
 
-    /// Releases capacity held by drained frames, saturating at zero so an
-    /// accounting bug fails closed toward refusals instead of unbounded
+    /// Releases the charged units of a drained frame. Saturates at zero so
+    /// an accounting bug fails closed toward refusals instead of unbounded
     /// buffering.
     pub(super) fn record_drained(&mut self, drained_bytes: usize) {
         self.queued_bytes = self.queued_bytes.saturating_sub(drained_bytes);
@@ -132,7 +152,9 @@ impl InboundQueueBound {
 mod tests {
     use super::*;
 
-    const LIMIT: usize = 8;
+    /// Comfortably above [`MIN_FRAME_CHARGE_BYTES`] so tests exercise
+    /// realistic payload sizes end to end.
+    const LIMIT: usize = 1024;
 
     #[test]
     fn default_limit_matches_native_eight_mib_policy() {
@@ -140,26 +162,44 @@ mod tests {
     }
 
     #[test]
+    fn zero_length_frames_carry_the_minimum_charge() {
+        assert_eq!(charged_frame_bytes(0), MIN_FRAME_CHARGE_BYTES);
+        assert_eq!(
+            charged_frame_bytes(MIN_FRAME_CHARGE_BYTES - 1),
+            MIN_FRAME_CHARGE_BYTES
+        );
+        assert_eq!(
+            charged_frame_bytes(MIN_FRAME_CHARGE_BYTES),
+            MIN_FRAME_CHARGE_BYTES
+        );
+        assert_eq!(
+            charged_frame_bytes(MIN_FRAME_CHARGE_BYTES + 1),
+            MIN_FRAME_CHARGE_BYTES + 1
+        );
+        assert_eq!(charged_frame_bytes(usize::MAX), usize::MAX);
+    }
+
+    #[test]
     fn admits_frames_up_to_the_inclusive_limit_and_released_capacity_is_reusable() {
         let mut bound = InboundQueueBound::new(Some(LIMIT));
-        bound.admit(3).unwrap();
+        bound.admit(charged_frame_bytes(300)).unwrap();
         // Exactly-at-limit totals are admitted, mirroring the native codec's
         // inclusive maximum.
-        bound.admit(LIMIT - 3).unwrap();
+        bound.admit(charged_frame_bytes(LIMIT - 300)).unwrap();
 
-        // Draining releases exactly the drained bytes...
-        bound.record_drained(5);
-        bound.record_drained(3);
+        // Draining releases exactly the charged bytes...
+        bound.record_drained(charged_frame_bytes(300));
+        bound.record_drained(charged_frame_bytes(LIMIT - 300));
 
         // ...and released capacity admits new work again.
-        bound.admit(LIMIT).unwrap();
+        bound.admit(charged_frame_bytes(LIMIT)).unwrap();
     }
 
     #[test]
     fn oversized_frames_refuse_and_fuse_permanently() {
         let mut bound = InboundQueueBound::new(Some(LIMIT));
         assert_eq!(
-            bound.admit(LIMIT + 1),
+            bound.admit(charged_frame_bytes(LIMIT + 1)),
             Err(QueueRefusal::FrameExceedsLimit {
                 frame_bytes: LIMIT + 1,
                 limit: LIMIT,
@@ -168,7 +208,10 @@ mod tests {
 
         // Even zero-byte input is refused once fused so callers drop flood
         // traffic uniformly without allocating.
-        assert_eq!(bound.admit(0), Err(QueueRefusal::AlreadyFused));
+        assert_eq!(
+            bound.admit(charged_frame_bytes(0)),
+            Err(QueueRefusal::AlreadyFused)
+        );
 
         // Draining does not unfuse.
         bound.record_drained(usize::MAX);
@@ -182,13 +225,14 @@ mod tests {
     #[test]
     fn aggregate_backlog_refuses_before_exceeding_the_limit() {
         let mut bound = InboundQueueBound::new(Some(LIMIT));
-        bound.admit(6).unwrap();
-        // 6 queued + 3 incoming > 8 refuses even though either alone fits.
+        bound.admit(charged_frame_bytes(600)).unwrap();
+        // 600 queued + 500 incoming > 1024 refuses even though either alone
+        // fits.
         assert_eq!(
-            bound.admit(3),
+            bound.admit(charged_frame_bytes(500)),
             Err(QueueRefusal::QueueWouldExceedLimit {
-                queued_bytes: 6,
-                frame_bytes: 3,
+                queued_bytes: charged_frame_bytes(600),
+                frame_bytes: charged_frame_bytes(500),
                 limit: LIMIT,
             })
         );
@@ -196,22 +240,37 @@ mod tests {
     }
 
     #[test]
-    fn disabled_limit_never_refuses_or_fuses() {
-        let mut bound = InboundQueueBound::new(None);
-        bound.admit(usize::MAX).unwrap();
-        bound.admit(usize::MAX).unwrap();
-        bound.record_drained(7);
+    fn zero_length_flood_frames_cannot_bypass_the_bound() {
+        let mut bound = InboundQueueBound::new(Some(2 * MIN_FRAME_CHARGE_BYTES));
+        // Each empty frame reserves its queuing overhead...
+        bound.admit(charged_frame_bytes(0)).unwrap();
+        bound.admit(charged_frame_bytes(0)).unwrap();
+        // ...so the count flood hits the same aggregate refusal as payloads.
+        assert_eq!(
+            bound.admit(charged_frame_bytes(0)),
+            Err(QueueRefusal::QueueWouldExceedLimit {
+                queued_bytes: 2 * MIN_FRAME_CHARGE_BYTES,
+                frame_bytes: MIN_FRAME_CHARGE_BYTES,
+                limit: 2 * MIN_FRAME_CHARGE_BYTES,
+            })
+        );
+
+        // Releasing a drained empty frame restores exactly its charge —
+        // pinned by the reusable-capacity test — while fusion here remains
+        // permanent even after a drain.
+        bound.record_drained(charged_frame_bytes(0));
+        assert_eq!(
+            bound.admit(charged_frame_bytes(0)),
+            Err(QueueRefusal::AlreadyFused)
+        );
     }
 
     #[test]
-    fn empty_frames_stay_free_even_at_full_capacity() {
-        let mut bound = InboundQueueBound::new(Some(LIMIT));
-        bound.admit(LIMIT).unwrap();
-        // Zero-byte frames add nothing to the ledger, so they neither trip
-        // the aggregate bound nor disturb later admissions.
-        bound.admit(0).unwrap();
-        bound.record_drained(LIMIT);
-        bound.admit(LIMIT).unwrap();
+    fn disabled_limit_never_refuses_or_fuses() {
+        let mut bound = InboundQueueBound::new(None);
+        bound.admit(charged_frame_bytes(0)).unwrap();
+        bound.admit(usize::MAX).unwrap();
+        bound.record_drained(7);
     }
 
     #[test]

--- a/src/transports/emscripten_inbound_queue.rs
+++ b/src/transports/emscripten_inbound_queue.rs
@@ -1,0 +1,237 @@
+//! Target-independent inbound-byte accounting for the Emscripten callback
+//! queue.
+//!
+//! Emscripten WebSocket callbacks deliver complete frames into an internal
+//! channel between polling ticks. Without a bound, a hostile or buggy server
+//! can grow that buffer without limit while the game loop is busy. This
+//! module keeps the admission, fusion, and drain accounting free of FFI so
+//! the ordinary workspace test suite exercises it when the Emscripten target
+//! is absent.
+
+/// Default inclusive bound on buffered inbound WebSocket input, matching the
+/// native transport's 8 MiB client resource policy.
+pub(super) const DEFAULT_MAX_INBOUND_QUEUE_BYTES: usize = 8 * 1024 * 1024;
+
+/// Why [`InboundQueueBound::admit`] refused inbound input.
+///
+/// Every hard refusal permanently fuses the queue;
+/// [`QueueRefusal::AlreadyFused`] reports an earlier fusion.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum QueueRefusal {
+    /// The transport already fused after an earlier refusal. Callers must
+    /// drop further input silently so a flood cannot enqueue unbounded error
+    /// events.
+    AlreadyFused,
+    /// One frame alone exceeded the configured bound.
+    FrameExceedsLimit { frame_bytes: usize, limit: usize },
+    /// Bytes already buffered plus this frame would exceed the configured
+    /// bound before the next drain.
+    QueueWouldExceedLimit {
+        queued_bytes: usize,
+        frame_bytes: usize,
+        limit: usize,
+    },
+}
+
+impl QueueRefusal {
+    /// Terminal-error text for the first refusal. Exposes byte counts only;
+    /// never payload data.
+    pub(super) fn message(self) -> String {
+        match self {
+            Self::AlreadyFused => "inbound WebSocket input refused after the \
+                 callback queue was already fused"
+                .to_owned(),
+            Self::FrameExceedsLimit { frame_bytes, limit } => format!(
+                "inbound WebSocket frame of {frame_bytes} bytes exceeds the \
+                 {limit}-byte client resource limit; connection fused"
+            ),
+            Self::QueueWouldExceedLimit {
+                queued_bytes,
+                frame_bytes,
+                limit,
+            } => format!(
+                "buffered inbound WebSocket input ({queued_bytes} bytes) plus a \
+                 {frame_bytes}-byte frame would exceed the {limit}-byte client \
+                 resource limit; connection fused"
+            ),
+        }
+    }
+}
+
+/// Admission ledger for buffered inbound frames.
+///
+/// Shared between the Emscripten message callback (admission) and
+/// `poll_recv` (drain) through interior mutability; both sides run on the
+/// single emscripten main thread and never interleave.
+#[derive(Clone, Copy)]
+pub(super) struct InboundQueueBound {
+    /// Inclusive byte ceiling; `None` disables every bound.
+    limit: Option<usize>,
+    queued_bytes: usize,
+    fused: bool,
+}
+
+impl InboundQueueBound {
+    pub(super) const fn new(limit: Option<usize>) -> Self {
+        Self {
+            limit,
+            queued_bytes: 0,
+            fused: false,
+        }
+    }
+
+    /// Admits `frame_bytes` of inbound input, recording them against the
+    /// buffered total on success.
+    ///
+    /// The first over-limit input permanently fuses the queue; later calls
+    /// report [`QueueRefusal::AlreadyFused`] regardless of size so callers
+    /// can drop flood traffic without allocating.
+    ///
+    /// Capacity returns only through [`Self::record_drained`], keeping the
+    /// admitted total at most `limit` bytes between drains.
+    pub(super) fn admit(&mut self, frame_bytes: usize) -> Result<(), QueueRefusal> {
+        if self.fused {
+            return Err(QueueRefusal::AlreadyFused);
+        }
+        if let Some(limit) = self.limit {
+            if frame_bytes > limit {
+                self.fused = true;
+                return Err(QueueRefusal::FrameExceedsLimit { frame_bytes, limit });
+            }
+            match self.queued_bytes.checked_add(frame_bytes) {
+                Some(total) if total <= limit => self.queued_bytes = total,
+                _ => {
+                    self.fused = true;
+                    return Err(QueueRefusal::QueueWouldExceedLimit {
+                        queued_bytes: self.queued_bytes,
+                        frame_bytes,
+                        limit,
+                    });
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Releases capacity held by drained frames, saturating at zero so an
+    /// accounting bug fails closed toward refusals instead of unbounded
+    /// buffering.
+    pub(super) fn record_drained(&mut self, drained_bytes: usize) {
+        self.queued_bytes = self.queued_bytes.saturating_sub(drained_bytes);
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects
+)]
+mod tests {
+    use super::*;
+
+    const LIMIT: usize = 8;
+
+    #[test]
+    fn default_limit_matches_native_eight_mib_policy() {
+        assert_eq!(DEFAULT_MAX_INBOUND_QUEUE_BYTES, 8 * 1024 * 1024);
+    }
+
+    #[test]
+    fn admits_frames_up_to_the_inclusive_limit_and_released_capacity_is_reusable() {
+        let mut bound = InboundQueueBound::new(Some(LIMIT));
+        bound.admit(3).unwrap();
+        // Exactly-at-limit totals are admitted, mirroring the native codec's
+        // inclusive maximum.
+        bound.admit(LIMIT - 3).unwrap();
+
+        // Draining releases exactly the drained bytes...
+        bound.record_drained(5);
+        bound.record_drained(3);
+
+        // ...and released capacity admits new work again.
+        bound.admit(LIMIT).unwrap();
+    }
+
+    #[test]
+    fn oversized_frames_refuse_and_fuse_permanently() {
+        let mut bound = InboundQueueBound::new(Some(LIMIT));
+        assert_eq!(
+            bound.admit(LIMIT + 1),
+            Err(QueueRefusal::FrameExceedsLimit {
+                frame_bytes: LIMIT + 1,
+                limit: LIMIT,
+            })
+        );
+
+        // Even zero-byte input is refused once fused so callers drop flood
+        // traffic uniformly without allocating.
+        assert_eq!(bound.admit(0), Err(QueueRefusal::AlreadyFused));
+
+        // Draining does not unfuse.
+        bound.record_drained(usize::MAX);
+        assert_eq!(
+            bound.admit(1),
+            Err(QueueRefusal::AlreadyFused),
+            "draining must not clear fusion"
+        );
+    }
+
+    #[test]
+    fn aggregate_backlog_refuses_before_exceeding_the_limit() {
+        let mut bound = InboundQueueBound::new(Some(LIMIT));
+        bound.admit(6).unwrap();
+        // 6 queued + 3 incoming > 8 refuses even though either alone fits.
+        assert_eq!(
+            bound.admit(3),
+            Err(QueueRefusal::QueueWouldExceedLimit {
+                queued_bytes: 6,
+                frame_bytes: 3,
+                limit: LIMIT,
+            })
+        );
+        assert_eq!(bound.admit(1), Err(QueueRefusal::AlreadyFused));
+    }
+
+    #[test]
+    fn disabled_limit_never_refuses_or_fuses() {
+        let mut bound = InboundQueueBound::new(None);
+        bound.admit(usize::MAX).unwrap();
+        bound.admit(usize::MAX).unwrap();
+        bound.record_drained(7);
+    }
+
+    #[test]
+    fn empty_frames_stay_free_even_at_full_capacity() {
+        let mut bound = InboundQueueBound::new(Some(LIMIT));
+        bound.admit(LIMIT).unwrap();
+        // Zero-byte frames add nothing to the ledger, so they neither trip
+        // the aggregate bound nor disturb later admissions.
+        bound.admit(0).unwrap();
+        bound.record_drained(LIMIT);
+        bound.admit(LIMIT).unwrap();
+    }
+
+    #[test]
+    fn refusal_messages_carry_byte_counts_only() {
+        let frame = QueueRefusal::FrameExceedsLimit {
+            frame_bytes: 9,
+            limit: 8,
+        }
+        .message();
+        assert!(frame.contains("9"));
+        assert!(frame.contains("8"));
+
+        let backlog = QueueRefusal::QueueWouldExceedLimit {
+            queued_bytes: 6,
+            frame_bytes: 3,
+            limit: 8,
+        }
+        .message();
+        assert!(backlog.contains("6"));
+        assert!(backlog.contains("3"));
+        assert!(backlog.contains("8"));
+    }
+}

--- a/src/transports/emscripten_websocket.rs
+++ b/src/transports/emscripten_websocket.rs
@@ -23,9 +23,11 @@
 //! (default 8 MiB, configurable through
 //! [`EmscriptenWebSocketConnectOptions::max_inbound_queue_bytes`]) before it
 //! copies any payload, so a server cannot grow this transport's heap without
-//! limit between polling ticks. The first over-limit frame or backlog fuses
-//! the transport with one terminal receive error; later flood frames drop
-//! silently. Drained frames release their capacity back to the ledger.
+//! limit between polling ticks; zero-length frames carry a conservative
+//! minimum charge so count-based floods hit the same bound. The first
+//! over-limit frame or backlog fuses the transport with one terminal receive
+//! error; later flood frames drop silently. Drained frames release their
+//! charge back to the ledger.
 //!
 //! # Compatibility
 //!
@@ -98,7 +100,7 @@ use std::sync::mpsc as std_mpsc;
 
 use super::emscripten_cleanup::{CleanupState, DeleteAuthorization, ReclaimAuthorization};
 use super::emscripten_inbound_queue::{
-    InboundQueueBound, QueueRefusal, DEFAULT_MAX_INBOUND_QUEUE_BYTES,
+    charged_frame_bytes, InboundQueueBound, QueueRefusal, DEFAULT_MAX_INBOUND_QUEUE_BYTES,
 };
 use crate::error::SignalFishError;
 use crate::transport::{poll_accept_frame, Transport, TransportCloseInfo, TransportFrame};
@@ -307,10 +309,12 @@ pub struct EmscriptenWebSocketConnectOptions {
     ///
     /// Callback-delivered frames queue here while the game loop is busy, so
     /// this bounds both any single frame and the total bytes waiting for
-    /// `poll_recv`. Exceeding it refuses the offending input and fuses the
-    /// transport with one terminal receive error — mirroring how the native
-    /// WebSocket transport surfaces over-limit inbound messages instead of
-    /// growing memory without limit between drains.
+    /// `poll_recv`; zero-length frames reserve a small minimum charge so a
+    /// count-based flood cannot bypass the bound. Exceeding it refuses the
+    /// offending input and fuses the transport with one terminal receive
+    /// error — mirroring how the native WebSocket transport surfaces
+    /// over-limit inbound messages instead of growing memory without limit
+    /// between drains.
     ///
     /// Defaults to 8 MiB, matching the native default. This is a protective
     /// client resource policy for memory-constrained browser tabs, not a
@@ -693,10 +697,11 @@ extern "C" fn on_open_callback(
 
 /// Release queue capacity for frames that left the buffer, whether drained
 /// by [`Transport::poll_recv`] or rejected after admission by UTF-8
-/// validation.
-fn release_queued_bytes(queue: &Cell<InboundQueueBound>, bytes: usize) {
+/// validation. Uses the same charge [`on_message_callback`] admitted so the
+/// ledger never drifts.
+fn release_queued_bytes(queue: &Cell<InboundQueueBound>, payload_len: usize) {
     let mut bound = queue.get();
-    bound.record_drained(bytes);
+    bound.record_drained(charged_frame_bytes(payload_len));
     queue.set(bound);
 }
 
@@ -724,11 +729,12 @@ extern "C" fn on_message_callback(
 
     // Bound buffered inbound input before copying payload memory so an
     // oversized or flooding server cannot grow this transport's heap between
-    // polling ticks. The first refusal enqueues exactly one terminal error
-    // event; afterwards messages drop silently because the ledger reports
-    // `AlreadyFused`.
+    // polling ticks. Empty frames carry the minimum charge, so a zero-length
+    // flood hits the same bound as payloads. The first refusal enqueues
+    // exactly one terminal error event; afterwards messages drop silently
+    // because the ledger reports `AlreadyFused`.
     let mut bound = state.inbound_queue.get();
-    let admission = bound.admit(content_len);
+    let admission = bound.admit(charged_frame_bytes(content_len));
     state.inbound_queue.set(bound);
     if let Err(refusal) = admission {
         if !matches!(refusal, QueueRefusal::AlreadyFused) {

--- a/src/transports/emscripten_websocket.rs
+++ b/src/transports/emscripten_websocket.rs
@@ -19,6 +19,14 @@
 //! thread. A `std::sync::mpsc` channel bridges callback events into the
 //! transport's `poll_recv()` method.
 //!
+//! The message callback admits input against a shared inbound-byte ledger
+//! (default 8 MiB, configurable through
+//! [`EmscriptenWebSocketConnectOptions::max_inbound_queue_bytes`]) before it
+//! copies any payload, so a server cannot grow this transport's heap without
+//! limit between polling ticks. The first over-limit frame or backlog fuses
+//! the transport with one terminal receive error; later flood frames drop
+//! silently. Drained frames release their capacity back to the ledger.
+//!
 //! # Compatibility
 //!
 //! This transport is designed exclusively for use with
@@ -83,10 +91,15 @@ compile_error!(
      Remove this feature or compile with `--target wasm32-unknown-emscripten`."
 );
 
+use std::cell::Cell;
 use std::ffi::{c_char, c_int, c_void};
+use std::rc::Rc;
 use std::sync::mpsc as std_mpsc;
 
 use super::emscripten_cleanup::{CleanupState, DeleteAuthorization, ReclaimAuthorization};
+use super::emscripten_inbound_queue::{
+    InboundQueueBound, QueueRefusal, DEFAULT_MAX_INBOUND_QUEUE_BYTES,
+};
 use crate::error::SignalFishError;
 use crate::transport::{poll_accept_frame, Transport, TransportCloseInfo, TransportFrame};
 
@@ -224,6 +237,10 @@ enum IncomingEvent {
 /// State shared with C callbacks via raw pointer (`Box::into_raw`).
 struct CallbackState {
     tx: std_mpsc::Sender<IncomingEvent>,
+    /// Shared admission ledger for buffered inbound frames. The owning
+    /// transport keeps an [`Rc`] clone so drained frames release capacity
+    /// without dereferencing this raw callback allocation.
+    inbound_queue: Rc<Cell<InboundQueueBound>>,
 }
 
 /// Owns callback state without freeing it in `Drop`. Reclamation requires the
@@ -233,8 +250,11 @@ struct CallbackState {
 struct RegisteredCallbackState(Option<std::ptr::NonNull<CallbackState>>);
 
 impl RegisteredCallbackState {
-    fn new(tx: std_mpsc::Sender<IncomingEvent>) -> Self {
-        let state = Box::new(CallbackState { tx });
+    fn new(
+        tx: std_mpsc::Sender<IncomingEvent>,
+        inbound_queue: Rc<Cell<InboundQueueBound>>,
+    ) -> Self {
+        let state = Box::new(CallbackState { tx, inbound_queue });
         Self(std::ptr::NonNull::new(Box::into_raw(state)))
     }
 
@@ -254,6 +274,76 @@ impl RegisteredCallbackState {
         // SAFETY: The non-forgeable authorization proves successful callback
         // unregistration, and `take` makes this the allocation's sole reclaim.
         unsafe { drop(Box::from_raw(state_ptr.as_ptr())) };
+    }
+}
+
+// ── Connect Options ─────────────────────────────────────────────────────────
+
+/// Options controlling how an [`EmscriptenWebSocketTransport`] connection is
+/// established.
+///
+/// Construct with [`new`](Self::new) (or [`Default`]) and adjust with the
+/// `with_*` builders:
+///
+/// ```rust,ignore
+/// use signal_fish_client::EmscriptenWebSocketConnectOptions;
+///
+/// // Raise the buffered-inbound bound for snapshot-heavy deployments.
+/// let options =
+///     EmscriptenWebSocketConnectOptions::new().with_max_inbound_queue_bytes(Some(16 << 20));
+/// let transport = EmscriptenWebSocketTransport::connect_with_options(
+///     "wss://server/v2/ws",
+///     options,
+/// )?;
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[deprecated(
+    since = "0.8.0",
+    note = "for standard Godot exports use GodotWebSocketTransport; this transport requires a custom Emscripten host that links the WebSocket library"
+)]
+pub struct EmscriptenWebSocketConnectOptions {
+    /// Maximum inbound WebSocket input buffered between polling ticks, in
+    /// bytes, inclusive.
+    ///
+    /// Callback-delivered frames queue here while the game loop is busy, so
+    /// this bounds both any single frame and the total bytes waiting for
+    /// `poll_recv`. Exceeding it refuses the offending input and fuses the
+    /// transport with one terminal receive error — mirroring how the native
+    /// WebSocket transport surfaces over-limit inbound messages instead of
+    /// growing memory without limit between drains.
+    ///
+    /// Defaults to 8 MiB, matching the native default. This is a protective
+    /// client resource policy for memory-constrained browser tabs, not a
+    /// protocol maximum: deployments with larger room snapshots must raise
+    /// it. Set it to `None` to restore the previous unbounded buffering.
+    /// `Some(0)` is invalid and makes connection setup fail before network
+    /// I/O.
+    pub max_inbound_queue_bytes: Option<usize>,
+}
+
+impl Default for EmscriptenWebSocketConnectOptions {
+    fn default() -> Self {
+        Self {
+            max_inbound_queue_bytes: Some(DEFAULT_MAX_INBOUND_QUEUE_BYTES),
+        }
+    }
+}
+
+impl EmscriptenWebSocketConnectOptions {
+    /// Create options with the default 8 MiB buffered-inbound bound.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            max_inbound_queue_bytes: Some(DEFAULT_MAX_INBOUND_QUEUE_BYTES),
+        }
+    }
+
+    /// Set the inclusive bound on buffered inbound WebSocket input; `None`
+    /// disables it.
+    #[must_use]
+    pub const fn with_max_inbound_queue_bytes(mut self, max_bytes: Option<usize>) -> Self {
+        self.max_inbound_queue_bytes = max_bytes;
+        self
     }
 }
 
@@ -287,6 +377,9 @@ impl RegisteredCallbackState {
 pub struct EmscriptenWebSocketTransport {
     socket: EMSCRIPTEN_WEBSOCKET_T,
     incoming_rx: std_mpsc::Receiver<IncomingEvent>,
+    /// Shared with the registered callback state; admits callback-delivered
+    /// input and releases capacity as `poll_recv` drains frames.
+    inbound_queue: Rc<Cell<InboundQueueBound>>,
     /// Registered callback state while the browser may still dereference it.
     /// Successful socket deletion yields the authorization that reclaims it;
     /// a terminal deletion failure deliberately leaks it rather than exposing
@@ -310,7 +403,8 @@ pub struct EmscriptenWebSocketTransport {
 // ── Constructor ─────────────────────────────────────────────────────────────
 
 impl EmscriptenWebSocketTransport {
-    /// Create a new WebSocket connection to the given URL.
+    /// Create a new WebSocket connection to the given URL with the default
+    /// 8 MiB buffered-inbound bound.
     ///
     /// This function is synchronous — the WebSocket is created immediately,
     /// but the connection handshake completes asynchronously. The transport
@@ -322,11 +416,41 @@ impl EmscriptenWebSocketTransport {
     /// Returns [`SignalFishError::Io`] if the URL contains interior NUL bytes
     /// or if `emscripten_websocket_new` fails.
     pub fn connect(url: &str) -> Result<Self, SignalFishError> {
+        Self::connect_with_options(url, EmscriptenWebSocketConnectOptions::default())
+    }
+
+    /// Create a new WebSocket connection to the given URL with explicit
+    /// options.
+    ///
+    /// This function is synchronous — the WebSocket is created immediately,
+    /// but the connection handshake completes asynchronously. The transport
+    /// retains caller-owned messages until the browser reports that the
+    /// connection is open.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SignalFishError::Io`] if the URL contains interior NUL bytes,
+    /// if `max_inbound_queue_bytes` is `Some(0)`, or if
+    /// `emscripten_websocket_new` fails.
+    pub fn connect_with_options(
+        url: &str,
+        options: EmscriptenWebSocketConnectOptions,
+    ) -> Result<Self, SignalFishError> {
+        if options.max_inbound_queue_bytes == Some(0) {
+            return Err(SignalFishError::Io(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "Emscripten max_inbound_queue_bytes must be greater than zero or None",
+            )));
+        }
+
         let c_url = std::ffi::CString::new(url).map_err(|e| {
             SignalFishError::Io(std::io::Error::new(std::io::ErrorKind::InvalidInput, e))
         })?;
 
         let (tx, rx) = std_mpsc::channel();
+        let inbound_queue = Rc::new(Cell::new(InboundQueueBound::new(
+            options.max_inbound_queue_bytes,
+        )));
 
         let attrs = EmscriptenWebSocketCreateAttributes {
             url: c_url.as_ptr(),
@@ -344,7 +468,7 @@ impl EmscriptenWebSocketTransport {
             )));
         }
 
-        let mut callback_state = RegisteredCallbackState::new(tx);
+        let mut callback_state = RegisteredCallbackState::new(tx, Rc::clone(&inbound_queue));
         let state_ptr = callback_state.as_ptr();
         let mut cleanup = CleanupState::new();
 
@@ -444,6 +568,7 @@ impl EmscriptenWebSocketTransport {
         Ok(Self {
             socket,
             incoming_rx: rx,
+            inbound_queue,
             callback_state,
             closed: false,
             opened: false,
@@ -566,6 +691,15 @@ extern "C" fn on_open_callback(
     1 // EM_TRUE
 }
 
+/// Release queue capacity for frames that left the buffer, whether drained
+/// by [`Transport::poll_recv`] or rejected after admission by UTF-8
+/// validation.
+fn release_queued_bytes(queue: &Cell<InboundQueueBound>, bytes: usize) {
+    let mut bound = queue.get();
+    bound.record_drained(bytes);
+    queue.set(bound);
+}
+
 // SAFETY: See the callback SAFETY block comment above for pointer guarantees.
 extern "C" fn on_message_callback(
     _event_type: c_int,
@@ -579,14 +713,37 @@ extern "C" fn on_message_callback(
     // duration of this synchronous invocation and is not retained.
     let event = unsafe { &*event };
 
-    if event.is_text != 0 {
+    let is_text = event.is_text != 0;
+    // Text payloads include a trailing NUL terminator that is not part of
+    // the message content.
+    let content_len = if is_text {
+        event.num_bytes.saturating_sub(1)
+    } else {
+        event.num_bytes
+    } as usize;
+
+    // Bound buffered inbound input before copying payload memory so an
+    // oversized or flooding server cannot grow this transport's heap between
+    // polling ticks. The first refusal enqueues exactly one terminal error
+    // event; afterwards messages drop silently because the ledger reports
+    // `AlreadyFused`.
+    let mut bound = state.inbound_queue.get();
+    let admission = bound.admit(content_len);
+    state.inbound_queue.set(bound);
+    if let Err(refusal) = admission {
+        if !matches!(refusal, QueueRefusal::AlreadyFused) {
+            let _ = state.tx.send(IncomingEvent::Error(refusal.message()));
+        }
+        return 1; // EM_TRUE
+    }
+
+    if is_text {
         // Text message — create String from UTF-8 bytes.
-        // num_bytes includes the NUL terminator for text messages.
-        let len = event.num_bytes.saturating_sub(1) as usize;
         // SAFETY: For a non-empty payload, Emscripten guarantees `event.data`
-        // points to `event.num_bytes` valid bytes for this callback. `len`
-        // excludes the NUL terminator. Empty payloads do not dereference data.
-        let bytes = unsafe { copy_event_payload(event.data, len) };
+        // points to `event.num_bytes` valid bytes for this callback.
+        // `content_len` excludes the NUL terminator. Empty payloads do not
+        // dereference data.
+        let bytes = unsafe { copy_event_payload(event.data, content_len) };
         match std::str::from_utf8(&bytes) {
             Ok(s) => {
                 let _ = state
@@ -595,15 +752,15 @@ extern "C" fn on_message_callback(
             }
             Err(e) => {
                 tracing::warn!("received non-UTF-8 text message: {e}");
+                release_queued_bytes(&state.inbound_queue, content_len);
             }
         }
     } else {
-        let len = event.num_bytes as usize;
         // SAFETY: For a non-empty payload, Emscripten guarantees `event.data`
         // points to `event.num_bytes` valid bytes for this callback. Empty
         // binary frames may carry a null data pointer and are copied directly
         // to an empty Vec without constructing a slice.
-        let bytes = unsafe { copy_event_payload(event.data, len) };
+        let bytes = unsafe { copy_event_payload(event.data, content_len) };
         let _ = state
             .tx
             .send(IncomingEvent::Message(TransportFrame::Binary(bytes)));
@@ -727,6 +884,11 @@ impl Transport for EmscriptenWebSocketTransport {
         loop {
             match self.incoming_rx.try_recv() {
                 Ok(IncomingEvent::Message(frame)) => {
+                    let drained = match &frame {
+                        TransportFrame::Text(message) => message.len(),
+                        TransportFrame::Binary(payload) => payload.len(),
+                    };
+                    release_queued_bytes(&self.inbound_queue, drained);
                     return std::task::Poll::Ready(Some(Ok(frame)));
                 }
                 Ok(IncomingEvent::Open) => {

--- a/src/transports/emscripten_websocket.rs
+++ b/src/transports/emscripten_websocket.rs
@@ -319,9 +319,12 @@ pub struct EmscriptenWebSocketConnectOptions {
     /// Defaults to 8 MiB, matching the native default. This is a protective
     /// client resource policy for memory-constrained browser tabs, not a
     /// protocol maximum: deployments with larger room snapshots must raise
-    /// it. Set it to `None` to restore the previous unbounded buffering.
-    /// `Some(0)` is invalid and makes connection setup fail before network
-    /// I/O.
+    /// it. Every admitted frame reserves a 64-byte minimum charge
+    /// approximating its queuing overhead, so bounds below that minimum
+    /// cannot admit even an empty frame and fuse on first input — realistic
+    /// limits are orders of magnitude larger. Set it to `None` to restore
+    /// the previous unbounded buffering. `Some(0)` is invalid and makes
+    /// connection setup fail before network I/O.
     pub max_inbound_queue_bytes: Option<usize>,
 }
 

--- a/src/transports/mod.rs
+++ b/src/transports/mod.rs
@@ -40,6 +40,12 @@ pub use websocket::{WebSocketConnectOptions, WebSocketTransport};
 ))]
 mod emscripten_cleanup;
 
+#[cfg(all(
+    feature = "transport-websocket-emscripten",
+    any(target_os = "emscripten", test)
+))]
+mod emscripten_inbound_queue;
+
 // Gated on both feature and target: this module uses Emscripten's C WebSocket API,
 // which only exists on wasm32-unknown-emscripten. The dual gate keeps `--all-features`
 // working on non-Emscripten hosts (features must be additive per Cargo convention).
@@ -49,4 +55,4 @@ pub mod emscripten_websocket;
 
 #[cfg(all(feature = "transport-websocket-emscripten", target_os = "emscripten"))]
 #[allow(deprecated)]
-pub use emscripten_websocket::EmscriptenWebSocketTransport;
+pub use emscripten_websocket::{EmscriptenWebSocketConnectOptions, EmscriptenWebSocketTransport};

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -1333,13 +1333,16 @@ mod docsrs_policy {
         //
         // If new target-gated types are introduced, add their names here.
         //
-        // The pattern omits the trailing `]` to also catch method-level
+        // The patterns omit the trailing `]` to also catch method-level
         // links like [`EmscriptenWebSocketTransport::connect`].
-        let forbidden = "[`EmscriptenWebSocketTransport";
+        let forbidden = [
+            "[`EmscriptenWebSocketTransport",
+            "[`EmscriptenWebSocketConnectOptions",
+        ];
         let src_dir = project_root().join("src");
         let mut violations = Vec::new();
 
-        fn visit_rs_files(dir: &std::path::Path, forbidden: &str, violations: &mut Vec<String>) {
+        fn visit_rs_files(dir: &std::path::Path, forbidden: &[&str], violations: &mut Vec<String>) {
             // Tolerant traversal: concurrent processes (rust-analyzer, builds)
             // may make listed entries vanish mid-walk; skipping them keeps the
             // scanner deterministic on stable trees without racing.
@@ -1373,7 +1376,7 @@ mod docsrs_policy {
                         continue;
                     };
                     for (i, line) in contents.lines().enumerate() {
-                        if line.contains(forbidden) {
+                        if forbidden.iter().any(|pattern| line.contains(pattern)) {
                             violations.push(format!("{}:{}: {line}", path.display(), i + 1));
                         }
                     }
@@ -1381,7 +1384,7 @@ mod docsrs_policy {
             }
         }
 
-        visit_rs_files(&src_dir, forbidden, &mut violations);
+        visit_rs_files(&src_dir, &forbidden, &mut violations);
 
         assert!(
             violations.is_empty(),
@@ -7921,7 +7924,7 @@ mod ffi_safety_documentation {
             .find("if socket <= 0 {")
             .expect("socket creation failure must be handled");
         let owner_creation = contents
-            .find("RegisteredCallbackState::new(tx)")
+            .find("RegisteredCallbackState::new(")
             .expect("callback allocation must use its owner");
         assert!(
             socket_failure < owner_creation,


### PR DESCRIPTION
## Why

Between two game-loop polls, the Emscripten transport's message callback copied every server payload onto an unbounded queue, so a hostile or buggy server could grow a web build's memory without limit (#160). Every other transport already bounds input: native caps frames and assembled messages at 8 MiB, and the Godot adapter uses an 8 MiB inbound buffer with Pending parking for oversized sends.

## How

- Callback-delivered input is now admitted against a shared byte ledger **before** any payload copy. One oversized frame — or a backlog that would overfill between polls — fuses the transport with a single terminal receive error; later flood frames drop silently instead of allocating.
- The default bound is 8 MiB, matching native. Raise it or disable it with the new `EmscriptenWebSocketConnectOptions::max_inbound_queue_bytes` option and `connect_with_options` constructor.
- Drained frames release their capacity. The ledger logic lives in a new target-independent module so it is unit-tested on every host build, and the wasm32-unknown-emscripten build/clippy lane was verified locally.

Closes #160.

---

Also carries one small docs fix from this session: the devcontainer README now documents recovery from VS Code's "removal is already in progress" rebuild race (with its changelog entry).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Emscripten FFI message-callback admission and connection setup defaults; mis-tuned `max_inbound_queue_bytes` could fuse legitimate high-throughput web sessions, though `None` preserves legacy behavior.
> 
> **Overview**
> **Bounds buffered inbound WebSocket data on the Emscripten transport** so a server cannot grow memory without limit between `poll_recv` ticks. Callbacks now **admit frames against a shared byte ledger before copying payload**, default **8 MiB** (aligned with native policy), with a **64-byte minimum charge** per frame so zero-length floods hit the same limit. The first over-limit frame or backlog **fuses** the connection with one terminal receive error; later flood traffic is dropped silently.
> 
> Adds **`EmscriptenWebSocketConnectOptions`** and **`connect_with_options`** so callers can raise the bound or set **`None`** for prior unbounded behavior; **`connect`** keeps the new default. Ledger logic lives in **`emscripten_inbound_queue`** and is unit-tested on every host; **`poll_recv`** and invalid UTF-8 paths release drained capacity back to the ledger.
> 
> Also documents **VS Code Dev Container** recovery when rebuild fails with Docker **"removal is already in progress"**, and extends CI guards for intra-doc links to the new options type.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db6b418bd78805a05bf5fcc586c720cc4b9e7688. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->