### PR TITLE
Fix misleading token-binding connect errors; warn on unused TLS config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `SendBufferFull` now also names "drain events promptly" as a remedy: a task
+  awaiting a reliable send while it is the sole event consumer can deadlock
+  against a full event channel (which pauses the transport loop that drains
+  the command queue), and pacing or capacity changes alone do not fix that
+  case. The variant itself and its matching/emission behavior are unchanged.
 - Documented quick-start sketches (crate docs, `MeshController` docs, and the
   mesh guide) now request the protocol-v2 game start only once instead of on
   every repeated all-ready update, matching the guidance in the events guide
@@ -287,6 +292,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed misleading token-binding connect errors for HTTP upgrade rejections:
+  a non-101 response (404 wrong path, 401/403 rejected auth, 500, ...) on an
+  `Optional` or `Required` token-binding connect was reported as
+  `TokenBindingFailure::NegotiationRejected` ("the server rejected
+  token-binding negotiation"), hiding the actual HTTP status and suggesting a
+  server capability problem for what is usually a URL or credential
+  misconfiguration. HTTP upgrade rejections now surface as `Io` carrying the
+  underlying HTTP error — the same classification the `Disabled` mode already
+  used — so one misconfigured URL fails the same way in every mode.
+  `TokenBindingFailure::NegotiationRejected` remains in the exhaustive enum
+  as a reserved, no-longer-produced variant.
+- Fixed `TokenBindingFailure::MalformedChallenge` mislabeling the
+  control-flood case: a selected token-binding connection whose server sent
+  only control frames (and never any challenge) was reported as "the server
+  sent a malformed token-binding challenge" even though no challenge was
+  ever delivered. The variant now reads "the server did not send a valid
+  token-binding challenge" and its documentation covers both faces (an
+  invalid first application frame, or the control-frame budget exhausting
+  before any challenge).
+- `WebSocketTransport::connect_with_tls_config` now logs a warning when
+  called with a plain `ws://` URL: tokio-tungstenite bypasses the connector
+  for plain URLs, so the entire custom TLS configuration — including any
+  mTLS client identity — was silently unused.
+- Corrected published documentation: `SignalFishError::ServerError` is
+  reserved and no current server/SDK combination constructs it (server
+  errors surface as events); `SessionPlanUnavailable`'s trigger list now
+  includes relay (non-WebRTC) session transports; the six compatibility-only
+  `ErrorCode` variants are labeled at their definitions and in the docs
+  tables; and `require_client_fingerprint`'s failure timing is stated
+  precisely (pre-I/O on every path without a tracking resolver, after the
+  handshake and challenge on the custom-TLS token-binding path, including
+  the plain `ws://` case where no selection can ever be observed).
 - Fixed `SignalFishEvent::Disconnected` reason mislabeling for custom
   transports: close metadata that the transport did not report as
   peer-initiated was formatted as `"closed by server: …"`; it now formats as

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -477,9 +477,9 @@ directly from client methods as `Result<(), SignalFishError>`.
 | `WrongRoomRole { required, actual }` | The operation requires player or spectator membership of a different kind. |
 | `AuthorityRequired` | The current player is not authorized for an authority-only command. |
 | `NotAuthenticated` | A directed room operation was attempted before the server confirmed authentication; wait for the `Authenticated` event first. |
-| `ServerError { message, error_code }` | The server returned an error; `error_code` is `Option<ErrorCode>` and may be absent. |
+| `ServerError { message, error_code }` | Reserved for compatibility — no current server/SDK combination constructs this variant; server errors surface as events instead. |
 | `ProtocolUnsupported { mode }` | A protocol-v3-only send was attempted before v3 was negotiated. See [Protocol versioning and topology](#protocol-versioning-and-topology). |
-| `SessionPlanUnavailable` | A WebRTC signal was attempted but no authoritative session plan currently authorizes it (before a plan, or targeting self, unknown, or departed players). |
+| `SessionPlanUnavailable` | A WebRTC signal was attempted but no authoritative session plan currently authorizes it (before a plan, targeting self, unknown, or departed players, or the negotiated session transport is not WebRTC). |
 | `StaleSessionGeneration { .. }` | A WebRTC signal was produced under an already-replaced session-plan generation; the newer plan remains authoritative. |
 | `BinaryFormatNotNegotiated` | Binary game data was requested while the connection uses JSON. |
 | `TokenBinding(TokenBindingFailure)` | Native token-binding negotiation or proof generation failed (see `TokenBindingFailure` for the specific reason). |

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -31,15 +31,15 @@ exhaustive public enum:
 | `Serialization` | `serde_json::Error` | Failed to serialize or deserialize a protocol message. Implements `From<serde_json::Error>`. |
 | `NotConnected` | — | Attempted an operation requiring an active connection but the client is not connected. |
 | `NotAuthenticated` | — | Attempted a directed room operation (`join_room`, `leave_room`, `reconnect`, `join_as_spectator`, or `leave_spectator`) before the server confirmed authentication. The command was **not** queued; retry once the `Authenticated` event arrives. Non-room commands keep their pre-authentication behavior. |
-| `SendBufferFull` | `capacity: usize` | The bounded outgoing command queue is full — the caller is producing messages faster than the transport can drain them. The message was refused, **not** queued; nothing is silently dropped. See [Handling `SendBufferFull`](#handling-sendbufferfull). |
+| `SendBufferFull` | `capacity: usize` | The bounded outgoing command queue is full — the caller is producing messages faster than the transport can drain them. The message was refused, **not** queued; nothing is silently dropped. Retry later, pace with a `*_reliable` variant, drain events promptly, or raise `command_channel_capacity`. See [Handling `SendBufferFull`](#handling-sendbufferfull). |
 | `NotInRoom` | — | Attempted a room operation but the client is not in a room. |
 | `AlreadyInRoom` | — | Attempted to join as a player/spectator or reconnect while already in a room. |
 | `RoomOperationPending` | — | A previously admitted join, leave, or reconnect still awaits a matching typed terminal response. `ping` remains available; generic errors and absent responses stay fenced until transport teardown, after which a new connection may retry. The fence applies to undecodable responses too: an unknown `error_code` string from a newer server makes the whole frame surface as a `DecodeFailed` event, so a correlated result never releases the pending operation. One benign wire race is absorbed rather than fenced: when an authoritative spectator exit (`Disconnected`, `Removed`, or `RoomClosed`) tears the room down before the server's mandatory reply to an admitted voluntary `leave_spectator`, that one superseded reply is silently consumed — any duplicate or unrelated late result still violates. |
 | `WrongRoomRole` | `required: RoomRole`, `actual: RoomRole` | Attempted a player-only command as a spectator, or `leave_spectator` as a player. |
 | `AuthorityRequired` | — | Attempted `start_game` while another player is authority, or attempted to relinquish authority without currently holding it. |
-| `ServerError` | `message: String`, `error_code: Option<ErrorCode>` | The server returned an error message. |
+| `ServerError` | `message: String`, `error_code: Option<ErrorCode>` | Reserved for compatibility — no current server/SDK combination constructs this variant. Server error messages surface as `SignalFishEvent::Error`, `AuthenticationError`, `RoomJoinFailed`, or `RoomOperationFailed` instead. |
 | `ProtocolUnsupported` | `mode: &'static str` | A protocol-v3-only operation (classified latest/volatile JSON, binary game data, signaling, or transport-status reporting) was attempted before v3 was negotiated. `mode` is `"pre-negotiation"` (no `ProtocolInfo` yet — negotiation still in flight) or `"relay-only"` (a `ProtocolInfo` arrived but negotiated v2, the terminal relay floor). See [Protocol Versioning](protocol-versioning.md#the-fail-fast-guard). |
-| `SessionPlanUnavailable` | — | No authoritative WebRTC plan currently authorizes the signal: no plan has arrived, or the target is self, unknown, departed, or absent from the replace-on-plan peer set/current room roster. The set may be extended by a valid compatibility `NewPeer`; the frame is refused locally. |
+| `SessionPlanUnavailable` | — | No authoritative WebRTC plan currently authorizes the signal: no plan has arrived, the target is self, unknown, departed, or absent from the replace-on-plan peer set/current room roster, or the negotiated session transport is not WebRTC (a relay plan). The set may be extended by a valid compatibility `NewPeer`; the frame is refused locally. |
 | `StaleSessionGeneration` | `attempted: Option<SessionGeneration>`, `current: Option<SessionGeneration>` | A generation-bound driver signal was produced after its session plan had been replaced. The client refuses it rather than relabeling stale signaling. |
 | `BinaryFormatNotNegotiated` | — | A binary send was attempted after negotiation resolved to JSON. Request `MessagePack` and confirm `effective_game_data_format() == Some(MessagePack)`; unsupported requests resolve to JSON and are refused before transport admission. Before `ProtocolInfo`, v3-only sends return `ProtocolUnsupported` instead. |
 | `Timeout` | — | The WebSocket handshake did not complete within its deadline. Only `WebSocketTransport::connect_with_timeout` emits this variant, when the connection is not established within the duration it is given. |
@@ -111,12 +111,12 @@ println!("{}", code.description());
 | Variant | Description |
 |---------|-------------|
 | `Unauthorized` | Access denied. Authentication credentials are missing or invalid. |
-| `InvalidToken` | The authentication token is invalid, malformed, or has expired. |
-| `AuthenticationRequired` | This operation requires authentication. |
+| `InvalidToken` *(compatibility-only)* | The authentication token is invalid, malformed, or has expired. |
+| `AuthenticationRequired` *(compatibility-only)* | This operation requires authentication. |
 | `InvalidAppId` | The provided application ID is not recognized. |
-| `AppIdExpired` | The application ID has expired. |
-| `AppIdRevoked` | The application ID has been revoked. |
-| `AppIdSuspended` | The application ID has been suspended. |
+| `AppIdExpired` *(compatibility-only)* | The application ID has expired. |
+| `AppIdRevoked` *(compatibility-only)* | The application ID has been revoked. |
+| `AppIdSuspended` *(compatibility-only)* | The application ID has been suspended. |
 | `MissingAppId` | Application ID is required but was not provided. |
 | `AuthenticationTimeout` | Authentication took too long to complete. |
 | `SdkVersionUnsupported` | The SDK version you are using is no longer supported. |
@@ -184,7 +184,7 @@ println!("{}", code.description());
 |---------|-------------|
 | `InternalError` | An internal server error occurred. |
 | `StorageError` | A storage error occurred while processing your request. |
-| `ServiceUnavailable` | The service is temporarily unavailable. |
+| `ServiceUnavailable` *(compatibility-only)* | The service is temporarily unavailable. |
 
 ### Game Start — protocol v2 (2)
 
@@ -331,7 +331,7 @@ The synchronous send methods (`send_game_data`, `send_signal`, `join_room`, …)
 fail fast with `SignalFishError::SendBufferFull` when the bounded outgoing
 command queue (default **1024**, set via
 `SignalFishConfig::command_channel_capacity`) is full. The message is refused,
-not queued — congestion is surfaced, never hidden. Three remedies, in order of
+not queued — congestion is surfaced, never hidden. Four remedies, in order of
 preference:
 
 1. **Pace with the waiting variants.** `send_game_data_reliable` /
@@ -343,6 +343,12 @@ preference:
 3. **Raise the capacity.** `SignalFishConfig::with_command_channel_capacity(n)`
    buys more burst headroom, at the cost of more queued latency when the
    transport truly cannot keep up.
+4. **Drain events promptly.** The command queue only drains while the
+   transport loop runs, and the loop pauses whenever the *event* channel is
+   full (overflow pauses the loop instead of dropping the event). A task that
+   awaits a waiting variant while it is also the sole event consumer can
+   deadlock under simultaneous send + receive pressure — drain events from a
+   separate task.
 
 ```rust,ignore
 use signal_fish_client::{SignalFishClient, SignalFishError};

--- a/docs/token-binding.md
+++ b/docs/token-binding.md
@@ -39,7 +39,7 @@ assert_eq!(transport.token_binding_status(), TokenBindingStatus::Active);
 |---|---|
 | `Disabled` | Default. Does not offer a subprotocol and preserves the old connection path exactly. |
 | `Optional` | Offers v2. If the server completes the upgrade without selecting a subprotocol, reconnects once without the offer and reports `NotNegotiated`. It never retries an HTTP rejection, malformed challenge, unexpected selection, network error, or TLS failure. |
-| `Required` | Fails with a typed `SignalFishError::TokenBinding` unless the server selects v2 and sends a valid first-message challenge before the configured deadline. |
+| `Required` | Fails with a typed `SignalFishError::TokenBinding` unless the server selects v2 and sends a valid first-message challenge before the configured deadline. HTTP upgrade rejections (404, 401, 500, ...) are not negotiation outcomes and surface as `Io` carrying the underlying status, exactly like `Disabled`. |
 
 Optional mode permits an explicit downgrade when the server accepts an
 unsigned upgrade. TLS authenticates the handshake and prevents an on-path
@@ -82,6 +82,9 @@ that clone so every offered physical connection performs a certificate
 selection that the proof signer can observe. In `Optional` mode this also
 applies to the unsigned fallback connection after the server omits the
 subprotocol. The caller's configuration and resumption cache are not mutated.
+A plain `ws://` URL bypasses the connector entirely — the custom configuration,
+including any mTLS client identity, is silently unused, and the transport logs
+a warning — so always use `wss://` with a custom configuration.
 Server 0.7 profiles with `require_client_fingerprint=true` additionally require
 built-in WSS, a trusted client CA, mTLS client authentication, and required
 token binding.
@@ -108,9 +111,14 @@ let transport = WebSocketTransport::connect_with_tls_config(
 ```
 
 When the policy is set, the connect fails with a typed
-`TokenBindingFailure::MissingClientFingerprint` — before any network I/O when
-the path cannot observe a certificate selection at all, and after the handshake
-when rustls completed it without selecting an X.509 client signer. Optional
+`TokenBindingFailure::MissingClientFingerprint` — before any network I/O on
+every path that cannot observe a certificate selection (every path except
+`connect_with_tls_config` with token binding enabled, including built-in
+`wss://` connects, which perform TLS but install no tracking resolver). On the
+custom-TLS token-binding path the check runs after the handshake and challenge,
+failing when rustls selected no X.509 client signer; on a plain `ws://` URL the
+custom TLS configuration is not used at all, so no certificate can ever be
+selected and the failure still surfaces only after the challenge. Optional
 mode's unsigned fallback connection produces no proofs at all and fails the
 same way, so the policy can never be silently skipped. Only
 `connect_with_tls_config` with token binding enabled can satisfy the policy;

--- a/src/error.rs
+++ b/src/error.rs
@@ -14,7 +14,14 @@ use thiserror::Error;
 pub enum TokenBindingFailure {
     /// The crate was built without the opt-in `token-binding` feature.
     FeatureDisabled,
-    /// The server rejected the WebSocket upgrade while token binding was offered.
+    /// Reserved for compatibility; no longer produced.
+    ///
+    /// Current SDK versions report HTTP upgrade rejections as
+    /// [`SignalFishError::Io`] carrying the
+    /// underlying HTTP error (including its status), whether or not token
+    /// binding was offered, so a misconfigured URL reports the same way in
+    /// every token-binding mode. Match on this variant only in exhaustive
+    /// arms.
     NegotiationRejected,
     /// Required mode completed an upgrade without selecting token-binding-v2.
     SubprotocolNotNegotiated,
@@ -24,7 +31,9 @@ pub enum TokenBindingFailure {
     MissingChallenge,
     /// The selected connection did not send its challenge before the deadline.
     ChallengeTimeout,
-    /// The first application frame was not a valid token-binding challenge.
+    /// The connection never produced a valid token-binding challenge: the
+    /// first application frame was not a valid challenge, or the server
+    /// exhausted the client's control-frame budget before sending one.
     MalformedChallenge,
     /// The challenge declared an unsupported protocol version.
     UnsupportedVersion,
@@ -66,7 +75,7 @@ impl std::fmt::Display for TokenBindingFailure {
             Self::UnexpectedSubprotocol => "the server selected an unexpected subprotocol",
             Self::MissingChallenge => "the server closed before the token-binding challenge",
             Self::ChallengeTimeout => "the server token-binding challenge timed out",
-            Self::MalformedChallenge => "the server sent a malformed token-binding challenge",
+            Self::MalformedChallenge => "the server did not send a valid token-binding challenge",
             Self::UnsupportedVersion => "the server selected an unsupported token-binding version",
             Self::UnsupportedScheme => "the server selected an unsupported token-binding scheme",
             Self::InvalidNonce => "the server challenge nonce is invalid",
@@ -115,12 +124,16 @@ pub enum SignalFishError {
     /// pace high-rate payloads with a waiting `*_reliable` variant
     /// ([`SignalFishClient::send_game_data_reliable`](crate::SignalFishClient::send_game_data_reliable),
     /// [`SignalFishClient::send_signal_reliable`](crate::SignalFishClient::send_signal_reliable)),
-    /// or raise
+    /// drain events promptly, or raise
     /// [`SignalFishConfig::command_channel_capacity`](crate::SignalFishConfig::command_channel_capacity).
+    /// Draining matters when the task awaiting a reliable send is also the
+    /// sole event consumer: a full event channel pauses the transport loop
+    /// that drains the command queue, so that task can deadlock against
+    /// itself (drain events from a separate task).
     #[error(
         "outgoing command queue full (capacity {capacity}): the transport cannot keep up; \
-         retry later, pace high-rate sends with a waiting *_reliable variant, or increase \
-         command_channel_capacity"
+         retry later, pace high-rate sends with a waiting *_reliable variant, drain events \
+         promptly, or increase command_channel_capacity"
     )]
     SendBufferFull {
         /// Configured capacity of the outgoing command queue.
@@ -173,6 +186,14 @@ pub enum SignalFishError {
     AuthorityRequired,
 
     /// The server returned an error message.
+    ///
+    /// Reserved for compatibility: no current server/SDK combination
+    /// constructs this variant. Server error messages surface as events
+    /// ([`SignalFishEvent::Error`](crate::SignalFishEvent::Error),
+    /// [`SignalFishEvent::AuthenticationError`](crate::SignalFishEvent::AuthenticationError),
+    /// [`SignalFishEvent::RoomJoinFailed`](crate::SignalFishEvent::RoomJoinFailed),
+    /// or [`SignalFishEvent::RoomOperationFailed`](crate::SignalFishEvent::RoomOperationFailed)),
+    /// so exhaustive matches should treat this arm as unreachable.
     #[error("server error: {message}")]
     ServerError {
         /// Human-readable error message from the server.
@@ -206,8 +227,9 @@ pub enum SignalFishError {
 
     /// No authoritative WebRTC session plan currently authorizes this signal.
     ///
-    /// This covers signaling before a plan and targeting self, an unknown or
-    /// departed player, or a peer removed by a replacement plan.
+    /// This covers signaling before a plan, targeting self, an unknown or
+    /// departed player, a peer removed by a replacement plan, and connections
+    /// whose negotiated session transport is not WebRTC (a relay plan).
     #[error("no authoritative SessionPlan authorizes this WebRTC signal")]
     SessionPlanUnavailable,
 
@@ -275,7 +297,10 @@ mod tests {
             (TokenBindingFailure::UnexpectedSubprotocol, "unexpected"),
             (TokenBindingFailure::MissingChallenge, "closed"),
             (TokenBindingFailure::ChallengeTimeout, "timed out"),
-            (TokenBindingFailure::MalformedChallenge, "malformed"),
+            (
+                TokenBindingFailure::MalformedChallenge,
+                "did not send a valid",
+            ),
             (TokenBindingFailure::UnsupportedVersion, "version"),
             (TokenBindingFailure::UnsupportedScheme, "scheme"),
             (TokenBindingFailure::InvalidNonce, "nonce"),

--- a/src/error_codes.rs
+++ b/src/error_codes.rs
@@ -17,11 +17,26 @@ use std::fmt;
 pub enum ErrorCode {
     // Authentication errors
     Unauthorized,
+    /// Compatibility only (see [`NON_EMITTED`](ErrorCode::NON_EMITTED)): no
+    /// longer emitted by Server 0.7+; retained so older deployments stay
+    /// decodable.
     InvalidToken,
+    /// Compatibility only (see [`NON_EMITTED`](ErrorCode::NON_EMITTED)): no
+    /// longer emitted by Server 0.7+; retained so older deployments stay
+    /// decodable.
     AuthenticationRequired,
     InvalidAppId,
+    /// Compatibility only (see [`NON_EMITTED`](ErrorCode::NON_EMITTED)): no
+    /// longer emitted by Server 0.7+; retained so older deployments stay
+    /// decodable.
     AppIdExpired,
+    /// Compatibility only (see [`NON_EMITTED`](ErrorCode::NON_EMITTED)): no
+    /// longer emitted by Server 0.7+; retained so older deployments stay
+    /// decodable.
     AppIdRevoked,
+    /// Compatibility only (see [`NON_EMITTED`](ErrorCode::NON_EMITTED)): no
+    /// longer emitted by Server 0.7+; retained so older deployments stay
+    /// decodable.
     AppIdSuspended,
     MissingAppId,
     AuthenticationTimeout,
@@ -69,6 +84,9 @@ pub enum ErrorCode {
     // Server errors
     InternalError,
     StorageError,
+    /// Compatibility only (see [`NON_EMITTED`](ErrorCode::NON_EMITTED)): no
+    /// longer emitted by Server 0.7+; retained so older deployments stay
+    /// decodable.
     ServiceUnavailable,
 
     // Game-start errors (protocol v2)

--- a/src/transports/websocket.rs
+++ b/src/transports/websocket.rs
@@ -304,12 +304,7 @@ async fn connect_with_token_binding(
                 options.disable_nagle,
             )
             .await;
-            let (stream, _response) = fallback.map_err(|error| match error {
-                WebSocketError::Http(_) => {
-                    SignalFishError::TokenBinding(crate::TokenBindingFailure::NegotiationRejected)
-                }
-                error => map_connect_error(error),
-            })?;
+            let (stream, _response) = fallback.map_err(map_connect_error)?;
             if options.require_client_fingerprint {
                 // The unsigned fallback sends no proofs at all, so a locally
                 // required certificate binding cannot be honored: fail closed
@@ -333,11 +328,6 @@ async fn connect_with_token_binding(
         ))) => {
             return Err(SignalFishError::TokenBinding(
                 crate::TokenBindingFailure::UnexpectedSubprotocol,
-            ))
-        }
-        Err(WebSocketError::Http(_)) => {
-            return Err(SignalFishError::TokenBinding(
-                crate::TokenBindingFailure::NegotiationRejected,
             ))
         }
         Err(error) => return Err(map_connect_error(error)),
@@ -462,12 +452,18 @@ pub struct WebSocketConnectOptions {
     /// selected, and enforcement stays with the server's profile. When
     /// `true`, the connect fails with
     /// [`TokenBindingFailure::MissingClientFingerprint`](crate::TokenBindingFailure::MissingClientFingerprint)
-    /// — before any network I/O when the path cannot satisfy the policy, or
-    /// after the handshake when rustls completed it without selecting an
-    /// X.509 client signer — letting deployments enforce the stricter
-    /// contract locally instead of trusting the server to. Optional mode's
-    /// unsigned fallback connection produces no proofs at all and fails the
-    /// same way, so the policy can never be silently skipped.
+    /// — before any network I/O on every path that cannot observe a
+    /// certificate selection (every path except
+    /// [`WebSocketTransport::connect_with_tls_config`](crate::WebSocketTransport::connect_with_tls_config)
+    /// with token binding enabled, including built-in `wss://` connects,
+    /// which perform TLS but install no tracking resolver). On the
+    /// custom-TLS token-binding path the check runs after the handshake and
+    /// challenge, failing when rustls selected no X.509 client signer; on a
+    /// plain `ws://` URL the custom TLS configuration is not used at all, so
+    /// no certificate can ever be selected and the failure still surfaces
+    /// only after the challenge. Optional mode's unsigned fallback
+    /// connection produces no proofs at all and fails the same way, so the
+    /// policy can never be silently skipped.
     ///
     /// Only [`WebSocketTransport::connect_with_tls_config`] with token
     /// binding enabled can ever satisfy the policy; every other connect path
@@ -760,10 +756,13 @@ impl WebSocketTransport {
     /// Returns [`SignalFishError::Io`] if the URL is invalid or the connection
     /// cannot be established. When the underlying error is an I/O error its
     /// [`ErrorKind`](std::io::ErrorKind) is preserved; all other errors are
-    /// mapped to [`ErrorKind::Other`](std::io::ErrorKind::Other). Optional or
-    /// required mode returns [`SignalFishError::TokenBinding`] when the feature
-    /// is disabled or negotiation, challenge validation, or key derivation
-    /// fails. A zero inbound size limit returns [`SignalFishError::Io`] with
+    /// mapped to [`ErrorKind::Other`](std::io::ErrorKind::Other) — including
+    /// HTTP upgrade rejections, which carry the underlying status in every
+    /// token-binding mode. Optional or required mode returns
+    /// [`SignalFishError::TokenBinding`] when the feature
+    /// is disabled or subprotocol negotiation, challenge validation, or key
+    /// derivation fails. A zero inbound size limit returns
+    /// [`SignalFishError::Io`] with
     /// [`ErrorKind::InvalidInput`](std::io::ErrorKind::InvalidInput) before URL
     /// parsing or network I/O. When token binding is requested without the
     /// `token-binding` feature, its feature-disabled error takes precedence.
@@ -853,8 +852,14 @@ impl WebSocketTransport {
     /// [`ErrorKind::InvalidInput`](std::io::ErrorKind::InvalidInput) for a zero
     /// inbound size limit. The `require_client_fingerprint` policy fails
     /// before network I/O when token binding is disabled (no proofs exist to
-    /// bind), and after the handshake when rustls selected no X.509 client
-    /// signer or Optional mode fell back to an unsigned connection.
+    /// bind), after the handshake and challenge when rustls selected no
+    /// X.509 client signer, and after the unsigned fallback handshake (no
+    /// challenge is consumed) when Optional mode fell back to an unsigned
+    /// connection. On a plain `ws://` URL the custom TLS configuration is
+    /// not used at all — tokio-tungstenite bypasses the connector, so no TLS
+    /// handshake or certificate selection runs and a warning is logged; with
+    /// token binding enabled the fingerprint policy still fails only after
+    /// the completed challenge.
     #[cfg(feature = "tls")]
     pub async fn connect_with_tls_config(
         url: &str,
@@ -879,8 +884,20 @@ impl WebSocketTransport {
 
         install_tls_provider();
         let connector = tokio_tungstenite::Connector::Rustls(tls_config.clone());
+        let secure = url.starts_with("wss://");
+        if !secure {
+            // tokio-tungstenite bypasses the connector for plain URLs, so the
+            // entire custom configuration — including mTLS client identity —
+            // is silently inert. Never inline the URL here.
+            tracing::warn!(
+                custom_tls = true,
+                secure,
+                "custom TLS configuration is ignored: no TLS handshake or certificate \
+                 selection runs on a plain URL"
+            );
+        }
         tracing::debug!(
-            secure = url.starts_with("wss://"),
+            secure,
             disable_nagle = options.disable_nagle,
             max_inbound_message_size = options.max_inbound_message_size,
             token_binding = ?options.token_binding,
@@ -1638,6 +1655,27 @@ mod tests {
         ));
     }
 
+    #[cfg(not(feature = "token-binding"))]
+    #[tokio::test]
+    async fn unavailable_token_binding_precedes_a_required_client_fingerprint() {
+        // `not-a-valid-url` proves the precedence without any network I/O:
+        // the feature-disabled fence must win over the fingerprint policy so
+        // callers see the actual capability gap first.
+        let result = WebSocketTransport::connect_with_options(
+            "not-a-valid-url",
+            WebSocketConnectOptions::new()
+                .with_token_binding(TokenBindingMode::Required)
+                .with_require_client_fingerprint(true),
+        )
+        .await;
+        assert!(matches!(
+            result,
+            Err(SignalFishError::TokenBinding(
+                crate::TokenBindingFailure::FeatureDisabled
+            ))
+        ));
+    }
+
     #[tokio::test]
     async fn required_client_fingerprint_fails_before_io_on_plain_connect_paths() {
         // `not-a-valid-url` proves the rejection happens before URL parsing:
@@ -2103,10 +2141,18 @@ mod tests {
         )
         .await
         .expect_err("optional mode must preserve an HTTP rejection");
-        assert!(matches!(
-            error,
-            SignalFishError::TokenBinding(crate::TokenBindingFailure::NegotiationRejected)
-        ));
+        // An HTTP rejection says nothing about the offered subprotocol, so it
+        // surfaces through the same Io mapping as the disabled path and keeps
+        // the underlying status instead of a negotiation-specific label.
+        let message = error.to_string();
+        assert!(
+            matches!(error, SignalFishError::Io(_)),
+            "HTTP rejection must keep the generic I/O classification: {message}"
+        );
+        assert!(
+            message.contains("403"),
+            "HTTP rejection must preserve the server's status code: {message}"
+        );
         finish_mock_server(server_task).await;
     }
 
@@ -2164,6 +2210,57 @@ mod tests {
             "connect must stay parked awaiting the challenge"
         );
         drop(connect);
+        finish_mock_server(server_task).await;
+    }
+
+    #[cfg(feature = "token-binding")]
+    #[tokio::test]
+    async fn challengeless_control_flood_reports_no_valid_challenge() {
+        use futures_util::SinkExt as _;
+        use tokio_tungstenite::tungstenite::http::header::SEC_WEBSOCKET_PROTOCOL;
+
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("control-flood listener must bind");
+        let addr = listener
+            .local_addr()
+            .expect("control-flood listener must have an address");
+        let server_task = tokio::spawn(async move {
+            let (tcp, _) = listener.accept().await.expect("server must accept client");
+            let mut ws = tokio_tungstenite::accept_hdr_async(
+                tcp,
+                |_request: &tokio_tungstenite::tungstenite::handshake::server::Request,
+                 mut response: tokio_tungstenite::tungstenite::handshake::server::Response| {
+                    response.headers_mut().insert(
+                        SEC_WEBSOCKET_PROTOCOL,
+                        tokio_tungstenite::tungstenite::http::HeaderValue::from_static(
+                            crate::token_binding::TOKEN_BINDING_SUBPROTOCOL,
+                        ),
+                    );
+                    Ok(response)
+                },
+            )
+            .await
+            .expect("selected handshake must succeed");
+            // One control frame over the skip budget without any application
+            // frame is a server that never speaks the challenge protocol.
+            for _ in 0..MAX_SKIPPED_CONTROL_FRAMES_PER_POLL {
+                if ws.send(Message::Pong(Vec::new().into())).await.is_err() {
+                    break;
+                }
+            }
+        });
+
+        let error = WebSocketTransport::connect_with_options(
+            &format!("ws://{addr}"),
+            required_token_binding_options(),
+        )
+        .await
+        .expect_err("a connection that never delivers a challenge must fail");
+        assert!(matches!(
+            error,
+            SignalFishError::TokenBinding(crate::TokenBindingFailure::MalformedChallenge)
+        ));
         finish_mock_server(server_task).await;
     }
 

--- a/tests/error_code_conformance_tests.rs
+++ b/tests/error_code_conformance_tests.rs
@@ -329,9 +329,12 @@ fn public_documentation_covers_every_error_code_variant_and_current_count() {
 
     for code in &codes {
         let variant = format!("{code:?}");
-        let table_cell = format!("| `{variant}` |");
+        // Each variant must open its own table row; an annotation may follow
+        // the name (e.g. the compatibility-only markers), so match the row
+        // prefix rather than the whole cell.
+        let row_prefix = format!("| `{variant}`");
         assert!(
-            errors.contains(&table_cell),
+            errors.lines().any(|line| line.starts_with(&row_prefix)),
             "docs/errors.md must document ErrorCode::{variant} in its variant tables"
         );
     }


### PR DESCRIPTION
## Why

Paranoid-audit round fifteen (issue #126) audited three fresh surfaces with adversarial agents. The two real defects found were both about **error messages that send users in the wrong direction**:

- Connecting with token binding to a wrong URL (404) or rejected credentials (401/403) reported *"the server rejected token-binding negotiation"* — hiding the HTTP status and suggesting a server-capability problem. The same failure without token binding already reported `I/O error: HTTP error: 404`.
- A server that sent only control frames (never a challenge) was reported as *"the server sent a malformed token-binding challenge"* — nothing malformed was ever received.

## What changed

- HTTP upgrade rejections now surface as `Io` carrying `HTTP error: NNN` in every token-binding mode. `NegotiationRejected` stays in the enum as a documented reserved variant (no breaking removal).
- `MalformedChallenge` now reads *"the server did not send a valid token-binding challenge"*, truthful at every site, with a new mock-server pin (64-control flood).
- `connect_with_tls_config` logs a warning when a plain `ws://` URL would silently bypass the custom TLS configuration — including any mTLS client identity (verified against tokio-tungstenite 0.30's Plain-mode connector bypass).
- `SendBufferFull` now names **drain events promptly** as a remedy — the event-coupled deadlock case that pacing and capacity changes cannot fix.
- Doc corrections: `ServerError` marked reserved (never constructed; server errors are events), `SessionPlanUnavailable` gained the relay-plan trigger, the six compatibility-only `ErrorCode` variants are labeled, and `require_client_fingerprint`'s failure timing is stated precisely (pre-I/O vs after-handshake-and-challenge, including the `ws://` case).

## Performance (audited, no change accepted)

Token-binding proof overhead was measured on the real code path: ~2–4 µs per small frame, 2 allocations/frame on the binary path (optimal), one-time ~1.7 µs handshake. At signaling rates this is ≤0.0003% of a core — per PLAN.md policy, no optimization accepted.

## Evidence

- fmt / clippy (`-D warnings`, all features + 4 sparse combos) / 23 test suites: clean
- `cargo doc --all-features`: 0 warnings
- Two adversarial review rounds converged to zero findings (caught 4 plan-stage and 2 diff-stage doc errors before landing)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to error classification and logging on WebSocket connect paths; callers matching `NegotiationRejected` for HTTP failures need to handle `Io` instead, but the enum variant remains for exhaustive matches.
> 
> **Overview**
> Fixes **misleading token-binding connect diagnostics** so wrong URLs and auth failures are easier to debug, and tightens related docs and guardrails.
> 
> **Token-binding errors:** Non-101 HTTP upgrade responses (404, 401/403, 500, …) no longer become `TokenBindingFailure::NegotiationRejected`; they surface as **`SignalFishError::Io`** with the underlying HTTP status in every token-binding mode, matching `Disabled`. `NegotiationRejected` stays in the enum as a **reserved, undocumented producer** variant. `MalformedChallenge` now means the server **never delivered a valid challenge** (bad first app frame or control-frame flood before any challenge), with an updated user-facing string and a mock-server test for the flood case.
> 
> **TLS / fingerprint docs:** `connect_with_tls_config` **logs a warning** when the URL is plain `ws://`, because tokio-tungstenite skips the custom connector (mTLS config silently unused). Rustdoc and the token-binding guide now spell out **`require_client_fingerprint`** timing (pre-I/O vs after handshake/challenge, including `ws://`).
> 
> **Backpressure guidance:** `SendBufferFull` messaging and guides add **drain events promptly** as a fourth remedy for the sole-consumer deadlock when the event channel is full and the transport loop stops draining the command queue.
> 
> **Documentation-only API clarity:** `ServerError` is labeled reserved (errors arrive as events); `SessionPlanUnavailable` includes relay (non-WebRTC) plans; six **`ErrorCode`** variants are marked compatibility-only in source and tables. Conformance tests accept annotated table rows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7318fc0b3e1f76c8a36dbc5a526ec54264d4b910. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->