### PR TITLE
Bound per-room metadata under hostile server churn

### DIFF
--- a/.llm/context.md
+++ b/.llm/context.md
@@ -399,7 +399,9 @@ mutating state: more than 16 unresolved incarnation announcements or
 uncovered departed incarnations per sender; more than 1024 total retained
 exact gap ranges; roster inserts beyond the advertised `max_players`
 (wire-absolute `u8::MAX + 1` fallback when the latest baseline cannot
-advertise one). Unknown-player `PlayerReconnected` sender cursors remain the
+advertise one) — servers swapping players on a full room must order the
+departure before the replacement join. Unknown-player `PlayerReconnected`
+sender cursors remain the
 one documented trusted-server envelope: containment gates would reject
 legitimate reconnects of players absent from the local roster snapshot.
 

--- a/.llm/context.md
+++ b/.llm/context.md
@@ -30,9 +30,7 @@ reproduce, attest, and publish every crates.io-publishable workspace member at
 the single `[workspace.package].version`. `scripts/release.py workspace-plan`
 discovers members with Cargo metadata and orders internal dependencies; Release
 has no version input and resumes only checksum-identical partial publication.
-Prepare Release derives its bump and breaking policy from `[Unreleased]`, so it
-also accepts no version, bump, breaking, or crate-selection input beyond its
-reversible dry-run switch.
+Prepare Release derives its bump and breaking policy from `[Unreleased]`; it accepts no version/bump/breaking/crate-selection input beyond a reversible dry-run switch.
 Release jobs pin Rust 1.96.1 and Ubuntu 24.04; crate archives contain library source, required unit-test data, manifest, license, and readme.
 Repository-only material stays in the linked source repository; see `skills/release-recovery/SKILL.md` and `docs/releasing.md`.
 
@@ -40,17 +38,7 @@ Every blocking workflow runs on PR and default-branch SHAs and ends in a
 uniquely named aggregate `Required` job. The names and desired rules live in
 `.github/required-checks.json`; the scheduled Repository Policy workflow audits
 GitHub for visible drift with its authenticated built-in `GITHUB_TOKEN`.
-GitHub hides ruleset bypass actors from workflow tokens, so maintainers verify
-an empty bypass list in the ruleset UI. Prepare Release also uses only
-`GITHUB_TOKEN` and explicitly dispatches the required workflows on its generated
-branch because ordinary token-created pull-request events are suppressed.
-Path filters must not suppress a configured required gate. No checked-in
-`GITHUB_TOKEN` workflow may auto-merge Dependabot PRs: besides relying on live
-rules that may drift, such a merge can suppress push CI on the resulting
-default-branch SHA. The fail-closed workflow policy therefore rejects any
-Dependabot-specific workflow, all automated-merge primitives, and write
-permissions outside the release/docs allowlist. Ruleset #14801090 live-enforces
-reviewed merges and all required checks.
+GitHub hides ruleset bypass actors from workflow tokens, so maintainers verify an empty bypass list in the ruleset UI. Prepare Release uses only `GITHUB_TOKEN` and dispatches required workflows explicitly on its generated branch because token-created pull-request events are suppressed; path filters must not suppress a configured gate. No checked-in `GITHUB_TOKEN` workflow may auto-merge Dependabot PRs: such merges rely on drifting rules and can suppress push CI on the resulting SHA, so the fail-closed policy rejects Dependabot-specific workflows, automated-merge primitives, and write permissions outside the release/docs allowlist. Ruleset #14801090 live-enforces reviewed merges and all required checks.
 
 ## GitHub Tool Order
 
@@ -91,9 +79,7 @@ instrumentation covers the parsers it drives. Blanket Clippy
 pedantic/nursery/cargo groups remain deferred after a noisy inventory; add them
 only for stable, actionable defects.
 
-Dependabot uses one root-workspace updater; minimum/latest Godot fixtures remain
-standalone because combining incompatible godot-rust versions would break the
-workspace. Hosted run 31969079956 proved clean root discovery.
+Dependabot uses one root-workspace updater; minimum/latest Godot fixtures stay standalone because incompatible godot-rust versions would break the workspace (hosted run 31969079956 proved clean root discovery).
 
 ## Architecture — Core Modules
 
@@ -140,12 +126,7 @@ admission and boundedly process immediately ready frames through `ClientCore` un
 `Pending`, terminal input, work bound, protocol stop, or deadline (the polling driver clamps this drain to
 its caller-configured receive budget). A ready farewell precedes `Disconnected`; only peer-close metadata replaces the send cause; native WebSocket retains buffered read state.
 
-Public `Debug`/tracing form an ambient-log boundary:
-reconnect/relay/TURN credentials, WebRTC SDP/ICE, arbitrary application data,
-buffered protocol frames, peer close reasons, and URL userinfo/query values
-must never be formatted. Safe diagnostics expose only variants, state flags,
-identifiers where appropriate, and byte lengths. Wire serialization and
-explicit public-field access remain unchanged.
+Public `Debug`/tracing form an ambient-log boundary: reconnect/relay/TURN credentials, WebRTC SDP/ICE, arbitrary application data, buffered protocol frames, peer close reasons, and URL userinfo/query values are never formatted; safe diagnostics expose only variants, state flags, identifiers where appropriate, and byte lengths. Wire serialization and explicit public-field access remain unchanged.
 
 The Emscripten transport reports `Pending` while its browser WebSocket is still
 connecting and must not call `emscripten_websocket_send_*` or consume the
@@ -411,6 +392,17 @@ the first canonical Server 0.7 `ProtocolInfo`, with unsupported requests using
 JSON. V3 reconnects require replay, complete watermarks, and a rotated token;
 v2 exposes none. `Reconnected` fences peers until a fresh live `SessionPlan`.
 
+Per-room accountability metadata is bounded against hostile or pathologically
+churning servers (issue #166); overflow is an ordinary server-misbehavior
+diagnostic under the violation policy, and every bound validates before
+mutating state: more than 16 unresolved incarnation announcements or
+uncovered departed incarnations per sender; more than 1024 total retained
+exact gap ranges; roster inserts beyond the advertised `max_players`
+(wire-absolute `u8::MAX + 1` fallback when the latest baseline cannot
+advertise one). Unknown-player `PlayerReconnected` sender cursors remain the
+one documented trusted-server envelope: containment gates would reject
+legitimate reconnects of players absent from the local roster snapshot.
+
 ### No Heavy Dependencies
 
 No `chrono` (timestamps remain `String` from the server), no `bytes` (binary
@@ -460,21 +452,13 @@ frontmatter names must match and use lowercase hyphen-case.
 
 ## Progress Records
 
-Planning records are local-only working notes: session logs and evidence
-under `progress/` plus the `PLAN.md` roadmap are gitignored and never
-committed or force-added. Durable, reviewer-visible conclusions belong in
-`CHANGELOG.md`, docs, or tests instead. No file may be both tracked and
-ignored; `no_file_is_both_tracked_and_ignored` enforces that boundary.
+Planning records are local-only working notes: session logs/evidence under `progress/` and the `PLAN.md` roadmap are gitignored, never committed or force-added; durable conclusions belong in `CHANGELOG.md`, docs, or tests. No file may be both tracked and ignored (`no_file_is_both_tracked_and_ignored`).
 
 ## Documentation Rendering (MkDocs)
 
 MkDocs Material + pymdownx powers Pages. `hooks/rustdoc_codeblocks.py` strips
 rustdoc fence annotations for Pygments; `hooks/llms_txt.py` generates model text.
-Mermaid requires `custom_fences` in `mkdocs.yml`. Approved Vector assets use
-pinned provenance and local OFL fonts preloaded via `overrides/main.html`, with
-no runtime provider. Both palettes retain AA contrast, visible focus,
-reduced-motion behavior, and responsive scrolling. `docs_brand_policy` pins
-these contracts; evidence lives under local-only `progress/assets/`. CI runs strict MkDocs
+Mermaid requires `custom_fences` in `mkdocs.yml`. Approved Vector assets use pinned provenance and local OFL fonts preloaded via `overrides/main.html`; both palettes retain AA contrast, visible focus, reduced-motion behavior, and responsive scrolling (`docs_brand_policy` pins these contracts; evidence under local-only `progress/assets/`). CI runs strict MkDocs
 (`.github/workflows/docs-deploy.yml`) and 17 checks in
 `.github/workflows/docs-validation.yml`; see `skills/markdown-and-doc-validation/SKILL.md`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -232,6 +232,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Bounded per-room metadata growth fed by a hostile or pathologically
+  churning server. Delivery accountability now refuses, as ordinary
+  violation diagnostics, a sender that accumulates more than 16 unresolved
+  incarnation announcements or uncovered departures, and a delivery report
+  that would push total retained exact gap ranges past 1024 — previously all
+  three grew for the whole room stay under churn that never completes
+  retirement. Room rosters are now admission-bounded by the server-advertised
+  `max_players` (with a wire-absolute `u8` fallback when the latest baseline
+  cannot advertise one): an over-capacity `PlayerJoined` is a lifecycle
+  violation instead of unbounded roster growth, while duplicates and
+  slot-freed rejoins keep working.
 - Bounded the session-plan replay fence to the eight most recently superseded
   generations. Previously every generation change retained its superseded
   generation for the whole room stay, so a hostile or pathologically churning

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -237,8 +237,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   violation diagnostics, a sender that accumulates more than 16 unresolved
   incarnation announcements or uncovered departures, and a delivery report
   that would push total retained exact gap ranges past 1024 — previously all
-  three grew for the whole room stay under churn that never completes
-  retirement. Room rosters are now admission-bounded by the server-advertised
+  three grew without bound for the whole room stay under churn that never
+  completes retirement. Room rosters are now admission-bounded by the server-advertised
   `max_players` (with a wire-absolute `u8` fallback when the latest baseline
   cannot advertise one): an over-capacity `PlayerJoined` is a lifecycle
   violation instead of unbounded roster growth, while duplicates and

--- a/src/accountability.rs
+++ b/src/accountability.rs
@@ -2166,4 +2166,50 @@ mod tests {
         assert!(error.contains("retention bound"), "{error}");
         assert_eq!(outstanding(&state), MAX_TOTAL_PENDING_GAPS);
     }
+
+    #[test]
+    fn departure_bound_refuses_the_next_uncoverable_leave() {
+        let sender = id(6);
+        let mut state = DeliveryAccountability::default();
+        state
+            .rebaseline_snapshot(&[player_at(sender, 1, 0)])
+            .unwrap();
+
+        // One uncovered departure at the current epoch needs no announcement,
+        // so the departure count runs one ahead of the announcements.
+        state
+            .note_player_left(sender, Some(1), Some(u64::MAX))
+            .unwrap();
+        for epoch in 2..=16u32 {
+            state.note_player_reconnected(sender, Some(epoch)).unwrap();
+            state
+                .note_player_left(sender, Some(epoch), Some(u64::MAX))
+                .unwrap();
+        }
+        assert_eq!(
+            state.departed_count(sender),
+            MAX_DEPARTED_SENDERS_PER_PLAYER
+        );
+        assert_eq!(
+            state.announced_epochs.get(&sender).map(BTreeSet::len),
+            Some(MAX_DEPARTED_SENDERS_PER_PLAYER - 1)
+        );
+
+        // The next announcement still fits under the announcement bound, but
+        // its uncoverable leave is refused by the departure bound — proving
+        // the two bounds are independent. The refused leave mutates nothing.
+        state.note_player_reconnected(sender, Some(17)).unwrap();
+        let error = state
+            .note_player_left(sender, Some(17), Some(u64::MAX))
+            .unwrap_err();
+        assert!(error.contains("uncovered departure"), "{error}");
+        assert_eq!(
+            state.departed_count(sender),
+            MAX_DEPARTED_SENDERS_PER_PLAYER
+        );
+        assert_eq!(
+            state.announced_epochs.get(&sender).map(BTreeSet::len),
+            Some(MAX_DEPARTED_SENDERS_PER_PLAYER)
+        );
+    }
 }

--- a/src/accountability.rs
+++ b/src/accountability.rs
@@ -13,6 +13,30 @@ use crate::protocol::{
 };
 use crate::{ErrorCode, ServerMessage};
 
+// Resource bounds for long sessions fed by a hostile or pathologically
+// churning server (issue #166). Every bound classifies overflow as server
+// misbehavior through the ordinary delivery-accountability diagnostics, and
+// every enforcing site validates before mutating state, so a refused frame
+// leaves the machine untouched.
+
+/// Maximum simultaneously unresolved incarnation announcements tracked for
+/// one sender. Legitimate reconnect churn retires instantly (`final_seq == 0`)
+/// or advances watermarks, pruning announcements; only churn that never
+/// delivers data and never completes retirement accumulates toward this bound.
+const MAX_ANNOUNCED_EPOCHS_PER_SENDER: usize = 16;
+
+/// Maximum simultaneously uncovered departed incarnations retained for one
+/// sender. Retirement completes whenever terminal coverage is explainable;
+/// retaining more than this many uncovered terminals per sender means the
+/// server keeps leaving incarnations whose tails it never explains.
+const MAX_DEPARTED_SENDERS_PER_PLAYER: usize = 16;
+
+/// Maximum total exact gap ranges retained across all senders while awaiting
+/// matching data, retirement, or a room reset. One report carries at most
+/// [`DELIVERY_REPORT_MAX_GAPS`] ranges, so legitimate loss patterns drain far
+/// below this ceiling between reports.
+const MAX_TOTAL_PENDING_GAPS: usize = 1024;
+
 #[derive(Debug, Clone, Copy)]
 struct SenderProgress {
     epoch: u32,
@@ -311,10 +335,24 @@ impl DeliveryAccountability {
                 "delivery accountability violation: gap report for {player_id} extends beyond PlayerLeft final_seq {final_seq}"
             ));
         }
+        if !self.departed_senders.contains_key(&(player_id, epoch))
+            && self.departed_count(player_id) >= MAX_DEPARTED_SENDERS_PER_PLAYER
+        {
+            return Err(format!(
+                "delivery accountability violation: PlayerLeft terminal epoch {epoch} for {player_id} exceeds the {MAX_DEPARTED_SENDERS_PER_PLAYER} uncovered departure bound"
+            ));
+        }
         self.departed_senders
             .insert((player_id, epoch), DepartedSender { final_seq });
         self.stale_senders.insert(player_id);
         self.try_retire_departed(player_id, epoch)
+    }
+
+    /// Number of unresolved departed incarnations retained for one player.
+    fn departed_count(&self, player_id: PlayerId) -> usize {
+        self.departed_senders
+            .range((player_id, u32::MIN)..=(player_id, u32::MAX))
+            .count()
     }
 
     /// Accept an optional rate-limited unsupported-format advisory only after
@@ -436,6 +474,11 @@ impl DeliveryAccountability {
                 "delivery accountability violation: {source} epoch {epoch} for {player_id} is not newer than announced epochs {announced:?}"
             ));
         }
+        if announced.len() >= MAX_ANNOUNCED_EPOCHS_PER_SENDER {
+            return Err(format!(
+                "delivery accountability violation: {source} epoch {epoch} for {player_id} exceeds the {MAX_ANNOUNCED_EPOCHS_PER_SENDER} unresolved announcement bound"
+            ));
+        }
         announced.insert(epoch);
         self.stale_senders.insert(player_id);
         Ok(())
@@ -452,6 +495,16 @@ impl DeliveryAccountability {
         if report.gaps.len() > DELIVERY_REPORT_MAX_GAPS {
             return Err(format!(
                 "delivery accountability violation: DeliveryReport contains {} gap ranges, limit is {DELIVERY_REPORT_MAX_GAPS}",
+                report.gaps.len()
+            ));
+        }
+        let outstanding_gaps = self
+            .pending_gaps
+            .values()
+            .fold(0usize, |total, gaps| total.saturating_add(gaps.len()));
+        if outstanding_gaps.saturating_add(report.gaps.len()) > MAX_TOTAL_PENDING_GAPS {
+            return Err(format!(
+                "delivery accountability violation: DeliveryReport would exceed the {MAX_TOTAL_PENDING_GAPS} exact-gap retention bound ({outstanding_gaps} outstanding plus {} new)",
                 report.gaps.len()
             ));
         }
@@ -1983,5 +2036,134 @@ mod tests {
 
         valid.reset_connection();
         valid.record_relay_stats(2_000, 0, 0, 0).unwrap();
+    }
+
+    #[test]
+    fn reconnect_epoch_flood_hits_the_announcement_bound() {
+        let sender = id(1);
+        let mut state = DeliveryAccountability::default();
+        state.rebaseline_snapshot(&[player(sender, 1)]).unwrap();
+
+        // Exactly the bound's worth of newer announcements is accepted. The
+        // literals pin the shipped threshold: retuning the constant must
+        // consciously update this evidence.
+        assert_eq!(MAX_ANNOUNCED_EPOCHS_PER_SENDER, 16);
+        for epoch in 2..=17u32 {
+            state.note_player_reconnected(sender, Some(epoch)).unwrap();
+        }
+        assert_eq!(
+            state.announced_epochs.get(&sender).map(BTreeSet::len),
+            Some(MAX_ANNOUNCED_EPOCHS_PER_SENDER)
+        );
+
+        // The next announcement is refused as server misbehavior and the
+        // refused frame leaves the machine untouched.
+        let error = state.note_player_reconnected(sender, Some(18)).unwrap_err();
+        assert!(error.contains("unresolved announcement"), "{error}");
+        assert_eq!(
+            state.announced_epochs.get(&sender).map(BTreeSet::len),
+            Some(MAX_ANNOUNCED_EPOCHS_PER_SENDER)
+        );
+    }
+
+    #[test]
+    fn uncoverable_departure_flood_stays_bounded() {
+        let sender = id(3);
+        let mut state = DeliveryAccountability::default();
+        state
+            .rebaseline_snapshot(&[player_at(sender, 1, 0)])
+            .unwrap();
+
+        // Each churn cycle announces a newer epoch and departs it with a
+        // terminal watermark retirement can never cover (the issue #166
+        // pathology), so both per-sender sets would grow monotonically.
+        for epoch in 2..=17u32 {
+            state.note_player_reconnected(sender, Some(epoch)).unwrap();
+            state
+                .note_player_left(sender, Some(epoch), Some(u64::MAX))
+                .unwrap();
+        }
+        assert_eq!(
+            state.announced_epochs.get(&sender).map(BTreeSet::len),
+            Some(MAX_ANNOUNCED_EPOCHS_PER_SENDER)
+        );
+        assert_eq!(
+            state.departed_count(sender),
+            MAX_DEPARTED_SENDERS_PER_PLAYER
+        );
+
+        // The next cycle is refused at the announcement bound before either
+        // structure can grow further.
+        let error = state.note_player_reconnected(sender, Some(18)).unwrap_err();
+        assert!(error.contains("unresolved announcement"), "{error}");
+        assert_eq!(
+            state.departed_count(sender),
+            MAX_DEPARTED_SENDERS_PER_PLAYER
+        );
+    }
+
+    #[test]
+    fn healthy_reconnect_churn_never_accumulates_toward_the_bounds() {
+        let sender = id(5);
+        let mut state = DeliveryAccountability::default();
+        state
+            .rebaseline_snapshot(&[player_at(sender, 1, 0)])
+            .unwrap();
+
+        // Legitimate flapping retires instantly: an idle departure carries
+        // final_seq == 0, so every churn cycle prunes both structures.
+        for epoch in 2..=64u32 {
+            state.note_player_reconnected(sender, Some(epoch)).unwrap();
+            state
+                .note_player_left(sender, Some(epoch), Some(0))
+                .unwrap();
+        }
+        assert!(state.announced_epochs.is_empty());
+        assert!(state.departed_senders.is_empty());
+        assert!(state.senders.is_empty());
+    }
+
+    #[test]
+    fn disjoint_gap_flood_hits_the_retention_ceiling() {
+        let sender = id(4);
+        let mut state = DeliveryAccountability::default();
+        state
+            .rebaseline_snapshot(&[player_at(sender, 1, 0)])
+            .unwrap();
+
+        // Four full reports of 256 singleton exact ranges saturate the bound;
+        // counter deltas match the causal gap units exactly throughout.
+        let batch_size = u64::try_from(DELIVERY_REPORT_MAX_GAPS).unwrap();
+        for batch in 1..=4u64 {
+            let gaps: Vec<DeliveryGap> = (0..DELIVERY_REPORT_MAX_GAPS as u64)
+                .map(|index| {
+                    let seq = (batch - 1) * batch_size + index + 1;
+                    gap(sender, seq, seq)
+                })
+                .collect();
+            let report = DeliveryReportPayload {
+                gaps,
+                per_class: counters_with_superseded(batch * batch_size),
+            };
+            state.record_report(&report).unwrap();
+        }
+        fn outstanding(state: &DeliveryAccountability) -> usize {
+            state
+                .pending_gaps
+                .values()
+                .map(Vec::len)
+                .fold(0usize, usize::saturating_add)
+        }
+        assert_eq!(outstanding(&state), MAX_TOTAL_PENDING_GAPS);
+
+        // One more exact range — even a single sequence — exceeds the ceiling,
+        // and the refused report does not mutate pending state.
+        let overflow = DeliveryReportPayload {
+            gaps: vec![gap(sender, 4 * batch_size + 1, 4 * batch_size + 1)],
+            per_class: counters_with_superseded(4 * batch_size + 1),
+        };
+        let error = state.record_report(&overflow).unwrap_err();
+        assert!(error.contains("retention bound"), "{error}");
+        assert_eq!(outstanding(&state), MAX_TOTAL_PENDING_GAPS);
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -4964,7 +4964,7 @@ mod tests {
             .unwrap_or_else(|| panic!("the absolute fallback must eventually reject joins"));
         assert_eq!(
             first_violation, 256,
-            "u8::MAX slots minus the baseline member"
+            "256 slots total including the baseline member"
         );
         client.shutdown().await;
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -4114,9 +4114,13 @@ mod tests {
                     self.sent.lock().unwrap().push(message);
                     Poll::Ready(Ok(()))
                 }
-                Some(TransportFrame::Binary(_)) => Poll::Ready(Err(
-                    SignalFishError::TransportSend("gated mock expected a text frame".into()),
-                )),
+                Some(TransportFrame::Binary(bytes)) => {
+                    self.sent
+                        .lock()
+                        .unwrap()
+                        .push(format!("<binary:{} bytes>", bytes.len()));
+                    Poll::Ready(Ok(()))
+                }
                 None => Poll::Ready(Ok(())),
             }
         }
@@ -4664,6 +4668,322 @@ mod tests {
 
         let mut client = Arc::into_inner(client).expect("all client clones should be dropped");
         client.shutdown().await;
+    }
+
+    /// Pins the cancellation contract for the remaining waiting-send entry
+    /// points: dropping `send_binary_game_data_reliable` or
+    /// `send_signal_reliable` while parked on queue capacity leaves no state
+    /// mutation, no statistics change, and no leaked queue permit, so an
+    /// identical command still completes afterwards.
+    #[tokio::test]
+    async fn dropping_parked_binary_and_signal_reliable_sends_leaves_no_trace() {
+        let peer = uuid::Uuid::from_u128(7);
+        let (transport, entered_send, permits, sent) = GatedSendTransport::new(0);
+        let mut config = SignalFishConfig::new("mb_test")
+            .enable_v3()
+            .with_command_channel_capacity(1);
+        config.game_data_format = Some(GameDataEncoding::MessagePack);
+        let (mut client, mut events) = SignalFishClient::start(transport, config);
+
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Connected)
+        ));
+        wait_until(|| entered_send.load(Ordering::Acquire)).await;
+
+        // Script a v3 room plus WebRTC plan directly into the shared core:
+        // binary sends need a negotiated MessagePack format and signals need
+        // an authoritative plan naming the peer.
+        {
+            let mut core = lock_core(&client.state);
+            let _ = core.process_frame(TransportFrame::Text(authenticated_json()));
+            let _ = core.process_frame(TransportFrame::Text(protocol_info_v3_json()));
+            core.record_admission(ClientCore::admission_for(&ClientOperation::JoinRoom(
+                JoinRoomParams::new("test-game", "local"),
+            )));
+            let _ = core.process_frame(TransportFrame::Text(finalized_room_v3_json(peer)));
+            let plan = session_plan_v3_json(peer);
+            let _ = core.process_frame(TransportFrame::Text(plan));
+        }
+
+        client
+            .send_game_data(serde_json::json!({ "fills": "queue" }))
+            .expect("capacity-1 queue should accept one filler command");
+        let client = Arc::new(client);
+
+        // Park and drop each waiting send in turn; nothing may change.
+        let stats_before = client.stats();
+        let snapshot_before = client.snapshot();
+
+        let binary_sender = Arc::clone(&client);
+        let mut parked_binary = Box::pin(async move {
+            binary_sender
+                .send_binary_game_data_reliable(vec![0xDE, 0xAD])
+                .await
+        });
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), parked_binary.as_mut())
+                .await
+                .is_err(),
+            "binary reliable send should be parked on queue capacity"
+        );
+        drop(parked_binary);
+
+        let signal_sender = Arc::clone(&client);
+        let mut parked_signal = Box::pin(async move {
+            signal_sender
+                .send_signal_reliable(peer, PeerSignal::Offer("cancelled-sdp".into()))
+                .await
+        });
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), parked_signal.as_mut())
+                .await
+                .is_err(),
+            "signal reliable send should be parked on queue capacity"
+        );
+        drop(parked_signal);
+
+        assert_eq!(client.stats(), stats_before, "stats must not move");
+        assert_eq!(client.snapshot(), snapshot_before, "snapshot must not move");
+        assert_eq!(client.send_capacity(), 0, "the filler still owns the slot");
+
+        // Capacity restored: identical commands complete; the cancelled
+        // payloads must never appear on the wire. The gated mock records text
+        // frames verbatim and binary frames as length markers, so both
+        // completions and both cancelled payloads are observable.
+        permits.add_permits(16);
+        client
+            .send_binary_game_data_reliable(vec![1, 2, 3])
+            .await
+            .expect("an identical binary reliable send must complete after cancellation");
+        client
+            .send_signal_reliable(peer, PeerSignal::Offer("fresh-sdp".into()))
+            .await
+            .expect("an identical signal reliable send must complete after cancellation");
+        wait_until(|| {
+            sent.lock()
+                .unwrap()
+                .iter()
+                .any(|json| json.contains("fresh-sdp"))
+        })
+        .await;
+        {
+            let payloads = sent.lock().unwrap();
+            assert!(
+                !payloads.iter().any(|json| json.contains("cancelled")),
+                "cancelled payloads must not reach the wire: {payloads:?}"
+            );
+            assert!(
+                !payloads
+                    .iter()
+                    .any(|json| json.contains("<binary:2 bytes>")),
+                "the cancelled 2-byte payload must not reach the wire: {payloads:?}"
+            );
+            assert!(
+                payloads
+                    .iter()
+                    .any(|json| json.contains("<binary:3 bytes>")),
+                "the identical binary payload must reach the wire: {payloads:?}"
+            );
+            assert!(
+                payloads.iter().any(|json| json.contains("fresh-sdp")),
+                "the identical signal must reach the wire: {payloads:?}"
+            );
+            assert_eq!(client.stats().game_data_sent, 2);
+        }
+
+        let mut client = Arc::into_inner(client).expect("all client clones should be dropped");
+        client.shutdown().await;
+    }
+
+    /// beyond the advertised capacity are lifecycle violations, while
+    /// duplicates, freed slots, and fresh baselines keep working. Spectator
+    /// baselines carry no capacity on the wire and fall back to the
+    /// protocol-absolute `u8` ceiling.
+    #[tokio::test]
+    async fn over_capacity_player_joins_violate_roster_admission() {
+        let (transport, entered_send, _permits, _sent) = GatedSendTransport::new(0);
+        let (mut client, mut events) =
+            SignalFishClient::start(transport, SignalFishConfig::new("mb_test").enable_v3());
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Connected)
+        ));
+        wait_until(|| entered_send.load(Ordering::Acquire)).await;
+
+        let local = uuid::Uuid::from_u128(42);
+        let room_id = uuid::Uuid::from_u128(41);
+        fn joiner(id: u128) -> ServerMessage {
+            ServerMessage::PlayerJoined {
+                player: crate::protocol::PlayerInfo {
+                    id: uuid::Uuid::from_u128(id),
+                    name: "joiner".into(),
+                    is_authority: false,
+                    is_ready: false,
+                    connected_at: "2026-01-01T00:00:00Z".into(),
+                    connection_info: None,
+                    epoch: Some(1),
+                    seq: Some(0),
+                },
+            }
+        }
+        let feed = |client: &SignalFishClient, message: &ServerMessage| {
+            let frame = TransportFrame::Text(serde_json::to_string(message).unwrap());
+            lock_core(&client.state).process_frame(frame).events
+        };
+        let baseline = |max_players: u8, players: &[u128]| {
+            ServerMessage::RoomJoined(Box::new(RoomJoinedPayload {
+                room_id,
+                room_code: "ROOM".into(),
+                player_id: local,
+                game_name: "game".into(),
+                max_players,
+                supports_authority: true,
+                current_players: players
+                    .iter()
+                    .map(|id| crate::protocol::PlayerInfo {
+                        id: uuid::Uuid::from_u128(*id),
+                        name: "member".into(),
+                        is_authority: *id == 42,
+                        is_ready: false,
+                        connected_at: "2026-01-01T00:00:00Z".into(),
+                        connection_info: None,
+                        epoch: Some(1),
+                        seq: Some(0),
+                    })
+                    .collect(),
+                is_authority: true,
+                lobby_state: LobbyState::Waiting,
+                ready_players: vec![],
+                relay_type: "websocket".into(),
+                current_spectators: vec![],
+                ice_servers: vec![],
+                reconnection_token: None,
+            }))
+        };
+
+        {
+            let mut core = lock_core(&client.state);
+            let _ = core.process_frame(TransportFrame::Text(authenticated_json()));
+            let _ = core.process_frame(TransportFrame::Text(protocol_info_v3_json()));
+            core.record_admission(ClientCore::admission_for(&ClientOperation::JoinRoom(
+                JoinRoomParams::new("game", "local"),
+            )));
+        }
+        assert!(feed(&client, &baseline(3, &[42, 7]))
+            .iter()
+            .any(|event| matches!(event, SignalFishEvent::RoomJoined { .. })));
+
+        // The final advertised slot is admitted normally.
+        let events = feed(&client, &joiner(8));
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| matches!(event, SignalFishEvent::PlayerJoined { .. }))
+                .count(),
+            1
+        );
+        // The roster is full: another distinct join violates instead of growing it.
+        let events = feed(&client, &joiner(9));
+        let violation = events.iter().find_map(|event| match event {
+            SignalFishEvent::ProtocolViolation { diagnostic, .. } => Some(diagnostic),
+            _ => None,
+        });
+        assert!(
+            violation.is_some_and(|diagnostic| diagnostic.contains("capacity")),
+            "expected a capacity violation: {events:?}"
+        );
+        assert!(client.snapshot().quarantined);
+        // Duplicates of an existing member stay idempotent echoes, not violations.
+        assert!(feed(&client, &joiner(8))
+            .iter()
+            .any(|event| matches!(event, SignalFishEvent::PlayerJoined { .. })));
+
+        // A tighter baseline lowers the ceiling; a departure frees its slot
+        // again. Leaving first because baselines require absent membership.
+        core_leave_room(&client);
+        {
+            let mut core = lock_core(&client.state);
+            core.record_admission(ClientCore::admission_for(&ClientOperation::JoinRoom(
+                JoinRoomParams::new("game", "local"),
+            )));
+        }
+        assert!(feed(&client, &baseline(2, &[42, 7]))
+            .iter()
+            .any(|event| matches!(event, SignalFishEvent::RoomJoined { .. })));
+        let left = ServerMessage::PlayerLeft {
+            player_id: uuid::Uuid::from_u128(7),
+            epoch: Some(1),
+            final_seq: Some(0),
+        };
+        assert_eq!(
+            feed(&client, &left)
+                .iter()
+                .filter(|event| matches!(event, SignalFishEvent::PlayerLeft { .. }))
+                .count(),
+            1
+        );
+        assert!(feed(&client, &joiner(10))
+            .iter()
+            .any(|event| matches!(event, SignalFishEvent::PlayerJoined { .. })));
+
+        // Spectator baselines omit `max_players`, so the wire-absolute
+        // fallback becomes the ceiling: the 256th distinct join violates on
+        // a roster already holding one baseline member, everything before
+        // stays admitted.
+        core_record_spectator_join(&client);
+        let spectator =
+            ServerMessage::SpectatorJoined(Box::new(crate::protocol::SpectatorJoinedPayload {
+                room_id,
+                room_code: "ROOM".into(),
+                spectator_id: local,
+                game_name: "game".into(),
+                current_players: vec![crate::protocol::PlayerInfo {
+                    id: uuid::Uuid::from_u128(42),
+                    name: "local".into(),
+                    is_authority: false,
+                    is_ready: false,
+                    connected_at: "2026-01-01T00:00:00Z".into(),
+                    connection_info: None,
+                    epoch: Some(1),
+                    seq: Some(0),
+                }],
+                current_spectators: vec![],
+                lobby_state: LobbyState::Waiting,
+                reason: None,
+            }));
+        assert!(feed(&client, &spectator)
+            .iter()
+            .any(|event| matches!(event, SignalFishEvent::SpectatorJoined { .. })));
+        let first_violation = (1u64..=300)
+            .find(|ordinal| {
+                feed(&client, &joiner(u128::from(*ordinal) + 1000))
+                    .iter()
+                    .any(|event| matches!(event, SignalFishEvent::ProtocolViolation { .. }))
+            })
+            .unwrap_or_else(|| panic!("the absolute fallback must eventually reject joins"));
+        assert_eq!(
+            first_violation, 256,
+            "u8::MAX slots minus the baseline member"
+        );
+        client.shutdown().await;
+    }
+
+    /// Admits and confirms a voluntary room leave.
+    fn core_leave_room(client: &SignalFishClient) {
+        let mut core = lock_core(&client.state);
+        core.record_admission(ClientCore::admission_for(&ClientOperation::LeaveRoom));
+        let _ = core.process_frame(TransportFrame::Text(r#"{"type":"RoomLeft"}"#.into()));
+    }
+
+    /// Admits the voluntary leave that precedes the spectator baseline in the
+    /// roster-capacity pin above.
+    fn core_record_spectator_join(client: &SignalFishClient) {
+        core_leave_room(client);
+        let mut core = lock_core(&client.state);
+        core.record_admission(ClientCore::admission_for(
+            &ClientOperation::JoinAsSpectator("game".into(), "ROOM".into(), "local".into()),
+        ));
     }
 
     #[tokio::test]

--- a/src/client_core.rs
+++ b/src/client_core.rs
@@ -123,6 +123,12 @@ impl FrameOutcome {
 /// while bounding per-room memory under generation churn.
 const RETIRED_SESSION_GENERATION_FENCE: usize = 8;
 
+/// Absolute roster admission fallback for baselines that do not advertise a
+/// capacity (spectator joins). `max_players` is a `u8` on the wire, so no
+/// legitimate room can hold more distinct players than this; the fallback
+/// bounds `room_players` growth even when the exact ceiling is unknown.
+const ABSOLUTE_ROSTER_CAPACITY: usize = 256;
+
 /// Shared protocol state and behavior used by both public client drivers.
 pub(crate) struct ClientCore {
     snapshot: ClientSnapshot,
@@ -137,6 +143,12 @@ pub(crate) struct ClientCore {
     authority_player: Option<PlayerId>,
     room_finalized: bool,
     room_players: HashSet<PlayerId>,
+    // Player-slot capacity advertised by the latest authoritative baseline
+    // (`RoomJoined`/`Reconnected`). Spectator baselines omit the field on the
+    // wire, leaving the absolute [`ABSOLUTE_ROSTER_CAPACITY`] fallback as the
+    // admission ceiling. Incremental `PlayerJoined` inserts beyond the ceiling
+    // are lifecycle violations instead of unbounded roster growth (issue #166).
+    room_max_players: Option<u8>,
     session_plan_seen: bool,
     session_peers: HashSet<PlayerId>,
     // Recently superseded plan generations, fenced against replayed plans
@@ -176,6 +188,8 @@ struct RoomBaseline {
     authority_player: Option<PlayerId>,
     finalized: bool,
     players: HashSet<PlayerId>,
+    // Spectator baselines omit the wire field, so this is `None` there.
+    max_players: Option<u8>,
 }
 
 pub(crate) struct PendingReconnect {
@@ -257,6 +271,7 @@ impl ClientCore {
             authority_player: None,
             room_finalized: false,
             room_players: HashSet::new(),
+            room_max_players: None,
             session_plan_seen: false,
             session_peers: HashSet::new(),
             retired_session_generations: VecDeque::new(),
@@ -737,6 +752,7 @@ impl ClientCore {
         self.authority_player = None;
         self.room_finalized = false;
         self.room_players.clear();
+        self.room_max_players = None;
         self.session_plan_seen = false;
         self.session_peers.clear();
         self.retired_session_generations.clear();
@@ -1373,6 +1389,16 @@ impl ClientCore {
                         .into(),
                 )
             }
+            ServerMessage::PlayerJoined { player }
+                if !self.room_players.contains(&player.id)
+                    && self.room_players.len() >= self.roster_capacity() =>
+            {
+                Err(format!(
+                    "lifecycle violation: PlayerJoined {} exceeds the advertised room capacity of {} players",
+                    player.id,
+                    self.roster_capacity()
+                ))
+            }
             ServerMessage::AuthorityChanged {
                 authority_player,
                 you_are_authority,
@@ -1424,6 +1450,14 @@ impl ClientCore {
             ),
             _ => Ok(()),
         }
+    }
+
+    /// Effective player-roster admission ceiling: the advertised
+    /// `max_players`, or the wire-absolute fallback when the latest baseline
+    /// could not advertise one (spectator joins).
+    fn roster_capacity(&self) -> usize {
+        self.room_max_players
+            .map_or(ABSOLUTE_ROSTER_CAPACITY, usize::from)
     }
 
     fn validate_pending_room_response(
@@ -1737,6 +1771,7 @@ impl ClientCore {
                         .iter()
                         .map(|player| player.id)
                         .collect(),
+                    max_players: Some(payload.max_players),
                 });
             }
             ServerMessage::RoomJoinFailed { .. } => {
@@ -1768,6 +1803,7 @@ impl ClientCore {
                         .iter()
                         .map(|player| player.id)
                         .collect(),
+                    max_players: Some(payload.max_players),
                 });
             }
             ServerMessage::SpectatorJoined(payload) => {
@@ -1788,6 +1824,7 @@ impl ClientCore {
                         .iter()
                         .map(|player| player.id)
                         .collect(),
+                    max_players: None,
                 });
             }
             ServerMessage::SpectatorJoinFailed { .. } => {
@@ -1868,6 +1905,7 @@ impl ClientCore {
         self.authority_player = baseline.authority_player;
         self.room_finalized = baseline.finalized;
         self.room_players = baseline.players;
+        self.room_max_players = baseline.max_players;
         self.session_plan_seen = false;
         self.session_peers.clear();
         self.retired_session_generations.clear();
@@ -1891,6 +1929,7 @@ impl ClientCore {
         self.authority_player = None;
         self.room_finalized = false;
         self.room_players.clear();
+        self.room_max_players = None;
         self.session_plan_seen = false;
         self.session_peers.clear();
         self.retired_session_generations.clear();

--- a/src/transports/websocket.rs
+++ b/src/transports/websocket.rs
@@ -1837,6 +1837,63 @@ mod tests {
         finish_mock_server(server_task).await;
     }
 
+    /// Pins connect-future cancellation for required token binding: dropping
+    /// the future while it waits for the server challenge must tear down the
+    /// selected socket promptly instead of leaking a half-open connection.
+    #[cfg(feature = "token-binding")]
+    #[tokio::test]
+    async fn dropping_required_connect_mid_challenge_closes_the_socket() {
+        use tokio_tungstenite::tungstenite::http::header::SEC_WEBSOCKET_PROTOCOL;
+
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("mid-challenge listener must bind");
+        let addr = listener
+            .local_addr()
+            .expect("mid-challenge listener must have an address");
+        let server_task = tokio::spawn(async move {
+            let (tcp, _) = listener.accept().await.expect("server must accept client");
+            let mut ws = tokio_tungstenite::accept_hdr_async(
+                tcp,
+                |_request: &tokio_tungstenite::tungstenite::handshake::server::Request,
+                 mut response: tokio_tungstenite::tungstenite::handshake::server::Response| {
+                    response.headers_mut().insert(
+                        SEC_WEBSOCKET_PROTOCOL,
+                        tokio_tungstenite::tungstenite::http::HeaderValue::from_static(
+                            crate::token_binding::TOKEN_BINDING_SUBPROTOCOL,
+                        ),
+                    );
+                    Ok(response)
+                },
+            )
+            .await
+            .expect("selected handshake must succeed");
+            // The client never receives its challenge: dropping the connect
+            // future must end this stream within the timeout below.
+            match tokio::time::timeout(std::time::Duration::from_secs(1), ws.next()).await {
+                Ok(None | Some(Err(_))) => {}
+                Ok(Some(Ok(message))) => {
+                    panic!("dropped connect future must not send frames: {message:?}")
+                }
+                Err(_) => panic!("the socket stayed open after the connect future was dropped"),
+            }
+        });
+
+        let url = format!("ws://{addr}");
+        let mut connect = Box::pin(WebSocketTransport::connect_with_options(
+            &url,
+            required_token_binding_options(),
+        ));
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(100), connect.as_mut())
+                .await
+                .is_err(),
+            "connect must stay parked awaiting the challenge"
+        );
+        drop(connect);
+        finish_mock_server(server_task).await;
+    }
+
     #[cfg(feature = "token-binding")]
     #[tokio::test]
     async fn selected_mode_times_out_waiting_for_the_first_challenge() {


### PR DESCRIPTION
Closes #166.

## Why

Long game sessions accumulate per-room bookkeeping that never shrinks on its own. A hostile or pathologically churning server could grow a client's memory without limit for the whole room stay — through sender incarnation records, uncovered departure terminals, retained exact-gap ranges, and roster inserts. Issue #166 asked for an explicit trade-off; this PR adopts both options: numeric caps with violation diagnostics, plus documented resource envelopes for what intentionally stays uncapped.

## How

- Delivery accountability refuses (as ordinary violation diagnostics, validating before mutating state) more than **16 unresolved incarnation announcements** or **uncovered departures per sender**, and delivery reports pushing total retained gap ranges past **1024**.
- Room rosters are admission-bounded by the server-advertised `max_players`, with a wire-absolute fallback (`u8::MAX + 1`) when the latest baseline cannot advertise one (spectator joins). Duplicates and slot-freed rejoins keep working; over-capacity `PlayerJoined` is a lifecycle violation.
- Unknown-player `PlayerReconnected` sender cursors stay the one documented trusted-server envelope: containment gates would reject legitimate reconnects of players absent from the local snapshot.
- Lands the two missing cancellation pins: dropping parked `send_binary_game_data_reliable` / `send_signal_reliable` futures leaves no trace, and dropping a required token-binding `connect_with_options` future mid-challenge closes the socket promptly.

## Verification

- Mandatory workflow clean (`fmt`, clippy `-D warnings`, full workspace tests).
- Red/green evidence: loosening any threshold fails its pinned test while healthy-churn controls stay green under both settings; thresholds frozen by literal test assertions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when the client quarantines or rejects server-driven lifecycle and accountability frames under adversarial churn; legitimate traffic should stay well below the new limits, but mis-tuned thresholds could theoretically flag a buggy server sooner than before.
> 
> **Overview**
> Closes **#166** by capping client-side per-room bookkeeping that could grow without limit during long sessions against pathological server churn.
> 
> **Delivery accountability** now rejects overflow as ordinary violation diagnostics (validated before any state mutation): at most **16** unresolved incarnation announcements or uncovered departures per sender, and at most **1024** total retained exact gap ranges across pending delivery reports.
> 
> **Room rosters** track `max_players` from the latest `RoomJoined`/`Reconnected` baseline; incremental `PlayerJoined` beyond that ceiling (or beyond a **256**-player wire fallback when spectator baselines omit capacity) becomes a **lifecycle violation** instead of unbounded `HashSet` growth. Duplicates, departures that free slots, and tighter baselines still behave as before.
> 
> Also adds **regression pins** for two cancellation contracts: dropping parked `send_binary_game_data_reliable` / `send_signal_reliable` futures must leave no stats, snapshot, or wire trace; dropping required token-binding `connect_with_options` mid-challenge must close the socket promptly. `.llm/context.md` is tightened to document the new envelopes; **CHANGELOG** records the user-visible fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5ff1b96624de42f950ade5ac620220792ab9404. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->