### PR TITLE
feat!: let clients require certificate-bound token-binding proofs (#175)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,6 +181,9 @@ jobs:
             test_name: e2e_server_070_required_client_fingerprint_token_binding_wss
           - server_version: "0.7.0"
             server_sha256: "70c6d12ac77843038c96d374a91225825c685cbf65fd7bedfd26b08d4003af7e"
+            test_name: e2e_server_070_require_client_fingerprint_option_rejects_fingerprint_less_signer
+          - server_version: "0.7.0"
+            server_sha256: "70c6d12ac77843038c96d374a91225825c685cbf65fd7bedfd26b08d4003af7e"
             test_name: e2e_server_070_polling_client_fingerprint_token_binding_wss
           - server_version: "0.7.0"
             server_sha256: "70c6d12ac77843038c96d374a91225825c685cbf65fd7bedfd26b08d4003af7e"

--- a/.llm/context.md
+++ b/.llm/context.md
@@ -141,7 +141,9 @@ the exact frame available to its caller.
 Native token binding belongs exclusively to `WebSocketTransport`. Disabled is
 the byte/dependency-compatible default; optional retries without the offer only
 after tungstenite's exact successful-upgrade/no-selection result; required
-fails closed. A selected connection consumes and validates the first challenge
+fails closed. The opt-in `require_client_fingerprint` connect option fails
+connects locally — pre-I/O on unsatisfiable paths, post-handshake when no X.509
+client signer is selected — with `TokenBindingFailure::MissingClientFingerprint`. A selected connection consumes and validates the first challenge
 before either client sees a ready transport, derives HKDF-SHA-256 from the exact
 RFC 6455 key plus server nonce, zeroizes retained key material, and protects all
 outbound JSON/binary frames with one sequence. Sequence commits only at backend
@@ -165,22 +167,18 @@ blocking workflow covers official native/web Godot 4.5, requires a valid frame
 over the legacy 65,535-byte default, and runs clean, seeded-netem impaired, and
 3,600-frame soak jobs on Server 0.7 plus a clean Server 0.4 gate. It checksum-verifies and builds iproute2
 6.6.0 for seeded netem rather
-than relying on the runner's older `tc`. A 20-frame Fortress prediction window
-leaves recovery headroom. Simulated frames 1 through 60 form an explicit
-renderer/JIT warm-up phase bounded by that window; steady-state and final
-confirmation lag are capped at eight frames clean or 13 frames impaired/soak.
-The fixture uses a
-peer-independent fixed 18 Hz simulation cadence that preserves elapsed
-deadline debt and catches up by at most one frame per rendered callback, plus
-a one-time proposal/ack/commit startup barrier that maps a shared same-host
-wall-clock deadline to each browser's monotonic clock, preventing process-launch
-order from becoming frame advantage. A bounded causal relay hold and the polling-hitch
-oracle then require rollback and forward gameplay progress. These controls must prove
-rollback/resimulation, bounded confirmation lag with zero stalls (advisory
-frame-advantage wait recommendations are observed but not required to be zero —
-they fire inside the lag bound and the fixed cadence never acts on them), exact
-state checksum convergence, drained queue age/depth with a non-positive final
-eight-sample soak age slope, relay/server conservation, and v3 peer departure.
+than relying on the runner's older `tc`.
+The fixture uses a peer-independent fixed 18 Hz simulation cadence with a
+20-frame Fortress prediction window (60-frame renderer/JIT warm-up bounded by
+it; steady-state and final lag capped at eight frames clean or 13 impaired/soak),
+a one-time proposal/ack/commit startup barrier mapping a shared same-host
+wall-clock deadline to each browser's monotonic clock, and a bounded causal
+relay hold plus a polling-hitch oracle requiring rollback and forward gameplay
+progress. These controls must prove rollback/resimulation, bounded
+confirmation lag with zero stalls (advisory frame-advantage wait recommendations
+are observed, never acted on), exact state checksum convergence, drained queue
+age/depth with a non-positive final eight-sample soak age slope, relay/server
+conservation, and v3 peer departure.
 
 Delivery accountability accepts coalesced, mixed-reason
 `unsupported_format` gap ranges emitted by newer servers. Their inclusive

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,9 +136,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Derived `PartialEq`/`Eq` for `SignalFishConfig` and `JoinRoomParams` so
   applications can compare constructed configurations and parameters in
   assertions.
+- Added the opt-in `require_client_fingerprint` connect option on
+  `WebSocketConnectOptions` (builder:
+  `with_require_client_fingerprint`). When set, a connect fails with a typed
+  error unless the transport observes rustls selecting a real X.509 client
+  certificate signer, letting deployments enforce the strictest mTLS
+  token-binding profile locally instead of trusting the server to reject
+  fingerprint-less proofs. The check happens before network I/O on paths that
+  cannot satisfy it (plain connects, custom-TLS connects without token
+  binding) and after the handshake when no signer was selected, including
+  Optional mode's unsigned fallback.
+  **Breaking:** `WebSocketConnectOptions` gains a public field and
+  `TokenBindingFailure` gains the `MissingClientFingerprint` variant, so
+  exhaustive struct literals and matches require updates; both are breaking
+  API additions for the forthcoming 0.11 release.
 
 ### Changed
 
+- Documented quick-start sketches (crate docs, `MeshController` docs, and the
+  mesh guide) now request the protocol-v2 game start only once instead of on
+  every repeated all-ready update, matching the guidance in the events guide
+  and the compiling `basic_lobby` example.
 - The shared diagnostic accessors on both drivers —
   `send_capacity`, `max_send_capacity`, `stats`, `snapshot`, and
   `transport_diagnostics`, plus the polling driver's `polling_stats` and

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -27,7 +27,7 @@ exhaustive public enum:
 | `TransportSend` | `String` | Failed to send a message through the transport. |
 | `TransportReceive` | `String` | Failed to receive a message from the transport. |
 | `TransportClosed` | — | The transport connection was closed unexpectedly. |
-| `TokenBinding` | `TokenBindingFailure` | Native WebSocket token-binding negotiation, challenge validation, key derivation, canonicalization, encoding, or sequence handling failed. Reasons are typed and contain no key, nonce, proof, signature, fingerprint, URL credential, or payload material. See [WebSocket Token Binding](token-binding.md). |
+| `TokenBinding` | `TokenBindingFailure` | Native WebSocket token-binding negotiation, challenge validation, key derivation, canonicalization, encoding, or sequence handling failed. Reasons are typed and contain no key, nonce, proof, signature, fingerprint, URL credential, or payload material. Includes `MissingClientFingerprint`, raised by the opt-in `require_client_fingerprint` connect policy when no X.509 client signer is selected. See [WebSocket Token Binding](token-binding.md). |
 | `Serialization` | `serde_json::Error` | Failed to serialize or deserialize a protocol message. Implements `From<serde_json::Error>`. |
 | `NotConnected` | — | Attempted an operation requiring an active connection but the client is not connected. |
 | `NotAuthenticated` | — | Attempted a directed room operation (`join_room`, `leave_room`, `reconnect`, `join_as_spectator`, or `leave_spectator`) before the server confirmed authentication. The command was **not** queued; retry once the `Authenticated` event arrives. Non-room commands keep their pre-authentication behavior. |

--- a/docs/mesh-guide.md
+++ b/docs/mesh-guide.md
@@ -183,13 +183,19 @@ use signal_fish_client::{JoinRoomParams, SignalFishConfig, SignalFishEvent};
 // `start` ensures v3 + WebRTC + a P2P topology while preserving compatible choices.
 let mut mesh = MeshController::start(transport, SignalFishConfig::new("app"), my_driver);
 
+let mut start_requested = false;
 while let Some(event) = mesh.recv().await {
     match event {
         MeshEvent::Signaling(sig) => match *sig {
             SignalFishEvent::Authenticated { .. } =>
                 mesh.join_room(JoinRoomParams::new("my-game", "Alice"))?,
-            SignalFishEvent::LobbyStateChanged { all_ready: true, .. } =>
-                mesh.start_game()?,
+            // Ready-state updates repeat — request the start only once.
+            SignalFishEvent::LobbyStateChanged { all_ready: true, .. }
+                if !start_requested =>
+            {
+                start_requested = true;
+                mesh.start_game()?;
+            }
             _ => {}
         },
         MeshEvent::PeerConnected(peer) => {

--- a/docs/token-binding.md
+++ b/docs/token-binding.md
@@ -86,6 +86,37 @@ Server 0.7 profiles with `require_client_fingerprint=true` additionally require
 built-in WSS, a trusted client CA, mTLS client authentication, and required
 token binding.
 
+## Requiring a certificate-bound proof locally
+
+Server-side enforcement of the strictest profile is fail-closed, but a client
+whose server does not request a client certificate sends fingerprint-less
+proofs with no local signal. Deployments that want to enforce the stricter
+contract locally can set the opt-in `require_client_fingerprint` connect
+policy:
+
+```rust,ignore
+use signal_fish_client::{TokenBindingMode, WebSocketConnectOptions, WebSocketTransport};
+
+let options = WebSocketConnectOptions::new()
+    .with_token_binding(TokenBindingMode::Required)
+    .with_require_client_fingerprint(true);
+let transport = WebSocketTransport::connect_with_tls_config(
+    "wss://signal.example/v2/ws",
+    options,
+    tls_config, // your Arc<rustls::ClientConfig> with a client certificate
+).await?;
+```
+
+When the policy is set, the connect fails with a typed
+`TokenBindingFailure::MissingClientFingerprint` — before any network I/O when
+the path cannot observe a certificate selection at all, and after the handshake
+when rustls completed it without selecting an X.509 client signer. Optional
+mode's unsigned fallback connection produces no proofs at all and fails the
+same way, so the policy can never be silently skipped. Only
+`connect_with_tls_config` with token binding enabled can satisfy the policy;
+plain connects and token-binding-disabled custom-TLS connects reject it up
+front.
+
 ## Wire and failure contract
 
 The transport consumes the challenge before it can be passed to

--- a/scripts/check-workflows.sh
+++ b/scripts/check-workflows.sh
@@ -240,7 +240,45 @@ else
                     echo "$CI_MSRV_BLOCK"
                     VIOLATIONS=$((VIOLATIONS + 1))
                 else
-                    echo -e "${GREEN}Phase 5: PASS${NC}"
+                    # The Godot adapter declares its own rust-version because
+                    # godot-rust requires a newer compiler than the core crate;
+                    # its dedicated CI lane must track that declaration.
+                    ADAPTER_MSRV="$(awk -F'"' '/^rust-version[[:space:]]*=[[:space:]]*"/ {print $2; exit}' crates/signal-fish-client-godot/Cargo.toml | tr -d '\r')"
+                    ADAPTER_MSRV_BLOCK="$(awk '
+                        /^  adapter-msrv:/ {in_adapter=1}
+                        in_adapter && /^  [a-zA-Z0-9-]+:/ && $0 !~ /^  adapter-msrv:/ {exit}
+                        in_adapter {gsub(/\r/, ""); print}
+                    ' .github/workflows/ci.yml)"
+
+                    if [ -z "$ADAPTER_MSRV" ]; then
+                        echo -e "${RED}Phase 5: FAIL${NC}"
+                        echo "Could not read rust-version from crates/signal-fish-client-godot/Cargo.toml."
+                        echo "Action: Add a quoted rust-version (e.g., rust-version = \"1.94.0\") to the adapter manifest."
+                        VIOLATIONS=$((VIOLATIONS + 1))
+                    elif [ -z "$ADAPTER_MSRV_BLOCK" ]; then
+                        echo -e "${RED}Phase 5: FAIL${NC}"
+                        echo "Action: Add an 'adapter-msrv' job to .github/workflows/ci.yml testing the Godot adapter at its declared MSRV."
+                        VIOLATIONS=$((VIOLATIONS + 1))
+                    elif [[ "$ADAPTER_MSRV_BLOCK" != *"uses: dtolnay/rust-toolchain@stable"* ]]; then
+                        echo -e "${RED}Phase 5: FAIL${NC}"
+                        echo "The adapter-msrv job must use 'dtolnay/rust-toolchain@stable' with an explicit 'with.toolchain'."
+                        VIOLATIONS=$((VIOLATIONS + 1))
+                    else
+                        ADAPTER_CI_TOOLCHAIN="$(printf '%s\n' "$ADAPTER_MSRV_BLOCK" | awk '/toolchain:[[:space:]]*/ {sub(/.*toolchain:[[:space:]]*/, "", $0); gsub(/[[:space:]]+$/, "", $0); gsub(/\r/, ""); print; exit}')"
+                        ADAPTER_CI_TOOLCHAIN="${ADAPTER_CI_TOOLCHAIN%\"}"
+                        ADAPTER_CI_TOOLCHAIN="${ADAPTER_CI_TOOLCHAIN#\"}"
+                        ADAPTER_CI_TOOLCHAIN="${ADAPTER_CI_TOOLCHAIN%\'}"
+                        ADAPTER_CI_TOOLCHAIN="${ADAPTER_CI_TOOLCHAIN#\'}"
+
+                        if [ "$ADAPTER_CI_TOOLCHAIN" != "$ADAPTER_MSRV" ]; then
+                            echo -e "${RED}Phase 5: FAIL${NC}"
+                            echo "Adapter MSRV mismatch: crates/signal-fish-client-godot/Cargo.toml rust-version is '$ADAPTER_MSRV' but the ci.yml adapter-msrv toolchain is '$ADAPTER_CI_TOOLCHAIN'."
+                            echo "Action: Update .github/workflows/ci.yml adapter-msrv toolchain to match the adapter's rust-version."
+                            VIOLATIONS=$((VIOLATIONS + 1))
+                        else
+                            echo -e "${GREEN}Phase 5: PASS${NC}"
+                        fi
+                    fi
                 fi
             fi
         fi

--- a/src/error.rs
+++ b/src/error.rs
@@ -44,6 +44,15 @@ pub enum TokenBindingFailure {
     MessageEncoding,
     /// The shared text/binary sequence space has been exhausted.
     SequenceExhausted,
+    /// A client-certificate fingerprint was required, but the connect path
+    /// could not observe an X.509 client signer.
+    ///
+    /// Raised only by the opt-in
+    /// [`require_client_fingerprint`](crate::WebSocketConnectOptions::with_require_client_fingerprint)
+    /// policy: either the connect path can never observe a certificate
+    /// selection (it is not a custom-rustls token-binding connection), or the
+    /// TLS handshake completed without the server selecting one.
+    MissingClientFingerprint,
 }
 
 impl std::fmt::Display for TokenBindingFailure {
@@ -67,6 +76,10 @@ impl std::fmt::Display for TokenBindingFailure {
             Self::UnsupportedJson => "the outbound JSON frame is not token-binding compatible",
             Self::MessageEncoding => "the token-bound frame could not be encoded",
             Self::SequenceExhausted => "the token-binding sequence space is exhausted",
+            Self::MissingClientFingerprint => {
+                "a client certificate fingerprint was required, but no X.509 client signer \
+                 was selected"
+            }
         })
     }
 }
@@ -272,6 +285,10 @@ mod tests {
             (TokenBindingFailure::UnsupportedJson, "JSON"),
             (TokenBindingFailure::MessageEncoding, "encoded"),
             (TokenBindingFailure::SequenceExhausted, "exhausted"),
+            (
+                TokenBindingFailure::MissingClientFingerprint,
+                "client certificate fingerprint",
+            ),
         ];
 
         for (failure, expected) in cases {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,6 +110,7 @@
 //!     let (mut client, mut event_rx) = SignalFishClient::start(transport, config);
 //!
 //!     // 4. Process events — wait for Authenticated before joining a room.
+//!     let mut start_requested = false;
 //!     while let Some(event) = event_rx.recv().await {
 //!         match event {
 //!             SignalFishEvent::Authenticated { app_name, .. } => {
@@ -122,7 +123,11 @@
 //!                 client.set_ready()?;
 //!             }
 //!             // Protocol v2: the game starts explicitly, not on readiness.
-//!             SignalFishEvent::LobbyStateChanged { all_ready: true, .. } => {
+//!             // Ready-state updates repeat — request the start only once.
+//!             SignalFishEvent::LobbyStateChanged { all_ready: true, .. }
+//!                 if !start_requested =>
+//!             {
+//!                 start_requested = true;
 //!                 client.start_game()?;
 //!             }
 //!             SignalFishEvent::Disconnected { .. } => break,

--- a/src/transports/websocket.rs
+++ b/src/transports/websocket.rs
@@ -72,6 +72,21 @@ fn websocket_config(options: WebSocketConnectOptions) -> Result<WebSocketConfig,
         .max_message_size(options.max_inbound_message_size))
 }
 
+/// Reject a required client fingerprint on a connect path that can never
+/// observe a certificate selection: only a custom-rustls token-binding
+/// connection installs the tracking signer, so every other path fails before
+/// network I/O instead of silently dropping the policy.
+fn reject_unsatisfiable_client_fingerprint_requirement(
+    options: &WebSocketConnectOptions,
+) -> Result<(), SignalFishError> {
+    if options.require_client_fingerprint {
+        return Err(SignalFishError::TokenBinding(
+            crate::TokenBindingFailure::MissingClientFingerprint,
+        ));
+    }
+    Ok(())
+}
+
 #[cfg(feature = "tls")]
 fn install_tls_provider() {
     use std::sync::Once;
@@ -295,6 +310,14 @@ async fn connect_with_token_binding(
                 }
                 error => map_connect_error(error),
             })?;
+            if options.require_client_fingerprint {
+                // The unsigned fallback sends no proofs at all, so a locally
+                // required certificate binding cannot be honored: fail closed
+                // instead of silently proceeding fingerprint-less.
+                return Err(SignalFishError::TokenBinding(
+                    crate::TokenBindingFailure::MissingClientFingerprint,
+                ));
+            }
             return Ok((stream, WebSocketTokenBinding::NotNegotiated));
         }
         Err(WebSocketError::Protocol(ProtocolError::SecWebSocketSubProtocolError(
@@ -326,13 +349,19 @@ async fn connect_with_token_binding(
     )
     .await
     .map_err(|_| SignalFishError::TokenBinding(crate::TokenBindingFailure::ChallengeTimeout))??;
+    #[cfg(feature = "tls")]
+    let selected_fingerprint = client_fingerprint.and_then(|tracker| tracker.fingerprint());
+    #[cfg(not(feature = "tls"))]
+    let selected_fingerprint = None;
+    if options.require_client_fingerprint && selected_fingerprint.is_none() {
+        return Err(SignalFishError::TokenBinding(
+            crate::TokenBindingFailure::MissingClientFingerprint,
+        ));
+    }
     let session = crate::token_binding::TokenBindingSession::from_challenge(
         handshake_key.as_str(),
         challenge,
-        #[cfg(feature = "tls")]
-        client_fingerprint.and_then(|tracker| tracker.fingerprint()),
-        #[cfg(not(feature = "tls"))]
-        None,
+        selected_fingerprint,
     )?;
     Ok((stream, WebSocketTokenBinding::Active(Some(session))))
 }
@@ -425,6 +454,25 @@ pub struct WebSocketConnectOptions {
     ///
     /// Defaults to 10 seconds and is ignored when token binding is not selected.
     pub token_binding_challenge_timeout: std::time::Duration,
+    /// Require that token-binding proofs bind to a real X.509 client
+    /// certificate (opt-in local enforcement of the strictest mTLS profile).
+    ///
+    /// Defaults to `false`, which mirrors the server-side contract: proofs
+    /// simply omit the fingerprint claim when no client certificate is
+    /// selected, and enforcement stays with the server's profile. When
+    /// `true`, the connect fails with
+    /// [`TokenBindingFailure::MissingClientFingerprint`](crate::TokenBindingFailure::MissingClientFingerprint)
+    /// — before any network I/O when the path cannot satisfy the policy, or
+    /// after the handshake when rustls completed it without selecting an
+    /// X.509 client signer — letting deployments enforce the stricter
+    /// contract locally instead of trusting the server to. Optional mode's
+    /// unsigned fallback connection produces no proofs at all and fails the
+    /// same way, so the policy can never be silently skipped.
+    ///
+    /// Only [`WebSocketTransport::connect_with_tls_config`] with token
+    /// binding enabled can ever satisfy the policy; every other connect path
+    /// rejects it up front.
+    pub require_client_fingerprint: bool,
 }
 
 impl Default for WebSocketConnectOptions {
@@ -435,6 +483,7 @@ impl Default for WebSocketConnectOptions {
             max_inbound_message_size: Some(DEFAULT_MAX_INBOUND_MESSAGE_SIZE),
             token_binding: TokenBindingMode::Disabled,
             token_binding_challenge_timeout: std::time::Duration::from_secs(10),
+            require_client_fingerprint: false,
         }
     }
 }
@@ -477,6 +526,17 @@ impl WebSocketConnectOptions {
     #[must_use]
     pub fn with_token_binding_challenge_timeout(mut self, timeout: std::time::Duration) -> Self {
         self.token_binding_challenge_timeout = timeout;
+        self
+    }
+
+    /// Set whether token-binding proofs must bind to an X.509 client
+    /// certificate.
+    ///
+    /// See [`require_client_fingerprint`](Self::require_client_fingerprint).
+    /// Defaults to `false`.
+    #[must_use]
+    pub fn with_require_client_fingerprint(mut self, require: bool) -> Self {
+        self.require_client_fingerprint = require;
         self
     }
 }
@@ -707,6 +767,9 @@ impl WebSocketTransport {
     /// [`ErrorKind::InvalidInput`](std::io::ErrorKind::InvalidInput) before URL
     /// parsing or network I/O. When token binding is requested without the
     /// `token-binding` feature, its feature-disabled error takes precedence.
+    /// The `require_client_fingerprint` policy always fails before network
+    /// I/O here with [`SignalFishError::TokenBinding`], because this path can
+    /// never observe a certificate selection.
     pub async fn connect_with_options(
         url: &str,
         options: WebSocketConnectOptions,
@@ -717,6 +780,7 @@ impl WebSocketTransport {
                 crate::TokenBindingFailure::FeatureDisabled,
             ));
         }
+        reject_unsatisfiable_client_fingerprint_requirement(&options)?;
         let websocket_config = websocket_config(options)?;
 
         #[cfg(feature = "tls")]
@@ -787,7 +851,10 @@ impl WebSocketTransport {
     /// [`connect_with_options`](Self::connect_with_options), including
     /// [`SignalFishError::Io`] with
     /// [`ErrorKind::InvalidInput`](std::io::ErrorKind::InvalidInput) for a zero
-    /// inbound size limit.
+    /// inbound size limit. The `require_client_fingerprint` policy fails
+    /// before network I/O when token binding is disabled (no proofs exist to
+    /// bind), and after the handshake when rustls selected no X.509 client
+    /// signer or Optional mode fell back to an unsigned connection.
     #[cfg(feature = "tls")]
     pub async fn connect_with_tls_config(
         url: &str,
@@ -799,6 +866,14 @@ impl WebSocketTransport {
             return Err(SignalFishError::TokenBinding(
                 crate::TokenBindingFailure::FeatureDisabled,
             ));
+        }
+        #[cfg(not(feature = "token-binding"))]
+        reject_unsatisfiable_client_fingerprint_requirement(&options)?;
+        #[cfg(feature = "token-binding")]
+        if options.token_binding == TokenBindingMode::Disabled {
+            // A disabled connection produces no proofs, so a fingerprint
+            // requirement can never be observed or enforced.
+            reject_unsatisfiable_client_fingerprint_requirement(&options)?;
         }
         let websocket_config = websocket_config(options)?;
 
@@ -1563,6 +1638,74 @@ mod tests {
         ));
     }
 
+    #[tokio::test]
+    async fn required_client_fingerprint_fails_before_io_on_plain_connect_paths() {
+        // `not-a-valid-url` proves the rejection happens before URL parsing:
+        // no path without a custom-rustls token-binding connect can observe a
+        // certificate selection, so the policy must fail closed immediately.
+        let result = WebSocketTransport::connect_with_options(
+            "not-a-valid-url",
+            WebSocketConnectOptions::new()
+                .with_require_client_fingerprint(true)
+                .with_max_inbound_message_size(Some(0)),
+        )
+        .await;
+        assert!(matches!(
+            result,
+            Err(SignalFishError::TokenBinding(
+                crate::TokenBindingFailure::MissingClientFingerprint
+            ))
+        ));
+    }
+
+    #[cfg(all(feature = "tls", not(feature = "token-binding")))]
+    #[tokio::test]
+    async fn required_client_fingerprint_fails_closed_without_the_feature_on_custom_tls() {
+        let tls_config = std::sync::Arc::new(
+            rustls::ClientConfig::builder()
+                .with_root_certificates(rustls::RootCertStore::empty())
+                .with_no_client_auth(),
+        );
+        let result = WebSocketTransport::connect_with_tls_config(
+            "not-a-valid-url",
+            WebSocketConnectOptions::new().with_require_client_fingerprint(true),
+            tls_config,
+        )
+        .await;
+        assert!(matches!(
+            result,
+            Err(SignalFishError::TokenBinding(
+                crate::TokenBindingFailure::MissingClientFingerprint
+            ))
+        ));
+    }
+
+    #[cfg(all(feature = "tls", feature = "token-binding"))]
+    #[tokio::test]
+    async fn required_client_fingerprint_fails_fast_without_token_binding_on_custom_tls() {
+        // Disabled token binding produces no proofs, so the requirement is
+        // unsatisfiable and must be rejected before network I/O.
+        let tls_config = std::sync::Arc::new(
+            rustls::ClientConfig::builder()
+                .with_root_certificates(rustls::RootCertStore::empty())
+                .with_no_client_auth(),
+        );
+        let result = WebSocketTransport::connect_with_tls_config(
+            "not-a-valid-url",
+            WebSocketConnectOptions::new()
+                .with_require_client_fingerprint(true)
+                .with_max_inbound_message_size(Some(0)),
+            tls_config,
+        )
+        .await;
+        assert!(matches!(
+            result,
+            Err(SignalFishError::TokenBinding(
+                crate::TokenBindingFailure::MissingClientFingerprint
+            ))
+        ));
+    }
+
     // ── Mock-stream helpers ──────────────────────────────────────────────
 
     use tokio::net::TcpListener;
@@ -1732,6 +1875,136 @@ mod tests {
         assert!(matches!(
             crate::transport::recv_frame(&mut transport).await,
             Some(Err(SignalFishError::TransportReceive(_)))
+        ));
+        finish_mock_server(server_task).await;
+    }
+
+    #[cfg(all(feature = "tls", feature = "token-binding"))]
+    #[tokio::test]
+    async fn required_client_fingerprint_fails_after_an_unobserved_certificate_selection() {
+        use tokio_tungstenite::tungstenite::http::header::SEC_WEBSOCKET_PROTOCOL;
+
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("fingerprint listener must bind");
+        let addr = listener
+            .local_addr()
+            .expect("fingerprint listener must have an address");
+        let server_task = tokio::spawn(async move {
+            let (tcp, _) = listener.accept().await.expect("server must accept");
+            let mut ws = tokio_tungstenite::accept_hdr_async(
+                tcp,
+                |request: &tokio_tungstenite::tungstenite::handshake::server::Request,
+                 mut response: tokio_tungstenite::tungstenite::handshake::server::Response| {
+                    assert_eq!(
+                        request
+                            .headers()
+                            .get(SEC_WEBSOCKET_PROTOCOL)
+                            .and_then(|value| value.to_str().ok()),
+                        Some(crate::token_binding::TOKEN_BINDING_SUBPROTOCOL)
+                    );
+                    response.headers_mut().insert(
+                        SEC_WEBSOCKET_PROTOCOL,
+                        tokio_tungstenite::tungstenite::http::HeaderValue::from_static(
+                            crate::token_binding::TOKEN_BINDING_SUBPROTOCOL,
+                        ),
+                    );
+                    Ok(response)
+                },
+            )
+            .await
+            .expect("handshake must succeed");
+            ws.send(Message::Text(challenge_json().into()))
+                .await
+                .expect("server must send challenge");
+            // The client must reject the fingerprint-less selection and drop
+            // the connection instead of producing unsigned proofs.
+            let _dropped = ws.next().await;
+        });
+
+        let tls_config = std::sync::Arc::new(
+            rustls::ClientConfig::builder()
+                .with_root_certificates(rustls::RootCertStore::empty())
+                .with_no_client_auth(),
+        );
+        let result = WebSocketTransport::connect_with_tls_config(
+            &format!("ws://{addr}"),
+            required_token_binding_options().with_require_client_fingerprint(true),
+            tls_config,
+        )
+        .await;
+        assert!(matches!(
+            result,
+            Err(SignalFishError::TokenBinding(
+                crate::TokenBindingFailure::MissingClientFingerprint
+            ))
+        ));
+        finish_mock_server(server_task).await;
+    }
+
+    #[cfg(all(feature = "tls", feature = "token-binding"))]
+    #[tokio::test]
+    async fn required_client_fingerprint_fails_the_optional_unsigned_fallback() {
+        use tokio_tungstenite::tungstenite::http::header::SEC_WEBSOCKET_PROTOCOL;
+
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("fallback listener must bind");
+        let addr = listener
+            .local_addr()
+            .expect("fallback listener must have an address");
+        let server_task = tokio::spawn(async move {
+            let (first, _) = listener.accept().await.expect("server must accept offer");
+            // Complete the upgrade without selecting the offered subprotocol:
+            // the exact server behavior that permits an unsigned fallback.
+            let mut first = tokio_tungstenite::accept_hdr_async(
+                first,
+                |request: &tokio_tungstenite::tungstenite::handshake::server::Request,
+                 response: tokio_tungstenite::tungstenite::handshake::server::Response| {
+                    assert!(request.headers().get(SEC_WEBSOCKET_PROTOCOL).is_some());
+                    Ok(response)
+                },
+            )
+            .await
+            .expect("unsigned-capable first upgrade must succeed");
+            let _closed_first_attempt = first.next().await;
+
+            let (second, _) = listener
+                .accept()
+                .await
+                .expect("server must accept fallback");
+            let mut second = tokio_tungstenite::accept_hdr_async(
+                second,
+                |request: &tokio_tungstenite::tungstenite::handshake::server::Request,
+                 response: tokio_tungstenite::tungstenite::handshake::server::Response| {
+                    assert!(request.headers().get(SEC_WEBSOCKET_PROTOCOL).is_none());
+                    Ok(response)
+                },
+            )
+            .await
+            .expect("unsigned fallback handshake must succeed");
+            // The client must reject the fallback and drop the connection.
+            let _dropped = second.next().await;
+        });
+
+        let tls_config = std::sync::Arc::new(
+            rustls::ClientConfig::builder()
+                .with_root_certificates(rustls::RootCertStore::empty())
+                .with_no_client_auth(),
+        );
+        let result = WebSocketTransport::connect_with_tls_config(
+            &format!("ws://{addr}"),
+            WebSocketConnectOptions::new()
+                .with_token_binding(TokenBindingMode::Optional)
+                .with_require_client_fingerprint(true),
+            tls_config,
+        )
+        .await;
+        assert!(matches!(
+            result,
+            Err(SignalFishError::TokenBinding(
+                crate::TokenBindingFailure::MissingClientFingerprint
+            ))
         ));
         finish_mock_server(server_task).await;
     }

--- a/src/webrtc.rs
+++ b/src/webrtc.rs
@@ -245,13 +245,19 @@ mod controller {
     ///
     /// ```rust,ignore
     /// let (mut mesh) = MeshController::start(transport, SignalFishConfig::new("app"), my_driver);
+    /// let mut start_requested = false;
     /// while let Some(event) = mesh.recv().await {
     ///     match event {
     ///         MeshEvent::Signaling(sig) => match *sig {
     ///             SignalFishEvent::Authenticated { .. } =>
     ///                 mesh.join_room(JoinRoomParams::new("game", "Alice"))?,
-    ///             SignalFishEvent::LobbyStateChanged { all_ready: true, .. } =>
-    ///                 mesh.start_game()?,
+    ///             // Ready-state updates repeat — request the start only once.
+    ///             SignalFishEvent::LobbyStateChanged { all_ready: true, .. }
+    ///                 if !start_requested =>
+    ///             {
+    ///                 start_requested = true;
+    ///                 mesh.start_game()?;
+    ///             }
     ///             _ => {}
     ///         },
     ///         MeshEvent::PeerConnected(peer) => { /* peer ready */ }

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -1648,6 +1648,11 @@ mod ci_workflow_policy {
             (
                 "signal-fish-server-v0.7.0-x86_64-unknown-linux-gnu.tar.gz",
                 "0.7.0",
+                "e2e_server_070_require_client_fingerprint_option_rejects_fingerprint_less_signer",
+            ),
+            (
+                "signal-fish-server-v0.7.0-x86_64-unknown-linux-gnu.tar.gz",
+                "0.7.0",
                 "e2e_server_070_polling_client_fingerprint_token_binding_wss",
             ),
             (

--- a/tests/real_server_e2e.rs
+++ b/tests/real_server_e2e.rs
@@ -40,7 +40,7 @@ use signal_fish_client::protocol::GameDataEncoding;
 use signal_fish_client::SignalFishPollingClient;
 use signal_fish_client::{
     ErrorCode, JoinRoomParams, SignalFishClient, SignalFishConfig, SignalFishError,
-    SignalFishEvent, WebSocketTransport,
+    SignalFishEvent, TokenBindingFailure, WebSocketTransport,
 };
 #[cfg(all(feature = "tls", feature = "token-binding"))]
 use signal_fish_client::{TokenBindingMode, TokenBindingStatus, WebSocketConnectOptions};
@@ -636,7 +636,9 @@ async fn e2e_server_070_required_client_fingerprint_token_binding_wss() {
         eprintln!("skipping: SIGNAL_FISH_SERVER_BIN not set");
         return;
     };
-    let options = WebSocketConnectOptions::new().with_token_binding(TokenBindingMode::Required);
+    let options = WebSocketConnectOptions::new()
+        .with_token_binding(TokenBindingMode::Required)
+        .with_require_client_fingerprint(true);
     let transport =
         WebSocketTransport::connect_with_tls_config(&url, options, tls.mtls_client_config())
             .await
@@ -684,6 +686,61 @@ async fn e2e_server_070_required_client_fingerprint_token_binding_wss() {
     client.shutdown().await;
 }
 
+/// Local enforcement of the strictest profile: against a server that requires
+/// token binding but never requests a client certificate, the opt-in policy
+/// must fail the connect locally after the unsigned-capable handshake instead
+/// of trusting the server to reject the fingerprint-less proof.
+#[cfg(all(feature = "tls", feature = "token-binding"))]
+#[tokio::test]
+#[ignore = "requires pinned Signal Fish Server 0.7 and openssl; set SIGNAL_FISH_SERVER_BIN"]
+async fn e2e_server_070_require_client_fingerprint_option_rejects_fingerprint_less_signer() {
+    let tls = TlsFixture::generate();
+    let certificate = tls.certificate.to_string_lossy().into_owned();
+    let private_key = tls.private_key.to_string_lossy().into_owned();
+    let Some((_guard, url)) = spawn_server(&[
+        ("SIGNAL_FISH__SECURITY__TRANSPORT__TLS__ENABLED", "true"),
+        (
+            "SIGNAL_FISH__SECURITY__TRANSPORT__TLS__CERTIFICATE_PATH",
+            certificate.as_str(),
+        ),
+        (
+            "SIGNAL_FISH__SECURITY__TRANSPORT__TLS__PRIVATE_KEY_PATH",
+            private_key.as_str(),
+        ),
+        (
+            "SIGNAL_FISH__SECURITY__TRANSPORT__TOKEN_BINDING__ENABLED",
+            "true",
+        ),
+        (
+            "SIGNAL_FISH__SECURITY__TRANSPORT__TOKEN_BINDING__REQUIRED",
+            "true",
+        ),
+    ])
+    .await
+    else {
+        eprintln!("skipping: SIGNAL_FISH_SERVER_BIN not set");
+        return;
+    };
+    let url = url.replacen("ws://127.0.0.1", "wss://localhost", 1);
+    let options = WebSocketConnectOptions::new()
+        .with_token_binding(TokenBindingMode::Required)
+        .with_require_client_fingerprint(true);
+    let error = WebSocketTransport::connect_with_tls_config(
+        &url,
+        options,
+        tls.client_config(), // trusted server roots, no client certificate
+    )
+    .await
+    .expect_err("fingerprint-less signer must fail the local requirement");
+    assert!(
+        matches!(
+            error,
+            SignalFishError::TokenBinding(TokenBindingFailure::MissingClientFingerprint)
+        ),
+        "unexpected error: {error:?}"
+    );
+}
+
 /// The caller-driven client uses the same fully connected native transport and
 /// fingerprint-bound signer as the Tokio background driver.
 #[cfg(all(feature = "tls", feature = "token-binding", feature = "polling-client"))]
@@ -695,7 +752,9 @@ async fn e2e_server_070_polling_client_fingerprint_token_binding_wss() {
         eprintln!("skipping: SIGNAL_FISH_SERVER_BIN not set");
         return;
     };
-    let options = WebSocketConnectOptions::new().with_token_binding(TokenBindingMode::Required);
+    let options = WebSocketConnectOptions::new()
+        .with_token_binding(TokenBindingMode::Required)
+        .with_require_client_fingerprint(true);
     let transport =
         WebSocketTransport::connect_with_tls_config(&url, options, tls.mtls_client_config())
             .await

--- a/tests/real_server_e2e.rs
+++ b/tests/real_server_e2e.rs
@@ -38,9 +38,11 @@ use sha2::{Digest as _, Sha256};
 use signal_fish_client::protocol::GameDataEncoding;
 #[cfg(all(feature = "tls", feature = "token-binding", feature = "polling-client"))]
 use signal_fish_client::SignalFishPollingClient;
+#[cfg(all(feature = "tls", feature = "token-binding"))]
+use signal_fish_client::TokenBindingFailure;
 use signal_fish_client::{
     ErrorCode, JoinRoomParams, SignalFishClient, SignalFishConfig, SignalFishError,
-    SignalFishEvent, TokenBindingFailure, WebSocketTransport,
+    SignalFishEvent, WebSocketTransport,
 };
 #[cfg(all(feature = "tls", feature = "token-binding"))]
 use signal_fish_client::{TokenBindingMode, TokenBindingStatus, WebSocketConnectOptions};


### PR DESCRIPTION
## Why

A server that never requests a client certificate accepts fingerprint-less token-binding proofs silently. Enforcement was server-side only (fail-closed under strict profiles), but deployments had no way to enforce the stricter contract locally (#175).

## What

- New opt-in `require_client_fingerprint` option on `WebSocketConnectOptions`. When set, the connect fails with a typed `TokenBindingFailure::MissingClientFingerprint` error:
  - before any network I/O on paths that cannot satisfy it (plain connects, custom-TLS connects without token binding),
  - after the handshake when rustls selected no X.509 client signer,
  - and on `Optional` mode's unsigned fallback, so the policy can never be silently skipped.
- Hosted E2E proves the option end to end against the real fingerprint-required Server 0.7 (both drivers) and the fingerprint-less rejection.

**Breaking:** `WebSocketConnectOptions` gains a public field and `TokenBindingFailure` gains a variant; exhaustive literals and matches need updating.

## Also in this PR (audit round 14)

- Quick-start sketches now request the game start only once instead of on every repeated all-ready update (they previously taught the exact error-spam pattern the events guide forbids).
- CI guard: the `adapter-msrv` lane's toolchain is now cross-checked against the Godot adapter's declared `rust-version`.
- MSRV claims re-verified by building and running the suites on Rust 1.87.0 / 1.94.0.
- Multi-caller concurrency audited: zero findings (14 candidates mechanically refuted).

Closes #175

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes WebSocket connect and token-binding negotiation with a new fail-closed auth policy; breaking public API requires downstream match/struct updates.
> 
> **Overview**
> Adds an **opt-in `require_client_fingerprint`** policy on `WebSocketConnectOptions` (`with_require_client_fingerprint`) so deployments can enforce certificate-bound token-binding proofs **locally**, without relying on the server to reject fingerprint-less traffic.
> 
> When enabled, connect fails with **`TokenBindingFailure::MissingClientFingerprint`**: immediately on paths that cannot observe rustls client-cert selection (plain connect, custom TLS without token binding, or disabled binding), after handshake if no X.509 signer was selected, and on **Optional** mode’s unsigned fallback so the policy cannot be bypassed. **Breaking for 0.11:** new public field on `WebSocketConnectOptions` and new `TokenBindingFailure` variant.
> 
> Docs and quick-start snippets now call **`start_game()` only once** on repeated `LobbyStateChanged { all_ready: true }` events. CI adds a hosted E2E for fingerprint-less rejection, wires the new test into the matrix, and extends **`check-workflows.sh`** so the Godot adapter’s `rust-version` matches the `adapter-msrv` job toolchain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4251c7a9839bdda453fe596819940b6180b8211e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->