### PR TITLE
Fix mesh departure-race blackhole; add token-binding fuzzer

### DIFF
--- a/.github/workflows/deep-safety.yml
+++ b/.github/workflows/deep-safety.yml
@@ -168,7 +168,7 @@ jobs:
           fuzz_corpus=$(mktemp -d)
           trap 'rm -rf "$fuzz_corpus"' EXIT
           status=0
-          for target in fuzz_server_message fuzz_client_message fuzz_binary_game_data; do
+          for target in fuzz_server_message fuzz_client_message fuzz_binary_game_data fuzz_token_binding; do
             corpus="$fuzz_corpus/$target"
             mkdir -p "$corpus"
             seed_args=()

--- a/.github/workflows/deep-safety.yml
+++ b/.github/workflows/deep-safety.yml
@@ -8,7 +8,7 @@
 # Jobs:
 #   miri    — Miri undefined behavior detection (nightly, protocol tests)
 #   tsan    — ThreadSanitizer data-race detection (nightly, full workspace suite)
-#   fuzz    — Fuzz smoke tests for protocol parsing (nightly)
+#   fuzz    — Fuzz smoke tests for protocol and token-binding parsing (nightly)
 #   mutants — Mutation testing on pure-logic modules (stable)
 #
 # Schedule: Weekdays at 04:00 UTC — staggered from unused-deps (05:00)
@@ -124,14 +124,16 @@ jobs:
           cargo +nightly test -Zbuild-std --target "$host" --workspace --all-features --tests
 
   # ──────────────────────────────────────────────────────────────
-  # Fuzz — smoke test protocol parsers with random input
+  # Fuzz — smoke test protocol and token-binding parsers with random input
   #
   # Runs each fuzz target for 30 seconds to catch obvious panics
-  # or crashes in the JSON deserialization paths. This is a smoke
+  # or crashes in the deserialization paths. This is a smoke
   # test, not a deep fuzzing campaign.
   #
   # JSON targets exercise both UTF-8 and raw-byte deserialization. The binary
-  # target exercises the strict physical MessagePack envelope decoder.
+  # target exercises the strict physical MessagePack envelope decoder. The
+  # token-binding target drives challenge validation, canonicalization, and
+  # proof preparation through the internal-fuzz-facade feature.
   # ──────────────────────────────────────────────────────────────
   fuzz:
     name: Fuzz smoke tests

--- a/.llm/context.md
+++ b/.llm/context.md
@@ -136,9 +136,9 @@ The async driver polls retained sends and receives with one runtime waker, so
 outbound backpressure cannot hide inbound work, peer close, or shutdown.
 Graceful termination finishes transport-owned sends before close under one
 deadline; expiry aborts. After terminal send failure both drivers freeze command
-admission and boundedly process immediately ready frames through `ClientCore`
-until `Pending`, terminal input, work bound, protocol stop, or deadline. A ready farewell precedes
-`Disconnected`; only peer-close metadata replaces the send cause; native WebSocket retains buffered read state.
+admission and boundedly process immediately ready frames through `ClientCore` until
+`Pending`, terminal input, work bound, protocol stop, or deadline (the polling driver clamps this drain to
+its caller-configured receive budget). A ready farewell precedes `Disconnected`; only peer-close metadata replaces the send cause; native WebSocket retains buffered read state.
 
 Public `Debug`/tracing form an ambient-log boundary:
 reconnect/relay/TURN credentials, WebRTC SDP/ICE, arbitrary application data,
@@ -282,9 +282,9 @@ client.shutdown().await      // async, graceful
 ```
 
 WebRTC signaling also requires an authoritative `SessionPlan`. Server 0.7
-plans/signals carry a UUID generation; the shared core stamps outgoing signals,
-suppresses stale/unknown inbound generations, rejects self/off-plan/departed
-peers, and snapshots the generation plus selected topology/transport atomically.
+plans/signals carry a UUID generation; the core stamps outgoing signals, suppresses stale/unknown inbound
+generations plus departed/re-planned-out peers' late same-generation signals (benign races), rejects
+self/off-plan/unknown senders, and snapshots the generation plus selected topology/transport atomically.
 Accepted finalized-room, current-roster plans use one of four Server 0.7 topology/transport pairs and replace peer authority atomically; superseded non-null generations are rejected before authoritative plan fields, peers, or mesh revision change.
 Current-generation duplicates and generation-less Server 0.4 plans remain valid, while authoritative room/session teardown clears replay history.
 `supports_mesh()` reports negotiated WebRTC + Host/Mesh capability, not the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added the opt-in `internal-fuzz-facade` feature (which builds on the
+  native token-binding support) exposing a `#[doc(hidden)]`, semver-exempt
+  module that lets the repository's new `fuzz_token_binding` cargo-fuzz
+  target drive the internal challenge parsing, canonicalization, and
+  proof-preparation paths without widening the supported public API. The
+  target is wired into the Deep Safety fuzz lane with seed inputs;
+  production builds are unaffected.
 - Bounded the Emscripten WebSocket transport's callback-bridged inbound queue
   at 8 MiB by default through the new
   `EmscriptenWebSocketConnectOptions::max_inbound_queue_bytes` option and the
@@ -212,6 +219,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed a mesh-signaling availability defect where one routine departure race
+  blackholed game data for the rest of the room session. A `Signal` frame from
+  a peer the server had just dropped — via `PlayerLeft` or a same-generation
+  re-plan — could arrive after the departure was processed while still stamped
+  with the current session generation. The frame was valid when the server
+  relayed it, but the core classified it as a lifecycle integrity violation:
+  under the default `Quarantine` policy that latched quarantine and silently
+  suppressed every later game-data delivery until a reconnect, and under
+  `Disconnect` it tore the connection down entirely. Departed and
+  re-planned-out peers now join the same benign-race fence Server 0.4
+  generation-less signaling already used: their late same-generation signals
+  are suppressed silently, senders never authorized for the session remain
+  violations under every policy, and a peer named by a new plan (or a
+  compatibility `NewPeer`) is reauthorized immediately.
 - Fixed delivery accountability accepting or wrongly rejecting game data after
   a player fully departed and later rejoined reusing an epoch value. A zero
   terminal (`final_seq = 0`) retired the sender while exact gap ranges from

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,10 @@ tokio-runtime = ["tokio/rt", "tokio/time"]
 # Protocol v3 mesh orchestration helpers (MeshSession tracker + WebRtcDriver seam).
 # Pure-std, zero extra dependencies.
 mesh = []
+# Internal-only: exposes the doc(hidden) `token_binding::__internal_fuzz_facade`
+# module consumed by the repository's cargo-fuzz target. Not covered by semver;
+# production code must never enable it.
+internal-fuzz-facade = ["token-binding"]
 
 [dependencies]
 # Async

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -34,7 +34,7 @@ exhaustive public enum:
 | `SendBufferFull` | `capacity: usize` | The bounded outgoing command queue is full — the caller is producing messages faster than the transport can drain them. The message was refused, **not** queued; nothing is silently dropped. See [Handling `SendBufferFull`](#handling-sendbufferfull). |
 | `NotInRoom` | — | Attempted a room operation but the client is not in a room. |
 | `AlreadyInRoom` | — | Attempted to join as a player/spectator or reconnect while already in a room. |
-| `RoomOperationPending` | — | A previously admitted join, leave, or reconnect still awaits a matching typed terminal response. `ping` remains available; generic errors and absent responses stay fenced until transport teardown, after which a new connection may retry. |
+| `RoomOperationPending` | — | A previously admitted join, leave, or reconnect still awaits a matching typed terminal response. `ping` remains available; generic errors and absent responses stay fenced until transport teardown, after which a new connection may retry. The fence applies to undecodable responses too: an unknown `error_code` string from a newer server makes the whole frame surface as a `DecodeFailed` event, so a correlated result never releases the pending operation. |
 | `WrongRoomRole` | `required: RoomRole`, `actual: RoomRole` | Attempted a player-only command as a spectator, or `leave_spectator` as a player. |
 | `AuthorityRequired` | — | Attempted `start_game` while another player is authority, or attempted to relinquish authority without currently holding it. |
 | `ServerError` | `message: String`, `error_code: Option<ErrorCode>` | The server returned an error message. |

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -14,6 +14,7 @@ serde_json = "1.0"
 [dependencies.signal-fish-client]
 path = ".."
 default-features = false
+features = ["token-binding", "internal-fuzz-facade"]
 
 # Prevent this from interfering with workspace members.
 [workspace]
@@ -32,4 +33,9 @@ doc = false
 [[bin]]
 name = "fuzz_binary_game_data"
 path = "fuzz_targets/fuzz_binary_game_data.rs"
+doc = false
+
+[[bin]]
+name = "fuzz_token_binding"
+path = "fuzz_targets/fuzz_token_binding.rs"
 doc = false

--- a/fuzz/fuzz_targets/fuzz_token_binding.rs
+++ b/fuzz/fuzz_targets/fuzz_token_binding.rs
@@ -47,8 +47,9 @@ fn exercise_session(challenge_text: &str, payload: &[u8], fingerprint: Option<&s
         if session.prepare(&frame).is_ok() {
             let _ = session.commit();
         }
-        // A Pending or failed send must leave the sequence untouched; both
-        // retries here reuse the same sequence by construction.
+        // A failed or pending prepare leaves the sequence untouched, so this
+        // retry reuses it; after a successful commit the retry exercises the
+        // next sequence instead.
         let _ = session.prepare(&frame);
     }
 }

--- a/fuzz/fuzz_targets/fuzz_token_binding.rs
+++ b/fuzz/fuzz_targets/fuzz_token_binding.rs
@@ -1,0 +1,77 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use signal_fish_client::token_binding::__internal_fuzz_facade as facade;
+use signal_fish_client::transport::TransportFrame;
+
+// A valid 32-byte nonce (bytes 0x00..=0x1f) and a valid 16-byte RFC 6455
+// handshake key keep the fuzzer past the shape/type/length frontier from its
+// first iteration. Perturbed inputs then explore the strict validation
+// branches of every parse path.
+const CHALLENGE: &[u8] =
+    br#"{"type":"TokenBindingChallenge","data":{"version":2,"scheme":"server_nonce_hkdf_sha256","nonce":"AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8=","first_sequence":1}}"#;
+const HANDSHAKE_KEY: &str = "dGhlIHNhbXBsZSBub25jZQ==";
+const FINGERPRINT: &str =
+    "aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99:aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99";
+
+fn perturb(canonical: &[u8], input: &[u8]) -> Vec<u8> {
+    let mut candidate = canonical.to_vec();
+    for (index, byte) in input.iter().enumerate() {
+        let slot = index % candidate.len();
+        candidate[slot] ^= byte;
+    }
+    candidate
+}
+
+fn exercise_challenge(text: &str) -> Option<signal_fish_client::token_binding::TokenBindingChallenge> {
+    match facade::parse_challenge(text) {
+        Ok(challenge) => Some(challenge),
+        Err(_) => None,
+    }
+}
+
+fn exercise_session(challenge_text: &str, payload: &[u8], fingerprint: Option<&str>) {
+    let Some(challenge) = exercise_challenge(challenge_text) else {
+        return;
+    };
+    let Ok(mut session) = facade::FuzzSession::from_challenge(
+        HANDSHAKE_KEY,
+        challenge,
+        fingerprint,
+    ) else {
+        return;
+    };
+    let text_frame = TransportFrame::Text(String::from_utf8_lossy(payload).into_owned());
+    let binary_frame = TransportFrame::Binary(payload.to_vec());
+    for frame in [text_frame, binary_frame] {
+        if session.prepare(&frame).is_ok() {
+            let _ = session.commit();
+        }
+        // A Pending or failed send must leave the sequence untouched; both
+        // retries here reuse the same sequence by construction.
+        let _ = session.prepare(&frame);
+    }
+}
+
+fuzz_target!(|input: &[u8]| {
+    let lossy = String::from_utf8_lossy(input);
+
+    // Raw bytes as challenge text plus perturbed valid challenges.
+    let _ = exercise_challenge(&lossy);
+    let perturbed_bytes = perturb(CHALLENGE, input);
+    let perturbed = String::from_utf8_lossy(&perturbed_bytes).into_owned();
+    let _ = exercise_challenge(&perturbed);
+
+    // Canonical JSON rendering over arbitrary parsed values.
+    if let Ok(value) = serde_json::from_slice::<serde_json::Value>(input) {
+        let _ = facade::canonical_json(&value);
+    }
+
+    // Session derivation plus prepare/commit cycles with and without an
+    // optional client-certificate fingerprint claim. The unperturbed
+    // challenge guarantees derived sessions; the perturbed one lets hostile
+    // challenges reach session construction whenever validation permits.
+    let canonical_challenge = String::from_utf8_lossy(CHALLENGE).into_owned();
+    exercise_session(&canonical_challenge, input, None);
+    exercise_session(&perturbed, input, Some(FINGERPRINT));
+});

--- a/fuzz/seeds/fuzz_token_binding/bad_version_and_sequence
+++ b/fuzz/seeds/fuzz_token_binding/bad_version_and_sequence
@@ -1,0 +1,1 @@
+{"type":"TokenBindingChallenge","data":{"version":1,"scheme":"server_nonce_hkdf_sha256","nonce":"AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8=","first_sequence":2}}

--- a/fuzz/seeds/fuzz_token_binding/extra_field_bad_scheme
+++ b/fuzz/seeds/fuzz_token_binding/extra_field_bad_scheme
@@ -1,0 +1,1 @@
+{"type":"TokenBindingChallenge","data":{"version":2,"scheme":"other","nonce":"!!!not-base64!!!","first_sequence":1},"extra":true}

--- a/fuzz/seeds/fuzz_token_binding/valid_challenge
+++ b/fuzz/seeds/fuzz_token_binding/valid_challenge
@@ -1,0 +1,1 @@
+{"type":"TokenBindingChallenge","data":{"version":2,"scheme":"server_nonce_hkdf_sha256","nonce":"AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8=","first_sequence":1}}

--- a/src/client.rs
+++ b/src/client.rs
@@ -1048,6 +1048,14 @@ impl SignalFishClient {
     /// the command nor mutates any state, and the operation is admitted at
     /// most once per awaited completion.
     ///
+    /// # Multiple parked senders
+    ///
+    /// Several tasks may await reliable sends concurrently. Freed queue slots
+    /// are granted to parked senders first-in-first-out by park order, one
+    /// sender per slot, so no waiter starves while the loop runs. When the
+    /// transport loop exits, every still-parked sender resolves with
+    /// [`SignalFishError::NotConnected`] instead of hanging.
+    ///
     /// # Errors
     ///
     /// Returns the membership errors documented by
@@ -6168,6 +6176,180 @@ mod tests {
             })
             .collect();
         assert_eq!(names, expected, "wedged delivery must preserve order");
+    }
+
+    /// Several tasks may park on reliable sends at once. Freed queue capacity
+    /// must wake them first-in-first-out (exactly one grant per slot), and
+    /// `shutdown()` must resolve every still-parked sender with
+    /// [`SignalFishError::NotConnected`] instead of hanging any of them.
+    #[tokio::test]
+    async fn multiple_parked_reliable_senders_wake_in_order_and_release_on_shutdown() {
+        // Two permits let Authenticate and JoinRoom reach the wire; every
+        // later frame stalls inside the transport so the command queue stays
+        // saturated and reliable senders park on reserve.
+        let (transport, _sent, _closed, controls, gate, frames_taken) =
+            MockTransport::new_send_gated(
+                vec![
+                    Some(Ok(authenticated_json())),
+                    Some(Ok(protocol_info_v2_json())),
+                    Some(Ok(room_joined_json())),
+                ],
+                2,
+            );
+        let config = SignalFishConfig::new("mb_test")
+            .with_event_channel_capacity(16)
+            .with_command_channel_capacity(2)
+            .with_shutdown_timeout(std::time::Duration::from_millis(500));
+        let (mut client, _events) = SignalFishClient::start(transport, config);
+
+        let give_up = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
+        while !client.is_authenticated() {
+            assert!(
+                tokio::time::Instant::now() < give_up,
+                "the scripted handshake never authenticated"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+        }
+        client
+            .join_room(JoinRoomParams::new("test-game", "local"))
+            .expect("join must be admitted once authenticated");
+        while client.current_room_id().await.is_none() {
+            assert!(
+                tokio::time::Instant::now() < give_up,
+                "the scripted room baseline never landed"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+        }
+
+        // Saturate the capacity-2 command queue behind the stalled transport:
+        // once the first ping is stranded inside the gated transport, the
+        // next two occupy both queue slots.
+        client
+            .ping()
+            .expect("first ping strands inside the stalled transport");
+        wait_until(|| frames_taken.load(Ordering::Acquire) >= 3).await;
+        client.ping().expect("queue slot one");
+        client.ping().expect("queue slot two");
+
+        let client = Arc::new(client);
+        let mut parked = Vec::new();
+        for tag in 1_usize..=3 {
+            let sender = Arc::clone(&client);
+            parked.push(tokio::spawn(async move {
+                let result = sender
+                    .send_game_data_reliable(serde_json::json!({ "tag": tag }))
+                    .await;
+                (tag, result)
+            }));
+        }
+        for task in parked.iter_mut() {
+            assert!(
+                tokio::time::timeout(std::time::Duration::from_millis(100), task)
+                    .await
+                    .is_err(),
+                "no reliable sender may finish while the queue is saturated"
+            );
+        }
+
+        // One freed transport slot drains exactly one queued command, which
+        // frees exactly one queue slot: only the first-parked sender may
+        // complete.
+        gate.add_permits(1);
+        let mut granted_tags = Vec::new();
+        for task in parked.iter_mut() {
+            if let Ok(outcome) =
+                tokio::time::timeout(std::time::Duration::from_millis(300), task).await
+            {
+                let (tag, result) = outcome.expect("granted sender task must not panic");
+                assert!(
+                    result.is_ok(),
+                    "the granted sender must succeed: {result:?}"
+                );
+                granted_tags.push(tag);
+            }
+        }
+        assert_eq!(
+            granted_tags,
+            vec![1_usize],
+            "the first-parked sender must receive the single freed slot; others stay parked"
+        );
+
+        // Terminal peer close drops the command receiver: every still-parked
+        // sender resolves with NotConnected instead of hanging.
+        controls.close_peer();
+        for tag in [2_usize, 3] {
+            let index = tag - 1;
+            let outcome =
+                tokio::time::timeout(std::time::Duration::from_secs(2), &mut parked[index])
+                    .await
+                    .expect("terminal close must release every parked sender")
+                    .expect("parked sender task should not panic");
+            let (resolved_tag, result) = outcome;
+            assert_eq!(resolved_tag, tag);
+            assert!(
+                matches!(result, Err(SignalFishError::NotConnected)),
+                "parked sender {tag} must fail cleanly on loop exit: {result:?}"
+            );
+        }
+    }
+
+    /// A dropped event receiver must not wedge or spin the transport loop:
+    /// scripted inbound traffic keeps landing and later commands keep flowing,
+    /// and a subsequent graceful shutdown completes cleanly.
+    #[tokio::test]
+    async fn dropped_event_receiver_keeps_the_loop_alive_until_shutdown() {
+        let (transport, sent, closed) = MockTransport::new(vec![
+            Some(Ok(authenticated_json())),
+            Some(Ok(protocol_info_v2_json())),
+            Some(Ok(room_joined_json())),
+        ]);
+        let config = SignalFishConfig::new("mb_test")
+            .with_event_channel_capacity(8)
+            .with_shutdown_timeout(std::time::Duration::from_millis(500));
+        let (mut client, events) = SignalFishClient::start(transport, config);
+
+        let give_up = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        while !client.is_authenticated() {
+            assert!(
+                give_up.elapsed() < std::time::Duration::from_secs(2),
+                "the scripted handshake never authenticated"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+        }
+        drop(events);
+
+        client
+            .join_room(JoinRoomParams::new("test-game", "local"))
+            .expect("join must be admitted once authenticated");
+        while client.current_room_id().await.is_none() {
+            assert!(
+                give_up.elapsed() < std::time::Duration::from_secs(2),
+                "the loop stopped servicing inbound frames after the receiver was dropped"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+        }
+
+        for _ in 0..2 {
+            client
+                .ping()
+                .expect("commands keep flowing without a receiver");
+        }
+        wait_until(|| {
+            sent.lock()
+                .unwrap()
+                .iter()
+                .filter(|message| {
+                    serde_json::from_str::<ClientMessage>(message)
+                        .is_ok_and(|m| matches!(m, ClientMessage::Ping))
+                })
+                .count()
+                >= 2
+        })
+        .await;
+
+        client.shutdown().await;
+        assert!(!client.is_connected());
+        assert!(closed.load(Ordering::Relaxed));
     }
 
     /// A receive error wedges terminal delivery exactly like a clean close:

--- a/src/client.rs
+++ b/src/client.rs
@@ -6257,8 +6257,7 @@ mod tests {
         gate.add_permits(1);
         let mut granted_tags = Vec::new();
         for task in parked.iter_mut() {
-            if let Ok(outcome) =
-                tokio::time::timeout(std::time::Duration::from_millis(300), task).await
+            if let Ok(outcome) = tokio::time::timeout(std::time::Duration::from_secs(2), task).await
             {
                 let (tag, result) = outcome.expect("granted sender task must not panic");
                 assert!(

--- a/src/client_core.rs
+++ b/src/client_core.rs
@@ -1541,8 +1541,10 @@ impl ClientCore {
             // generation: a departed or re-planned-out peer's final signals
             // were valid when the server relayed them and merely raced this
             // client's view of the departure, whatever transport now carries
-            // the stream. The window extends through a roster rejoin until
-            // the peer is re-paired by a plan or compatibility `NewPeer`.
+            // the stream — gating on the current transport would re-open the
+            // relay-fallback race this fence closes. The window extends
+            // through a roster rejoin until the peer is re-paired by a plan
+            // or compatibility `NewPeer`.
             Some(_) => {
                 self.retired_signal_peers.contains(&from) && !self.session_peers.contains(&from)
             }

--- a/src/client_core.rs
+++ b/src/client_core.rs
@@ -1901,11 +1901,18 @@ impl ClientCore {
             self.retired_signal_peers.clear();
         }
         let peers: HashSet<_> = peers.into_iter().collect();
-        if self.session_plan_seen && self.snapshot.session_transport == Some(TransportKind::WebRtc)
+        if self.session_plan_seen
+            && self.snapshot.session_generation == generation
+            && self.snapshot.session_transport == Some(TransportKind::WebRtc)
         {
-            // Peers dropped by the replacement plan may still have signals in
-            // flight stamped with a still-live generation; retire them so
-            // those final frames stay benign races.
+            // Peers dropped by a same-generation replacement may still have
+            // signals in flight stamped with that still-live generation;
+            // retire them so those final frames stay benign races. A
+            // generation change must not carry retirement across: dropped
+            // peers never held authority under the new generation, so their
+            // current-generation signals are genuine violations while their
+            // superseded-generation frames already die in the generation
+            // check.
             self.retired_signal_peers.extend(
                 self.session_peers
                     .iter()
@@ -5175,6 +5182,52 @@ mod tests {
             outcome.events.as_slice(),
             [SignalFishEvent::SignalReceived { .. }]
         ));
+    }
+
+    /// A generation-changing plan must not carry peer retirement into the
+    /// new generation: dropped peers never held authority under it, so their
+    /// current-generation signals are genuine violations (their
+    /// superseded-generation frames still die in the generation check).
+    #[test]
+    fn generation_change_does_not_carry_retirement_to_the_new_generation() {
+        let mut core = v3_room(ProtocolViolationPolicy::Quarantine);
+        let _ = process(
+            &mut core,
+            ServerMessage::SessionPlan(Box::new(plan(Topology::Mesh, TransportKind::WebRtc))),
+        );
+        assert!(core.retired_signal_peers.is_empty());
+
+        let mut replanned = plan(Topology::Mesh, TransportKind::WebRtc);
+        replanned.generation = Some(SessionGeneration::from_u128(GENERATION + 1));
+        replanned.peers.clear();
+        let _ = process(&mut core, ServerMessage::SessionPlan(Box::new(replanned)));
+        // The generation change clears retirements without re-retiring the
+        // dropped peer under the new generation.
+        assert!(core.retired_signal_peers.is_empty());
+
+        // A stale superseded-generation frame stays a benign race.
+        let stale = process(
+            &mut core,
+            ServerMessage::Signal {
+                from: PlayerId::from_u128(PEER),
+                generation: Some(SessionGeneration::from_u128(GENERATION)),
+                signal: serde_json::json!({"Offer": "superseded"}),
+            },
+        );
+        assert!(stale.events.is_empty(), "{:#?}", stale.events);
+
+        // A current-generation signal from a sender who never held this
+        // generation's authority is a violation, not silent suppression.
+        let outcome = process(
+            &mut core,
+            ServerMessage::Signal {
+                from: PlayerId::from_u128(PEER),
+                generation: Some(SessionGeneration::from_u128(GENERATION + 1)),
+                signal: serde_json::json!({"Offer": "never-authorized-here"}),
+            },
+        );
+        assert_lifecycle_violation(&outcome);
+        assert!(core.snapshot().quarantined);
     }
 
     #[test]

--- a/src/client_core.rs
+++ b/src/client_core.rs
@@ -138,7 +138,9 @@ pub(crate) struct ClientCore {
     // replacement) whose final in-flight signals may still arrive stamped
     // with the still-current generation. Their late signals are benign
     // races to suppress, not integrity violations. Cleared whenever an
-    // authoritative baseline rebuilds the room/session.
+    // authoritative baseline rebuilds the room/session; within one room the
+    // bound is O(distinct departed peers between generation bumps), because
+    // Server 0.7 re-plans on membership churn.
     retired_signal_peers: HashSet<PlayerId>,
     pending_room_operation: Option<PendingRoomOperationState>,
     pending_reconnects: VecDeque<PendingReconnect>,
@@ -1539,7 +1541,8 @@ impl ClientCore {
             // generation: a departed or re-planned-out peer's final signals
             // were valid when the server relayed them and merely raced this
             // client's view of the departure, whatever transport now carries
-            // the stream.
+            // the stream. The window extends through a roster rejoin until
+            // the peer is re-paired by a plan or compatibility `NewPeer`.
             Some(_) => {
                 self.retired_signal_peers.contains(&from) && !self.session_peers.contains(&from)
             }

--- a/src/client_core.rs
+++ b/src/client_core.rs
@@ -134,7 +134,12 @@ pub(crate) struct ClientCore {
     session_plan_seen: bool,
     session_peers: HashSet<PlayerId>,
     retired_session_generations: HashSet<SessionGeneration>,
-    retired_generationless_signal_peers: HashSet<PlayerId>,
+    // Peers the authoritative plan dropped (via `PlayerLeft` or a plan
+    // replacement) whose final in-flight signals may still arrive stamped
+    // with the still-current generation. Their late signals are benign
+    // races to suppress, not integrity violations. Cleared whenever an
+    // authoritative baseline rebuilds the room/session.
+    retired_signal_peers: HashSet<PlayerId>,
     pending_room_operation: Option<PendingRoomOperationState>,
     pending_reconnects: VecDeque<PendingReconnect>,
     #[cfg(feature = "tokio-runtime")]
@@ -238,7 +243,7 @@ impl ClientCore {
             session_plan_seen: false,
             session_peers: HashSet::new(),
             retired_session_generations: HashSet::new(),
-            retired_generationless_signal_peers: HashSet::new(),
+            retired_signal_peers: HashSet::new(),
             pending_room_operation: None,
             pending_reconnects: VecDeque::new(),
             #[cfg(feature = "tokio-runtime")]
@@ -718,7 +723,7 @@ impl ClientCore {
         self.session_plan_seen = false;
         self.session_peers.clear();
         self.retired_session_generations.clear();
-        self.retired_generationless_signal_peers.clear();
+        self.retired_signal_peers.clear();
         self.pending_room_operation = None;
         self.pending_reconnects.clear();
         #[cfg(feature = "tokio-runtime")]
@@ -1518,14 +1523,27 @@ impl ClientCore {
         from: PlayerId,
         generation: Option<SessionGeneration>,
     ) -> bool {
-        generation != self.snapshot.session_generation
+        if generation != self.snapshot.session_generation {
+            return true;
+        }
+        match self.snapshot.session_generation {
             // Server 0.4 omitted generations. Retained peer identity is the
-            // only fence for a signal racing a generation-less re-plan.
-            || (generation.is_none()
-                && self.snapshot.session_generation.is_none()
-                && self.retired_generationless_signal_peers.contains(&from)
-                && !(self.snapshot.session_transport == Some(TransportKind::WebRtc)
-                    && self.session_peers.contains(&from)))
+            // only fence for a signal racing a generation-less re-plan, so
+            // retirement persists for the whole room session.
+            None => {
+                self.retired_signal_peers.contains(&from)
+                    && !(self.snapshot.session_transport == Some(TransportKind::WebRtc)
+                        && self.session_peers.contains(&from))
+            }
+            // Generation-carrying sessions bound retirement to the live
+            // generation: a departed or re-planned-out peer's final signals
+            // were valid when the server relayed them and merely raced this
+            // client's view of the departure, whatever transport now carries
+            // the stream.
+            Some(_) => {
+                self.retired_signal_peers.contains(&from) && !self.session_peers.contains(&from)
+            }
+        }
     }
 
     fn validate_reconnect_replay(
@@ -1782,21 +1800,16 @@ impl ClientCore {
             }
             ServerMessage::NewPeer { peer_id, .. } => {
                 self.session_peers.insert(*peer_id);
-                if self.snapshot.session_generation.is_none()
-                    && self.snapshot.session_transport == Some(TransportKind::WebRtc)
-                {
-                    self.retired_generationless_signal_peers.remove(peer_id);
-                }
+                self.retired_signal_peers.remove(peer_id);
             }
             ServerMessage::PlayerLeft { player_id, .. } => {
                 if self.authority_player == Some(*player_id) {
                     self.authority_player = None;
                 }
-                if self.snapshot.session_generation.is_none()
-                    && self.snapshot.session_transport == Some(TransportKind::WebRtc)
+                if self.snapshot.session_transport == Some(TransportKind::WebRtc)
                     && self.session_peers.contains(player_id)
                 {
-                    self.retired_generationless_signal_peers.insert(*player_id);
+                    self.retired_signal_peers.insert(*player_id);
                 }
                 self.session_peers.remove(player_id);
                 self.room_players.remove(player_id);
@@ -1838,7 +1851,7 @@ impl ClientCore {
         self.session_plan_seen = false;
         self.session_peers.clear();
         self.retired_session_generations.clear();
-        self.retired_generationless_signal_peers.clear();
+        self.retired_signal_peers.clear();
         self.pending_room_operation = None;
         #[cfg(feature = "tokio-runtime")]
         self.advance_room_revision();
@@ -1861,7 +1874,7 @@ impl ClientCore {
         self.session_plan_seen = false;
         self.session_peers.clear();
         self.retired_session_generations.clear();
-        self.retired_generationless_signal_peers.clear();
+        self.retired_signal_peers.clear();
         self.pending_room_operation = None;
         #[cfg(feature = "tokio-runtime")]
         self.advance_room_revision();
@@ -1878,19 +1891,26 @@ impl ClientCore {
             if let Some(current) = self.snapshot.session_generation {
                 self.retired_session_generations.insert(current);
             }
-        }
-        if self.session_plan_seen
-            && self.snapshot.session_generation.is_none()
-            && self.snapshot.session_transport == Some(TransportKind::WebRtc)
-        {
-            self.retired_generationless_signal_peers
-                .extend(self.session_peers.iter().copied());
+            // Peer retirements were scoped to the superseded generation;
+            // its signals now die in the generation check alone.
+            self.retired_signal_peers.clear();
         }
         let peers: HashSet<_> = peers.into_iter().collect();
-        if generation.is_none() && transport == TransportKind::WebRtc {
-            self.retired_generationless_signal_peers
-                .retain(|peer| !peers.contains(peer));
+        if self.session_plan_seen && self.snapshot.session_transport == Some(TransportKind::WebRtc)
+        {
+            // Peers dropped by the replacement plan may still have signals in
+            // flight stamped with a still-live generation; retire them so
+            // those final frames stay benign races.
+            self.retired_signal_peers.extend(
+                self.session_peers
+                    .iter()
+                    .filter(|peer| !peers.contains(*peer))
+                    .copied(),
+            );
         }
+        // Every peer named by the new plan is live again.
+        self.retired_signal_peers
+            .retain(|peer| !peers.contains(peer));
         self.snapshot.session_generation = generation;
         self.snapshot.session_topology = Some(topology);
         self.snapshot.session_transport = Some(transport);
@@ -4738,7 +4758,7 @@ mod tests {
     }
 
     #[test]
-    fn invalid_reconnect_accountability_never_resets_the_existing_frontier() {
+    fn in_room_reconnect_violation_preserves_the_existing_frontier() {
         for policy in [
             ProtocolViolationPolicy::Quarantine,
             ProtocolViolationPolicy::Disconnect,
@@ -4951,6 +4971,268 @@ mod tests {
     }
 
     #[test]
+    fn departed_peer_inflight_signal_is_a_suppressed_race_under_every_policy() {
+        const LIVE_PEER: u128 = 4;
+        let player_left = ServerMessage::PlayerLeft {
+            player_id: PlayerId::from_u128(PEER),
+            epoch: Some(1),
+            final_seq: Some(1),
+        };
+        let departed_signal = ServerMessage::Signal {
+            from: PlayerId::from_u128(PEER),
+            generation: Some(SessionGeneration::from_u128(GENERATION)),
+            signal: serde_json::json!({"Answer": "queued-before-departure"}),
+        };
+        let live_signal = || ServerMessage::Signal {
+            from: PlayerId::from_u128(LIVE_PEER),
+            generation: Some(SessionGeneration::from_u128(GENERATION)),
+            signal: serde_json::json!({"Offer": "still-live"}),
+        };
+        for policy in [
+            ProtocolViolationPolicy::Quarantine,
+            ProtocolViolationPolicy::Disconnect,
+            ProtocolViolationPolicy::Observe,
+        ] {
+            for player_left_first in [true, false] {
+                let mut core = v3_room(policy);
+                let mut webrtc = plan(Topology::Mesh, TransportKind::WebRtc);
+                webrtc.peers.push(peer(LIVE_PEER));
+                let _ = process(&mut core, ServerMessage::SessionPlan(Box::new(webrtc)));
+                // PEER was an active sender whose final frames raced our
+                // view of its departure.
+                let _ = process(
+                    &mut core,
+                    ServerMessage::GameData {
+                        from_player: PlayerId::from_u128(PEER),
+                        data: serde_json::json!({"seq": 1}),
+                        seq: Some(1),
+                        epoch: Some(1),
+                        class: Some(DeliveryClass::Reliable),
+                        key: None,
+                    },
+                );
+
+                if player_left_first {
+                    let _ = process(&mut core, player_left.clone());
+                    assert!(core
+                        .retired_signal_peers
+                        .contains(&PlayerId::from_u128(PEER)));
+                    let outcome = process(&mut core, departed_signal.clone());
+                    assert!(
+                        outcome.events.is_empty(),
+                        "{policy:?}: {:#?}",
+                        outcome.events
+                    );
+                    assert!(!outcome.disconnect, "{policy:?}");
+                    assert!(!core.snapshot().quarantined, "{policy:?}");
+                } else {
+                    let outcome = process(&mut core, departed_signal.clone());
+                    assert!(
+                        matches!(
+                            outcome.events.as_slice(),
+                            [SignalFishEvent::SignalReceived { .. }]
+                        ),
+                        "{policy:?}: {:#?}",
+                        outcome.events
+                    );
+                    let _ = process(&mut core, player_left.clone());
+                }
+
+                // The session stays healthy either way: a current-generation
+                // signal from a still-rostered peer is delivered and no
+                // quarantine latched over the relay floor.
+                let outcome = process(&mut core, live_signal());
+                assert!(
+                    matches!(
+                        outcome.events.as_slice(),
+                        [SignalFishEvent::SignalReceived { .. }]
+                    ),
+                    "{policy:?}: {:#?}",
+                    outcome.events
+                );
+                assert!(!core.snapshot().quarantined, "{policy:?}");
+            }
+        }
+    }
+
+    #[test]
+    fn same_generation_plan_replacement_suppresses_dropped_peer_signals() {
+        const LIVE_PEER: u128 = 4;
+        for policy in [
+            ProtocolViolationPolicy::Quarantine,
+            ProtocolViolationPolicy::Disconnect,
+            ProtocolViolationPolicy::Observe,
+        ] {
+            let mut core = v3_room(policy);
+            let mut webrtc = plan(Topology::Mesh, TransportKind::WebRtc);
+            webrtc.peers.push(peer(LIVE_PEER));
+            let _ = process(&mut core, ServerMessage::SessionPlan(Box::new(webrtc)));
+
+            let mut replanned = plan(Topology::Mesh, TransportKind::WebRtc);
+            replanned.peers = vec![peer(LIVE_PEER)];
+            let _ = process(&mut core, ServerMessage::SessionPlan(Box::new(replanned)));
+            assert!(core
+                .retired_signal_peers
+                .contains(&PlayerId::from_u128(PEER)));
+
+            let dropped = process(
+                &mut core,
+                ServerMessage::Signal {
+                    from: PlayerId::from_u128(PEER),
+                    generation: Some(SessionGeneration::from_u128(GENERATION)),
+                    signal: serde_json::json!({"IceCandidate": "in-flight"}),
+                },
+            );
+            assert!(dropped.events.is_empty(), "{policy:?}");
+            assert!(!dropped.disconnect, "{policy:?}");
+            let retained = process(
+                &mut core,
+                ServerMessage::Signal {
+                    from: PlayerId::from_u128(LIVE_PEER),
+                    generation: Some(SessionGeneration::from_u128(GENERATION)),
+                    signal: serde_json::json!({"Offer": "retained"}),
+                },
+            );
+            assert!(
+                matches!(
+                    retained.events.as_slice(),
+                    [SignalFishEvent::SignalReceived { .. }]
+                ),
+                "{policy:?}: {:#?}",
+                retained.events
+            );
+        }
+    }
+
+    #[test]
+    fn new_peer_reauthorization_clears_departure_retirement_for_current_generation() {
+        let mut core = v3_room(ProtocolViolationPolicy::Observe);
+        let _ = process(
+            &mut core,
+            ServerMessage::SessionPlan(Box::new(plan(Topology::Mesh, TransportKind::WebRtc))),
+        );
+        let _ = process(
+            &mut core,
+            ServerMessage::GameData {
+                from_player: PlayerId::from_u128(PEER),
+                data: serde_json::json!({"seq": 1}),
+                seq: Some(1),
+                epoch: Some(1),
+                class: Some(DeliveryClass::Reliable),
+                key: None,
+            },
+        );
+        let _ = process(
+            &mut core,
+            ServerMessage::PlayerLeft {
+                player_id: PlayerId::from_u128(PEER),
+                epoch: Some(1),
+                final_seq: Some(1),
+            },
+        );
+        assert!(core
+            .retired_signal_peers
+            .contains(&PlayerId::from_u128(PEER)));
+
+        let _ = process(
+            &mut core,
+            ServerMessage::PlayerJoined {
+                player: PlayerInfo {
+                    id: PlayerId::from_u128(PEER),
+                    name: "peer".into(),
+                    is_authority: false,
+                    is_ready: false,
+                    connected_at: "2026-01-01T00:00:00Z".into(),
+                    connection_info: None,
+                    epoch: Some(2),
+                    seq: Some(0),
+                },
+            },
+        );
+        let _ = process(
+            &mut core,
+            ServerMessage::NewPeer {
+                peer_id: PlayerId::from_u128(PEER),
+                you_initiate: true,
+            },
+        );
+        assert!(core.retired_signal_peers.is_empty());
+
+        let outcome = process(
+            &mut core,
+            ServerMessage::Signal {
+                from: PlayerId::from_u128(PEER),
+                generation: Some(SessionGeneration::from_u128(GENERATION)),
+                signal: serde_json::json!({"Offer": "rejoined"}),
+            },
+        );
+        assert!(matches!(
+            outcome.events.as_slice(),
+            [SignalFishEvent::SignalReceived { .. }]
+        ));
+    }
+
+    #[test]
+    fn unknown_sender_signal_after_departure_remains_a_lifecycle_violation() {
+        for policy in [
+            ProtocolViolationPolicy::Quarantine,
+            ProtocolViolationPolicy::Disconnect,
+            ProtocolViolationPolicy::Observe,
+        ] {
+            let mut core = v3_room(policy);
+            let _ = process(
+                &mut core,
+                ServerMessage::SessionPlan(Box::new(plan(Topology::Mesh, TransportKind::WebRtc))),
+            );
+            let _ = process(
+                &mut core,
+                ServerMessage::GameData {
+                    from_player: PlayerId::from_u128(PEER),
+                    data: serde_json::json!({"seq": 1}),
+                    seq: Some(1),
+                    epoch: Some(1),
+                    class: Some(DeliveryClass::Reliable),
+                    key: None,
+                },
+            );
+            let _ = process(
+                &mut core,
+                ServerMessage::PlayerLeft {
+                    player_id: PlayerId::from_u128(PEER),
+                    epoch: Some(1),
+                    final_seq: Some(1),
+                },
+            );
+
+            let outcome = process(
+                &mut core,
+                ServerMessage::Signal {
+                    from: PlayerId::from_u128(3),
+                    generation: Some(SessionGeneration::from_u128(GENERATION)),
+                    signal: serde_json::json!({"Offer": "never-authorized"}),
+                },
+            );
+            assert_lifecycle_violation_containing(
+                &outcome,
+                "not in the authoritative session peer set",
+            );
+            match policy {
+                ProtocolViolationPolicy::Quarantine => {
+                    assert!(core.snapshot().quarantined);
+                    assert!(!outcome.disconnect);
+                }
+                ProtocolViolationPolicy::Disconnect => {
+                    assert!(outcome.disconnect);
+                }
+                ProtocolViolationPolicy::Observe => {
+                    assert!(!core.snapshot().quarantined);
+                    assert!(!outcome.disconnect);
+                }
+            }
+        }
+    }
+
+    #[test]
     fn generationless_webrtc_updates_reauthorize_a_retired_peer() {
         let mut core = v3_room(ProtocolViolationPolicy::Observe);
         let mut webrtc = plan(Topology::Mesh, TransportKind::WebRtc);
@@ -4982,7 +5264,7 @@ mod tests {
         webrtc.peers.clear();
         let _ = process(&mut core, ServerMessage::SessionPlan(Box::new(webrtc)));
         assert!(core
-            .retired_generationless_signal_peers
+            .retired_signal_peers
             .contains(&PlayerId::from_u128(PEER)));
         let _ = process(
             &mut core,
@@ -5014,7 +5296,7 @@ mod tests {
         let mut relay = plan(Topology::Relay, TransportKind::Relay);
         relay.generation = None;
         let _ = process(&mut core, ServerMessage::SessionPlan(Box::new(relay)));
-        assert!(!core.retired_generationless_signal_peers.is_empty());
+        assert!(!core.retired_signal_peers.is_empty());
         assert_eq!(core.snapshot().session_topology, Some(Topology::Relay));
         assert_eq!(
             core.snapshot().session_transport,
@@ -5023,7 +5305,7 @@ mod tests {
 
         core.record_admission(ClientCore::admission_for(&ClientOperation::LeaveRoom));
         let _ = process(&mut core, ServerMessage::RoomLeft);
-        assert!(core.retired_generationless_signal_peers.is_empty());
+        assert!(core.retired_signal_peers.is_empty());
         assert!(core.snapshot().session_topology.is_none());
         assert!(core.snapshot().session_transport.is_none());
 

--- a/src/mesh.rs
+++ b/src/mesh.rs
@@ -143,6 +143,12 @@ impl MeshSession {
                 }
                 // Only mutate liveness; never invent a peer the server's plan
                 // didn't include.
+                //
+                // `PeerTransportStatus` carries no generation, so a status
+                // relayed before a re-plan can land just after it and refresh
+                // a pre-handshake view. That is inherent last-known-liveness
+                // staleness, bounded by the next report; the controller's own
+                // driver-driven view stays generation-exact.
                 if let Some(p) = self.peers.iter_mut().find(|p| p.player_id == *peer_id) {
                     let changed = p.connected != *connected;
                     p.connected = *connected;

--- a/src/polling_client.rs
+++ b/src/polling_client.rs
@@ -950,6 +950,11 @@ impl<T: Transport> SignalFishPollingClient<T> {
     /// [`PollingClosePolicy`] either abandons client-owned work or flushes it
     /// under the normal work budget before starting the transport close.
     /// [`SignalFishConfig::shutdown_timeout`] bounds the complete operation.
+    ///
+    /// Unlike the async driver's `shutdown()`, `close` emits **no** terminal
+    /// `Disconnected` event and no application events at all: observe
+    /// completion through [`snapshot`](Self::snapshot) instead of waiting on
+    /// the event stream.
     pub fn close(&mut self) {
         self.close_at(Instant::now());
     }

--- a/src/token_binding.rs
+++ b/src/token_binding.rs
@@ -705,6 +705,24 @@ mod tests {
         assert_ne!(wire_order, std::str::from_utf8(&canonical).unwrap());
     }
 
+    /// Pin string-value escaping to the ECMAScript/JCS set the server's
+    /// canonicalizer implements: short escapes for `\b\t\n\f\r`, lowercase
+    /// `\u00xx` for the remaining control characters below 0x20, and raw
+    /// UTF-8 for DEL and all non-ASCII scalar values. The golden vectors only
+    /// exercise ASCII values, so this test is the parity pin for the rest.
+    #[test]
+    fn canonical_json_escapes_control_and_non_ascii_values_like_the_server() {
+        let value = serde_json::json!({
+            "z": "\u{01}\u{1F600}",
+            "a": "q\"b\\c\u{08}\u{7F}",
+        });
+        let canonical = canonical_json(&value).expect("escaping fixture must canonicalize");
+        assert_eq!(
+            std::str::from_utf8(&canonical).expect("canonical output is UTF-8"),
+            "{\"a\":\"q\\\"b\\\\c\\b\u{7F}\",\"z\":\"\\u0001\u{1F600}\"}",
+        );
+    }
+
     #[test]
     fn server_070_fingerprint_goldens_bind_json_and_binary_proofs() {
         let vectors = golden_vectors();

--- a/src/token_binding.rs
+++ b/src/token_binding.rs
@@ -877,3 +877,62 @@ mod tests {
         ));
     }
 }
+
+/// Internal entry points for the repository's `fuzz_token_binding` cargo-fuzz
+/// target.
+///
+/// This module is `#[doc(hidden)]`, gated behind the non-default
+/// `internal-fuzz-facade` feature (which itself requires `token-binding`),
+/// and is explicitly **not part of the public API**: no semver guarantee
+/// covers anything here, the surface may change or vanish at any time, and
+/// production code must never enable the feature. It exists so the fuzz
+/// target can drive `pub(crate)` parsing/profiling paths without widening
+/// the supported API (issue #163).
+#[cfg(all(feature = "token-binding", feature = "internal-fuzz-facade"))]
+#[doc(hidden)]
+pub mod __internal_fuzz_facade {
+    use super::{
+        canonical_json as internal_canonical_json, parse_challenge as internal_parse_challenge,
+        SignalFishError, TokenBindingChallenge, TokenBindingSession,
+    };
+    use crate::transport::TransportFrame;
+
+    /// Parse raw challenge text through the strict internal validator.
+    pub fn parse_challenge(text: &str) -> Result<TokenBindingChallenge, SignalFishError> {
+        internal_parse_challenge(text)
+    }
+
+    /// Render already-parsed JSON through the internal canonicalizer.
+    pub fn canonical_json(value: &serde_json::Value) -> Result<Vec<u8>, SignalFishError> {
+        internal_canonical_json(value)
+    }
+
+    /// Opaque handle driving a secret-bearing session's prepare/commit cycle.
+    pub struct FuzzSession(TokenBindingSession);
+
+    impl FuzzSession {
+        /// Build a session exactly as the transport would after selection.
+        pub fn from_challenge(
+            handshake_key: &str,
+            challenge: TokenBindingChallenge,
+            client_fingerprint: Option<&str>,
+        ) -> Result<Self, SignalFishError> {
+            TokenBindingSession::from_challenge(
+                handshake_key,
+                challenge,
+                client_fingerprint.map(std::borrow::ToOwned::to_owned),
+            )
+            .map(Self)
+        }
+
+        /// Protect one frame with the current sequence without committing it.
+        pub fn prepare(&self, frame: &TransportFrame) -> Result<TransportFrame, SignalFishError> {
+            self.0.prepare(frame)
+        }
+
+        /// Advance the sequence exactly as a successful send would.
+        pub fn commit(&mut self) -> Result<(), SignalFishError> {
+            self.0.commit()
+        }
+    }
+}

--- a/src/webrtc.rs
+++ b/src/webrtc.rs
@@ -40,6 +40,13 @@ pub trait WebRtcDriver {
     /// emit it via [`poll`](Self::poll) as [`DriverEvent::Signal`]; otherwise
     /// wait for the remote offer. Obey `initiate` verbatim — it is the server's
     /// deterministic offerer assignment.
+    ///
+    /// Role assignments can flip within one session generation (a `NewPeer`
+    /// with a changed `you_initiate`). Because both sides' flips land
+    /// asynchronously, an implementor may still be handed the remote side's
+    /// Offer after being told to initiate; tolerate that glare the way
+    /// perfect-negotiation implementations do (treat the inbound Offer as the
+    /// winner or roll back the local offer) rather than erroring or wedging.
     fn connect(&mut self, peer: PlayerId, generation: Option<SessionGeneration>, initiate: bool);
 
     /// Feed a remote signal (offer/answer/ICE candidate) received from `peer`.
@@ -58,6 +65,10 @@ pub trait WebRtcDriver {
 
     /// Drain the next driver output, or `None` when idle. The controller calls
     /// this in a loop until it returns `None`.
+    ///
+    /// Implementations must guarantee forward progress toward `None`: every
+    /// call must either return an event or retire it internally. Returning
+    /// stale events forever livelocks the controller's synchronous drain.
     fn poll(&mut self) -> Option<DriverEvent>;
 
     /// Register a [`MeshWaker`] the driver signals (via [`MeshWaker::wake`]) when
@@ -442,9 +453,11 @@ mod controller {
         }
 
         /// Drive the driver in response to a single signaling event. The mesh
-        /// session view is assumed to be already folded (by [`handle_event`], or
-        /// by the recursive `MeshSession::apply` for events replayed out of a
-        /// `Reconnected`'s `missed_events`).
+        /// session view is assumed to be already folded (by [`handle_event`]).
+        /// Replay membership inside a `Reconnected`'s `missed_events` is
+        /// deliberately *not* folded here or in `MeshSession::apply`: the core
+        /// fences peers until a fresh live plan, and this arm above tears the
+        /// known peers down on the `Reconnected` event itself.
         fn choreograph(&mut self, event: &SignalFishEvent) {
             match event {
                 SignalFishEvent::SessionPlan {

--- a/tests/polling_parity_tests.rs
+++ b/tests/polling_parity_tests.rs
@@ -3436,23 +3436,6 @@ async fn lifecycle_plan_and_signal_matrix_has_complete_driver_parity() {
                 .collect(),
             "SignalReceived",
         ),
-        (
-            "removed-by-replan-signal",
-            room_prefix
-                .iter()
-                .cloned()
-                .chain([
-                    text_server_frame(plan.clone()),
-                    text_server_frame(ServerMessage::SessionPlan(Box::new(replacement_plan))),
-                    text_server_frame(ServerMessage::Signal {
-                        from: peer,
-                        generation: Some(uuid::Uuid::from_u128(353)),
-                        signal: serde_json::json!({"Offer": "removed"}),
-                    }),
-                ])
-                .collect(),
-            "SignalReceived",
-        ),
     ];
 
     for policy in [
@@ -3534,6 +3517,43 @@ async fn lifecycle_plan_and_signal_matrix_has_complete_driver_parity() {
                 !event.starts_with("SignalReceived") && !event.starts_with("ProtocolViolation")
             }),
             "generation-less late signal under {policy:?}: {events:?}"
+        );
+    }
+
+    // A same-generation signal from a peer the replacement plan dropped is a
+    // benign departure race, not an integrity violation: it is suppressed
+    // silently under every policy (mirrors the generation-less fence above).
+    for policy in [
+        ProtocolViolationPolicy::Quarantine,
+        ProtocolViolationPolicy::Disconnect,
+        ProtocolViolationPolicy::Observe,
+    ] {
+        let events = assert_frame_trace_parity(
+            room_prefix
+                .iter()
+                .cloned()
+                .chain([
+                    text_server_frame(plan.clone()),
+                    text_server_frame(ServerMessage::SessionPlan(Box::new(
+                        replacement_plan.clone(),
+                    ))),
+                    text_server_frame(ServerMessage::Signal {
+                        from: peer,
+                        generation: Some(uuid::Uuid::from_u128(353)),
+                        signal: serde_json::json!({"Offer": "removed"}),
+                    }),
+                ])
+                .collect(),
+            SignalFishConfig::new("app")
+                .enable_v3()
+                .with_protocol_violation_policy(policy),
+        )
+        .await;
+        assert!(
+            events.iter().all(|event| {
+                !event.starts_with("SignalReceived") && !event.starts_with("ProtocolViolation")
+            }),
+            "removed-by-replan signal under {policy:?}: {events:?}"
         );
     }
 

--- a/tests/polling_parity_tests.rs
+++ b/tests/polling_parity_tests.rs
@@ -3317,13 +3317,6 @@ async fn lifecycle_plan_and_signal_matrix_has_complete_driver_parity() {
     noncanonical_plan.topology = Topology::Relay;
     noncanonical_plan.transport = TransportKind::Relay;
 
-    let mut replacement_plan = match plan.clone() {
-        ServerMessage::SessionPlan(plan) => *plan,
-        _ => unreachable!("plan fixture is a SessionPlan"),
-    };
-    replacement_plan.generation = Some(uuid::Uuid::from_u128(353));
-    replacement_plan.peers.clear();
-
     let invalid_cases = [
         (
             "pre-auth",
@@ -3523,6 +3516,16 @@ async fn lifecycle_plan_and_signal_matrix_has_complete_driver_parity() {
     // A same-generation signal from a peer the replacement plan dropped is a
     // benign departure race, not an integrity violation: it is suppressed
     // silently under every policy (mirrors the generation-less fence above).
+    // A generation-changing replacement instead scopes retirement away: the
+    // dropped peer never held authority under the new generation, so its
+    // current-generation signal is a lifecycle violation there.
+    let mut same_generation_replacement = match plan.clone() {
+        ServerMessage::SessionPlan(plan) => *plan,
+        _ => unreachable!("plan fixture is a SessionPlan"),
+    };
+    same_generation_replacement.peers.clear();
+    let mut next_generation_replacement = same_generation_replacement.clone();
+    next_generation_replacement.generation = Some(uuid::Uuid::from_u128(353));
     for policy in [
         ProtocolViolationPolicy::Quarantine,
         ProtocolViolationPolicy::Disconnect,
@@ -3535,11 +3538,11 @@ async fn lifecycle_plan_and_signal_matrix_has_complete_driver_parity() {
                 .chain([
                     text_server_frame(plan.clone()),
                     text_server_frame(ServerMessage::SessionPlan(Box::new(
-                        replacement_plan.clone(),
+                        same_generation_replacement.clone(),
                     ))),
                     text_server_frame(ServerMessage::Signal {
                         from: peer,
-                        generation: Some(uuid::Uuid::from_u128(353)),
+                        generation: Some(generation),
                         signal: serde_json::json!({"Offer": "removed"}),
                     }),
                 ])
@@ -3562,6 +3565,41 @@ async fn lifecycle_plan_and_signal_matrix_has_complete_driver_parity() {
                 .count(),
             2,
             "both plans must be applied before the retired-peer signal under {policy:?}"
+        );
+
+        let events = assert_frame_trace_parity(
+            room_prefix
+                .iter()
+                .cloned()
+                .chain([
+                    text_server_frame(plan.clone()),
+                    text_server_frame(ServerMessage::SessionPlan(Box::new(
+                        next_generation_replacement.clone(),
+                    ))),
+                    text_server_frame(ServerMessage::Signal {
+                        from: peer,
+                        generation: Some(uuid::Uuid::from_u128(353)),
+                        signal: serde_json::json!({"Offer": "removed-next-generation"}),
+                    }),
+                ])
+                .collect(),
+            SignalFishConfig::new("app")
+                .enable_v3()
+                .with_protocol_violation_policy(policy),
+        )
+        .await;
+        assert!(
+            events
+                .iter()
+                .any(|event| event.starts_with("ProtocolViolation|Lifecycle|")),
+            "a next-generation signal from a peer the generation change dropped must be a \
+             violation under {policy:?}: {events:?}"
+        );
+        assert!(
+            events
+                .iter()
+                .all(|event| !event.starts_with("SignalReceived")),
+            "the unauthorized next-generation signal must not be delivered under {policy:?}: {events:?}"
         );
     }
 

--- a/tests/polling_parity_tests.rs
+++ b/tests/polling_parity_tests.rs
@@ -3555,6 +3555,14 @@ async fn lifecycle_plan_and_signal_matrix_has_complete_driver_parity() {
             }),
             "removed-by-replan signal under {policy:?}: {events:?}"
         );
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| event.starts_with("SessionPlan"))
+                .count(),
+            2,
+            "both plans must be applied before the retired-peer signal under {policy:?}"
+        );
     }
 
     let mut valid = room_prefix;


### PR DESCRIPTION
Closes #163. Continues #126 (round-7 paranoid audit).

## Why

A routine roster churn could blackhole gameplay: a signal from a peer the server had just dropped (`PlayerLeft`, or a same-generation re-plan) arrived after we processed the departure, still stamped with the live generation. The frame was valid when relayed, but the core called it a lifecycle violation — latching quarantine over the relay floor until reconnect (or tearing the connection down under the `Disconnect` policy).

Separately, issue #163 deferred a token-binding fuzz target pending maintainer acceptance of an internal fuzz facade; that acceptance is included here.

## How

- Generalize the Server-0.4 retired-peer fence to generation-carrying sessions: departed and re-planned-out peers' late same-generation signals are suppressed as the benign races they are. Retirement is scoped to the live session generation (cleared on generation change), pruned when a plan or compatibility `NewPeer` re-authorizes a peer, and unknown senders remain violations under every policy.
- Add the non-default `internal-fuzz-facade` feature exposing a `#[doc(hidden)]` semver-exempt module driving challenge parsing, canonicalization, and proof preparation from a new `fuzz_token_binding` cargo-fuzz target wired into Deep Safety with seeds (154k+ clean local runs).
- Land round-7 contract documentation: multi-sender FIFO wake order for reliable sends, receiver-drop lifecycle, polling `close()` event suppression, `WebRtcDriver` glare-tolerance and bounded-drain requirements, `PeerTransportStatus` last-known-liveness staleness, and the unknown-error-code fence interaction in docs/errors.md.
- Pin new behavior with red/green tests (both race faces fail on reverted code), a canonical_json ECMAScript/JCS escaping parity pin, multi-parked-sender FIFO + release tests, and receiver-drop lifecycle coverage.

## Verification

- fmt / clippy (all targets, all features, `-D warnings`) clean; full workspace test suite green across 23 binaries.
- Two adversarial review rounds converged: round 1 FIX-FIRST items all addressed, round 2 SHIP with nits applied.
- Fuzz target compiled on nightly and executed 154,751 runs without a crash.
- Deep Safety workflow guards pass; CHANGELOG updated under `[Unreleased]`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The mesh fix changes core protocol violation vs suppression semantics for WebRTC signaling under roster churn; incorrect retirement scoping could still drop legitimate signals or admit unauthorized ones.
> 
> **Overview**
> Fixes a **mesh-signaling blackhole** where late same-generation `Signal` frames from peers just removed via `PlayerLeft` or a same-generation re-plan were treated as lifecycle violations—under `Quarantine` that latched silent suppression for the rest of the session. The core now tracks **`retired_signal_peers`** (replacing the generation-less-only fence): those in-flight frames are **silently suppressed** as benign races; unknown senders stay violations; retirement clears on generation change and drops when a plan or `NewPeer` re-authorizes the peer.
> 
> Adds an opt-in **`internal-fuzz-facade`** feature and **`fuzz_token_binding`** cargo-fuzz target (challenge parse, canonical JSON, prepare/commit) with seeds and **Deep Safety** CI wiring; production builds do not enable the feature.
> 
> Also documents and tests **reliable-send FIFO wake** on queue drain, **NotConnected** for parked senders on shutdown, **transport loop** behavior when the event receiver is dropped, polling **`close()`** not emitting terminal events, **`WebRtcDriver`** glare tolerance and bounded `poll` progress, plus a **canonical JSON** escaping parity pin and polling/async parity for re-plan signal suppression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 521c54bdd130b149c4ad3700a72b03c627765627. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->