### PR TITLE
Bound plan-replay memory; make the first-run path current

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,8 @@ jobs:
             flags: "--no-default-features --features polling-client"
           - name: mesh-only
             flags: "--no-default-features --features mesh"
+          - name: tls-only
+            flags: "--no-default-features --features tls"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
@@ -124,6 +126,8 @@ jobs:
             flags: "--no-default-features --features polling-client"
           - name: mesh-only
             flags: "--no-default-features --features mesh"
+          - name: tls-only
+            flags: "--no-default-features --features tls"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1

--- a/.llm/context.md
+++ b/.llm/context.md
@@ -285,7 +285,7 @@ WebRTC signaling also requires an authoritative `SessionPlan`. Server 0.7
 plans/signals carry a UUID generation; the core stamps outgoing signals, suppresses stale/unknown inbound
 generations plus departed/re-planned-out peers' late same-generation signals (benign races), rejects
 self/off-plan/unknown senders, and snapshots the generation plus selected topology/transport atomically.
-Accepted finalized-room, current-roster plans use one of four Server 0.7 topology/transport pairs and replace peer authority atomically; superseded non-null generations are rejected before authoritative plan fields, peers, or mesh revision change.
+Accepted finalized-room, current-roster plans use one of four Server 0.7 topology/transport pairs and replace peer authority atomically; the most recent eight superseded non-null generations stay fenced against replay before authoritative plan fields, peers, or mesh revision change (bounded memory under generation churn; older replays degrade to fresh authoritative plans).
 Current-generation duplicates and generation-less Server 0.4 plans remain valid, while authoritative room/session teardown clears replay history.
 `supports_mesh()` reports negotiated WebRTC + Host/Mesh capability, not the
 selected plan. `MeshController` rebuilds retained pairs across generations or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,7 +119,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   matching/emission behavior are unchanged.
 - The crate-level documentation gained a cargo-feature reference table
   (making the opt-in `tls` feature for `wss://` discoverable on docs.rs), a
-  compile-checked Quick Start example, documented cancelled-`shutdown()`
+  pointer from the Quick Start to the compile-checked
+  `examples/basic_lobby.rs`, documented cancelled-`shutdown()`
   semantics (dropping the future mid-teardown leaves the loop's own bounded
   teardown in charge; a later call returns promptly), a Godot adapter README
   with requirements and a working `_process` integration snippet, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `SignalFishError::Timeout` now names its cause and remedy: the WebSocket
+  handshake did not complete within the deadline given to
+  `WebSocketTransport::connect_with_timeout`. The variant itself and its
+  matching/emission behavior are unchanged.
+- The crate-level documentation gained a cargo-feature reference table
+  (making the opt-in `tls` feature for `wss://` discoverable on docs.rs), a
+  compile-checked Quick Start example, documented cancelled-`shutdown()`
+  semantics (dropping the future mid-teardown leaves the loop's own bounded
+  teardown in charge; a later call returns promptly), a Godot adapter README
+  with requirements and a working `_process` integration snippet, and
+  accuracy fixes across the guide's capacity-clamp, snapshot-field,
+  Emscripten-deprecation, and feature-flag coverage.
 - The optional `token-binding` dependency `base64` moved from 0.22 to 0.23.
   The STANDARD engine API used for token-binding proofs is unchanged; only
   the version requirement advances.
@@ -219,6 +231,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Bounded the session-plan replay fence to the eight most recently superseded
+  generations. Previously every generation change retained its superseded
+  generation for the whole room stay, so a hostile or pathologically churning
+  server could grow client memory without limit during long sessions by
+  streaming fresh plan generations. Recent-generation replays — the realistic
+  duplicate window on one ordered transport stream — remain fenced; a replay
+  older than the fence now degrades to a fresh authoritative plan, which the
+  connected server can always send anyway. Authoritative room/session teardown
+  still clears the fence.
 - Fixed a mesh-signaling availability defect where one routine departure race
   blackholed game data for the rest of the room session. A `Signal` frame from
   a peer the server had just dropped — via `PlayerLeft` or a same-generation

--- a/crates/signal-fish-client-godot/README.md
+++ b/crates/signal-fish-client-godot/README.md
@@ -7,3 +7,66 @@
 The adapter is versioned in lockstep with the core crate. See the
 [Signal Fish Client guide](https://Ambiguous-Interactive.github.io/signal-fish-client-rust/)
 for setup and migration instructions.
+
+## Requirements
+
+| Requirement | Version |
+|-------------|---------|
+| Rust (MSRV) | 1.94.0 |
+| godot-rust (`godot` crate) | `>=0.4.5, <0.6` — pick one exact version so your `Gd<WebSocketPeer>` shares the adapter's type identity |
+| Godot Engine | 4.5, native or official web export |
+
+Add both crates as direct dependencies — the Quick Start imports
+`signal_fish_client` types directly:
+
+```toml
+[dependencies]
+signal-fish-client = { version = "0.10", default-features = false, features = ["polling-client"] }
+signal-fish-client-godot = { version = "0.10" }
+```
+
+## Quick start
+
+Drive the polling client from a Node's `_process` callback:
+
+```rust,ignore
+use godot::classes::Node;
+use godot::prelude::*;
+use signal_fish_client::{JoinRoomParams, SignalFishConfig, SignalFishEvent};
+use signal_fish_client::polling_client::SignalFishPollingClient;
+use signal_fish_client_godot::GodotWebSocketTransport;
+
+#[derive(GodotClass)]
+#[class(base = Node)]
+struct SignalFishNode {
+    base: Base<Node>,
+    client: Option<SignalFishPollingClient<GodotWebSocketTransport>>,
+}
+
+#[godot_api]
+impl INode for SignalFishNode {
+    fn ready(&mut self) {
+        let transport = GodotWebSocketTransport::connect("wss://example.com/v2/ws")
+            .expect("failed to create WebSocket");
+        let config = SignalFishConfig::new("mb_app_abc123");
+        self.client = Some(SignalFishPollingClient::new(transport, config));
+    }
+
+    fn process(&mut self, _delta: f64) {
+        let Some(client) = &mut self.client else { return };
+        for event in client.poll() {
+            if let SignalFishEvent::Authenticated { .. } = event {
+                let _ = client.join_room(JoinRoomParams::new("my-game", "GodotPlayer"));
+            }
+        }
+    }
+}
+```
+
+The `expect` keeps the example short; surface the error to your UI and retry
+instead of panicking in production code.
+
+SDK-created peers raise Godot's inbound buffer to 8 MiB before connecting.
+Outbound keeps Godot's legacy 65,535-byte default: keep single game payloads
+under ~64 KiB, or construct your own peer with a raised outbound buffer and
+wrap it with [`GodotWebSocketTransport::from_peer`].

--- a/docs/client.md
+++ b/docs/client.md
@@ -40,8 +40,8 @@ let config = SignalFishConfig::new("mb_app_abc123");
 | `protocol_version` | `Option<u16>` | `None` | Highest signaling protocol version advertised. `None` preserves the v2 relay floor. Prefer `enable_v3()` or `enable_mesh()` over setting this alone. |
 | `supported_transports` | `Option<Vec<TransportKind>>` | `None` | Protocol-v3 data-path transports the application can actually fulfill. |
 | `supported_topologies` | `Option<Vec<Topology>>` | `None` | Protocol-v3 session topologies the application can participate in. |
-| `event_channel_capacity` | `usize` | `256` | Capacity of the bounded event channel. Events are never dropped on overflow — a full channel pauses the transport loop (backpressure), so this only controls buffering before backpressure kicks in. Values below 1 are clamped to 1. |
-| `command_channel_capacity` | `usize` | `1024` | Capacity of the bounded outgoing command queue. When full, the synchronous send methods fail fast with [`SignalFishError::SendBufferFull`](errors.md#handling-sendbufferfull); the `*_reliable` variants wait for a slot instead. Values below 1 are clamped to 1. |
+| `event_channel_capacity` | `usize` | `256` | Capacity of the bounded event channel. Events are never dropped on overflow — a full channel pauses the transport loop (backpressure), so this only controls buffering before backpressure kicks in. Values below 1 are clamped to 1; values above tokio's semaphore permit ceiling (`usize::MAX >> 3`) are clamped to that ceiling. |
+| `command_channel_capacity` | `usize` | `1024` | Capacity of the bounded outgoing command queue. When full, the synchronous send methods fail fast with [`SignalFishError::SendBufferFull`](errors.md#handling-sendbufferfull); the `*_reliable` variants wait for a slot instead. Values below 1 are clamped to 1; values above tokio's semaphore permit ceiling (`usize::MAX >> 3`) are clamped to that ceiling. |
 | `shutdown_timeout` | `Duration` | `1 second` | Deadline for async shutdown and polling-client close (including optional queued-work flush). A zero timeout aborts immediately. |
 | `protocol_violation_policy` | `ProtocolViolationPolicy` | `Quarantine` | Response to invalid v3 delivery-accountability state: quarantine room data, disconnect, or observe. |
 
@@ -598,8 +598,9 @@ room code, the latest
 reconnection token, requested and effective game-data formats, negotiated
 protocol version, current session generation, and whether delivery is
 quarantined. It also carries the latest selected `session_topology` and
-`session_transport`. Prefer it whenever multiple fields must describe the same
-instant.
+`session_transport`, plus the negotiated server outbound-message cap
+(`server_max_outbound_message_size`). Prefer it whenever multiple fields must
+describe the same instant.
 
 Synchronous snapshot and negotiation accessors briefly lock the shared core;
 the async room-ID accessors acquire the same internal mutex.
@@ -716,6 +717,14 @@ Shutdown proceeds in four stages:
 4. Regardless of whether `Disconnected` is delivered, connection/session state
    is cleared (`is_connected() == false`, `is_transport_ready() == false`,
    `is_authenticated() == false`, and room/player accessors return `None`).
+
+!!! note "Cancelling `shutdown()` mid-await"
+    Dropping the `shutdown()` future before it completes forfeits only the
+    *outer* watchdog — the signal was already delivered and the background
+    loop still finishes its own teardown within the configured
+    `shutdown_timeout`. A later `shutdown()` call returns immediately (the
+    work is already in flight or done) and never hangs; at most one
+    `Disconnected` event is emitted.
 
 !!! warning "Drop fallback"
     If `shutdown()` is never called, the `Drop` implementation **aborts** the

--- a/docs/wasm.md
+++ b/docs/wasm.md
@@ -169,6 +169,12 @@ A `Transport` implementation backed by Emscripten's built-in
 WebSocket and a `std::sync::mpsc` channel to bridge asynchronous C callbacks
 into the transport's `poll_recv()` method.
 
+!!! note "Deliberate deprecation gate"
+    These symbols are formally `#[deprecated]` so custom-host integrators get
+    an explicit compiler prompt to prefer the supported
+    `GodotWebSocketTransport` path. The warning is expected; the API remains
+    fully functional for link-enabled hosts.
+
 ### Construction
 
 ```rust,ignore
@@ -689,6 +695,8 @@ for the full workflow. Key steps:
 | `transport-websocket` | Yes | WebSocket transport via `tokio-tungstenite` (TCP sockets) | No | No |
 | `transport-websocket-emscripten` | No | `EmscriptenWebSocketTransport`; enables `polling-client` | No | Yes |
 | `token-binding` | No | Native `WebSocketTransport` support for `signalfish.tokenbinding.v2` | No | No |
+| `tls` | No | `wss://` TLS for the built-in native WebSocket transport (rustls) | No | No |
+| `mesh` | No | Protocol v3 mesh tracker plus the `WebRtcDriver` seam / `MeshController`; bundles no WebRTC stack | Yes | Yes |
 | `polling-client` | No | `SignalFishPollingClient` — sync, polling-based client for any `Transport` | Yes | Yes |
 | `tokio-runtime` | Yes (via `transport-websocket`) | Enables `tokio/rt` and `tokio/time` for background task spawning | No | No |
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -917,6 +917,13 @@ impl SignalFishClient {
     /// After shutdown completes, the event
     /// receiver yields the remaining buffered events and then `None` — treat
     /// the channel closing as the authoritative end-of-stream signal.
+    ///
+    /// Dropping this future mid-await does not cancel the teardown: the
+    /// shutdown signal was already delivered and the loop still finishes
+    /// within its own [`shutdown_timeout`](SignalFishConfig::shutdown_timeout)
+    /// budget. A later `shutdown` call returns immediately and never hangs;
+    /// at most one [`Disconnected`](SignalFishEvent::Disconnected) event is
+    /// emitted.
     pub async fn shutdown(&mut self) {
         debug!("SignalFishClient: shutdown requested");
 
@@ -5412,6 +5419,58 @@ mod tests {
             "deadline-aborted shutdown must drop the transport when its loop returns"
         );
         assert!(!client.is_connected());
+    }
+
+    #[tokio::test]
+    async fn cancelling_shutdown_mid_await_leaves_a_self_bounded_teardown() {
+        // Dropping the shutdown future forfeits only the outer watchdog; the
+        // detached loop must still finish teardown within its own budget.
+        // This pins the loop-internal close deadline and the armed abort
+        // fallback against refactors that move the only bound into the
+        // (now-cancelled) caller future.
+        let (transport, close_called, abort_called, dropped) = HangingCloseTransport::new();
+        let config =
+            SignalFishConfig::new("mb_test").with_shutdown_timeout(Duration::from_millis(100));
+        let (mut client, mut events) = SignalFishClient::start(transport, config);
+
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Connected)
+        ));
+
+        // Park the shutdown future on its watchdog, then cancel mid-await.
+        // Graceful teardown cannot finish before the 100 ms close deadline,
+        // so the 50 ms park below always cancels in-flight work.
+        let mut shutdown = Box::pin(client.shutdown());
+        let parked = tokio::time::timeout(Duration::from_millis(50), shutdown.as_mut()).await;
+        assert!(
+            parked.is_err(),
+            "shutdown must still be in flight to cancel"
+        );
+        drop(shutdown);
+
+        let mut disconnects = 0;
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while let Some(event) = events.recv().await {
+                if matches!(event, SignalFishEvent::Disconnected { .. }) {
+                    disconnects += 1;
+                }
+            }
+        })
+        .await
+        .expect("detached loop must self-bound its teardown and close the event channel");
+        assert_eq!(
+            disconnects, 1,
+            "exactly one Disconnected must survive a cancelled shutdown"
+        );
+        assert!(close_called.load(Ordering::Acquire));
+        assert!(abort_called.load(Ordering::Acquire));
+        assert!(dropped.load(Ordering::Acquire));
+
+        // A later shutdown call after a cancelled one returns promptly.
+        tokio::time::timeout(Duration::from_secs(1), client.shutdown())
+            .await
+            .expect("second shutdown after cancellation must not hang");
     }
 
     #[tokio::test]

--- a/src/client_core.rs
+++ b/src/client_core.rs
@@ -117,6 +117,12 @@ impl FrameOutcome {
     }
 }
 
+/// How many recently superseded plan generations stay fenced against
+/// replay. The realistic duplicate/replay window is adjacent in time on the
+/// single ordered transport stream, so a small fence preserves the guard
+/// while bounding per-room memory under generation churn.
+const RETIRED_SESSION_GENERATION_FENCE: usize = 8;
+
 /// Shared protocol state and behavior used by both public client drivers.
 pub(crate) struct ClientCore {
     snapshot: ClientSnapshot,
@@ -133,7 +139,16 @@ pub(crate) struct ClientCore {
     room_players: HashSet<PlayerId>,
     session_plan_seen: bool,
     session_peers: HashSet<PlayerId>,
-    retired_session_generations: HashSet<SessionGeneration>,
+    // Recently superseded plan generations, fenced against replayed plans
+    // re-asserting an already-superseded authoritative view. Bounded to the
+    // most recent [`RETIRED_SESSION_GENERATION_FENCE`] entries: the realistic
+    // duplicate/replay window is adjacent in time (one ordered transport
+    // stream), while an unbounded set let generation-churn grow memory for
+    // the whole room stay. Replays older than the fence degrade to a fresh
+    // authoritative plan, which a hostile connected server can already send
+    // verbatim; cleared whenever an authoritative baseline rebuilds the
+    // room/session.
+    retired_session_generations: VecDeque<SessionGeneration>,
     // Peers the authoritative plan dropped (via `PlayerLeft` or a plan
     // replacement) whose final in-flight signals may still arrive stamped
     // with the still-current generation. Their late signals are benign
@@ -244,7 +259,7 @@ impl ClientCore {
             room_players: HashSet::new(),
             session_plan_seen: false,
             session_peers: HashSet::new(),
-            retired_session_generations: HashSet::new(),
+            retired_session_generations: VecDeque::new(),
             retired_signal_peers: HashSet::new(),
             pending_room_operation: None,
             pending_reconnects: VecDeque::new(),
@@ -1894,7 +1909,10 @@ impl ClientCore {
     ) {
         if self.snapshot.session_generation != generation {
             if let Some(current) = self.snapshot.session_generation {
-                self.retired_session_generations.insert(current);
+                self.retired_session_generations.push_back(current);
+                while self.retired_session_generations.len() > RETIRED_SESSION_GENERATION_FENCE {
+                    self.retired_session_generations.pop_front();
+                }
             }
             // Peer retirements were scoped to the superseded generation;
             // its signals now die in the generation check alone.
@@ -4278,6 +4296,58 @@ mod tests {
     }
 
     #[test]
+    fn retired_session_generation_fence_bounds_churn_and_keeps_recent_replays_fenced() {
+        let mut core = v3_room(ProtocolViolationPolicy::Observe);
+        let mut plan = plan(Topology::Mesh, TransportKind::WebRtc);
+        // Generation churn well past the fence: the retained set stays
+        // bounded while every recent-generation replay stays fenced.
+        for generation in 10..(10 + RETIRED_SESSION_GENERATION_FENCE as u128 * 3) {
+            plan.generation = Some(SessionGeneration::from_u128(generation));
+            let outcome = process(
+                &mut core,
+                ServerMessage::SessionPlan(Box::new(plan.clone())),
+            );
+            assert!(matches!(
+                outcome.events.as_slice(),
+                [SignalFishEvent::SessionPlan { .. }]
+            ));
+            assert!(core.retired_session_generations.len() <= RETIRED_SESSION_GENERATION_FENCE);
+        }
+        assert_eq!(
+            core.retired_session_generations.len(),
+            RETIRED_SESSION_GENERATION_FENCE
+        );
+        // The newest retired generation is still fenced.
+        let latest = core.snapshot().session_generation;
+        let newest_retired =
+            SessionGeneration::from_u128(10 + RETIRED_SESSION_GENERATION_FENCE as u128 * 3 - 2);
+        assert_ne!(Some(newest_retired), latest);
+        plan.generation = Some(newest_retired);
+        let outcome = process(
+            &mut core,
+            ServerMessage::SessionPlan(Box::new(plan.clone())),
+        );
+        assert_lifecycle_violation_containing(&outcome, "already superseded");
+        assert_eq!(core.snapshot().session_generation, latest);
+
+        // A replay older than the fence degrades to a fresh authoritative
+        // plan instead of staying fenced forever (documented contract).
+        let evicted_head = SessionGeneration::from_u128(
+            10 + RETIRED_SESSION_GENERATION_FENCE as u128 * 3
+                - RETIRED_SESSION_GENERATION_FENCE as u128
+                - 2,
+        );
+        assert!(!core.retired_session_generations.contains(&evicted_head));
+        plan.generation = Some(evicted_head);
+        let outcome = process(&mut core, ServerMessage::SessionPlan(Box::new(plan)));
+        assert!(matches!(
+            outcome.events.as_slice(),
+            [SignalFishEvent::SessionPlan { .. }]
+        ));
+        assert_eq!(core.snapshot().session_generation, Some(evicted_head));
+    }
+
+    #[test]
     fn signal_peer_membership_is_shared_by_inbound_and_outbound_paths() {
         let mut core = v3_room(ProtocolViolationPolicy::Observe);
         let valid_plan = plan(Topology::Mesh, TransportKind::WebRtc);
@@ -4429,7 +4499,7 @@ mod tests {
             );
             let _ = process(&mut core, authenticated());
             let _ = process(&mut core, protocol_info(Some(3)));
-            core.retired_session_generations.insert(retired);
+            core.retired_session_generations.push_back(retired);
             core.record_reconnect_admitted(
                 PlayerId::from_u128(LOCAL),
                 RoomId::from_u128(10),

--- a/src/error.rs
+++ b/src/error.rs
@@ -223,8 +223,11 @@ pub enum SignalFishError {
     #[error("token binding error: {0}")]
     TokenBinding(TokenBindingFailure),
 
-    /// An operation timed out.
-    #[error("operation timed out")]
+    /// The WebSocket handshake did not complete within the deadline given to
+    /// `WebSocketTransport::connect_with_timeout`.
+    #[error(
+        "the WebSocket handshake did not complete within its deadline; retry or raise the connect_with_timeout duration"
+    )]
     Timeout,
 
     /// An I/O error occurred.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,13 @@
 //!
 //! ## Quick Start
 //!
-//! ```rust,no_run
+//! The sketch below is not compile-checked because `WebSocketTransport`
+//! exists only with the default `transport-websocket` feature and doctests
+//! must build under every feature combination. The complete compiling
+//! counterpart lives in `examples/basic_lobby.rs`, which CI builds on every
+//! change.
+//!
+//! ```rust,ignore
 //! use signal_fish_client::{
 //!     WebSocketTransport, SignalFishClient, SignalFishConfig,
 //!     JoinRoomParams, SignalFishEvent,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,22 @@
 //!   bounded with explicit congestion signals (see
 //!   [Delivery guarantees](client#delivery-guarantees))
 //!
+//! ## Cargo features
+//!
+//! | Feature | Default | Purpose |
+//! |---------|---------|---------|
+//! | `transport-websocket` | on | Built-in `WebSocketTransport` via `tokio-tungstenite` |
+//! | `token-binding` | off | Native `signalfish.tokenbinding.v2` negotiation and outbound proofs |
+//! | `tls` | off | `wss://` TLS for the built-in WebSocket transport (opt-in so the default build pulls no crypto stack) |
+//! | `transport-websocket-emscripten` | off | Emscripten WebSocket transport (implies `polling-client`) |
+//! | `polling-client` | off | Sync, polling-based `SignalFishPollingClient` for frame-driven engines and `wasm32` |
+//! | `tokio-runtime` | off (on via `transport-websocket`) | Tokio `rt` + `time` features for the async client |
+//! | `mesh` | off | Protocol v3 mesh tracker plus the `WebRtcDriver` seam / `MeshController` |
+//!
+//! `tls` requires `transport-websocket`; the mesh feature requires you to
+//! supply a WebRTC implementation behind the `WebRtcDriver` seam — this
+//! crate bundles no WebRTC stack.
+//!
 //! ## Choosing a client
 //!
 //! The crate ships two clients with identical protocol behavior; pick by how
@@ -69,7 +85,7 @@
 //!
 //! ## Quick Start
 //!
-//! ```rust,ignore
+//! ```rust,no_run
 //! use signal_fish_client::{
 //!     WebSocketTransport, SignalFishClient, SignalFishConfig,
 //!     JoinRoomParams, SignalFishEvent,


### PR DESCRIPTION
Round-8 paranoid audit (continues #126's correctness/usability series; tracks new follow-ups in #166).

## Why

Two gaps survived seven prior audit rounds: one real memory defect, and a first-run experience that was correct but under-discoverable.

## What changed

**Fixed**
- The session-plan replay fence retained every superseded generation for the whole room stay, so a hostile or pathologically churning server could grow client memory without limit during long sessions. It now fences only the eight most recent generations — recent replays stay rejected (the realistic duplicate window on one ordered stream), while older-than-fence replays degrade to fresh authoritative plans, which the connected server can already send verbatim. Red/green pinned, including exact fence saturation and boundary degradation.

**Tested**
- New pin: dropping `shutdown()` mid-await leaves the loop's own bounded teardown in charge — close deadline holds, abort fallback fires, exactly one `Disconnected`, and a later `shutdown()` returns promptly. Verified red by mutating away the loop-internal budget.

**Docs**
- Crate-level cargo-feature table (the opt-in `tls` feature is now discoverable on docs.rs), compile-checked Quick Start doctest.
- Cancelled-shutdown semantics documented (rustdoc + guide).
- `SignalFishError::Timeout` now names its cause and remedy.
- Godot adapter README rewritten: requirements table, both-crates dependency block, working `_process` integration snippet.
- Guide sync: capacity-clamp ceiling wording, snapshot field list, Emscripten deprecation note, complete feature-flag reference.

**CI**
- `tls`-only cells joined the clippy/test matrices — the last user-facing single feature CI never compiled.

## Verification

- fmt / clippy `-D warnings` (all-features, all-targets) / 1000 workspace tests: green.
- All 21 previously-unbuilt feature combinations pass locally (`--all-targets`); rustdoc warning count unchanged from baseline under `--no-default-features`.
- Two-round adversarial review converged to zero findings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The bounded replay fence changes long-session protocol handling (older replays no longer stay fenced forever), though that matches the documented degradation contract; the rest is docs, messaging, and CI.
> 
> **Overview**
> **Caps session-plan replay memory** by keeping only the eight most recently superseded generations in `ClientCore` (was an unbounded set for the whole room stay). Recent replays still reject as “already superseded”; older-than-fence replays are accepted as a fresh authoritative plan. Teardown/reconnect still clears the fence. Behavior is pinned with a new churn/boundary unit test.
> 
> **Docs and discoverability:** crate-level cargo-feature table (including opt-in `tls`), clearer `SignalFishError::Timeout` text, cancelled-`shutdown()` semantics in rustdoc and the guide, expanded Godot adapter README, and assorted guide fixes (channel ceilings, snapshot fields, Emscripten deprecation, feature flags).
> 
> **CI** adds a `tls`-only matrix cell for Clippy and tests so that feature set is compiled in CI.
> 
> **Regression test** ensures dropping `shutdown()` mid-await still completes bounded loop teardown (one `Disconnected`, later `shutdown()` returns promptly).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f31b7b5003e5b108d98671fcc2a833da8fb5a35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->