### PR TITLE
Round 12 audit: release answered operation fences, close sparse build hole

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,8 @@ jobs:
             flags: "--no-default-features --features polling-client"
           - name: mesh-only
             flags: "--no-default-features --features mesh"
+          - name: tokio-runtime-only
+            flags: "--no-default-features --features tokio-runtime"
           - name: tls-only
             flags: "--no-default-features --features tls"
     steps:
@@ -126,6 +128,8 @@ jobs:
             flags: "--no-default-features --features polling-client"
           - name: mesh-only
             flags: "--no-default-features --features mesh"
+          - name: tokio-runtime-only
+            flags: "--no-default-features --features tokio-runtime"
           - name: tls-only
             flags: "--no-default-features --features tls"
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added root re-exports for the `PlayerId` and `RoomId` identity aliases that
+  appear throughout the client API (`reconnect`, `send_signal`,
+  `ClientSnapshot`), so typed helpers no longer need a deep
+  `signal_fish_client::protocol::` import.
 - Added `ErrorCode::RoomSessionIncompatible` (wire
   `ROOM_SESSION_INCOMPATIBLE`) for the post-0.7 server response used when a
   running room's sticky peer-to-peer topology/transport pair is incompatible
@@ -135,6 +139,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The shared diagnostic accessors on both drivers —
+  `send_capacity`, `max_send_capacity`, `stats`, `snapshot`, and
+  `transport_diagnostics`, plus the polling driver's `polling_stats` and
+  `queue_age_stats` — are now `#[must_use]`; ignoring them is a compile
+  warning instead of silently discarding an entire coherent diagnostics view.
+- `MeshSession` now implements equality comparison like its sibling coherent
+  state views (`ClientSnapshot`, stats types), so folded session states can be
+  compared and asserted directly.
 - `SignalFishPollingClient::poll` is now `#[must_use]`; ignoring the returned
   event list is a compile warning instead of silently discarding that poll
   cycle's deliveries (the leading cause of "stuck in lobby" misuse reports).
@@ -257,6 +269,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed a liveness defect in protocol-v3 (and legacy-mode) room operations: a
+  typed terminal answer whose payload was rejected by delivery accountability
+  (for example, a drifting roster snapshot) left the operation's admission
+  fence armed forever, so every later join/leave/reconnect/spectator command
+  failed locally with `RoomOperationPending` until the connection tore down
+  (under every non-disconnecting violation policy). The answered fence is now
+  retired as soon as the matching terminal arrives. Violation handling,
+  suppression of the invalid payload, and retention of
+  mismatched/forged-operation fences are unchanged; as before, a later
+  duplicate reply for the already-settled id reports a lifecycle violation.
+  Red/green pinned across correlated, legacy-wire, and reconnect paths in
+  both drivers' shared core.
 - Fixed a release-automation defect that would make every future Prepare
   Release run fail before writing anything: the version-inventory still
   required `docs/examples.md` to mention the workspace version, but that page

--- a/docs/client.md
+++ b/docs/client.md
@@ -76,7 +76,7 @@ let config = SignalFishConfig::new("mb_app_abc123")
 Or using struct literal syntax with defaults:
 
 ```rust,ignore
-use signal_fish_client::{SignalFishConfig, protocol::GameDataEncoding};
+use signal_fish_client::{GameDataEncoding, SignalFishConfig};
 
 let config = SignalFishConfig {
     app_id: "mb_app_abc123".into(),
@@ -503,7 +503,7 @@ fn provide_connection_info(
 ```
 
 ```rust,ignore
-use signal_fish_client::protocol::ConnectionInfo;
+use signal_fish_client::ConnectionInfo;
 
 client.provide_connection_info(ConnectionInfo::Direct {
     host: "192.168.1.10".into(),

--- a/examples/basic_lobby.rs
+++ b/examples/basic_lobby.rs
@@ -18,7 +18,7 @@
 //! SIGNAL_FISH_URL=ws://my-server:3536/v2/ws cargo run --example basic_lobby
 //! ```
 
-use signal_fish_client::protocol::LobbyState;
+use signal_fish_client::LobbyState;
 use signal_fish_client::{
     JoinRoomParams, SignalFishClient, SignalFishConfig, SignalFishEvent, WebSocketTransport,
 };

--- a/examples/mesh_session.rs
+++ b/examples/mesh_session.rs
@@ -22,9 +22,9 @@
 
 use std::collections::VecDeque;
 
-use signal_fish_client::protocol::{IceServer, PlayerId, SessionGeneration};
 use signal_fish_client::transport::TransportFrame;
 use signal_fish_client::webrtc::{DriverEvent, MeshController, MeshEvent, WebRtcDriver};
+use signal_fish_client::{IceServer, PlayerId, SessionGeneration};
 use signal_fish_client::{
     JoinRoomParams, PeerSignal, SignalFishConfig, SignalFishError, SignalFishEvent, Transport,
 };

--- a/src/client.rs
+++ b/src/client.rs
@@ -1545,17 +1545,20 @@ impl SignalFishClient {
     /// A shrinking value is the congestion signal: the caller is producing
     /// faster than the transport drains. `0` means the next fail-fast send
     /// will be refused.
+    #[must_use = "this diagnostic view is discarded if not used"]
     pub fn send_capacity(&self) -> usize {
         self.cmd_tx.capacity()
     }
 
     /// Configured capacity of the outgoing command queue
     /// (see [`SignalFishConfig::command_channel_capacity`]).
+    #[must_use = "this diagnostic view is discarded if not used"]
     pub fn max_send_capacity(&self) -> usize {
         self.cmd_tx.max_capacity()
     }
 
     /// Cumulative game-data traffic counters (see [`ClientStats`]).
+    #[must_use = "this diagnostic view is discarded if not used"]
     pub fn stats(&self) -> ClientStats {
         lock_core(&self.state).stats()
     }
@@ -1574,11 +1577,13 @@ impl SignalFishClient {
     /// ([`SendBufferFull`](crate::SignalFishError::SendBufferFull), shrinking
     /// [`send_capacity`](Self::send_capacity)) apart from backend watermark or
     /// capacity deferrals when tuning a deployment.
+    #[must_use = "this diagnostic view is discarded if not used"]
     pub fn transport_diagnostics(&self) -> TransportDiagnostics {
         lock_core(&self.state).transport_diagnostics()
     }
 
     /// Return a coherent synchronous snapshot of connection and room state.
+    #[must_use = "this diagnostic view is discarded if not used"]
     pub fn snapshot(&self) -> ClientSnapshot {
         lock_core(&self.state).snapshot()
     }

--- a/src/client_api.rs
+++ b/src/client_api.rs
@@ -14,6 +14,12 @@ use crate::signal::PeerSignal;
 /// Driver-specific
 /// operations such as async waiting sends, `shutdown`, `poll`, and `close` are
 /// intentionally excluded.
+///
+/// Signal methods here take a concrete [`PeerSignal`] rather than
+/// `impl Into<PeerSignal>` because object safety forbids generic parameters;
+/// the inherent driver methods keep the ergonomic conversion, and the
+/// defaulted `send_offer`/`send_answer`/`send_ice_candidate` helpers accept
+/// raw SDP/candidate strings directly.
 pub trait SignalFishClientApi {
     /// Join or create a room.
     fn join_room(&mut self, params: JoinRoomParams) -> Result<()>;

--- a/src/client_core.rs
+++ b/src/client_core.rs
@@ -1016,7 +1016,7 @@ impl ClientCore {
                     pending.kind == PendingRoomOperation::LeaveSpectator
                         && pending.operation_id.is_none()
                 }) && absorbed.pending.operation_id.is_none()
-                    && !spectator_exit_is_authoritative(reason.as_ref())
+                    && spectator_exit_answers_voluntary_leave(reason.as_ref())
                     && room_identity_matches(
                         absorbed.room_id,
                         absorbed.room_code.as_ref(),
@@ -2232,6 +2232,23 @@ fn spectator_exit_is_authoritative(
     )
 }
 
+/// Whether a `SpectatorLeft` reason answers an admitted voluntary leave:
+/// exactly the no-reason or voluntary-leave faces.
+///
+/// The reason space partitions in three, and the third face is not the
+/// complement of either side above: a malformed
+/// [`Joined`](crate::protocol::SpectatorStateChangeReason::Joined) reason
+/// belongs to no valid partition, so every classifier must exclude it
+/// explicitly instead of folding it into the voluntary face via negation.
+fn spectator_exit_answers_voluntary_leave(
+    reason: Option<&crate::protocol::SpectatorStateChangeReason>,
+) -> bool {
+    matches!(
+        reason,
+        None | Some(crate::protocol::SpectatorStateChangeReason::VoluntaryLeave)
+    )
+}
+
 /// Whether an unwrapped server message is the typed terminal answer for a
 /// pending directed room operation (the uncorrelated face of
 /// [`ClientCore::retire_answered_room_operation`]).
@@ -2252,7 +2269,7 @@ fn terminal_message_matches(kind: PendingRoomOperation, message: &ServerMessage)
         ),
         PendingRoomOperation::LeaveSpectator => match message {
             ServerMessage::SpectatorLeft { reason, .. } => {
-                !spectator_exit_is_authoritative(reason.as_ref())
+                spectator_exit_answers_voluntary_leave(reason.as_ref())
             }
             _ => false,
         },
@@ -2282,7 +2299,7 @@ fn room_operation_result_matches(
         (
             PendingRoomOperation::LeaveSpectator,
             RoomOperationResult::SpectatorLeft { reason, .. },
-        ) => !spectator_exit_is_authoritative(reason.as_ref()),
+        ) => spectator_exit_answers_voluntary_leave(reason.as_ref()),
         _ => false,
     }
 }
@@ -3040,6 +3057,18 @@ mod tests {
                 },
             ));
         }
+        assert!(
+            !terminal_message_matches(
+                PendingRoomOperation::LeaveSpectator,
+                &ServerMessage::SpectatorLeft {
+                    room_id: None,
+                    room_code: None,
+                    reason: Some(crate::protocol::SpectatorStateChangeReason::Joined),
+                    current_spectators: vec![],
+                },
+            ),
+            "a malformed joined reason belongs to no valid partition"
+        );
     }
 
     #[test]
@@ -3548,6 +3577,82 @@ mod tests {
         );
         assert!(absorbed.events.is_empty());
         assert!(core.absorbed_spectator_leave.is_none());
+    }
+
+    #[test]
+    fn malformed_joined_reason_never_consumes_the_overtaken_leave_allowance() {
+        let mut core = correlated_outside(ProtocolViolationPolicy::Observe);
+        let (_, join_id) = prepare_and_admit(
+            &mut core,
+            ClientOperation::JoinAsSpectator("game".into(), "ROOM".into(), "viewer".into()),
+        );
+        let ServerMessage::SpectatorJoined(payload) = spectator_joined() else {
+            unreachable!("spectator_joined helper always returns SpectatorJoined")
+        };
+        assert!(matches!(
+            process(
+                &mut core,
+                correlated_result(join_id, RoomOperationResult::SpectatorJoined(payload))
+            )
+            .events
+            .as_slice(),
+            [SignalFishEvent::SpectatorJoined { .. }]
+        ));
+        let (_, leave_id) = prepare_and_admit(&mut core, ClientOperation::LeaveSpectator);
+        assert!(
+            process(
+                &mut core,
+                ServerMessage::SpectatorLeft {
+                    room_id: Some(RoomId::from_u128(10)),
+                    room_code: Some("ROOM".into()),
+                    reason: Some(crate::protocol::SpectatorStateChangeReason::Removed),
+                    current_spectators: vec![],
+                },
+            )
+            .events
+            .len()
+                == 1,
+            "the authoritative exit tears the spectator out and arms the allowance"
+        );
+
+        // A malformed joined-reason exit is not a voluntary-leave answer:
+        // the absorb seam must leave it alone, and with no pending operation
+        // left it violates at normalization instead of eating the awaited
+        // reply slot.
+        let malformed = process(
+            &mut core,
+            correlated_result(
+                leave_id,
+                RoomOperationResult::SpectatorLeft {
+                    room_id: Some(RoomId::from_u128(10)),
+                    room_code: Some("ROOM".into()),
+                    reason: Some(crate::protocol::SpectatorStateChangeReason::Joined),
+                    current_spectators: vec![],
+                },
+            ),
+        );
+        assert_lifecycle_violation_containing(&malformed, "without a pending room operation");
+        assert!(
+            core.absorbed_spectator_leave.is_some(),
+            "the allowance survives an unclassifiable exit frame"
+        );
+        assert_eq!(core.room_role(), None);
+
+        let true_reply = process(
+            &mut core,
+            correlated_result(leave_id, spectator_left_voluntary()),
+        );
+        assert!(true_reply.events.is_empty());
+        assert!(core.absorbed_spectator_leave.is_none());
+    }
+
+    fn spectator_left_voluntary() -> RoomOperationResult {
+        RoomOperationResult::SpectatorLeft {
+            room_id: Some(RoomId::from_u128(10)),
+            room_code: Some("ROOM".into()),
+            reason: Some(crate::protocol::SpectatorStateChangeReason::VoluntaryLeave),
+            current_spectators: vec![],
+        }
     }
 
     #[test]

--- a/src/client_core.rs
+++ b/src/client_core.rs
@@ -902,6 +902,12 @@ impl ClientCore {
             }
             Err(diagnostic) => {
                 self.push_violation(&mut outcome.events, diagnostic);
+                // An admitted directed operation's typed answer still settles
+                // that operation when delivery accountability rejects its
+                // payload: the fence exists to arbitrate the in-flight wire
+                // race, not to convert one drifting frame into a permanent
+                // local admission lockout under any violation policy.
+                self.retire_answered_room_operation(&server_msg);
                 if self.violation_policy == ProtocolViolationPolicy::Disconnect {
                     outcome.disconnect = true;
                     return outcome;
@@ -1010,10 +1016,7 @@ impl ClientCore {
                     pending.kind == PendingRoomOperation::LeaveSpectator
                         && pending.operation_id.is_none()
                 }) && absorbed.pending.operation_id.is_none()
-                    && matches!(
-                        reason,
-                        None | Some(crate::protocol::SpectatorStateChangeReason::VoluntaryLeave)
-                    )
+                    && !spectator_exit_is_authoritative(reason.as_ref())
                     && room_identity_matches(
                         absorbed.room_id,
                         absorbed.room_code.as_ref(),
@@ -1086,6 +1089,29 @@ impl ClientCore {
             .as_ref()
             .is_some_and(|pending| pending.kind == PendingRoomOperation::ReconnectPlayer)
         {
+            self.pending_reconnects.pop_front();
+        }
+        self.pending_room_operation = None;
+    }
+
+    /// Retire an admitted directed room operation's fence once a frame
+    /// classifies as that operation's typed terminal answer.
+    ///
+    /// Runs only when delivery accountability rejected the frame (the healthy
+    /// path retires inside `update_state`), so suppression never strands the
+    /// fence. Frames that merely name a different or forged operation keep it
+    /// armed exactly as before: they violate and stay fenced by contract.
+    /// Correlated `OperationFailed` results never reach this helper — their
+    /// envelope unwraps to the dedicated failure path above before any
+    /// validation runs.
+    fn retire_answered_room_operation(&mut self, message: &ServerMessage) {
+        let Some(pending) = self.pending_room_operation.as_ref() else {
+            return;
+        };
+        if !terminal_message_matches(pending.kind, message) {
+            return;
+        }
+        if pending.kind == PendingRoomOperation::ReconnectPlayer {
             self.pending_reconnects.pop_front();
         }
         self.pending_room_operation = None;
@@ -1381,14 +1407,7 @@ impl ClientCore {
                 reason,
                 ..
             } => {
-                let authoritative_exit = matches!(
-                    reason,
-                    Some(
-                        crate::protocol::SpectatorStateChangeReason::Disconnected
-                            | crate::protocol::SpectatorStateChangeReason::Removed
-                            | crate::protocol::SpectatorStateChangeReason::RoomClosed
-                    )
-                );
+                let authoritative_exit = spectator_exit_is_authoritative(reason.as_ref());
                 match reason {
                     Some(
                         crate::protocol::SpectatorStateChangeReason::Disconnected
@@ -1947,14 +1966,7 @@ impl ClientCore {
                 }
             }
             ServerMessage::SpectatorLeft { reason, .. } => {
-                let authoritative_exit = matches!(
-                    reason,
-                    Some(
-                        crate::protocol::SpectatorStateChangeReason::Disconnected
-                            | crate::protocol::SpectatorStateChangeReason::Removed
-                            | crate::protocol::SpectatorStateChangeReason::RoomClosed
-                    )
-                );
+                let authoritative_exit = spectator_exit_is_authoritative(reason.as_ref());
                 let mut overtaken_leave = None;
                 if authoritative_exit
                     && self
@@ -2196,15 +2208,54 @@ fn is_uncorrelated_directed_room_response(message: &ServerMessage) -> bool {
         | ServerMessage::ReconnectionFailed { .. }
         | ServerMessage::SpectatorJoined(_)
         | ServerMessage::SpectatorJoinFailed { .. } => true,
-        ServerMessage::SpectatorLeft { reason, .. } => !matches!(
-            reason,
-            Some(
-                crate::protocol::SpectatorStateChangeReason::Disconnected
-                    | crate::protocol::SpectatorStateChangeReason::Removed
-                    | crate::protocol::SpectatorStateChangeReason::RoomClosed
-            )
-        ),
+        ServerMessage::SpectatorLeft { reason, .. } => {
+            !spectator_exit_is_authoritative(reason.as_ref())
+        }
         _ => false,
+    }
+}
+
+/// Whether a [`SpectatorLeft`](crate::protocol::ServerMessage::SpectatorLeft)
+/// reason reports an authoritative exit rather than an answer to an admitted
+/// voluntary leave. Single source of truth for every classifier and state arm
+/// that partitions the two, so the boundary cannot drift apart between them.
+fn spectator_exit_is_authoritative(
+    reason: Option<&crate::protocol::SpectatorStateChangeReason>,
+) -> bool {
+    matches!(
+        reason,
+        Some(
+            crate::protocol::SpectatorStateChangeReason::Disconnected
+                | crate::protocol::SpectatorStateChangeReason::Removed
+                | crate::protocol::SpectatorStateChangeReason::RoomClosed
+        )
+    )
+}
+
+/// Whether an unwrapped server message is the typed terminal answer for a
+/// pending directed room operation (the uncorrelated face of
+/// [`ClientCore::retire_answered_room_operation`]).
+fn terminal_message_matches(kind: PendingRoomOperation, message: &ServerMessage) -> bool {
+    match kind {
+        PendingRoomOperation::JoinPlayer => matches!(
+            message,
+            ServerMessage::RoomJoined(_) | ServerMessage::RoomJoinFailed { .. }
+        ),
+        PendingRoomOperation::LeavePlayer => matches!(message, ServerMessage::RoomLeft),
+        PendingRoomOperation::ReconnectPlayer => matches!(
+            message,
+            ServerMessage::Reconnected(_) | ServerMessage::ReconnectionFailed { .. }
+        ),
+        PendingRoomOperation::JoinSpectator => matches!(
+            message,
+            ServerMessage::SpectatorJoined(_) | ServerMessage::SpectatorJoinFailed { .. }
+        ),
+        PendingRoomOperation::LeaveSpectator => match message {
+            ServerMessage::SpectatorLeft { reason, .. } => {
+                !spectator_exit_is_authoritative(reason.as_ref())
+            }
+            _ => false,
+        },
     }
 }
 
@@ -2231,10 +2282,7 @@ fn room_operation_result_matches(
         (
             PendingRoomOperation::LeaveSpectator,
             RoomOperationResult::SpectatorLeft { reason, .. },
-        ) => matches!(
-            reason,
-            None | Some(crate::protocol::SpectatorStateChangeReason::VoluntaryLeave)
-        ),
+        ) => !spectator_exit_is_authoritative(reason.as_ref()),
         _ => false,
     }
 }
@@ -2956,7 +3004,175 @@ mod tests {
         ));
         assert!(core.pending_room_operation.is_none());
         assert!(core.pending_reconnects.is_empty());
-        assert!(core.last_server_error.is_none());
+    }
+
+    #[test]
+    fn terminal_message_classifier_excludes_authoritative_spectator_exits() {
+        for reason in [
+            crate::protocol::SpectatorStateChangeReason::Disconnected,
+            crate::protocol::SpectatorStateChangeReason::Removed,
+            crate::protocol::SpectatorStateChangeReason::RoomClosed,
+        ] {
+            assert!(
+                !terminal_message_matches(
+                    PendingRoomOperation::LeaveSpectator,
+                    &ServerMessage::SpectatorLeft {
+                        room_id: None,
+                        room_code: None,
+                        reason: Some(reason),
+                        current_spectators: vec![],
+                    },
+                ),
+                "authoritative exits settle through teardown, never a leave fence"
+            );
+        }
+        for reason in [
+            None,
+            Some(crate::protocol::SpectatorStateChangeReason::VoluntaryLeave),
+        ] {
+            assert!(terminal_message_matches(
+                PendingRoomOperation::LeaveSpectator,
+                &ServerMessage::SpectatorLeft {
+                    room_id: None,
+                    room_code: None,
+                    reason,
+                    current_spectators: vec![],
+                },
+            ));
+        }
+    }
+
+    #[test]
+    fn accountability_invalid_baselines_retire_their_operation_fence() {
+        // The roster corruption must trip delivery-accountability baselining,
+        // not any earlier phase validator, so a non-authority player id is
+        // simply repeated.
+        let roster_duplicate_room_joined_payload = |mut payload: Box<RoomJoinedPayload>| {
+            payload.current_players.push(player(PEER));
+            payload
+        };
+        let room_joined_payload = |message: ServerMessage| match message {
+            ServerMessage::RoomJoined(payload) => payload,
+            _ => unreachable!("room_joined helper always returns RoomJoined"),
+        };
+
+        for policy in [
+            ProtocolViolationPolicy::Observe,
+            ProtocolViolationPolicy::Quarantine,
+        ] {
+            let mut core = correlated_outside(policy);
+            let (_, join_id) = prepare_and_admit(
+                &mut core,
+                ClientOperation::JoinRoom(JoinRoomParams::new("game", "local")),
+            );
+            let outcome = process(
+                &mut core,
+                correlated_result(
+                    join_id,
+                    RoomOperationResult::RoomJoined(roster_duplicate_room_joined_payload(
+                        room_joined_payload(room_joined()),
+                    )),
+                ),
+            );
+            assert!(
+                matches!(
+                    outcome.events.as_slice(),
+                    [SignalFishEvent::ProtocolViolation { .. }]
+                ),
+                "{policy:?}: the drifting baseline stays suppressed as a violation"
+            );
+            assert_eq!(
+                core.room_role(),
+                None,
+                "{policy:?}: a rejected baseline never applies membership"
+            );
+            match policy {
+                ProtocolViolationPolicy::Observe => {
+                    assert!(!core.snapshot.quarantined);
+                }
+                ProtocolViolationPolicy::Quarantine => {
+                    assert!(core.snapshot.quarantined);
+                }
+                _ => unreachable!("matrix covers Observe and Quarantine only"),
+            }
+
+            // The answer settled the admitted join even though its payload was
+            // rejected: the fence is gone, so the caller can retry immediately.
+            let (_, retry_id) = prepare_and_admit(
+                &mut core,
+                ClientOperation::JoinRoom(JoinRoomParams::new("game", "local")),
+            );
+            let recovery = process(
+                &mut core,
+                correlated_result(
+                    retry_id,
+                    RoomOperationResult::RoomJoined(room_joined_payload(room_joined())),
+                ),
+            );
+            assert!(matches!(
+                recovery.events.as_slice(),
+                [SignalFishEvent::RoomJoined { .. }]
+            ));
+            assert_eq!(core.room_role(), Some(RoomRole::Player));
+        }
+
+        // The same seam covers legacy-mode admissions: the uncorrelated
+        // baseline is equally suppressed yet must not strand its fence.
+        let mut legacy = ClientCore::new(
+            Some(GameDataEncoding::Json),
+            ProtocolViolationPolicy::Observe,
+            false,
+        );
+        let _ = process(&mut legacy, authenticated());
+        let _ = process(&mut legacy, protocol_info(None));
+        let (command, admission) = legacy
+            .prepare_with_admission(ClientOperation::JoinRoom(JoinRoomParams::new(
+                "game", "local",
+            )))
+            .expect("legacy join should prepare");
+        assert!(matches!(
+            command,
+            CoreCommand::Message(ClientMessage::JoinRoom { .. })
+        ));
+        legacy.record_admission(admission);
+        let outcome = process(
+            &mut legacy,
+            ServerMessage::RoomJoined(roster_duplicate_room_joined_payload(room_joined_payload(
+                room_joined(),
+            ))),
+        );
+        assert!(matches!(
+            outcome.events.as_slice(),
+            [SignalFishEvent::ProtocolViolation { .. }]
+        ));
+        assert!(legacy.pending_room_operation.is_none());
+
+        // ...and reconnect fences drain their credential queue exactly once.
+        let mut core = correlated_outside(ProtocolViolationPolicy::Observe);
+        let (_, reconnect_id) = prepare_and_admit(
+            &mut core,
+            ClientOperation::Reconnect(
+                PlayerId::from_u128(LOCAL),
+                RoomId::from_u128(10),
+                "submitted-token".into(),
+            ),
+        );
+        assert_eq!(core.pending_reconnects.len(), 1);
+        let mut payload = match reconnected(vec![]) {
+            ServerMessage::Reconnected(payload) => payload,
+            _ => unreachable!("reconnected helper always returns Reconnected"),
+        };
+        payload.current_players.push(player(PEER));
+        let outcome = process(
+            &mut core,
+            correlated_result(reconnect_id, RoomOperationResult::Reconnected(payload)),
+        );
+        assert!(matches!(
+            outcome.events.as_slice(),
+            [SignalFishEvent::ProtocolViolation { .. }]
+        ));
+        assert!(core.pending_room_operation.is_none());
+        assert!(core.pending_reconnects.is_empty());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,11 +178,11 @@ pub use protocol::{
     decode_v3_binary_game_data, ClientMessage, ConnectionInfo, DeliveryClass,
     DeliveryCountersByClass, DeliveryGap, DeliveryGapReason, DeliveryReportPayload, DirectEndpoint,
     GameDataEncoding, IceServer, LatestDeliveryCounters, LobbyState, MessageTransport,
-    PeerConnectionInfo, PlayerInfo, RateLimitInfo, RelayTransport, ReliableDeliveryCounters,
-    ReplayStatus, RoomOperationId, RoomOperationRequest, RoomOperationResult, SenderWatermark,
-    ServerMessage, SessionGeneration, SessionPeer, SessionPlanPayload, SpectatorInfo,
-    SpectatorStateChangeReason, Topology, TransportKind, V3BinaryGameDataFrame,
-    VolatileDeliveryCounters, ROOM_OPERATION_IDS_CAPABILITY,
+    PeerConnectionInfo, PlayerId, PlayerInfo, RateLimitInfo, RelayTransport,
+    ReliableDeliveryCounters, ReplayStatus, RoomId, RoomOperationId, RoomOperationRequest,
+    RoomOperationResult, SenderWatermark, ServerMessage, SessionGeneration, SessionPeer,
+    SessionPlanPayload, SpectatorInfo, SpectatorStateChangeReason, Topology, TransportKind,
+    V3BinaryGameDataFrame, VolatileDeliveryCounters, ROOM_OPERATION_IDS_CAPABILITY,
 };
 pub use signal::PeerSignal;
 #[cfg(feature = "transport-websocket")]

--- a/src/mesh.rs
+++ b/src/mesh.rs
@@ -38,7 +38,7 @@ pub struct MeshPeer {
 
 /// An always-consistent view of the current mesh/host/relay session, folded
 /// purely from [`SignalFishEvent`]s. See the [module docs](crate::mesh).
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct MeshSession {
     generation: Option<SessionGeneration>,
     topology: Option<Topology>,

--- a/src/polling_client.rs
+++ b/src/polling_client.rs
@@ -888,23 +888,27 @@ impl<T: Transport> SignalFishPollingClient<T> {
     ///
     /// The queue drains on every [`poll()`](Self::poll) while the transport
     /// accepts writes, so a shrinking value means the transport is congested.
+    #[must_use = "this diagnostic view is discarded if not used"]
     pub fn send_capacity(&self) -> usize {
         self.command_capacity.saturating_sub(self.cmd_queue.len())
     }
 
     /// Configured capacity of the outgoing command queue
     /// (see [`SignalFishConfig::command_channel_capacity`]).
+    #[must_use = "this diagnostic view is discarded if not used"]
     pub fn max_send_capacity(&self) -> usize {
         self.command_capacity
     }
 
     /// Cumulative game-data traffic counters
     /// (see [`ClientStats`](crate::client::ClientStats)).
+    #[must_use = "this diagnostic view is discarded if not used"]
     pub fn stats(&self) -> crate::client::ClientStats {
         self.core.stats()
     }
 
     /// Return polling-driver queue, budget, and close diagnostics.
+    #[must_use = "this diagnostic view is discarded if not used"]
     pub fn polling_stats(&self) -> PollingStats {
         self.polling_stats
     }
@@ -915,6 +919,7 @@ impl<T: Transport> SignalFishPollingClient<T> {
     /// report zero. Backend acceptance ends client ownership immediately; use
     /// [`transport_diagnostics`](Self::transport_diagnostics) for buffering
     /// after that boundary.
+    #[must_use = "this diagnostic view is discarded if not used"]
     pub fn queue_age_stats(&self) -> PollingQueueAgeStats {
         self.queue_age_stats
     }
@@ -926,6 +931,7 @@ impl<T: Transport> SignalFishPollingClient<T> {
     }
 
     /// Return backend-owned transport buffering and admission diagnostics.
+    #[must_use = "this diagnostic view is discarded if not used"]
     pub fn transport_diagnostics(&self) -> TransportDiagnostics {
         self.transport.diagnostics()
     }
@@ -939,6 +945,7 @@ impl<T: Transport> SignalFishPollingClient<T> {
     }
 
     /// Return a coherent synchronous snapshot of connection and room state.
+    #[must_use = "this diagnostic view is discarded if not used"]
     pub fn snapshot(&self) -> ClientSnapshot {
         self.core.snapshot()
     }

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -229,8 +229,10 @@ where
 }
 
 /// Drive one transport send to completion from an async runtime.
-#[cfg(feature = "tokio-runtime")]
-#[cfg(test)]
+///
+/// Test helper for transports with async-runtime tests; gated to those
+/// transports so sparse-feature builds never carry an unused helper.
+#[cfg(all(test, feature = "transport-websocket"))]
 pub(crate) async fn send_frame<T: Transport + ?Sized>(
     transport: &mut T,
     frame: TransportFrame,
@@ -240,8 +242,10 @@ pub(crate) async fn send_frame<T: Transport + ?Sized>(
 }
 
 /// Await one inbound transport frame.
-#[cfg(feature = "tokio-runtime")]
-#[cfg(test)]
+///
+/// Test helper for transports with async-runtime tests; gated to those
+/// transports so sparse-feature builds never carry an unused helper.
+#[cfg(all(test, feature = "transport-websocket"))]
 pub(crate) async fn recv_frame<T: Transport + ?Sized>(
     transport: &mut T,
 ) -> Option<Result<TransportFrame, SignalFishError>> {


### PR DESCRIPTION
## Why

Paranoid-audit round 12 (issue #126 cadence) found a real liveness defect: when a server's typed answer to an admitted room operation was rejected by delivery accountability (for example, a drifting roster snapshot), the operation's admission fence stayed armed forever. Every later `join_room` / `leave_room` / `reconnect` / spectator command then failed locally with `RoomOperationPending` until the connection tore down — under every non-disconnecting violation policy.

The same audit round also confirmed the round-11 follow-up: the bare `tokio-runtime` feature combination failed clippy because two async test helpers outlived their only consumers.

## What changed

**Correctness**
- An answered terminal now retires its fence as soon as it arrives; suppression of the invalid payload, quarantine/quarantine-latch behavior, and retention of mismatched/forged operations are unchanged.
- The spectator-exit voluntary/authoritative boundary collapsed from six hand-maintained copies into one predicate so classifiers cannot drift apart.
- Red/green pins cover correlated, legacy-wire, and reconnect paths (red evidence: retry admissions panicked on `RoomOperationPending` before the fix).

**Sparse-feature hygiene**
- Test helpers gated to their actual consumer feature; a `tokio-runtime-only` cell joined both CI matrices; a fresh 16-combination clippy sweep is clean end to end.

**Usability residuals**
- `PlayerId` / `RoomId` root re-exports plus doc/example import cleanup.
- `MeshSession` equality derives and `#[must_use]` on both drivers' diagnostic accessors (same accepted semver pattern as `poll()` in #173).

## Verification
- fmt + clippy (`-D warnings`, all-features/all-targets) clean; 1,029 tests pass with zero failures.
- 16 feature combinations clippy-swept clean, including the previously failing one.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core room-operation admission and fence lifecycle shared by both drivers; behavior change is intentional but affects all non-disconnect violation policies when accountability rejects terminal answers.
> 
> **Overview**
> Fixes a **liveness bug** in shared room-operation handling: when delivery accountability rejects a server’s typed terminal answer (e.g. bad roster baseline), the admitted operation fence is **cleared immediately** instead of staying armed and blocking later join/leave/reconnect/spectator commands with `RoomOperationPending`. Invalid payloads stay suppressed; violation policies and mismatched/forged-operation fencing are unchanged. Spectator leave classification is **centralized** in shared predicates so voluntary-leave answers, authoritative exits, and malformed `Joined` reasons cannot drift across classifiers.
> 
> **CI / build:** adds a `tokio-runtime-only` matrix job and gates WebSocket-only async test helpers so bare `tokio-runtime` clippy builds stay clean.
> 
> **API / ergonomics:** re-exports `PlayerId` and `RoomId` at the crate root; derives `PartialEq`/`Eq` on `MeshSession`; marks diagnostic accessors on both drivers with `#[must_use]`; docs and examples use the shorter imports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 939317355ea7b4ab3f1cc04e867930082f603acf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->