### PR TITLE
Fix the docs CI watchdog; harden close-reason labels (round 13)

### DIFF
--- a/.llm/context.md
+++ b/.llm/context.md
@@ -435,8 +435,9 @@ TLS is opt-in: the default build pulls no crypto stack; `wss://` support
 3. Server responds with `ServerMessage::Authenticated` → `SignalFishEvent::Authenticated`.
 4. Client may then call `join_room`, etc.
 5. Both clients emit synthetic `SignalFishEvent::Connected` when their driver first observes `Transport::is_ready() == true`.
-   `SignalFishEvent::Disconnected` is emitted when the transport closes (best-effort; missed only if the receiver is dropped,
-   delivery was preempted as bounded above, or the handle is dropped without `shutdown()`).
+   The async driver emits `Disconnected` when the transport closes or `shutdown()` wins; polling `close()` deliberately
+   emits none. Both are best-effort: missed only if the receiver is dropped, delivery was preempted as bounded above, or
+   the handle is dropped without `shutdown()`.
 
 ## Protocol Overview
 

--- a/.llm/context.md
+++ b/.llm/context.md
@@ -434,10 +434,9 @@ TLS is opt-in: the default build pulls no crypto stack; `wss://` support
    immediately before spawning the transport loop.
 3. Server responds with `ServerMessage::Authenticated` → `SignalFishEvent::Authenticated`.
 4. Client may then call `join_room`, etc.
-5. Both clients emit synthetic `SignalFishEvent::Connected` when their driver first observes `Transport::is_ready() == true`.
-   The async driver emits `Disconnected` when the transport closes or `shutdown()` wins; polling `close()` deliberately
-   emits none. Both are best-effort: missed only if the receiver is dropped, delivery was preempted as bounded above, or
-   the handle is dropped without `shutdown()`.
+5. Both clients emit synthetic `SignalFishEvent::Connected` on first observing `Transport::is_ready() == true`. The async
+   driver emits `Disconnected` on transport close or won `shutdown()`; polling `close()` deliberately emits none. Both are
+   best-effort: missed only on receiver drop, preempted delivery as bounded above, or handle drop without `shutdown()`.
 
 ## Protocol Overview
 

--- a/.llm/skills/serde-patterns/SKILL.md
+++ b/.llm/skills/serde-patterns/SKILL.md
@@ -246,6 +246,23 @@ assert_eq!(value["data"]["game_name"], "my-game");
   helper. Omission remains `None` for legacy 0.4 traffic, while explicit `null`
   and invalid present UUID strings fail decoding as required by Server 0.7.
 
+### The per-direction explicit-null policy
+
+Explicit `null` handling is asymmetric **by direction**, and that asymmetry is
+deliberate:
+
+- **Client-bound server fields** absorb `null` as `None` for legacy `Option`s
+  (the v2 sample wire literally carries `"reason": null`), except the
+  presence-sensitive fields above, which reject `null` to distinguish
+  "absent" from "present-but-null".
+- **SDK-authored client fields** (`ClientMessage::GameData.class`/`.key`) reject
+  `null`: the SDK never emits explicit nulls for them (omission convention),
+  so a `null` can only be a local construction bug — fail loudly.
+- Unit variants tolerate `"data": null` and absent `data` interchangeably; a
+  map-valued `data` for a unit variant is rejected.
+
+New fields must pick a side explicitly and document it here.
+
 ### The v2-byte-identical rule
 
 Every NEW optional field on an EXISTING message/payload (`Authenticate`'s

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -269,6 +269,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed `SignalFishEvent::Disconnected` reason mislabeling for custom
+  transports: close metadata that the transport did not report as
+  peer-initiated was formatted as `"closed by server: …"`; it now formats as
+  `"closed by transport: …"`. Peer-initiated close metadata (including every
+  built-in transport's WebSocket Close frames) keeps the established
+  `"closed by server: …"` format.
 - Fixed a liveness defect in protocol-v3 (and legacy-mode) room operations: a
   typed terminal answer whose payload was rejected by delivery accountability
   (for example, a drifting roster snapshot) left the operation's admission

--- a/docs/client.md
+++ b/docs/client.md
@@ -672,6 +672,9 @@ without changing membership. If the server does not echo the capability, the
 connection continues with the legacy Server 0.7 wire behavior. Operations
 admitted before the first `ProtocolInfo` also remain legacy for their complete
 request/response lifetime, even if negotiation finishes while one is pending.
+Legacy results carry no correlation identity on the wire, so a duplicated
+kind-compatible legacy reply can consume the next same-kind operation's fence;
+correlated UUID results are individually identifiable and immune to this.
 
 Room command admission is role-specific, and the five directed room operations
 additionally require server-confirmed authentication:

--- a/scripts/check-docs-accessibility.cjs
+++ b/scripts/check-docs-accessibility.cjs
@@ -7,6 +7,12 @@ const { chromium } = require("playwright");
 
 const host = "127.0.0.1";
 const repoRoot = path.resolve(__dirname, "..");
+
+// Generous enough for the slowest observed hosted runner (a healthy full pass
+// stayed under 180 seconds; a slow one exceeded it) while far below the job's
+// 20-minute ceiling, so a genuine hang still fails fast.
+const ACCESSIBILITY_BUDGET_MS = 300_000;
+
 let origin;
 let activeBrowser;
 let activeServer;
@@ -118,18 +124,23 @@ const cleanup = () => {
     return cleanupPromise;
 };
 
-const watchdog = setTimeout(() => {
-    timedOut = true;
-    process.stderr.write("Documentation accessibility checks exceeded 180 seconds.\n");
-    void cleanup()
-        .catch((error) => {
-            process.stderr.write(`Accessibility cleanup failed: ${error.message}\n`);
-        })
-        .finally(() => {
-            process.exitCode = 1;
-        });
-}, 180_000);
-watchdog.unref();
+// The deadline races the browser flow, so when it fires, its clear timeout
+// error deterministically wins the report and cleanup cannot mask it with a
+// mid-evaluate "Target crashed" from the closing browser.
+const accessibilityDeadline = () => {
+    let releaseDeadline;
+    const deadline = new Promise((_, reject) => {
+        const timer = setTimeout(() => {
+            timedOut = true;
+            reject(new Error(
+                `Documentation accessibility checks exceeded ${ACCESSIBILITY_BUDGET_MS / 1000} seconds.`
+            ));
+        }, ACCESSIBILITY_BUDGET_MS);
+        timer.unref();
+        releaseDeadline = () => clearTimeout(timer);
+    });
+    return [deadline, () => releaseDeadline()];
+};
 
 const settleShell = async (page) => {
     // The browser context requests reduced motion, so CSS transitions finish in
@@ -468,45 +479,39 @@ const checkSearchResize = async (page) => {
     );
 };
 
-(async () => {
+const runBrowserChecks = async () => {
     await assertBuildFreshness();
     activeServer = await startServer();
-    if (timedOut) {
-        await cleanup();
-        throw new Error("Documentation accessibility checks timed out");
-    }
     const browserErrors = [];
+    activeBrowser = await chromium.launch({
+        args: ["--disable-gpu"],
+        headless: true,
+    });
+    const context = await activeBrowser.newContext({
+        reducedMotion: "reduce",
+        viewport: { width: 1220, height: 800 },
+    });
+    const page = configurePage(await context.newPage());
+    attachErrorCapture(page, browserErrors);
+    await checkClosedBoundaries(page);
+    await checkDrawerResize(page, "ltr");
+    await checkDrawerResize(page, "rtl");
+    await checkSearchResize(page);
+    expectState(
+        browserErrors.length === 0,
+        "documentation pages emitted browser errors",
+        browserErrors
+    );
+    process.stdout.write("Documentation accessibility browser checks passed.\n");
+};
+
+(async () => {
+    const [deadline, releaseDeadline] = accessibilityDeadline();
     try {
-        activeBrowser = await chromium.launch({
-            args: ["--disable-gpu"],
-            headless: true,
-        });
-        if (timedOut) {
-            await cleanup();
-            throw new Error("Documentation accessibility checks timed out");
-        }
-        const context = await activeBrowser.newContext({
-            reducedMotion: "reduce",
-            viewport: { width: 1220, height: 800 },
-        });
-        const page = configurePage(await context.newPage());
-        attachErrorCapture(page, browserErrors);
-        await checkClosedBoundaries(page);
-        await checkDrawerResize(page, "ltr");
-        await checkDrawerResize(page, "rtl");
-        await checkSearchResize(page);
-        expectState(
-            browserErrors.length === 0,
-            "documentation pages emitted browser errors",
-            browserErrors
-        );
-        process.stdout.write("Documentation accessibility browser checks passed.\n");
+        await Promise.race([runBrowserChecks(), deadline]);
     } finally {
-        try {
-            await cleanup();
-        } finally {
-            clearTimeout(watchdog);
-        }
+        releaseDeadline();
+        await cleanup();
     }
 })().catch((error) => {
     process.stderr.write(`${error.stack || error.message}\n`);

--- a/scripts/check-docs-accessibility.cjs
+++ b/scripts/check-docs-accessibility.cjs
@@ -481,13 +481,25 @@ const checkSearchResize = async (page) => {
 
 const runBrowserChecks = async () => {
     await assertBuildFreshness();
-    activeServer = await startServer();
+    const server = await startServer();
+    if (timedOut) {
+        // The deadline won while startup was pending; cleanup already ran,
+        // so this resource would otherwise be orphaned.
+        await closeServer(server);
+        throw new Error("Documentation accessibility checks timed out");
+    }
+    activeServer = server;
     const browserErrors = [];
-    activeBrowser = await chromium.launch({
+    const browser = await chromium.launch({
         args: ["--disable-gpu"],
         headless: true,
     });
-    const context = await activeBrowser.newContext({
+    if (timedOut) {
+        await browser.close();
+        throw new Error("Documentation accessibility checks timed out");
+    }
+    activeBrowser = browser;
+    const context = await browser.newContext({
         reducedMotion: "reduce",
         viewport: { width: 1220, height: 800 },
     });
@@ -507,11 +519,23 @@ const runBrowserChecks = async () => {
 
 (async () => {
     const [deadline, releaseDeadline] = accessibilityDeadline();
+    let flowError;
     try {
         await Promise.race([runBrowserChecks(), deadline]);
+    } catch (error) {
+        flowError = error;
     } finally {
         releaseDeadline();
-        await cleanup();
+        try {
+            await cleanup();
+        } catch (cleanupError) {
+            // Never let cleanup noise mask the primary (timeout) error.
+            process.stderr.write(`Accessibility cleanup failed: ${cleanupError.message}\n`);
+            flowError = flowError || cleanupError;
+        }
+    }
+    if (flowError) {
+        throw flowError;
     }
 })().catch((error) => {
     process.stderr.write(`${error.stack || error.message}\n`);

--- a/scripts/check-docs-accessibility.cjs
+++ b/scripts/check-docs-accessibility.cjs
@@ -483,8 +483,9 @@ const runBrowserChecks = async () => {
     await assertBuildFreshness();
     const server = await startServer();
     if (timedOut) {
-        // The deadline won while startup was pending; cleanup already ran,
-        // so this resource would otherwise be orphaned.
+        // The deadline fired while startup was pending: cleanup has been
+        // initiated and this resource was never assigned to a global, so
+        // close it here or it is orphaned.
         await closeServer(server);
         throw new Error("Documentation accessibility checks timed out");
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -1000,9 +1000,9 @@ impl SignalFishClient {
     /// [`send_game_data_reliable`](Self::send_game_data_reliable), which
     /// waits for queue capacity instead of failing fast under congestion.
     ///
-    /// Non-finite floats (`NaN`/`±Infinity`) serialize as `null` (standard
-    /// `serde_json` behavior), so peers receive `null` where a non-finite
-    /// value was sent.
+    /// Game data is a `serde_json::Value`, which cannot represent non-finite
+    /// floats: `NaN`/`±Infinity` become `null` at construction, so peers
+    /// receive `null` where a non-finite value was intended.
     ///
     /// # Errors
     ///

--- a/src/client.rs
+++ b/src/client.rs
@@ -1000,6 +1000,10 @@ impl SignalFishClient {
     /// [`send_game_data_reliable`](Self::send_game_data_reliable), which
     /// waits for queue capacity instead of failing fast under congestion.
     ///
+    /// Non-finite floats (`NaN`/`±Infinity`) serialize as `null` (standard
+    /// `serde_json` behavior), so peers receive `null` where a non-finite
+    /// value was sent.
+    ///
     /// # Errors
     ///
     /// Returns [`SignalFishError::NotInRoom`] outside a room,

--- a/src/client_core.rs
+++ b/src/client_core.rs
@@ -1099,11 +1099,14 @@ impl ClientCore {
     ///
     /// Runs only when delivery accountability rejected the frame (the healthy
     /// path retires inside `update_state`), so suppression never strands the
-    /// fence. Frames that merely name a different or forged operation keep it
-    /// armed exactly as before: they violate and stay fenced by contract.
-    /// Correlated `OperationFailed` results never reach this helper — their
-    /// envelope unwraps to the dedicated failure path above before any
-    /// validation runs.
+    /// fence. Only the three authoritative baselines (`RoomJoined`,
+    /// `SpectatorJoined`, `Reconnected`) can be accountability-rejected, so in
+    /// practice this seam retires only join/spectator-join/reconnect fences;
+    /// the remaining classifier arms are shared-classifier symmetry. Frames
+    /// that merely name a different or forged operation keep it armed exactly
+    /// as before: they violate and stay fenced by contract. Correlated
+    /// `OperationFailed` results never reach this helper — their envelope
+    /// unwraps to the dedicated failure path above before any validation runs.
     fn retire_answered_room_operation(&mut self, message: &ServerMessage) {
         let Some(pending) = self.pending_room_operation.as_ref() else {
             return;

--- a/src/event.rs
+++ b/src/event.rs
@@ -67,7 +67,13 @@ pub enum SignalFishEvent {
         ///
         /// When the transport captured a WebSocket Close frame with a reason
         /// (see [`Transport::close_info`](crate::Transport::close_info)),
-        /// it is included here as `"closed by server: …"`.
+        /// it is included here as `"closed by server: …"`; close metadata the
+        /// transport did **not** report as peer-initiated formats as
+        /// `"closed by transport: …"` instead. When a send failure ends the
+        /// connection, peer-close metadata replaces the send cause, and a
+        /// protocol stop during the farewell drain leaves the send/peer-close
+        /// cause in place — the [`ProtocolViolation`](Self::ProtocolViolation)
+        /// event precedes this one.
         reason: Option<String>,
         /// The most recent `Error`/`AuthenticationError` received on this
         /// connection, if any.
@@ -477,7 +483,7 @@ pub enum SignalFishEvent {
         room_code: Option<String>,
         /// Reason for leaving, if available.
         reason: Option<SpectatorStateChangeReason>,
-        /// Remaining spectators in the room.
+        /// Remaining spectators in the room, as reported by the server.
         current_spectators: Vec<SpectatorInfo>,
     },
 
@@ -485,7 +491,7 @@ pub enum SignalFishEvent {
     NewSpectatorJoined {
         /// Information about the new spectator.
         spectator: SpectatorInfo,
-        /// All spectators currently watching.
+        /// All spectators currently watching, as reported by the server.
         current_spectators: Vec<SpectatorInfo>,
         /// Reason for the state change, if available.
         reason: Option<SpectatorStateChangeReason>,
@@ -497,7 +503,7 @@ pub enum SignalFishEvent {
         spectator_id: PlayerId,
         /// Reason for disconnection, if available.
         reason: Option<SpectatorStateChangeReason>,
-        /// Remaining spectators in the room.
+        /// Remaining spectators in the room, as reported by the server.
         current_spectators: Vec<SpectatorInfo>,
     },
 

--- a/src/polling_client.rs
+++ b/src/polling_client.rs
@@ -489,6 +489,10 @@ impl<T: Transport> SignalFishPollingClient<T> {
 
     /// Send game data to other players in the room.
     ///
+    /// Non-finite floats (`NaN`/`±Infinity`) serialize as `null` (standard
+    /// `serde_json` behavior), so peers receive `null` where a non-finite
+    /// value was sent.
+    ///
     /// # Errors
     ///
     /// Returns [`SignalFishError::NotInRoom`] outside a room,

--- a/src/polling_client.rs
+++ b/src/polling_client.rs
@@ -389,7 +389,7 @@ impl<T: Transport> SignalFishPollingClient<T> {
                         break;
                     }
                     std::task::Poll::Ready(None) => {
-                        debug!("transport closed by server");
+                        debug!("transport closed");
                         let reason = close_reason(&self.transport);
                         self.handle_disconnect_at(&mut events, reason, &mut cx, now);
                         break;
@@ -489,9 +489,9 @@ impl<T: Transport> SignalFishPollingClient<T> {
 
     /// Send game data to other players in the room.
     ///
-    /// Non-finite floats (`NaN`/`±Infinity`) serialize as `null` (standard
-    /// `serde_json` behavior), so peers receive `null` where a non-finite
-    /// value was sent.
+    /// Game data is a `serde_json::Value`, which cannot represent non-finite
+    /// floats: `NaN`/`±Infinity` become `null` at construction, so peers
+    /// receive `null` where a non-finite value was intended.
     ///
     /// # Errors
     ///

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -538,9 +538,10 @@ pub struct SessionPeer {
 pub struct DirectEndpoint {
     /// Hostname or IP address to connect to.
     pub host: String,
-    /// Transport port. The protocol authority requires a non-zero port; the
-    /// SDK treats this self-declared trusted-server field as opaque and does
-    /// not re-validate it.
+    /// Transport port. The protocol authority requires a non-zero port, and
+    /// the SDK enforces that during session-plan validation (a zero port is a
+    /// lifecycle violation); the wire field itself is not otherwise
+    /// re-validated.
     pub port: u16,
 }
 

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -538,7 +538,9 @@ pub struct SessionPeer {
 pub struct DirectEndpoint {
     /// Hostname or IP address to connect to.
     pub host: String,
-    /// Non-zero transport port.
+    /// Transport port. The protocol authority requires a non-zero port; the
+    /// SDK treats this self-declared trusted-server field as opaque and does
+    /// not re-validate it.
     pub port: u16,
 }
 

--- a/src/terminal_drain.rs
+++ b/src/terminal_drain.rs
@@ -88,8 +88,13 @@ pub(crate) fn frame_payload_len(frame: &TransportFrame) -> usize {
 }
 
 fn format_close_reason(info: crate::transport::TransportCloseInfo) -> String {
+    let initiator = if info.initiated_by_peer {
+        "closed by server"
+    } else {
+        "closed by transport"
+    };
     format!(
-        "closed by server: code={:?}, reason={:?}",
+        "{initiator}: code={:?}, reason={:?}",
         info.code, info.reason
     )
 }
@@ -103,4 +108,39 @@ pub(crate) fn peer_close_reason<T: Transport + ?Sized>(transport: &T) -> Option<
         .close_info()
         .filter(|info| info.initiated_by_peer)
         .map(format_close_reason)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::transport::TransportCloseInfo;
+
+    #[test]
+    fn close_reason_labels_match_the_reported_initiator() {
+        let cases = [
+            (
+                "peer-initiated close metadata keeps the established label",
+                TransportCloseInfo {
+                    code: Some(1000),
+                    reason: Some("normal closure".into()),
+                    clean: Some(true),
+                    initiated_by_peer: true,
+                },
+                "closed by server: code=Some(1000), reason=Some(\"normal closure\")",
+            ),
+            (
+                "locally-initiated metadata from a third-party transport is not mislabeled",
+                TransportCloseInfo {
+                    code: None,
+                    reason: None,
+                    clean: Some(false),
+                    initiated_by_peer: false,
+                },
+                "closed by transport: code=None, reason=None",
+            ),
+        ];
+        for (context, info, expected) in cases {
+            assert_eq!(format_close_reason(info), expected, "{context}");
+        }
+    }
 }


### PR DESCRIPTION
## Why

Main CI was red: a slow hosted runner pushed the docs accessibility harness past its own 180-second budget, and the watchdog's browser teardown reported the timeout as a confusing "Target crashed". This session also ran paranoid-audit round 13 (issue #126 cadence) over four never-audited surfaces — all four closed with **zero production defects**, and the audit produced a handful of small accuracy and robustness wins bundled here.

## What changed

**CI fix**
- The accessibility deadline now races the browser checks: the clear timeout message always wins, cleanup runs once, and the budget rises to 300 s (real headroom over the slowest observed pass, far below the 20-minute job ceiling). Startup-window resource leaks are closed and cleanup failures no longer mask the timeout.

**Robustness**
- Close metadata that a custom transport did **not** report as peer-initiated was formatted as `"closed by server: …"`; it now formats as `"closed by transport: …"`. Peer-initiated closes — including every built-in transport — keep the established label (pinned by a new data-driven test).

**Documentation accuracy** (all audit-backed)
- Session-plan validation does reject a zero `DirectEndpoint` port; the field doc now states that real two-layer contract.
- Spectator lists are documented as server-reported; the legacy-wire duplicate-reply ambiguity is documented in `docs/client.md`; game data's `NaN`→`null` behavior names its real mechanism; the per-direction explicit-null policy is written down in the serde skill.

## Round-13 audit scope (no defects found)

Post-#174 room-operation fence retirement interplay · mTLS certificate-fingerprint token-binding profile · protocol-type serde roundtrip identity and JSON↔MessagePack parity · event-stream ordering/attribution coherence. Every candidate finding was mechanically refuted; one hardening idea is filed as #175.

## Verification

- `cargo fmt` + `cargo clippy -D warnings` (all features/targets) clean; **1031 tests, 0 failures**.
- Accessibility harness reproduced locally: healthy pass ~9 s; patched 1 ms budget prints only the clean timeout error, exit 1.
- Two adversarial review rounds converged to zero functional findings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly CI scripting and docs; the only user-visible behavior change is disconnect reason wording for non-peer-initiated custom transport closes, which is a labeling fix rather than connection logic.
> 
> **Overview**
> Fixes flaky docs CI by racing the Playwright accessibility harness against a **300 s** deadline (up from 180 s), ensuring the timeout error wins over browser-teardown noise, closing startup-window leaks, and not letting cleanup failures mask the primary failure.
> 
> **Disconnect attribution:** `SignalFishEvent::Disconnected` close strings now use **`"closed by transport: …"`** when `TransportCloseInfo` is not peer-initiated; peer/WebSocket closes keep **`"closed by server: …"`**, with a unit test pinning both cases.
> 
> **Documentation-only accuracy** from audit round 13: per-direction explicit-null serde policy, legacy room-operation fence ambiguity, `Connected`/`Disconnected` driver differences, server-reported spectator lists, `DirectEndpoint.port` validation layering, and `serde_json::Value` turning non-finite floats into `null` on game-data sends (async + polling rustdoc).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26f3e1fdd1b25b3be7755a721980da1a4e352a95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->