### PR TITLE
Fix retired-sender gap reuse and web close metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -212,6 +212,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed delivery accountability accepting or wrongly rejecting game data after
+  a player fully departed and later rejoined reusing an epoch value. A zero
+  terminal (`final_seq = 0`) retired the sender while exact gap ranges from
+  that player's older incarnations stayed behind; those dead ranges could then
+  "explain" a new incarnation's sequence jump as already-reported loss
+  (silently delivering a gapped stream) or collide with its first genuine
+  report as an overlapping duplicate (tearing down the connection under the
+  `Disconnect` violation policy). Full sender retirement now drops every
+  remaining range keyed to that player, so only causal reports from the live
+  incarnation are honored.
+- Fixed the Godot adapter reporting web-export abnormal terminations — server
+  death, network drops, failed handshakes — with `clean: Some(true)` close
+  metadata. Godot's web build surfaces engine-synthesized close codes (1006
+  for abnormal termination, 1015 for TLS-handshake failure) that RFC 6455
+  forbids on the wire, while native reports no code at all, so the same
+  failure produced opposite `TransportCloseInfo::clean` values per platform.
+  Observed `-1`, `1006`, and `1015` codes now classify as unclean on both
+  platforms; real CLOSE-frame codes (1000, app-defined 4xxx) remain clean.
 - Fixed a deferred panic when absurdly large channel capacities were requested
   through `SignalFishConfig::with_event_channel_capacity` /
   `with_command_channel_capacity` (or assigned to the public fields directly):

--- a/crates/signal-fish-client-godot/src/lib.rs
+++ b/crates/signal-fish-client-godot/src/lib.rs
@@ -489,7 +489,13 @@ impl GodotWebSocketTransport {
             return;
         }
         let raw_code = self.backend.close_code();
-        let clean = raw_code != -1;
+        // -1 is Godot native's "no wire CLOSE frame" value. 1006 and 1015 are
+        // the codes engines synthesize for abnormal termination and TLS
+        // handshake failure; both are forbidden on the wire by RFC 6455
+        // section 7.4.1, so observing one means no clean CLOSE handshake
+        // occurred. 1005 stays clean: it reports a real CLOSE frame that
+        // merely carried no status code.
+        let clean = raw_code != -1 && raw_code != 1006 && raw_code != 1015;
         let code = u16::try_from(raw_code).ok();
         let reason = self.backend.close_reason();
         self.close_info = Some(TransportCloseInfo {
@@ -1618,6 +1624,36 @@ mod tests {
             Poll::Ready(Err(SignalFishError::TransportClosed))
         ));
         assert!(frame.is_some());
+    }
+
+    #[test]
+    fn observed_close_codes_classify_cleanliness_data_driven() {
+        let cases = [
+            // (-1): native reports no code for every abnormal termination.
+            (-1, None, Some(false)),
+            // 1006: engines synthesize it for abnormal termination and it is
+            // forbidden on the wire (RFC 6455 section 7.4.1).
+            (1006, Some(1006), Some(false)),
+            // 1015: reserved for local TLS-handshake failure reports; also
+            // never transmitted on the wire.
+            (1015, Some(1015), Some(false)),
+            (1000, Some(1000), Some(true)),
+            (4000, Some(4000), Some(true)),
+        ];
+        for (raw_code, expected_code, expected_clean) in cases {
+            let mut backend = FakeBackend::new(PeerState::Open);
+            backend.states.push_back(PeerState::Closed);
+            backend.close_code = raw_code;
+            let mut transport = GodotWebSocketTransport::from_backend(Box::new(backend));
+
+            assert!(matches!(
+                transport.poll_recv(&mut context()),
+                Poll::Ready(None)
+            ));
+            let info = transport.close_info().expect("close metadata recorded");
+            assert_eq!(info.code, expected_code, "code for raw {raw_code}");
+            assert_eq!(info.clean, expected_clean, "clean for raw {raw_code}");
+        }
     }
 
     #[test]

--- a/src/accountability.rs
+++ b/src/accountability.rs
@@ -931,6 +931,11 @@ impl DeliveryAccountability {
         if !has_terminal && !self.announced_epochs.contains_key(&player_id) {
             self.senders.remove(&player_id);
             self.stale_senders.remove(&player_id);
+            // Full retirement leaves no live incarnation: any pending range
+            // still keyed to this player belongs to a retired incarnation and
+            // must never explain or reject a future epoch-reuse incarnation.
+            self.pending_gaps
+                .retain(|(sender, _epoch), _gaps| *sender != player_id);
         }
     }
 }
@@ -1569,6 +1574,55 @@ mod tests {
         );
         assert!(state.senders.is_empty());
         assert!(state.departed_senders.is_empty());
+    }
+
+    /// Seat churn that ends in a full sender retirement (zero terminal at the
+    /// newest announced epoch) with a pending exact range from an older
+    /// incarnation. Returns the machine and the player id for reuse.
+    fn sender_with_orphaned_gap_from_retired_incarnation() -> (DeliveryAccountability, PlayerId) {
+        let sender = id(9);
+        let mut state = DeliveryAccountability::default();
+        state.note_player_joined(&player(sender, 1)).unwrap();
+        state
+            .record_report(&DeliveryReportPayload {
+                per_class: counters_with_superseded(1),
+                gaps: vec![gap_at_epoch(sender, 1, 1, 1)],
+            })
+            .unwrap();
+        state.note_player_joined(&player(sender, 2)).unwrap();
+        state.note_player_left(sender, Some(2), Some(0)).unwrap();
+        assert!(state.senders.is_empty());
+        // Full retirement drops every range keyed to the departed sender.
+        assert!(state.pending_gaps.is_empty());
+        // The server reuses epoch value 1 for the rejoining incarnation.
+        state.note_player_joined(&player(sender, 1)).unwrap();
+        (state, sender)
+    }
+
+    #[test]
+    fn retired_incarnation_gaps_do_not_authorize_reused_epoch_data() {
+        let (mut state, sender) = sender_with_orphaned_gap_from_retired_incarnation();
+        let error = state
+            .record_game_data(sender, Some(2), Some(1), None, None)
+            .expect_err("a dead incarnation's gap must not explain a reused epoch's jump");
+        assert!(error.contains("unexplained gap"), "{error}");
+    }
+
+    #[test]
+    fn retired_incarnation_gaps_do_not_collide_with_reused_epoch_reports() {
+        let (mut state, sender) = sender_with_orphaned_gap_from_retired_incarnation();
+        state
+            .record_report(&DeliveryReportPayload {
+                per_class: counters_with_superseded(3),
+                gaps: vec![gap_at_epoch(sender, 1, 1, 2)],
+            })
+            .expect("a fresh incarnation's causal report must not hit retired ranges");
+        assert_eq!(
+            state
+                .record_game_data(sender, Some(3), Some(1), None, None)
+                .unwrap(),
+            GameDataDisposition::Apply
+        );
     }
 
     #[test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -1845,6 +1845,14 @@ async fn finish_core_shutdown(
     state: &Arc<Mutex<ClientCore>>,
     shutdown_timeout: Duration,
 ) {
+    // A single nonblocking attempt is deliberate here, not a uniformity gap
+    // with the bounded terminal-disconnect farewells: every caller reaches
+    // this function with the sticky shutdown signal already observed,
+    // including one arriving via a shutdown-preempted ordinary batch, so a
+    // bounded delivery would collapse within one poll to exactly this
+    // attempt. Starting a fresh budget instead would stack teardown time
+    // past `shutdown_timeout` — the hang class issues #141 and #149
+    // eliminated.
     let event = lock_core(state).disconnect(Some("client shut down".into()));
     let _ = event_tx.try_send(event);
     finish_send_and_close_bounded(transport, pending_send, state, shutdown_timeout).await;

--- a/src/polling_client.rs
+++ b/src/polling_client.rs
@@ -117,7 +117,8 @@ pub struct PollingStats {
     pub send_budget_exhaustions: u64,
     /// Polls that stopped because the receive frame or byte budget was exhausted.
     pub receive_budget_exhaustions: u64,
-    /// Commands abandoned by close policy or close-deadline expiry.
+    /// Commands abandoned by close policy or close-deadline expiry, plus
+    /// dequeue-time serialization failures.
     pub abandoned_commands: u64,
     /// Flush/close lifecycles aborted after the configured deadline.
     pub close_deadline_expirations: u64,


### PR DESCRIPTION
Round six of the #126 paranoid-audit series, over five fresh surfaces: time/deadline handling, async lifecycle/wakers, delivery accountability, Godot adapter runtime semantics, and stats/snapshot coherence.

## Fixed

- **Delivery accountability:** full sender retirement now drops every pending exact-gap range keyed to the departed player. A zero terminal (`final_seq = 0`) previously retired the sender but left older incarnations' gap ranges alive, so a server that reused an epoch value on rejoin let a dead range silently "explain" a new incarnation's sequence jump (gapped stream delivered as complete) or collide with its first genuine report as an overlapping duplicate (teardown under the Disconnect violation policy). Data-driven red/green tests pin both faces.
- **Godot adapter close metadata:** observed `-1`, `1006`, and `1015` close codes now classify as unclean on both platforms. Web exports surfaced engine-synthesized codes (forbidden on the wire by RFC 6455 §7.4.1) for abnormal terminations while native reported none, so the same failure produced opposite `TransportCloseInfo::clean` values and misled reconnect logic on web.

## Reviewed and deliberately unchanged

The graceful-shutdown farewell keeps its single nonblocking attempt, now with a scoped proof comment: every reachable caller arrives with the sticky shutdown signal already observed, so a bounded delivery collapses within one poll to the same attempt, and a fresh budget would stack teardown past `shutdown_timeout` (the hang class #141/#149 eliminated).

Everything else audited this round verified clean; three LOW findings became one doc fix plus two documented refusals. Mandatory workflow and all 17 pre-commit checks pass locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes delivery accountability and disconnect metadata used for violation teardown and reconnect logic; scope is targeted with new regression tests but affects protocol-v3 correctness paths.
> 
> **Overview**
> Fixes **protocol-v3 delivery accountability** when a player fully leaves and later rejoins with a **reused epoch**. A zero terminal used to retire the sender but left **pending exact-gap ranges** from older incarnations; those stale ranges could wrongly explain a new incarnation's sequence jump or collide with its first gap report. **Full sender retirement** now drops every `pending_gaps` entry keyed to that player, with tests for both failure modes.
> 
> Aligns **Godot WebSocket close metadata** across native and web: observed **`-1`**, **`1006`**, and **`1015`** now set `TransportCloseInfo::clean` to **false** (engine-synthesized / no wire CLOSE), while normal codes like **1000** and app **4xxx** stay clean. A data-driven unit test pins the mapping.
> 
> Also documents why async **`finish_core_shutdown`** keeps a single nonblocking disconnect attempt (avoids stacking past `shutdown_timeout`), and clarifies that **`PollingStats::abandoned_commands`** includes dequeue-time serialization failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af431a693016fef0b6ff1963198ffaa47138f1aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->