### PR TITLE
Fix capacity panic; align docs and CI with audited behavior

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,10 @@ jobs:
             flags: "--no-default-features --features token-binding"
           - name: no-default-features
             flags: "--no-default-features"
+          - name: polling-client-only
+            flags: "--no-default-features --features polling-client"
+          - name: mesh-only
+            flags: "--no-default-features --features mesh"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
@@ -116,6 +120,10 @@ jobs:
             flags: "--no-default-features --features token-binding"
           - name: no-default-features
             flags: "--no-default-features"
+          - name: polling-client-only
+            flags: "--no-default-features --features polling-client"
+          - name: mesh-only
+            flags: "--no-default-features --features mesh"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -212,6 +212,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed a deferred panic when absurdly large channel capacities were requested
+  through `SignalFishConfig::with_event_channel_capacity` /
+  `with_command_channel_capacity` (or assigned to the public fields directly):
+  values above tokio's internal semaphore permit ceiling (`usize::MAX >> 3`)
+  previously panicked inside `SignalFishClient::start`, while the polling
+  client accepted the same configuration silently. Capacities are now clamped
+  to that ceiling everywhere, alongside the existing sub-1 clamp, and the
+  field documentation states both bounds.
+- Documented the Godot adapter's `GodotBackpressurePolicy` edge values: a
+  `Fixed` watermark of 0 degenerates to strict stop-and-wait (one frame in
+  flight until Godot drains it), zero `Adaptive::latency_target` drops the
+  latency term, and a floor above the ceiling pins the watermark to the
+  ceiling (behavior unchanged, previously undocumented).
+- Documented that `SignalFishConfig::enable_v3` resets advertised transports
+  and topologies to relay-only — overwriting a prior `enable_mesh` call — and
+  that `with_protocol_version` defers unknown-version handling to the server,
+  so mesh configurations call `enable_mesh` last (or use the power-user list
+  builders after it).
+- Corrected the published model-context page (`llms.txt`) to advertise the
+  current release instead of 0.8.0 and dropped its stale issue reference;
+  fixed the delivery guide's shutdown-preemption version anchor (client 0.8.0,
+  not 0.7.0); documented the Emscripten transport's
+  `connect_with_options` / inbound-queue bound on the wasm docs page; and
+  completed `concepts.md`'s `SignalFishError` table with the four missing
+  variants (`NotAuthenticated`, `SessionPlanUnavailable`,
+  `StaleSessionGeneration`, `TokenBinding`).
 - Documented deterministic recovery from the VS Code Dev Containers rebuild
   race where concurrent cleanup attempts report that container removal is
   already in progress, allowing contributors to retry without deleting the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ tls = [
     "dep:rustls",
     "tokio-tungstenite/rustls-tls-webpki-roots",
 ]
-# Requires --target wasm32-unknown-emscripten; compile_error!() fires on other targets.
+# Only takes effect on wasm32-unknown-emscripten (the module itself is target-gated; elsewhere the feature enables polling-client only).
 transport-websocket-emscripten = ["polling-client"]
 polling-client = []
 tokio-runtime = ["tokio/rt", "tokio/time"]

--- a/crates/signal-fish-client-godot/src/lib.rs
+++ b/crates/signal-fish-client-godot/src/lib.rs
@@ -45,10 +45,12 @@ const DEFAULT_INBOUND_BUFFER_SIZE: i32 = 8 * 1024 * 1024;
 pub enum GodotBackpressurePolicy {
     /// Refuse a frame when it would exceed a fixed buffered-byte watermark.
     ///
-    /// A frame is always admitted while the backend buffer is empty (so a
-    /// watermark of **0** degenerates to strict stop-and-wait: at most one
-    /// frame in flight until Godot drains it), and refused once any bytes are
-    /// buffered beyond the watermark.
+    /// A frame within Godot's native outbound capacity is always admitted
+    /// while the backend buffer is empty (so a watermark of **0** degenerates
+    /// to strict stop-and-wait: at most one such frame in flight until Godot
+    /// drains it), and refused once any bytes are buffered beyond the
+    /// watermark. Native-capacity refusal takes precedence over the
+    /// watermark in every state.
     Fixed {
         /// Maximum normally admitted backend-buffered payload bytes.
         high_water_mark_bytes: usize,

--- a/crates/signal-fish-client-godot/src/lib.rs
+++ b/crates/signal-fish-client-godot/src/lib.rs
@@ -44,11 +44,22 @@ const DEFAULT_INBOUND_BUFFER_SIZE: i32 = 8 * 1024 * 1024;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GodotBackpressurePolicy {
     /// Refuse a frame when it would exceed a fixed buffered-byte watermark.
+    ///
+    /// A frame is always admitted while the backend buffer is empty (so a
+    /// watermark of **0** degenerates to strict stop-and-wait: at most one
+    /// frame in flight until Godot drains it), and refused once any bytes are
+    /// buffered beyond the watermark.
     Fixed {
         /// Maximum normally admitted backend-buffered payload bytes.
         high_water_mark_bytes: usize,
     },
     /// Adapt the watermark to the observed accepted burst and drain rate.
+    ///
+    /// Edge values are safe by construction: a zero [`latency_target`](Self::Adaptive::latency_target)
+    /// drops the latency term (the watermark then tracks the burst estimate
+    /// alone), a [`floor_bytes`](Self::Adaptive::floor_bytes) above
+    /// [`ceiling_bytes`](Self::Adaptive::ceiling_bytes) pins the watermark to
+    /// the ceiling, and huge targets saturate without overflow.
     Adaptive {
         /// Target time for draining backend-owned buffered bytes.
         latency_target: Duration,

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -475,9 +475,13 @@ directly from client methods as `Result<(), SignalFishError>`.
 | `RoomOperationPending` | A prior admitted join, leave, or reconnect still awaits a matching typed terminal response. Generic errors and absent responses stay fenced until transport teardown. |
 | `WrongRoomRole { required, actual }` | The operation requires player or spectator membership of a different kind. |
 | `AuthorityRequired` | The current player is not authorized for an authority-only command. |
+| `NotAuthenticated` | A directed room operation was attempted before the server confirmed authentication; wait for the `Authenticated` event first. |
 | `ServerError { message, error_code }` | The server returned an error; `error_code` is `Option<ErrorCode>` and may be absent. |
 | `ProtocolUnsupported { mode }` | A protocol-v3-only send was attempted before v3 was negotiated. See [Protocol versioning and topology](#protocol-versioning-and-topology). |
+| `SessionPlanUnavailable` | A WebRTC signal was attempted but no authoritative session plan currently authorizes it (before a plan, or targeting self, unknown, or departed players). |
+| `StaleSessionGeneration { .. }` | A WebRTC signal was produced under an already-replaced session-plan generation; the newer plan remains authoritative. |
 | `BinaryFormatNotNegotiated` | Binary game data was requested while the connection uses JSON. |
+| `TokenBinding(TokenBindingFailure)` | Native token-binding negotiation or proof generation failed (see `TokenBindingFailure` for the specific reason). |
 | `Timeout` | An operation exceeded its time limit. |
 | `Io(std::io::Error)` | An underlying I/O error occurred. |
 

--- a/docs/delivery.md
+++ b/docs/delivery.md
@@ -158,7 +158,7 @@ If your event consumer stops draining **forever**, the transport loop
 blocks delivering the next event, stops reading the socket, and the server
 eventually evicts you (`SLOW_CONSUMER`) — but the wedged client cannot
 observe the eviction (it is not reading), so from the inside the session
-just goes quiet. As of 0.7.0, [`shutdown()`](client.md#shutdown) preempts
+just goes quiet. Since client 0.8.0, [`shutdown()`](client.md#shutdown) preempts
 the wedge: it abandons at most the one in-flight event delivery and progresses
 graceful transport close without waiting for event-channel capacity. A close
 error or the configured close deadline invokes `Transport::abort` before the

--- a/docs/wasm.md
+++ b/docs/wasm.md
@@ -185,6 +185,33 @@ queued command until Emscripten can accept it.
 Returns `Result<EmscriptenWebSocketTransport, SignalFishError>`. On failure the
 error is `SignalFishError::Io` (e.g., invalid URL or Emscripten API failure).
 
+For explicit control, pass `EmscriptenWebSocketConnectOptions` via
+`connect_with_options`:
+
+```rust,ignore
+use signal_fish_client::{
+    EmscriptenWebSocketConnectOptions, EmscriptenWebSocketTransport,
+};
+
+// Default: an 8 MiB bound on inbound bytes buffered between polls.
+let transport = EmscriptenWebSocketTransport::connect_with_options(
+    "wss://example.com/v2/ws",
+    EmscriptenWebSocketConnectOptions::new(),
+)?;
+
+// Raise the bound for deployments with larger room snapshots.
+let options = EmscriptenWebSocketConnectOptions::new()
+    .with_max_inbound_queue_bytes(Some(16 * 1024 * 1024));
+```
+
+The bound covers every byte callback-delivered input queues while the game
+loop is busy (including a small minimum charge per frame, so zero-length
+floods cannot bypass it) and releases as your loop drains `poll_recv`.
+Exceeding it fuses the transport with one terminal receive error instead of
+growing memory without limit — mirroring the native WebSocket transport.
+`None` restores fully unbounded buffering; `Some(0)` fails connection setup
+before any network I/O.
+
 ### How it works
 
 ```mermaid

--- a/llms.txt
+++ b/llms.txt
@@ -10,9 +10,9 @@ the raw Emscripten transport is only for custom hosts
 that explicitly link Emscripten's WebSocket library.
 
 The GitHub Pages documentation tracks the unreleased `main` branch. Install
-`signal-fish-client = "0.8.0"` for the current crates.io release; use the
-repository git dependency when evaluating APIs and issue #61 fixes listed
-under `Unreleased` until the next crate version is published.
+`signal-fish-client = "0.10.0"` for the current crates.io release; use the
+repository git dependency when evaluating APIs and fixes listed under
+`Unreleased` until the next crate version is published.
 
 ## Documentation
 

--- a/llms.txt
+++ b/llms.txt
@@ -29,7 +29,7 @@ repository git dependency when evaluating APIs and fixes listed under
 
 - [Repository](https://github.com/Ambiguous-Interactive/signal-fish-client-rust): Source, examples, fixtures, and CI
 - [Changelog](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/blob/main/CHANGELOG.md): Released and unreleased behavior changes
-- [Issue #61](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/issues/61): Godot throughput investigation and acceptance criteria
+- [Issue #61](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/issues/61): Historical Godot throughput investigation (closed; fixes shipped in 0.9)
 
 ## Optional
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -117,6 +117,25 @@ const DEFAULT_COMMAND_CHANNEL_CAPACITY: usize = 1024;
 /// Default timeout for the graceful shutdown.
 const DEFAULT_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(1);
 
+/// Upper clamp for bounded channel capacities.
+///
+/// tokio backs bounded mpsc channels with a semaphore that panics above its
+/// private `MAX_PERMITS` bound, mirrored here because tokio does not expose
+/// it. Clamping keeps an absurd-but-typeable capacity from deferring that
+/// panic to [`SignalFishClient::start`].
+#[cfg(any(feature = "tokio-runtime", feature = "polling-client"))]
+const MAX_CHANNEL_CAPACITY: usize = usize::MAX >> 3;
+
+/// Clamp a configured channel capacity into the range every driver accepts:
+/// at least 1 (tokio panics on 0) and at most
+/// [`MAX_CHANNEL_CAPACITY`] (tokio's semaphore panics above it).
+#[cfg(any(feature = "tokio-runtime", feature = "polling-client"))]
+fn clamped_channel_capacity(capacity: usize) -> usize {
+    // MAX_CHANNEL_CAPACITY is a compile-time constant >= 1, so `clamp`
+    // cannot panic.
+    capacity.clamp(1, MAX_CHANNEL_CAPACITY)
+}
+
 /// Scheduling grace for the task watchdog after the transport loop's own
 /// close deadline. This lets the loop invoke `Transport::abort` first.
 #[cfg(feature = "tokio-runtime")]
@@ -227,7 +246,9 @@ pub struct SignalFishConfig {
     /// nonblocking attempt) after [`shutdown_timeout`](SignalFishConfig::shutdown_timeout)
     /// and delivers the terminal `Disconnected` best-effort.
     ///
-    /// Defaults to **256**. Values below 1 are clamped to 1.
+    /// Defaults to **256**. Values below 1 are clamped to 1; values above
+    /// tokio's semaphore permit ceiling (`usize::MAX >> 3`) are clamped to
+    /// that ceiling.
     pub event_channel_capacity: usize,
     /// Capacity of the bounded outgoing command queue.
     ///
@@ -240,7 +261,9 @@ pub struct SignalFishConfig {
     /// queued when the connection ends are discarded with it (surfaced by
     /// the `Disconnected` event); *queued* is not *delivered*.
     ///
-    /// Defaults to **1024**. Values below 1 are clamped to 1.
+    /// Defaults to **1024**. Values below 1 are clamped to 1; values above
+    /// tokio's semaphore permit ceiling (`usize::MAX >> 3`) are clamped to
+    /// that ceiling.
     pub command_channel_capacity: usize,
     /// Deadline for graceful async shutdown and polling-client close.
     ///
@@ -287,10 +310,11 @@ impl SignalFishConfig {
 
     /// Set the capacity of the bounded event channel.
     ///
-    /// Defaults to **256**. Values below 1 are clamped to 1.
+    /// Defaults to **256**. Values below 1 are clamped to 1; absurdly large
+    /// values are clamped to tokio's semaphore permit ceiling.
     #[must_use]
     pub fn with_event_channel_capacity(mut self, capacity: usize) -> Self {
-        self.event_channel_capacity = capacity.max(1);
+        self.event_channel_capacity = clamped_channel_capacity(capacity);
         self
     }
 
@@ -299,10 +323,11 @@ impl SignalFishConfig {
     /// See [`command_channel_capacity`](Self::command_channel_capacity) for
     /// the backpressure semantics.
     ///
-    /// Defaults to **1024**. Values below 1 are clamped to 1.
+    /// Defaults to **1024**. Values below 1 are clamped to 1; absurdly large
+    /// values are clamped to tokio's semaphore permit ceiling.
     #[must_use]
     pub fn with_command_channel_capacity(mut self, capacity: usize) -> Self {
-        self.command_channel_capacity = capacity.max(1);
+        self.command_channel_capacity = clamped_channel_capacity(capacity);
         self
     }
 
@@ -341,6 +366,12 @@ impl SignalFishConfig {
     /// (and the pre-gathered `ice_servers` on `RoomJoined`/`Reconnected`) into
     /// your peer connection's STUN/TURN configuration, or NAT traversal will
     /// silently fail.
+    ///
+    /// Builder order matters: this resets the advertised transports and
+    /// topologies to the mesh-with-relay defaults, so call it **after**
+    /// [`enable_v3`](Self::enable_v3), not before (or use
+    /// [`with_transports`](Self::with_transports)/[`with_topologies`](Self::with_topologies)
+    /// last for custom lists).
     #[must_use]
     pub fn enable_mesh(mut self) -> Self {
         self = self.enable_v3();
@@ -408,7 +439,10 @@ impl SignalFishConfig {
     ///
     /// This enables delivery classes, accountability, reconnect snapshots, and
     /// binary relay while keeping both transport and topology on the universal
-    /// server-relay floor.
+    /// server-relay floor. It also resets the advertised transports and
+    /// topologies to relay-only: a prior [`enable_mesh`](Self::enable_mesh)
+    /// call is overwritten (mesh capability disappears from negotiation), so
+    /// call `enable_v3` first when combining them.
     #[must_use]
     pub fn enable_v3(mut self) -> Self {
         self.protocol_version = Some(crate::PROTOCOL_VERSION);
@@ -422,6 +456,8 @@ impl SignalFishConfig {
     /// Power-user escape hatch; most consumers want [`enable_mesh`](Self::enable_mesh)
     /// instead. Setting a version without also setting transports/topologies keeps
     /// the room on the relay floor (the server requires both to form a session).
+    /// Any `u16` is accepted here; an unknown version surfaces as the server's
+    /// own negotiation or error response.
     #[must_use]
     pub fn with_protocol_version(mut self, version: u16) -> Self {
         self.protocol_version = Some(version);
@@ -816,10 +852,11 @@ impl SignalFishClient {
         transport: impl Transport + Send + 'static,
         config: SignalFishConfig,
     ) -> (Self, mpsc::Receiver<SignalFishEvent>) {
-        // Clamp capacities to at least 1 (tokio panics on 0).
-        let cmd_capacity = config.command_channel_capacity.max(1);
+        // Clamp capacities into the range both channel backends accept
+        // (public fields can bypass the builder setters).
+        let cmd_capacity = clamped_channel_capacity(config.command_channel_capacity);
         let (cmd_tx, cmd_rx) = mpsc::channel::<ClientCommand>(cmd_capacity);
-        let capacity = config.event_channel_capacity.max(1);
+        let capacity = clamped_channel_capacity(config.event_channel_capacity);
         let (event_tx, event_rx) = mpsc::channel::<SignalFishEvent>(capacity);
         let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
 
@@ -3747,6 +3784,29 @@ mod tests {
         let event = events.recv().await.unwrap();
         assert!(matches!(event, SignalFishEvent::Connected));
 
+        client.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn huge_channel_capacities_do_not_panic_at_start() {
+        // tokio's bounded mpsc channels are backed by a semaphore that panics
+        // above its private MAX_PERMITS bound (`usize::MAX >> 3`). A
+        // typeable-but-absurd capacity used to defer that panic to `start`.
+        let config = SignalFishConfig::new("mb_test")
+            .with_event_channel_capacity(usize::MAX)
+            .with_command_channel_capacity(usize::MAX)
+            .with_shutdown_timeout(std::time::Duration::from_millis(50));
+
+        // Direct public-field assignment bypasses the setters too.
+        let config = SignalFishConfig {
+            event_channel_capacity: usize::MAX,
+            command_channel_capacity: usize::MAX,
+            ..config
+        };
+
+        let (transport, _sent, _closed) = MockTransport::new(vec![]);
+        let (mut client, _events) = SignalFishClient::start(transport, config);
+        assert_eq!(client.max_send_capacity(), usize::MAX >> 3);
         client.shutdown().await;
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -122,15 +122,15 @@ const DEFAULT_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(1);
 /// tokio backs bounded mpsc channels with a semaphore that panics above its
 /// private `MAX_PERMITS` bound, mirrored here because tokio does not expose
 /// it. Clamping keeps an absurd-but-typeable capacity from deferring that
-/// panic to [`SignalFishClient::start`].
-#[cfg(any(feature = "tokio-runtime", feature = "polling-client"))]
+/// panic to [`SignalFishClient::start`]. The async driver's channels are the
+/// only consumers with that panic bound; the polling driver clamps too so
+/// both drivers report identical capacities for identical configurations.
 const MAX_CHANNEL_CAPACITY: usize = usize::MAX >> 3;
 
 /// Clamp a configured channel capacity into the range every driver accepts:
 /// at least 1 (tokio panics on 0) and at most
 /// [`MAX_CHANNEL_CAPACITY`] (tokio's semaphore panics above it).
-#[cfg(any(feature = "tokio-runtime", feature = "polling-client"))]
-fn clamped_channel_capacity(capacity: usize) -> usize {
+pub(crate) fn clamped_channel_capacity(capacity: usize) -> usize {
     // MAX_CHANNEL_CAPACITY is a compile-time constant >= 1, so `clamp`
     // cannot panic.
     capacity.clamp(1, MAX_CHANNEL_CAPACITY)

--- a/src/polling_client.rs
+++ b/src/polling_client.rs
@@ -258,7 +258,9 @@ impl<T: Transport> SignalFishPollingClient<T> {
         let mut client = Self {
             transport,
             cmd_queue,
-            command_capacity: config.command_channel_capacity.max(1),
+            command_capacity: crate::client::clamped_channel_capacity(
+                config.command_channel_capacity,
+            ),
             core: ClientCore::new_with_room_operation_ids(
                 config.game_data_format,
                 config.protocol_violation_policy,
@@ -4745,7 +4747,6 @@ mod tests {
         // Authenticate occupies one of the three slots.
         assert_eq!(client.max_send_capacity(), 3);
         assert_eq!(client.send_capacity(), 2);
-
         client
             .send_game_data(serde_json::json!({ "seq": 0 }))
             .unwrap();
@@ -4779,6 +4780,21 @@ mod tests {
         client
             .send_game_data(serde_json::json!({ "seq": 3 }))
             .unwrap();
+    }
+
+    #[test]
+    fn huge_command_capacity_matches_the_async_driver_clamp() {
+        // The polling queue never allocates upfront, but both drivers must
+        // report the same capacity for the same configuration: clamped to
+        // tokio's semaphore ceiling, not the raw usize::MAX.
+        let mut config = default_config();
+        config.command_channel_capacity = usize::MAX;
+        let client = SignalFishPollingClient::new(MockTransport::new(), config);
+        assert_eq!(
+            client.max_send_capacity(),
+            crate::client::clamped_channel_capacity(usize::MAX)
+        );
+        assert_eq!(client.max_send_capacity(), usize::MAX >> 3);
     }
 
     #[test]

--- a/src/token_binding.rs
+++ b/src/token_binding.rs
@@ -353,6 +353,11 @@ pub(crate) fn parse_challenge(text: &str) -> Result<TokenBindingChallenge, Signa
 
 #[cfg(feature = "token-binding")]
 fn canonical_json(value: &serde_json::Value) -> Result<Vec<u8>, SignalFishError> {
+    // Recursion depth is bounded transitively: every `Value` reaching here is
+    // parsed by serde_json's default 128-level recursion limit (the
+    // `unbounded_depth` feature is not enabled anywhere), so `write` cannot
+    // drive the stack to exhaustion regardless of input size. Keep that true:
+    // never feed hand-built deeply nested `Value`s into this function.
     fn write(value: &serde_json::Value, output: &mut Vec<u8>) -> serde_json::Result<()> {
         use serde::ser::Error as _;
         use serde_json::Value;


### PR DESCRIPTION
## Why

Round-5 adversarial audit over surfaces earlier rounds had not covered (config-builder misuse, non-fuzzed inbound parsers, docs accuracy, dependency and feature-matrix freshness). It found one real defect and several places where docs contradicted or lagged the code.

## What

- **Fix a deferred panic.** Absurdly large channel capacities (`usize::MAX`) compiled cleanly but panicked inside `SignalFishClient::start` (tokio's semaphore permit ceiling). Capacities now clamp to that ceiling at the builders, at both drivers' consumption sites, and the bounds are documented. Red/green test pins it; both drivers report identical capacities for identical configs.
- **Document edge values we verified safe but unstated:** Godot backpressure-policy extremes (watermark 0 = stop-and-wait, zero latency target, floor above ceiling), with explicit native-capacity precedence.
- **Document builder ordering:** `enable_v3` resets mesh advertisement, so call `enable_mesh` last; `with_protocol_version` defers unknown versions to the server.
- **Docs-site accuracy:** llms.txt advertised 0.8.0 as current (published to Pages); delivery guide anchored shutdown preemption to the wrong version; the wasm page lacked the new Emscripten `connect_with_options` / inbound-queue-bound guidance; `concepts.md`'s error table missed four live variants.
- **CI:** add `polling-client`-only and `mesh`-only cells to the clippy/test matrices so sparse-feature breakage cannot recur (this exact class broke during development and only these cells catch it).
- **Proof comments:** `canonical_json` recursion is transitively bounded by serde_json's 128-level parser cap (now stated in code); corrected the stale `compile_error!()` claim in Cargo.toml.

## Verification

- fmt + clippy `-D warnings` + full test suite green under all-features, no-default-features, polling-client-only, mesh-only, and token-binding-no-tls
- Two adversarial review passes converged to zero merge blockers

Continues the #126 audit series.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> The behavioral change is defensive clamping of misconfigured capacities plus docs/CI; no auth, wire, or security-path changes beyond avoiding a startup panic.
> 
> **Overview**
> Fixes a **deferred panic** when event or command channel capacities exceed tokio's semaphore ceiling (`usize::MAX >> 3`): a shared `clamped_channel_capacity` now applies at config builders, `SignalFishClient::start` (including direct field assignment), and the polling client so both drivers report the same effective limits. Tests lock in `usize::MAX` configs.
> 
> **Documentation** catches up with audited behavior: Godot `GodotBackpressurePolicy` edge cases, `enable_v3` vs `enable_mesh` builder order, four missing `SignalFishError` rows in `concepts.md`, Emscripten `connect_with_options` / inbound queue bounds on `wasm.md`, `llms.txt` release **0.10.0**, and shutdown-preemption anchored to client **0.8.0** in `delivery.md`. `Cargo.toml` clarifies the Emscripten feature gate; `canonical_json` documents serde_json recursion bounds.
> 
> **CI** adds `polling-client`-only and `mesh`-only Clippy/test matrix rows so sparse-feature builds stay covered.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8d533019ec1426df3510266a4254c0ce72839bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->