### PR TITLE
feat!: structured transport error causes and typed config errors (#179)

### DIFF
--- a/.llm/skills/error-handling/SKILL.md
+++ b/.llm/skills/error-handling/SKILL.md
@@ -19,10 +19,12 @@ use thiserror::Error;
 pub enum SignalFishError {
     /// Failed to send a message through the transport. The boxed cause is
     /// the backend's original error (`#[source]`): `Error::source()` reaches
-    /// the root cause for programmatic handling (for example downcasting to
-    /// `std::io::Error` to read its `ErrorKind`). Display keeps the cause's
-    /// own message. Construct from any `Error + Send + Sync + 'static`, or
-    /// from a string detail (`"refused".into()`).
+    /// it for programmatic handling. The built-in native WebSocket boxes the
+    /// backend's own `tungstenite::Error`, whose chain reaches the underlying
+    /// `std::io::Error` one hop down; custom transports box whatever error
+    /// they produce. Display keeps the cause's own message. Construct from
+    /// any `Error + Send + Sync + 'static`, or from a string detail
+    /// (`"refused".into()`).
     #[error("transport send error: {0}")]
     TransportSend(#[source] Box<dyn std::error::Error + Send + Sync>),
 
@@ -84,6 +86,15 @@ pub enum SignalFishError {
     /// An operation timed out.
     #[error("operation timed out")]
     Timeout,
+
+    /// A caller-supplied configuration value (or required build feature) was
+    /// rejected before any network I/O. `problem` is non-secret and safe for
+    /// ambient logs.
+    #[error("invalid configuration: {field}: {problem}")]
+    InvalidConfig {
+        field: &'static str,
+        problem: String,
+    },
 
     /// An I/O error occurred.
     #[error("I/O error: {0}")]

--- a/.llm/skills/error-handling/SKILL.md
+++ b/.llm/skills/error-handling/SKILL.md
@@ -17,13 +17,19 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum SignalFishError {
-    /// Failed to send a message through the transport.
+    /// Failed to send a message through the transport. The boxed cause is
+    /// the backend's original error (`#[source]`): `Error::source()` reaches
+    /// the root cause for programmatic handling (for example downcasting to
+    /// `std::io::Error` to read its `ErrorKind`). Display keeps the cause's
+    /// own message. Construct from any `Error + Send + Sync + 'static`, or
+    /// from a string detail (`"refused".into()`).
     #[error("transport send error: {0}")]
-    TransportSend(String),
+    TransportSend(#[source] Box<dyn std::error::Error + Send + Sync>),
 
-    /// Failed to receive a message from the transport.
+    /// Failed to receive a message from the transport; boxed cause like
+    /// `TransportSend`.
     #[error("transport receive error: {0}")]
-    TransportReceive(String),
+    TransportReceive(#[source] Box<dyn std::error::Error + Send + Sync>),
 
     /// The transport connection was closed unexpectedly.
     #[error("transport connection closed")]
@@ -122,7 +128,7 @@ fn do_thing(&mut self) -> Result<(), SignalFishError> {
 
     // This example backend is not the SDK's poll-based Transport trait.
     self.backend.try_send(json)
-        .map_err(|e| SignalFishError::TransportSend(e.to_string()))?;
+        .map_err(|e| SignalFishError::TransportSend(Box::new(e)))?;
 
     Ok(())
 }
@@ -200,14 +206,35 @@ explicitly inspectable through the transport accessor, while its `Debug`
 redacts the nonce.
 
 ```rust
-// WebSocket transport errors → TransportSend / TransportReceive
+// WebSocket transport errors → TransportSend / TransportReceive.
+// Box the original error so source() stays structural; Display is unchanged.
 stream.send(msg).await
-    .map_err(|e| SignalFishError::TransportSend(e.to_string()))?;
+    .map_err(|e| SignalFishError::TransportSend(Box::new(e)))?;
 
 stream.next().await
     .ok_or(SignalFishError::TransportClosed)?
-    .map_err(|e| SignalFishError::TransportReceive(e.to_string()))?;
+    .map_err(|e| SignalFishError::TransportReceive(Box::new(e)))?;
 ```
+
+Caller-configuration rejections that happen before any network I/O use
+`SignalFishError::InvalidConfig { field, problem }` instead of an
+`io::ErrorKind::InvalidInput` costume:
+
+```rust
+// A zero limit is caller error, not a network condition.
+if options.max_inbound_message_size == Some(0) {
+    return Err(SignalFishError::InvalidConfig {
+        field: "max_inbound_message_size",
+        problem: "must be greater than zero or None".into(),
+    });
+}
+```
+
+`problem` strings must stay non-secret and safe for ambient logs; never echo
+URLs, credentials, or payload bytes into `field`/`problem`. The same rule
+governs boxing causes: if an error's own `Debug` would embed payload bytes
+(for example `std::ffi::NulError` retains the whole input vector), box its
+`Display` text (`error.to_string().into()`) instead of the error value.
 
 ## Error Propagation Patterns
 

--- a/.llm/skills/transport-abstraction/SKILL.md
+++ b/.llm/skills/transport-abstraction/SKILL.md
@@ -215,7 +215,7 @@ impl Transport for LoopbackTransport {
         };
         let result = match frame.take() {
             Some(frame) => tx.send(frame).map_err(|error| {
-                SignalFishError::TransportSend(error.to_string())
+                SignalFishError::TransportSend(Box::new(error))
             }),
             None => Ok(()),
         };

--- a/.llm/skills/websocket-client/SKILL.md
+++ b/.llm/skills/websocket-client/SKILL.md
@@ -29,7 +29,7 @@ network I/O. This is a protective client policy, not a Server 0.7 protocol
 maximum; signal-fish-server#399 tracks the missing outbound contract.
 Network-determined connection failures map to `SignalFishError::Io`,
 preserving an underlying I/O error kind when possible. Value- and
-build-determined rejections — an unparseable URL, a zero inbound-size limit,
+build-determined rejections — an unparsable URL, a zero inbound-size limit,
 or `wss://` without the `tls` feature — are the typed
 `SignalFishError::InvalidConfig { field, problem }` instead, decided before
 any network I/O.

--- a/.llm/skills/websocket-client/SKILL.md
+++ b/.llm/skills/websocket-client/SKILL.md
@@ -27,10 +27,12 @@ to tungstenite's frame and assembled-message limits together. The default is
 an inclusive 8 MiB; `None` disables both and `Some(0)` is rejected before
 network I/O. This is a protective client policy, not a Server 0.7 protocol
 maximum; signal-fish-server#399 tracks the missing outbound contract.
-Connection failures map to `SignalFishError::Io`, preserving an underlying I/O
-error kind when possible. Configuration rejected on its face — an unparseable
-URL or a zero inbound-size limit — is the typed
-`SignalFishError::InvalidConfig { field, problem }` instead.
+Network-determined connection failures map to `SignalFishError::Io`,
+preserving an underlying I/O error kind when possible. Value- and
+build-determined rejections — an unparseable URL, a zero inbound-size limit,
+or `wss://` without the `tls` feature — are the typed
+`SignalFishError::InvalidConfig { field, problem }` instead, decided before
+any network I/O.
 
 The opt-in `token-binding` feature adds `TokenBindingMode` to
 `WebSocketConnectOptions`. Keep disabled mode on the exact old connect path.

--- a/.llm/skills/websocket-client/SKILL.md
+++ b/.llm/skills/websocket-client/SKILL.md
@@ -28,7 +28,9 @@ an inclusive 8 MiB; `None` disables both and `Some(0)` is rejected before
 network I/O. This is a protective client policy, not a Server 0.7 protocol
 maximum; signal-fish-server#399 tracks the missing outbound contract.
 Connection failures map to `SignalFishError::Io`, preserving an underlying I/O
-error kind when possible.
+error kind when possible. Configuration rejected on its face — an unparseable
+URL or a zero inbound-size limit — is the typed
+`SignalFishError::InvalidConfig { field, problem }` instead.
 
 The opt-in `token-binding` feature adds `TokenBindingMode` to
 `WebSocketConnectOptions`. Keep disabled mode on the exact old connect path.
@@ -167,7 +169,7 @@ provider the application already installed) so tokio-tungstenite's
 `ClientConfig::builder()` never hits rustls' ambiguous feature auto-detection —
 which panics when both `ring` and `aws_lc_rs` are in the dependency graph.
 Without the `tls` feature, a `wss://` connect fails cleanly with
-`SignalFishError::Io` (never a panic). Keep TLS features aligned with
+`SignalFishError::InvalidConfig` (never a panic). Keep TLS features aligned with
 `Cargo.toml` rather than duplicating an alternative stack in the transport.
 `connect_with_tls_config` accepts caller-controlled roots or mTLS without
 retaining or formatting the configuration. When active token binding uses a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Breaking:** Runtime transport failures keep their structure.
+  `SignalFishError::TransportSend` and `TransportReceive` now carry the
+  backend's boxed original error (as the `#[source]` cause) instead of a
+  flattened `String`, so `std::error::Error::source()` reaches the root cause
+  and programmatic handling — for example distinguishing `ConnectionRefused`
+  from `Capacity` via `source().downcast_ref::<std::io::Error>()` — is
+  possible at runtime. `Display` text is unchanged, and custom transports
+  construct the variants from any `Error + Send + Sync` value or a plain
+  string detail as before.
+- **Breaking:** Misconfiguration no longer wears an I/O costume. The new
+  exhaustive `SignalFishError::InvalidConfig { field, problem }` variant
+  reports caller-supplied values rejected because they are unusable — a zero
+  `max_inbound_message_size`/`max_inbound_queue_bytes`, a URL that cannot be
+  parsed into a WebSocket request (native; Godot's `ERR_INVALID_PARAMETER`),
+  or a URL containing interior NUL bytes (Emscripten) — instead of `Io` with
+  `ErrorKind::InvalidInput`/`Other`. Failures determined by the engine or the
+  network (Godot's `ERR_UNAVAILABLE`/`FAILED`, malformed server handshake
+  responses, HTTP upgrade rejections) keep the `Io` classification.
+  Exhaustive `SignalFishError` matches must handle the new variant. These are
+  breaking API additions for the forthcoming 0.11 release; published 0.10
+  does not expose them.
 - `SendBufferFull` now also names "drain events promptly" as a remedy: a task
   awaiting a reliable send while it is the sole event consumer can deadlock
   against a full event channel (which pauses the transport loop that drains

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,17 +157,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `SignalFishError::TransportSend` and `TransportReceive` now carry the
   backend's boxed original error (as the `#[source]` cause) instead of a
   flattened `String`, so `std::error::Error::source()` reaches the root cause
-  and programmatic handling — for example distinguishing `ConnectionRefused`
-  from `Capacity` via `source().downcast_ref::<std::io::Error>()` — is
-  possible at runtime. `Display` text is unchanged, and custom transports
-  construct the variants from any `Error + Send + Sync` value or a plain
-  string detail as before.
+  for programmatic handling: the built-in native WebSocket boxes the
+  backend's own `tungstenite::Error` (whose chain reaches the underlying
+  `std::io::Error`), and custom transports box whatever error they produce.
+  `Display` text is unchanged; a plain string detail still converts via
+  `.into()`.
 - **Breaking:** Misconfiguration no longer wears an I/O costume. The new
   exhaustive `SignalFishError::InvalidConfig { field, problem }` variant
-  reports caller-supplied values rejected because they are unusable — a zero
+  reports caller-supplied values rejected before any network I/O — a zero
   `max_inbound_message_size`/`max_inbound_queue_bytes`, a URL that cannot be
   parsed into a WebSocket request (native; Godot's `ERR_INVALID_PARAMETER`),
-  or a URL containing interior NUL bytes (Emscripten) — instead of `Io` with
+  a URL containing interior NUL bytes (Emscripten), and `wss://` without the
+  opt-in `tls` feature — instead of `Io` with
   `ErrorKind::InvalidInput`/`Other`. Failures determined by the engine or the
   network (Godot's `ERR_UNAVAILABLE`/`FAILED`, malformed server handshake
   responses, HTTP upgrade rejections) keep the `Io` classification.

--- a/crates/signal-fish-client-godot/src/lib.rs
+++ b/crates/signal-fish-client-godot/src/lib.rs
@@ -486,7 +486,8 @@ impl GodotWebSocketTransport {
         backend.connect_to_url(url).map_err(|error| match error {
             // Godot 4.5 returns ERR_INVALID_PARAMETER exactly for URL faults
             // (empty URL, an unparseable URL, or a non-ws(s):// scheme)
-            // before any connection work starts.
+            // before any connection work starts; see `WSLPeer::connect_to_url`
+            // in the engine source `modules/websocket/wsl_peer.cpp` (4.5).
             Error::ERR_INVALID_PARAMETER => SignalFishError::InvalidConfig {
                 field: "url",
                 problem: format!("Godot rejected the URL with {error:?}"),

--- a/crates/signal-fish-client-godot/src/lib.rs
+++ b/crates/signal-fish-client-godot/src/lib.rs
@@ -485,7 +485,7 @@ impl GodotWebSocketTransport {
         backend.set_max_queued_packets(DEFAULT_MAX_QUEUED_PACKETS);
         backend.connect_to_url(url).map_err(|error| match error {
             // Godot 4.5 returns ERR_INVALID_PARAMETER exactly for URL faults
-            // (empty URL, an unparseable URL, or a non-ws(s):// scheme)
+            // (empty URL, an unparsable URL, or a non-ws(s):// scheme)
             // before any connection work starts; see `WSLPeer::connect_to_url`
             // in the engine source `modules/websocket/wsl_peer.cpp` (4.5).
             Error::ERR_INVALID_PARAMETER => SignalFishError::InvalidConfig {

--- a/crates/signal-fish-client-godot/src/lib.rs
+++ b/crates/signal-fish-client-godot/src/lib.rs
@@ -212,7 +212,7 @@ fn admission_decision(
 trait GodotWebSocketBackend {
     fn set_inbound_buffer_size(&mut self, bytes: i32);
     fn set_max_queued_packets(&mut self, packets: i32);
-    fn connect_to_url(&mut self, url: &str) -> Result<(), String>;
+    fn connect_to_url(&mut self, url: &str) -> Result<(), Error>;
     fn poll(&mut self);
     fn state(&self) -> PeerState;
     fn outbound_buffered_amount(&self) -> i32;
@@ -237,14 +237,12 @@ impl GodotWebSocketBackend for Gd<WebSocketPeer> {
         std::ops::DerefMut::deref_mut(self).set_max_queued_packets(packets);
     }
 
-    fn connect_to_url(&mut self, url: &str) -> Result<(), String> {
+    fn connect_to_url(&mut self, url: &str) -> Result<(), Error> {
         let result = std::ops::DerefMut::deref_mut(self).connect_to_url(url);
         if result == Error::OK {
             Ok(())
         } else {
-            Err(format!(
-                "Godot WebSocketPeer connect_to_url failed with {result:?}"
-            ))
+            Err(result)
         }
     }
 
@@ -346,6 +344,12 @@ fn godot_send_result(result: Error, operation: &str) -> BackendSendResult {
 /// [`SignalFishPollingClient`](signal_fish_client::SignalFishPollingClient). The contained
 /// Godot object is intentionally not required to be `Send`; call the polling
 /// client's `poll()` method from the same Godot thread on every frame.
+///
+/// A connection that closes before opening surfaces as
+/// [`SignalFishError::TransportReceive`] even when observed first through
+/// [`Transport::poll_send`]: the handshake result is a receive-path event, so
+/// the send defers it by one poll and the classification is identical on both
+/// sides.
 pub struct GodotWebSocketTransport {
     backend: Box<dyn GodotWebSocketBackend>,
     backpressure_policy: GodotBackpressurePolicy,
@@ -427,8 +431,9 @@ impl GodotWebSocketTransport {
     ///
     /// # Errors
     ///
-    /// Returns [`SignalFishError::Io`] when Godot rejects the URL or cannot
-    /// start the connection attempt.
+    /// Returns [`SignalFishError::InvalidConfig`] when Godot rejects the URL.
+    /// Returns [`SignalFishError::Io`] when Godot cannot start the connection
+    /// attempt.
     pub fn connect(url: &str) -> Result<Self, SignalFishError> {
         Self::connect_with_options(url, GodotWebSocketOptions::default())
     }
@@ -442,8 +447,9 @@ impl GodotWebSocketTransport {
     ///
     /// # Errors
     ///
-    /// Returns [`SignalFishError::Io`] when Godot rejects the URL or cannot
-    /// start the connection attempt.
+    /// Returns [`SignalFishError::InvalidConfig`] when Godot rejects the URL.
+    /// Returns [`SignalFishError::Io`] when Godot cannot start the connection
+    /// attempt.
     pub fn connect_with_options(
         url: &str,
         options: GodotWebSocketOptions,
@@ -477,9 +483,21 @@ impl GodotWebSocketTransport {
     ) -> Result<Self, SignalFishError> {
         backend.set_inbound_buffer_size(inbound_buffer_size);
         backend.set_max_queued_packets(DEFAULT_MAX_QUEUED_PACKETS);
-        backend
-            .connect_to_url(url)
-            .map_err(|error| SignalFishError::Io(std::io::Error::other(error)))?;
+        backend.connect_to_url(url).map_err(|error| match error {
+            // Godot 4.5 returns ERR_INVALID_PARAMETER exactly for URL faults
+            // (empty URL, an unparseable URL, or a non-ws(s):// scheme)
+            // before any connection work starts.
+            Error::ERR_INVALID_PARAMETER => SignalFishError::InvalidConfig {
+                field: "url",
+                problem: format!("Godot rejected the URL with {error:?}"),
+            },
+            // Engine- or resource-level failures (for example WSS on a build
+            // without the TLS module, or socket exhaustion) are platform
+            // conditions, not URL faults.
+            other => SignalFishError::Io(std::io::Error::other(format!(
+                "Godot WebSocketPeer connect_to_url failed with {other:?}"
+            ))),
+        })?;
         Ok(Self::from_backend_with_options(backend, options))
     }
 
@@ -553,7 +571,7 @@ impl GodotWebSocketTransport {
             Poll::Ready(None)
         } else {
             Poll::Ready(Some(Err(SignalFishError::TransportReceive(
-                "Godot WebSocket connection closed before opening".to_string(),
+                "Godot WebSocket connection closed before opening".into(),
             ))))
         }
     }
@@ -563,7 +581,7 @@ impl GodotWebSocketTransport {
             SignalFishError::TransportClosed
         } else {
             SignalFishError::TransportReceive(
-                "Godot WebSocket connection closed before opening".to_string(),
+                "Godot WebSocket connection closed before opening".into(),
             )
         }
     }
@@ -797,7 +815,7 @@ impl Transport for GodotWebSocketTransport {
                 Poll::Pending
             }
             BackendSendResult::Error(error) => {
-                Poll::Ready(Err(SignalFishError::TransportSend(error)))
+                Poll::Ready(Err(SignalFishError::TransportSend(error.into())))
             }
         }
     }
@@ -823,14 +841,16 @@ impl Transport for GodotWebSocketTransport {
         }
         let (bytes, is_text) = match self.backend.receive_packet() {
             Ok(packet) => packet,
-            Err(error) => return Poll::Ready(Some(Err(SignalFishError::TransportReceive(error)))),
+            Err(error) => {
+                return Poll::Ready(Some(Err(SignalFishError::TransportReceive(error.into()))))
+            }
         };
         if is_text {
             match String::from_utf8(bytes) {
                 Ok(text) => Poll::Ready(Some(Ok(TransportFrame::Text(text)))),
-                Err(error) => Poll::Ready(Some(Err(SignalFishError::TransportReceive(format!(
-                    "Godot WebSocket text packet was not valid UTF-8: {error}"
-                ))))),
+                Err(error) => Poll::Ready(Some(Err(SignalFishError::TransportReceive(
+                    format!("Godot WebSocket text packet was not valid UTF-8: {error}").into(),
+                )))),
             }
         } else {
             Poll::Ready(Some(Ok(TransportFrame::Binary(bytes))))
@@ -926,7 +946,7 @@ mod tests {
         configured_inbound_buffer_size: Rc<Cell<i32>>,
         configured_max_queued_packets: Rc<Cell<i32>>,
         connection_steps: Rc<RefCell<Vec<&'static str>>>,
-        connect_error: Option<String>,
+        connect_error: Option<Error>,
     }
 
     impl FakeBackend {
@@ -966,7 +986,7 @@ mod tests {
             self.connection_steps.borrow_mut().push("configure_packets");
         }
 
-        fn connect_to_url(&mut self, _url: &str) -> Result<(), String> {
+        fn connect_to_url(&mut self, _url: &str) -> Result<(), Error> {
             self.connection_steps.borrow_mut().push("connect");
             self.connect_error.take().map_or(Ok(()), Err)
         }
@@ -1177,7 +1197,8 @@ mod tests {
 
         assert!(matches!(
             transport.poll_send(&mut context(), &mut frame),
-            Poll::Ready(Err(SignalFishError::TransportSend(error))) if error.contains("ERR_BUG")
+            Poll::Ready(Err(SignalFishError::TransportSend(error)))
+                if error.to_string().contains("ERR_BUG")
         ));
         assert_eq!(frame, Some(expected));
     }
@@ -1368,7 +1389,7 @@ mod tests {
     #[test]
     fn connection_failure_follows_buffer_configuration() {
         let mut backend = FakeBackend::new(PeerState::Connecting);
-        backend.connect_error = Some("scripted connect failure".to_string());
+        backend.connect_error = Some(Error::FAILED);
         let observed_steps = Rc::clone(&backend.connection_steps);
 
         let error = GodotWebSocketTransport::connect_backend_with_options(
@@ -1384,6 +1405,25 @@ mod tests {
             &*observed_steps.borrow(),
             &["configure_inbound", "configure_packets", "connect"]
         );
+    }
+
+    #[test]
+    fn url_fault_error_code_is_invalid_config() {
+        let mut backend = FakeBackend::new(PeerState::Connecting);
+        backend.connect_error = Some(Error::ERR_INVALID_PARAMETER);
+
+        let error = GodotWebSocketTransport::connect_backend_with_options(
+            Box::new(backend),
+            "not a url",
+            DEFAULT_INBOUND_BUFFER_SIZE,
+            GodotWebSocketOptions::default(),
+        )
+        .expect_err("a URL-fault error code must surface");
+
+        assert!(matches!(
+            error,
+            SignalFishError::InvalidConfig { field: "url", .. }
+        ));
     }
 
     #[test]
@@ -1650,7 +1690,7 @@ mod tests {
         else {
             panic!("expected a transport receive error");
         };
-        assert!(error.contains("UTF-8"));
+        assert!(error.to_string().contains("UTF-8"));
     }
 
     #[test]
@@ -1666,7 +1706,7 @@ mod tests {
         else {
             panic!("expected a transport receive error");
         };
-        assert!(error.contains("ERR_BUSY"));
+        assert!(error.to_string().contains("ERR_BUSY"));
     }
 
     #[test]
@@ -1857,7 +1897,7 @@ mod tests {
         assert!(matches!(
             transport.poll_recv(&mut context()),
             Poll::Ready(Some(Err(SignalFishError::TransportReceive(error))))
-                if error.contains("closed before opening")
+                if error.to_string().contains("closed before opening")
         ));
         assert!(matches!(
             transport.poll_recv(&mut context()),
@@ -1879,7 +1919,7 @@ mod tests {
         assert!(matches!(
             transport.poll_send(&mut context(), &mut frame),
             Poll::Ready(Err(SignalFishError::TransportReceive(error)))
-                if error.contains("closed before opening")
+                if error.to_string().contains("closed before opening")
         ));
         assert!(frame.is_some());
     }

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -484,7 +484,7 @@ directly from client methods as `Result<(), SignalFishError>`.
 | `BinaryFormatNotNegotiated` | Binary game data was requested while the connection uses JSON. |
 | `TokenBinding(TokenBindingFailure)` | Native token-binding negotiation or proof generation failed (see `TokenBindingFailure` for the specific reason). |
 | `Timeout` | An operation exceeded its time limit. |
-| `InvalidConfig { field, problem }` | A configuration value was rejected because it is unusable (zero size limit, unparseable URL, `wss://` without the `tls` feature); correcting the value is required, retrying is not enough. |
+| `InvalidConfig { field, problem }` | A configuration value was rejected because it is unusable (zero size limit, unparsable URL, `wss://` without the `tls` feature); correcting the value is required, retrying is not enough. |
 | `Io(std::io::Error)` | An underlying I/O error occurred. |
 
 ### Server-Side: `ErrorCode`

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -484,7 +484,7 @@ directly from client methods as `Result<(), SignalFishError>`.
 | `BinaryFormatNotNegotiated` | Binary game data was requested while the connection uses JSON. |
 | `TokenBinding(TokenBindingFailure)` | Native token-binding negotiation or proof generation failed (see `TokenBindingFailure` for the specific reason). |
 | `Timeout` | An operation exceeded its time limit. |
-| `InvalidConfig { field, problem }` | A configuration value was rejected because it is unusable (zero size limit, unparseable URL); correcting the value is required, retrying is not enough. |
+| `InvalidConfig { field, problem }` | A configuration value was rejected because it is unusable (zero size limit, unparseable URL, `wss://` without the `tls` feature); correcting the value is required, retrying is not enough. |
 | `Io(std::io::Error)` | An underlying I/O error occurred. |
 
 ### Server-Side: `ErrorCode`

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -465,8 +465,8 @@ directly from client methods as `Result<(), SignalFishError>`.
 
 | Variant | Meaning |
 |---------|---------|
-| `TransportSend(String)` | Failed to write to the transport. |
-| `TransportReceive(String)` | Failed to read from the transport. |
+| `TransportSend(cause)` | Failed to write to the transport; `cause` is the backend's boxed original error (`Error::source()` reaches the root cause). |
+| `TransportReceive(cause)` | Failed to read from the transport; like `TransportSend`, the boxed cause stays inspectable. |
 | `TransportClosed` | The transport connection closed unexpectedly. |
 | `Serialization(serde_json::Error)` | JSON serialization / deserialization failed. |
 | `NotConnected` | Attempted an operation without an active connection. |
@@ -484,6 +484,7 @@ directly from client methods as `Result<(), SignalFishError>`.
 | `BinaryFormatNotNegotiated` | Binary game data was requested while the connection uses JSON. |
 | `TokenBinding(TokenBindingFailure)` | Native token-binding negotiation or proof generation failed (see `TokenBindingFailure` for the specific reason). |
 | `Timeout` | An operation exceeded its time limit. |
+| `InvalidConfig { field, problem }` | A configuration value was rejected because it is unusable (zero size limit, unparseable URL); correcting the value is required, retrying is not enough. |
 | `Io(std::io::Error)` | An underlying I/O error occurred. |
 
 ### Server-Side: `ErrorCode`

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -24,7 +24,7 @@ exhaustive public enum:
 
 | Variant | Fields | When it occurs |
 |---------|--------|----------------|
-| `TransportSend` | `Box<dyn Error + Send + Sync>` | Failed to send a message through the transport. The boxed cause is the backend's original error, so `Error::source()` reaches the root cause (for example, downcast to `std::io::Error` to read its `ErrorKind`). The `Display` text is the cause's own message. |
+| `TransportSend` | `Box<dyn Error + Send + Sync>` | Failed to send a message through the transport. The boxed cause is the backend's original error, so `Error::source()` reaches it: the built-in native WebSocket boxes the backend's own error whose chain reaches the underlying `std::io::Error`, and custom transports keep whatever error they produce. `Display` keeps the cause's own message. |
 | `TransportReceive` | `Box<dyn Error + Send + Sync>` | Failed to receive a message from the transport. Like `TransportSend`, the boxed cause stays inspectable through `Error::source()`. |
 | `TransportClosed` | — | The transport connection was closed unexpectedly. |
 | `TokenBinding` | `TokenBindingFailure` | Native WebSocket token-binding negotiation, challenge validation, key derivation, canonicalization, encoding, or sequence handling failed. Reasons are typed and contain no key, nonce, proof, signature, fingerprint, URL credential, or payload material. Includes `MissingClientFingerprint`, raised by the opt-in `require_client_fingerprint` connect policy when no X.509 client signer is selected. See [WebSocket Token Binding](token-binding.md). |
@@ -43,7 +43,7 @@ exhaustive public enum:
 | `StaleSessionGeneration` | `attempted: Option<SessionGeneration>`, `current: Option<SessionGeneration>` | A generation-bound driver signal was produced after its session plan had been replaced. The client refuses it rather than relabeling stale signaling. |
 | `BinaryFormatNotNegotiated` | — | A binary send was attempted after negotiation resolved to JSON. Request `MessagePack` and confirm `effective_game_data_format() == Some(MessagePack)`; unsupported requests resolve to JSON and are refused before transport admission. Before `ProtocolInfo`, v3-only sends return `ProtocolUnsupported` instead. |
 | `Timeout` | — | The WebSocket handshake did not complete within its deadline. Only `WebSocketTransport::connect_with_timeout` emits this variant, when the connection is not established within the duration it is given. |
-| `InvalidConfig` | `field: &'static str`, `problem: String` | A caller-supplied configuration value was rejected because the value itself is unusable: a zero inbound-size limit, a URL that cannot be parsed into a WebSocket request, or a URL containing interior NUL bytes. The failure is determined by the value, not by a network outcome — retrying without correcting it keeps failing. |
+| `InvalidConfig` | `field: &'static str`, `problem: String` | A caller-supplied configuration value was rejected because the value itself is unusable, before any network I/O: a zero inbound-size limit, a URL that cannot be parsed into a WebSocket request, a URL containing interior NUL bytes (Emscripten), or `wss://` without the opt-in `tls` feature. The failure is determined by the value or the build, not by a network outcome — retrying without correcting it keeps failing. |
 | `Io` | `std::io::Error` | An I/O error occurred. Implements `From<std::io::Error>`. |
 
 Local validation has stable precedence: connection state, server-confirmed

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -24,8 +24,8 @@ exhaustive public enum:
 
 | Variant | Fields | When it occurs |
 |---------|--------|----------------|
-| `TransportSend` | `String` | Failed to send a message through the transport. |
-| `TransportReceive` | `String` | Failed to receive a message from the transport. |
+| `TransportSend` | `Box<dyn Error + Send + Sync>` | Failed to send a message through the transport. The boxed cause is the backend's original error, so `Error::source()` reaches the root cause (for example, downcast to `std::io::Error` to read its `ErrorKind`). The `Display` text is the cause's own message. |
+| `TransportReceive` | `Box<dyn Error + Send + Sync>` | Failed to receive a message from the transport. Like `TransportSend`, the boxed cause stays inspectable through `Error::source()`. |
 | `TransportClosed` | — | The transport connection was closed unexpectedly. |
 | `TokenBinding` | `TokenBindingFailure` | Native WebSocket token-binding negotiation, challenge validation, key derivation, canonicalization, encoding, or sequence handling failed. Reasons are typed and contain no key, nonce, proof, signature, fingerprint, URL credential, or payload material. Includes `MissingClientFingerprint`, raised by the opt-in `require_client_fingerprint` connect policy when no X.509 client signer is selected. See [WebSocket Token Binding](token-binding.md). |
 | `Serialization` | `serde_json::Error` | Failed to serialize or deserialize a protocol message. Implements `From<serde_json::Error>`. |
@@ -43,6 +43,7 @@ exhaustive public enum:
 | `StaleSessionGeneration` | `attempted: Option<SessionGeneration>`, `current: Option<SessionGeneration>` | A generation-bound driver signal was produced after its session plan had been replaced. The client refuses it rather than relabeling stale signaling. |
 | `BinaryFormatNotNegotiated` | — | A binary send was attempted after negotiation resolved to JSON. Request `MessagePack` and confirm `effective_game_data_format() == Some(MessagePack)`; unsupported requests resolve to JSON and are refused before transport admission. Before `ProtocolInfo`, v3-only sends return `ProtocolUnsupported` instead. |
 | `Timeout` | — | The WebSocket handshake did not complete within its deadline. Only `WebSocketTransport::connect_with_timeout` emits this variant, when the connection is not established within the duration it is given. |
+| `InvalidConfig` | `field: &'static str`, `problem: String` | A caller-supplied configuration value was rejected because the value itself is unusable: a zero inbound-size limit, a URL that cannot be parsed into a WebSocket request, or a URL containing interior NUL bytes. The failure is determined by the value, not by a network outcome — retrying without correcting it keeps failing. |
 | `Io` | `std::io::Error` | An I/O error occurred. Implements `From<std::io::Error>`. |
 
 Local validation has stable precedence: connection state, server-confirmed
@@ -65,8 +66,8 @@ fn try_join(client: &mut SignalFishClient) {
         Err(SignalFishError::NotConnected) => {
             eprintln!("Cannot join — not connected to the server");
         }
-        Err(SignalFishError::TransportSend(msg)) => {
-            eprintln!("Transport send failed: {msg}");
+        Err(SignalFishError::TransportSend(cause)) => {
+            eprintln!("Transport send failed: {cause}");
         }
         Err(SignalFishError::Serialization(err)) => {
             eprintln!("Serialization error: {err}");
@@ -394,8 +395,8 @@ fn send_data(client: &mut SignalFishClient) {
     let payload = serde_json::json!({"action": "move", "x": 10, "y": 20});
     match client.send_game_data(payload) {
         Ok(()) => { /* sent successfully */ }
-        Err(SignalFishError::TransportSend(msg)) => {
-            eprintln!("Transport layer failed to send: {msg}");
+        Err(SignalFishError::TransportSend(cause)) => {
+            eprintln!("Transport layer failed to send: {cause}");
         }
         Err(SignalFishError::TransportClosed) => {
             eprintln!("Connection lost — need to reconnect");

--- a/docs/transport.md
+++ b/docs/transport.md
@@ -352,7 +352,7 @@ impl Transport for LoopbackTransport {
         };
         let result = match frame.take() {
             Some(frame) => tx.send(frame).map_err(|error| {
-                SignalFishError::TransportSend(error.to_string())
+                SignalFishError::TransportSend(Box::new(error))
             }),
             None => Ok(()),
         };

--- a/docs/wasm.md
+++ b/docs/wasm.md
@@ -188,8 +188,10 @@ but the connection handshake completes asynchronously in the browser. The
 transport returns `Pending` before `onopen`, so the polling client retains each
 queued command until Emscripten can accept it.
 
-Returns `Result<EmscriptenWebSocketTransport, SignalFishError>`. On failure the
-error is `SignalFishError::Io` (e.g., invalid URL or Emscripten API failure).
+Returns `Result<EmscriptenWebSocketTransport, SignalFishError>`. On failure
+the error is `SignalFishError::InvalidConfig` for an invalid URL or a zero
+`max_inbound_queue_bytes`, and `SignalFishError::Io` if
+`emscripten_websocket_new` fails.
 
 For explicit control, pass `EmscriptenWebSocketConnectOptions` via
 `connect_with_options`:

--- a/examples/custom_transport.rs
+++ b/examples/custom_transport.rs
@@ -88,7 +88,7 @@ impl Transport for LoopbackTransport {
         let result = match frame.take() {
             Some(TransportFrame::Text(message)) => tx
                 .send(message)
-                .map_err(|e| SignalFishError::TransportSend(e.to_string())),
+                .map_err(|e| SignalFishError::TransportSend(Box::new(e))),
             Some(TransportFrame::Binary(_)) => Err(SignalFishError::TransportSend(
                 "this text-only loopback does not accept binary frames".into(),
             )),

--- a/src/client.rs
+++ b/src/client.rs
@@ -3546,7 +3546,7 @@ mod tests {
             assert!(matches!(
                 result,
                 Poll::Ready(Err(SignalFishError::TransportSend(ref diagnostic)))
-                    if diagnostic.contains("nonempty caller frame slot")
+                    if diagnostic.to_string().contains("nonempty caller frame slot")
             ));
             assert!(pending.frame.is_some(), "the caller must retain ownership");
             assert!(pending.is_game_data, "no transfer may be recorded");

--- a/src/error.rs
+++ b/src/error.rs
@@ -100,31 +100,25 @@ pub enum SignalFishError {
     ///
     /// The boxed cause is the transport backend's original error, so
     /// [`Error::source`](std::error::Error::source) reaches the root cause for
-    /// programmatic handling — for example
-    /// `error.source().downcast_ref::<std::io::Error>()` to read its
-    /// [`ErrorKind`](std::io::ErrorKind). The `Display` text is the cause's
-    /// own message; the variant is safe to format in ambient logs.
+    /// programmatic handling. The built-in native WebSocket transport boxes
+    /// the backend's own `tungstenite::Error`, whose `source()` chain then
+    /// reaches the underlying [`std::io::Error`] when there is one; custom
+    /// transports box whatever error they produce (an `io::Error`, a typed
+    /// backend error, or a plain string detail via `.into()`). The `Display`
+    /// text is the cause's own message; the variant is safe to format in
+    /// ambient logs.
     ///
-    /// Custom transport implementations construct this from any
-    /// `std::error::Error + Send + Sync + 'static` value; a plain string
-    /// detail also converts (`"refused".into()`). When a cause's own `Debug`
-    /// would embed application payload bytes (for example `std::ffi::NulError`
-    /// retains the whole input vector), box its `Display` text instead.
+    /// When a cause's own `Debug` would embed application payload bytes (for
+    /// example `std::ffi::NulError` retains the whole input vector), box its
+    /// `Display` text instead.
     #[error("transport send error: {0}")]
     TransportSend(#[source] Box<dyn std::error::Error + Send + Sync>),
 
     /// Failed to receive a message from the transport.
     ///
-    /// The boxed cause is the transport backend's original error, so
-    /// [`Error::source`](std::error::Error::source) reaches the root cause for
-    /// programmatic handling — for example
-    /// `error.source().downcast_ref::<std::io::Error>()` to read its
-    /// [`ErrorKind`](std::io::ErrorKind). The `Display` text is the cause's
-    /// own message; the variant is safe to format in ambient logs.
-    ///
-    /// Custom transport implementations construct this from any
-    /// `std::error::Error + Send + Sync + 'static` value; a plain string
-    /// detail also converts (`"reset".into()`).
+    /// The boxed cause follows the same structure as
+    /// [`TransportSend`](SignalFishError::TransportSend): `Error::source()`
+    /// reaches the backend's original error for programmatic handling.
     #[error("transport receive error: {0}")]
     TransportReceive(#[source] Box<dyn std::error::Error + Send + Sync>),
 
@@ -290,15 +284,16 @@ pub enum SignalFishError {
     Timeout,
 
     /// A caller-supplied configuration value was rejected because the value
-    /// itself is unusable.
+    /// itself is unusable, before any network I/O.
     ///
-    /// Raised when a URL, connect option, or transport setting is invalid on
-    /// its face — for example a zero inbound-size limit, a URL that cannot be
-    /// parsed into a WebSocket request, or a URL containing interior NUL
-    /// bytes. The failure is determined by the value (or by a missing build
-    /// feature), not by a network outcome: retrying without correcting the
-    /// value keeps failing.
-    #[error("invalid configuration: {field} {problem}")]
+    /// Raised when a URL, connect option, transport setting, or required
+    /// build feature is invalid on its face — for example a zero
+    /// inbound-size limit, a URL that cannot be parsed into a WebSocket
+    /// request, a URL containing interior NUL bytes, or `wss://` without the
+    /// opt-in `tls` feature. The failure is determined by the value or the
+    /// build, not by a network outcome: retrying without correcting it keeps
+    /// failing.
+    #[error("invalid configuration: {field}: {problem}")]
     InvalidConfig {
         /// The rejected configuration field, option, or parameter name.
         field: &'static str,
@@ -390,6 +385,8 @@ mod tests {
         use std::error::Error as _;
         use std::io::ErrorKind;
 
+        // Custom transports box the error they produce; a directly boxed
+        // `io::Error` is reachable in one `source()` hop.
         let send = SignalFishError::TransportSend(Box::new(std::io::Error::new(
             ErrorKind::ConnectionRefused,
             "refused by peer",
@@ -401,12 +398,35 @@ mod tests {
             .map(std::io::Error::kind);
         assert_eq!(kind, Some(ErrorKind::ConnectionRefused));
 
-        let receive = SignalFishError::TransportReceive("connection reset".to_string().into());
+        // The built-in native WebSocket boxes the backend's own error
+        // (`tungstenite::Error`), whose chain reaches the underlying
+        // `io::Error` one hop further down.
+        #[derive(Debug)]
+        struct BackendError(std::io::Error);
+        impl std::fmt::Display for BackendError {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "backend io failure: {}", self.0)
+            }
+        }
+        impl std::error::Error for BackendError {
+            fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+                Some(&self.0)
+            }
+        }
+
+        let receive = SignalFishError::TransportReceive(Box::new(BackendError(
+            std::io::Error::new(ErrorKind::ConnectionReset, "connection reset"),
+        )));
         assert_eq!(
             receive.to_string(),
-            "transport receive error: connection reset"
+            "transport receive error: backend io failure: connection reset"
         );
-        assert!(receive.source().is_some());
+        let nested_kind = receive
+            .source()
+            .and_then(|backend| backend.source())
+            .and_then(|cause| cause.downcast_ref::<std::io::Error>())
+            .map(std::io::Error::kind);
+        assert_eq!(nested_kind, Some(ErrorKind::ConnectionReset));
     }
 
     #[test]
@@ -417,7 +437,7 @@ mod tests {
         };
         assert_eq!(
             error.to_string(),
-            "invalid configuration: max_inbound_message_size must be greater than zero or None"
+            "invalid configuration: max_inbound_message_size: must be greater than zero or None"
         );
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -97,12 +97,36 @@ impl std::fmt::Display for TokenBindingFailure {
 #[derive(Debug, Error)]
 pub enum SignalFishError {
     /// Failed to send a message through the transport.
+    ///
+    /// The boxed cause is the transport backend's original error, so
+    /// [`Error::source`](std::error::Error::source) reaches the root cause for
+    /// programmatic handling — for example
+    /// `error.source().downcast_ref::<std::io::Error>()` to read its
+    /// [`ErrorKind`](std::io::ErrorKind). The `Display` text is the cause's
+    /// own message; the variant is safe to format in ambient logs.
+    ///
+    /// Custom transport implementations construct this from any
+    /// `std::error::Error + Send + Sync + 'static` value; a plain string
+    /// detail also converts (`"refused".into()`). When a cause's own `Debug`
+    /// would embed application payload bytes (for example `std::ffi::NulError`
+    /// retains the whole input vector), box its `Display` text instead.
     #[error("transport send error: {0}")]
-    TransportSend(String),
+    TransportSend(#[source] Box<dyn std::error::Error + Send + Sync>),
 
     /// Failed to receive a message from the transport.
+    ///
+    /// The boxed cause is the transport backend's original error, so
+    /// [`Error::source`](std::error::Error::source) reaches the root cause for
+    /// programmatic handling — for example
+    /// `error.source().downcast_ref::<std::io::Error>()` to read its
+    /// [`ErrorKind`](std::io::ErrorKind). The `Display` text is the cause's
+    /// own message; the variant is safe to format in ambient logs.
+    ///
+    /// Custom transport implementations construct this from any
+    /// `std::error::Error + Send + Sync + 'static` value; a plain string
+    /// detail also converts (`"reset".into()`).
     #[error("transport receive error: {0}")]
-    TransportReceive(String),
+    TransportReceive(#[source] Box<dyn std::error::Error + Send + Sync>),
 
     /// The transport connection was closed unexpectedly.
     #[error("transport connection closed")]
@@ -265,6 +289,23 @@ pub enum SignalFishError {
     )]
     Timeout,
 
+    /// A caller-supplied configuration value was rejected because the value
+    /// itself is unusable.
+    ///
+    /// Raised when a URL, connect option, or transport setting is invalid on
+    /// its face — for example a zero inbound-size limit, a URL that cannot be
+    /// parsed into a WebSocket request, or a URL containing interior NUL
+    /// bytes. The failure is determined by the value (or by a missing build
+    /// feature), not by a network outcome: retrying without correcting the
+    /// value keeps failing.
+    #[error("invalid configuration: {field} {problem}")]
+    InvalidConfig {
+        /// The rejected configuration field, option, or parameter name.
+        field: &'static str,
+        /// Why the value was rejected; non-secret and safe for ambient logs.
+        problem: String,
+    },
+
     /// An I/O error occurred.
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),
@@ -342,5 +383,41 @@ mod tests {
         } else {
             panic!("expected ServerError");
         }
+    }
+
+    #[test]
+    fn transport_send_and_receive_expose_the_boxed_cause_through_source() {
+        use std::error::Error as _;
+        use std::io::ErrorKind;
+
+        let send = SignalFishError::TransportSend(Box::new(std::io::Error::new(
+            ErrorKind::ConnectionRefused,
+            "refused by peer",
+        )));
+        assert_eq!(send.to_string(), "transport send error: refused by peer");
+        let kind = send
+            .source()
+            .and_then(|cause| cause.downcast_ref::<std::io::Error>())
+            .map(std::io::Error::kind);
+        assert_eq!(kind, Some(ErrorKind::ConnectionRefused));
+
+        let receive = SignalFishError::TransportReceive("connection reset".to_string().into());
+        assert_eq!(
+            receive.to_string(),
+            "transport receive error: connection reset"
+        );
+        assert!(receive.source().is_some());
+    }
+
+    #[test]
+    fn invalid_config_display_names_field_and_problem() {
+        let error = SignalFishError::InvalidConfig {
+            field: "max_inbound_message_size",
+            problem: "must be greater than zero or None".into(),
+        };
+        assert_eq!(
+            error.to_string(),
+            "invalid configuration: max_inbound_message_size must be greater than zero or None"
+        );
     }
 }

--- a/src/transports/emscripten_websocket.rs
+++ b/src/transports/emscripten_websocket.rs
@@ -416,12 +416,16 @@ impl EmscriptenWebSocketTransport {
     /// This function is synchronous — the WebSocket is created immediately,
     /// but the connection handshake completes asynchronously. The transport
     /// retains caller-owned messages until the browser reports that the
-    /// connection is open.
+    /// connection is open. Peer-close metadata (`close_info`) is best-effort:
+    /// it is populated by the next `poll_recv` that drains the queued close
+    /// event, so closing or dropping the transport before that poll leaves
+    /// `close_info` empty.
     ///
     /// # Errors
     ///
-    /// Returns [`SignalFishError::Io`] if the URL contains interior NUL bytes
-    /// or if `emscripten_websocket_new` fails.
+    /// Returns [`SignalFishError::InvalidConfig`] if the URL contains interior
+    /// NUL bytes. Returns [`SignalFishError::Io`] if
+    /// `emscripten_websocket_new` fails.
     pub fn connect(url: &str) -> Result<Self, SignalFishError> {
         Self::connect_with_options(url, EmscriptenWebSocketConnectOptions::default())
     }
@@ -436,22 +440,24 @@ impl EmscriptenWebSocketTransport {
     ///
     /// # Errors
     ///
-    /// Returns [`SignalFishError::Io`] if the URL contains interior NUL bytes,
-    /// if `max_inbound_queue_bytes` is `Some(0)`, or if
+    /// Returns [`SignalFishError::InvalidConfig`] if the URL contains interior
+    /// NUL bytes or `max_inbound_queue_bytes` is `Some(0)` — neither attempts
+    /// socket creation. Returns [`SignalFishError::Io`] if
     /// `emscripten_websocket_new` fails.
     pub fn connect_with_options(
         url: &str,
         options: EmscriptenWebSocketConnectOptions,
     ) -> Result<Self, SignalFishError> {
         if options.max_inbound_queue_bytes == Some(0) {
-            return Err(SignalFishError::Io(std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                "Emscripten max_inbound_queue_bytes must be greater than zero or None",
-            )));
+            return Err(SignalFishError::InvalidConfig {
+                field: "max_inbound_queue_bytes",
+                problem: "must be greater than zero or None".into(),
+            });
         }
 
-        let c_url = std::ffi::CString::new(url).map_err(|e| {
-            SignalFishError::Io(std::io::Error::new(std::io::ErrorKind::InvalidInput, e))
+        let c_url = std::ffi::CString::new(url).map_err(|e| SignalFishError::InvalidConfig {
+            field: "url",
+            problem: e.to_string(),
         })?;
 
         let (tx, rx) = std_mpsc::channel();
@@ -837,8 +843,12 @@ impl Transport for EmscriptenWebSocketTransport {
         poll_accept_frame(self.opened, frame, |frame_ref| {
             let result = match frame_ref {
                 TransportFrame::Text(message) => {
-                    let c_msg = std::ffi::CString::new(message.as_str())
-                        .map_err(|error| SignalFishError::TransportSend(error.to_string()))?;
+                    // Keep only the Display text: the boxed `NulError` itself
+                    // embeds the whole frame byte vector, which would leak
+                    // application payload through the public `Debug` output.
+                    let c_msg = std::ffi::CString::new(message.as_str()).map_err(|error| {
+                        SignalFishError::TransportSend(error.to_string().into())
+                    })?;
                     // SAFETY: `self.socket` is a live Emscripten WebSocket handle and
                     // `c_msg` remains allocated and NUL-terminated for the duration
                     // of this synchronous FFI call.
@@ -864,9 +874,9 @@ impl Transport for EmscriptenWebSocketTransport {
             if result == EMSCRIPTEN_RESULT_SUCCESS {
                 Ok(())
             } else {
-                Err(SignalFishError::TransportSend(format!(
-                    "Emscripten WebSocket send failed: {result}"
-                )))
+                Err(SignalFishError::TransportSend(
+                    format!("Emscripten WebSocket send failed: {result}").into(),
+                ))
             }
         })
     }
@@ -906,7 +916,7 @@ impl Transport for EmscriptenWebSocketTransport {
                 Ok(IncomingEvent::Error(error)) => {
                     self.closed = true;
                     return std::task::Poll::Ready(Some(Err(SignalFishError::TransportReceive(
-                        error,
+                        error.into(),
                     ))));
                 }
                 Ok(IncomingEvent::Close {
@@ -941,12 +951,12 @@ impl Transport for EmscriptenWebSocketTransport {
         let close_error = self.close_native_socket().err();
         let delete_result = self.delete_after_close_attempt();
         let result = match (close_error, delete_result) {
-            (_, Err(delete_result)) => Err(SignalFishError::TransportSend(format!(
-                "Emscripten WebSocket callback deletion failed: {delete_result}"
-            ))),
-            (Some(close_result), Ok(())) => Err(SignalFishError::TransportSend(format!(
-                "Emscripten WebSocket close failed: {close_result}"
-            ))),
+            (_, Err(delete_result)) => Err(SignalFishError::TransportSend(
+                format!("Emscripten WebSocket callback deletion failed: {delete_result}").into(),
+            )),
+            (Some(close_result), Ok(())) => Err(SignalFishError::TransportSend(
+                format!("Emscripten WebSocket close failed: {close_result}").into(),
+            )),
             (None, Ok(())) => Ok(()),
         };
         std::task::Poll::Ready(result)

--- a/src/transports/websocket.rs
+++ b/src/transports/websocket.rs
@@ -52,20 +52,58 @@ pub type WsStream =
 const MAX_SKIPPED_CONTROL_FRAMES_PER_POLL: usize = 64;
 const DEFAULT_MAX_INBOUND_MESSAGE_SIZE: usize = 8 * 1024 * 1024;
 
+/// Classify post-request-construction connect failures.
+///
+/// `Url` errors remaining at this point are value- or build-determined gaps —
+/// an unsupported scheme, no host, or `wss://` without the `tls` feature —
+/// never network outcomes, so they stay `InvalidConfig`. Every reachable
+/// `UrlError` formats as static text (the blocking-only `UnableToConnect`
+/// that embeds the URL is unreachable on these async paths), so echoing the
+/// message stays inside the ambient-log boundary. `HttpFormat` here means
+/// tungstenite could not parse the server's own handshake response after the
+/// connection was established — a runtime server fault, which keeps the
+/// generic `Io` mapping instead of blaming the caller's configuration.
 fn map_connect_error(error: WebSocketError) -> SignalFishError {
-    let kind = match &error {
-        WebSocketError::Io(io) => io.kind(),
-        _ => std::io::ErrorKind::Other,
-    };
-    SignalFishError::Io(std::io::Error::new(kind, error))
+    match &error {
+        WebSocketError::Url(_) => SignalFishError::InvalidConfig {
+            field: "url",
+            problem: error.to_string(),
+        },
+        WebSocketError::Io(io) => SignalFishError::Io(std::io::Error::new(io.kind(), error)),
+        _ => SignalFishError::Io(std::io::Error::other(error)),
+    }
+}
+
+/// Classify client-side request-construction failures: an unparseable URL or
+/// an otherwise unbuildable handshake request is caller configuration,
+/// rejected before any network I/O.
+fn map_request_config_error(error: WebSocketError) -> SignalFishError {
+    match &error {
+        WebSocketError::Url(_) | WebSocketError::HttpFormat(_) => SignalFishError::InvalidConfig {
+            field: "url",
+            problem: error.to_string(),
+        },
+        _ => map_connect_error(error),
+    }
+}
+
+/// Build the WebSocket handshake request from `url` to validate it before any
+/// network I/O, so unparseable URLs report `InvalidConfig` and post-connect
+/// `HttpFormat` server-response failures cannot be mislabeled as
+/// configuration errors.
+fn validate_request_url(url: &str) -> Result<(), SignalFishError> {
+    use tokio_tungstenite::tungstenite::client::IntoClientRequest as _;
+    url.into_client_request()
+        .map_err(map_request_config_error)?;
+    Ok(())
 }
 
 fn websocket_config(options: WebSocketConnectOptions) -> Result<WebSocketConfig, SignalFishError> {
     if options.max_inbound_message_size == Some(0) {
-        return Err(SignalFishError::Io(std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            "WebSocket max_inbound_message_size must be greater than zero or None",
-        )));
+        return Err(SignalFishError::InvalidConfig {
+            field: "max_inbound_message_size",
+            problem: "must be greater than zero or None".into(),
+        });
     }
     Ok(WebSocketConfig::default()
         .max_frame_size(options.max_inbound_message_size)
@@ -248,7 +286,9 @@ async fn connect_with_token_binding(
     use tokio_tungstenite::tungstenite::error::{ProtocolError, SubProtocolError};
     use tokio_tungstenite::tungstenite::http::header::{SEC_WEBSOCKET_KEY, SEC_WEBSOCKET_PROTOCOL};
 
-    let mut request = url.into_client_request().map_err(map_connect_error)?;
+    let mut request = url
+        .into_client_request()
+        .map_err(map_request_config_error)?;
     let handshake_key = zeroize::Zeroizing::new(
         request
             .headers()
@@ -367,13 +407,13 @@ async fn receive_token_binding_challenge(
             .ok_or(SignalFishError::TokenBinding(
                 crate::TokenBindingFailure::MissingChallenge,
             ))?
-            .map_err(|error| SignalFishError::TransportReceive(error.to_string()))?;
+            .map_err(|error| SignalFishError::TransportReceive(Box::new(error)))?;
         match message {
             Message::Text(text) => return crate::token_binding::parse_challenge(&text),
             Message::Ping(_) => stream
                 .flush()
                 .await
-                .map_err(|error| SignalFishError::TransportSend(error.to_string()))?,
+                .map_err(|error| SignalFishError::TransportSend(Box::new(error)))?,
             Message::Pong(_) | Message::Frame(_) => {}
             Message::Close(_) => {
                 return Err(SignalFishError::TokenBinding(
@@ -724,7 +764,7 @@ impl WebSocketTransport {
     /// Establish a new WebSocket connection to the given URL.
     ///
     /// `ws://` is always supported. `wss://` requires the optional `tls` feature;
-    /// without it a `wss://` URL fails with [`SignalFishError::Io`].
+    /// without it a `wss://` URL fails with [`SignalFishError::InvalidConfig`].
     ///
     /// Nagle's algorithm is **disabled by default** (`TCP_NODELAY`) so small,
     /// latency-sensitive game messages are sent without delay. Inbound frames
@@ -734,8 +774,9 @@ impl WebSocketTransport {
     ///
     /// # Errors
     ///
-    /// Returns [`SignalFishError::Io`] if the URL is invalid or the connection
-    /// cannot be established. When the underlying error is an I/O error its
+    /// Returns [`SignalFishError::InvalidConfig`] if the URL is invalid and
+    /// [`SignalFishError::Io`] if the connection cannot be established. When
+    /// the underlying error is an I/O error its
     /// [`ErrorKind`](std::io::ErrorKind) is preserved; all other errors are
     /// mapped to [`ErrorKind::Other`](std::io::ErrorKind::Other).
     pub async fn connect(url: &str) -> Result<Self, SignalFishError> {
@@ -753,18 +794,20 @@ impl WebSocketTransport {
     ///
     /// # Errors
     ///
-    /// Returns [`SignalFishError::Io`] if the URL is invalid or the connection
-    /// cannot be established. When the underlying error is an I/O error its
-    /// [`ErrorKind`](std::io::ErrorKind) is preserved; all other errors are
-    /// mapped to [`ErrorKind::Other`](std::io::ErrorKind::Other) — including
-    /// HTTP upgrade rejections, which carry the underlying status in every
+    /// Returns [`SignalFishError::InvalidConfig`] when the URL cannot be
+    /// parsed into a WebSocket request or a connect option is invalid on its
+    /// face; neither attempts network I/O. Returns [`SignalFishError::Io`]
+    /// when the connection cannot be established: when the underlying error
+    /// is an I/O error its [`ErrorKind`](std::io::ErrorKind) is preserved, and
+    /// all other connection errors map to
+    /// [`ErrorKind::Other`](std::io::ErrorKind::Other) — including HTTP
+    /// upgrade rejections, which carry the underlying status in every
     /// token-binding mode. Optional or required mode returns
     /// [`SignalFishError::TokenBinding`] when the feature
     /// is disabled or subprotocol negotiation, challenge validation, or key
     /// derivation fails. A zero inbound size limit returns
-    /// [`SignalFishError::Io`] with
-    /// [`ErrorKind::InvalidInput`](std::io::ErrorKind::InvalidInput) before URL
-    /// parsing or network I/O. When token binding is requested without the
+    /// [`SignalFishError::InvalidConfig`] before URL parsing or network I/O.
+    /// When token binding is requested without the
     /// `token-binding` feature, its feature-disabled error takes precedence.
     /// The `require_client_fingerprint` policy always fails before network
     /// I/O here with [`SignalFishError::TokenBinding`], because this path can
@@ -781,6 +824,7 @@ impl WebSocketTransport {
         }
         reject_unsatisfiable_client_fingerprint_requirement(&options)?;
         let websocket_config = websocket_config(options)?;
+        validate_request_url(url)?;
 
         #[cfg(feature = "tls")]
         install_tls_provider();
@@ -848,16 +892,17 @@ impl WebSocketTransport {
     ///
     /// Returns the same connection and token-binding errors as
     /// [`connect_with_options`](Self::connect_with_options), including
-    /// [`SignalFishError::Io`] with
-    /// [`ErrorKind::InvalidInput`](std::io::ErrorKind::InvalidInput) for a zero
-    /// inbound size limit. The `require_client_fingerprint` policy fails
+    /// [`SignalFishError::InvalidConfig`] for a zero inbound size limit.
+    /// The `require_client_fingerprint` policy fails
     /// before network I/O when token binding is disabled (no proofs exist to
     /// bind), after the handshake and challenge when rustls selected no
     /// X.509 client signer, and after the unsigned fallback handshake (no
     /// challenge is consumed) when Optional mode fell back to an unsigned
     /// connection. On a plain `ws://` URL the custom TLS configuration is
     /// not used at all — tokio-tungstenite bypasses the connector, so no TLS
-    /// handshake or certificate selection runs and a warning is logged; with
+    /// handshake or certificate selection runs and a warning is logged (the
+    /// plain-URL predicate matches tungstenite's lowercase-only `ws`/`wss`
+    /// scheme handling); with
     /// token binding enabled the fingerprint policy still fails only after
     /// the completed challenge.
     #[cfg(feature = "tls")]
@@ -881,6 +926,7 @@ impl WebSocketTransport {
             reject_unsatisfiable_client_fingerprint_requirement(&options)?;
         }
         let websocket_config = websocket_config(options)?;
+        validate_request_url(url)?;
 
         install_tls_provider();
         let connector = tokio_tungstenite::Connector::Rustls(tls_config.clone());
@@ -1045,7 +1091,7 @@ where
                 Poll::Pending => return Poll::Pending,
                 Poll::Ready(Err(error)) => {
                     self.mark_send_failed();
-                    return Poll::Ready(Err(SignalFishError::TransportSend(error.to_string())));
+                    return Poll::Ready(Err(SignalFishError::TransportSend(Box::new(error))));
                 }
                 Poll::Ready(Ok(())) => {}
             }
@@ -1124,7 +1170,7 @@ where
                 if !retryable {
                     self.mark_send_failed();
                 }
-                return Poll::Ready(Err(SignalFishError::TransportSend(detail)));
+                return Poll::Ready(Err(SignalFishError::TransportSend(detail.into())));
             }
             if token_binding_active {
                 let _accepted_original = frame.take();
@@ -1149,7 +1195,7 @@ where
             }
             Poll::Ready(Err(error)) => {
                 self.mark_send_failed();
-                Poll::Ready(Err(SignalFishError::TransportSend(error.to_string())))
+                Poll::Ready(Err(SignalFishError::TransportSend(Box::new(error))))
             }
             Poll::Pending => Poll::Pending,
         }
@@ -1182,7 +1228,7 @@ where
                     Poll::Ready(Err(error)) => {
                         self.mark_terminal();
                         return Poll::Ready(Some(Err(SignalFishError::TransportReceive(
-                            error.to_string(),
+                            Box::new(error),
                         ))));
                     }
                     Poll::Ready(Ok(())) => {
@@ -1224,7 +1270,7 @@ where
                     Some(Err(e)) => {
                         self.mark_terminal();
                         return Poll::Ready(Some(Err(SignalFishError::TransportReceive(
-                            e.to_string(),
+                            Box::new(e),
                         ))));
                     }
                     None => {
@@ -1325,7 +1371,7 @@ where
                 }
                 Poll::Ready(Err(error)) => {
                     self.mark_terminal();
-                    Poll::Ready(Err(SignalFishError::TransportSend(error.to_string())))
+                    Poll::Ready(Err(SignalFishError::TransportSend(Box::new(error))))
                 }
             };
         }
@@ -1343,7 +1389,7 @@ where
             }
             Poll::Ready(Err(error)) => {
                 self.mark_terminal();
-                Poll::Ready(Err(SignalFishError::TransportSend(error.to_string())))
+                Poll::Ready(Err(SignalFishError::TransportSend(Box::new(error))))
             }
             Poll::Pending => Poll::Pending,
         }
@@ -1444,8 +1490,9 @@ mod tests {
         )
         .await
         .expect_err("zero must not create a degenerate WebSocket codec");
-        assert!(
-            matches!(error, SignalFishError::Io(ref io) if io.kind() == std::io::ErrorKind::InvalidInput)
+        assert_eq!(
+            error.to_string(),
+            "invalid configuration: max_inbound_message_size must be greater than zero or None"
         );
     }
 
@@ -1460,9 +1507,13 @@ mod tests {
         )
         .await
         .expect_err("zero must be rejected before token-binding handshake work");
-        assert!(
-            matches!(error, SignalFishError::Io(ref io) if io.kind() == std::io::ErrorKind::InvalidInput)
-        );
+        assert!(matches!(
+            error,
+            SignalFishError::InvalidConfig {
+                field: "max_inbound_message_size",
+                ..
+            }
+        ));
     }
 
     #[cfg(all(feature = "tls", feature = "token-binding"))]
@@ -1611,7 +1662,14 @@ mod tests {
     async fn connect_fails_with_invalid_url() {
         let result = WebSocketTransport::connect("not-a-valid-url").await;
         let err = result.unwrap_err();
-        assert!(matches!(err, SignalFishError::Io(_)));
+        assert!(matches!(
+            err,
+            SignalFishError::InvalidConfig { field: "url", .. }
+        ));
+        assert!(
+            !err.to_string().contains("not-a-valid-url"),
+            "URL parse failures must not echo the caller's URL: {err}"
+        );
     }
 
     #[tokio::test]
@@ -2111,47 +2169,88 @@ mod tests {
 
     #[cfg(feature = "token-binding")]
     #[tokio::test]
-    async fn optional_mode_does_not_retry_an_http_rejection() {
-        let listener = TcpListener::bind("127.0.0.1:0")
-            .await
-            .expect("rejection listener must bind");
-        let addr = listener
-            .local_addr()
-            .expect("rejection listener must have an address");
-        let server_task = tokio::spawn(async move {
-            let (mut tcp, _) = listener.accept().await.expect("server must accept offer");
-            tcp.write_all(
-                b"HTTP/1.1 403 Forbidden\r\nConnection: close\r\nContent-Length: 0\r\n\r\n",
+    async fn http_rejections_keep_io_classification_in_every_token_binding_mode() {
+        for mode in [
+            TokenBindingMode::Disabled,
+            TokenBindingMode::Optional,
+            TokenBindingMode::Required,
+        ] {
+            let listener = TcpListener::bind("127.0.0.1:0")
+                .await
+                .expect("rejection listener must bind");
+            let addr = listener
+                .local_addr()
+                .expect("rejection listener must have an address");
+            let server_task = tokio::spawn(async move {
+                let (mut tcp, _) = listener.accept().await.expect("server must accept offer");
+                tcp.write_all(
+                    b"HTTP/1.1 403 Forbidden\r\nConnection: close\r\nContent-Length: 0\r\n\r\n",
+                )
+                .await
+                .expect("server must reject the offered handshake");
+                drop(tcp);
+
+                assert!(
+                    tokio::time::timeout(std::time::Duration::from_millis(100), listener.accept())
+                        .await
+                        .is_err(),
+                    "HTTP rejection must not trigger an unsigned fallback"
+                );
+            });
+
+            let error = WebSocketTransport::connect_with_options(
+                &format!("ws://{addr}"),
+                WebSocketConnectOptions::new().with_token_binding(mode),
             )
             .await
-            .expect("server must reject the offered handshake");
-            drop(tcp);
-
+            .expect_err("an HTTP rejection must fail the connect in every mode");
+            // An HTTP rejection says nothing about the offered subprotocol, so
+            // it surfaces through the same Io mapping as the disabled path and
+            // keeps the underlying status instead of a negotiation-specific
+            // label.
+            let message = error.to_string();
             assert!(
-                tokio::time::timeout(std::time::Duration::from_millis(100), listener.accept())
-                    .await
-                    .is_err(),
-                "HTTP rejection must not trigger an unsigned fallback"
+                matches!(error, SignalFishError::Io(_)),
+                "HTTP rejection must keep the generic I/O classification in {mode:?}: {message}"
             );
+            assert!(
+                message.contains("403"),
+                "HTTP rejection must preserve the server's status code in {mode:?}: {message}"
+            );
+            finish_mock_server(server_task).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn malformed_server_handshake_response_is_io_not_invalid_config() {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("malformed listener must bind");
+        let addr = listener
+            .local_addr()
+            .expect("malformed listener must have an address");
+        let server_task = tokio::spawn(async move {
+            let (mut tcp, _) = listener.accept().await.expect("server must accept offer");
+            // An unparseable status line makes tungstenite fail the handshake
+            // with an `HttpFormat` error after the TCP connection exists —
+            // a runtime server fault, not caller configuration.
+            tcp.write_all(b"HTTP/1.1 099 Bogus\r\n\r\n")
+                .await
+                .expect("server must write the malformed response");
         });
 
-        let error = WebSocketTransport::connect_with_options(
-            &format!("ws://{addr}"),
-            WebSocketConnectOptions::new().with_token_binding(TokenBindingMode::Optional),
-        )
-        .await
-        .expect_err("optional mode must preserve an HTTP rejection");
-        // An HTTP rejection says nothing about the offered subprotocol, so it
-        // surfaces through the same Io mapping as the disabled path and keeps
-        // the underlying status instead of a negotiation-specific label.
+        let error = WebSocketTransport::connect(&format!("ws://{addr}"))
+            .await
+            .expect_err("a malformed server response must fail the connect");
         let message = error.to_string();
         assert!(
             matches!(error, SignalFishError::Io(_)),
-            "HTTP rejection must keep the generic I/O classification: {message}"
+            "a server-side response parse failure must stay an I/O error, not \
+             blame the caller's URL: {message}"
         );
         assert!(
-            message.contains("403"),
-            "HTTP rejection must preserve the server's status code: {message}"
+            !matches!(error, SignalFishError::InvalidConfig { .. }),
+            "post-connect HttpFormat failures must not wear the configuration costume: {message}"
         );
         finish_mock_server(server_task).await;
     }

--- a/src/transports/websocket.rs
+++ b/src/transports/websocket.rs
@@ -54,15 +54,17 @@ const DEFAULT_MAX_INBOUND_MESSAGE_SIZE: usize = 8 * 1024 * 1024;
 
 /// Classify post-request-construction connect failures.
 ///
-/// `Url` errors remaining at this point are value- or build-determined gaps —
-/// an unsupported scheme, no host, or `wss://` without the `tls` feature —
-/// never network outcomes, so they stay `InvalidConfig`. Every reachable
-/// `UrlError` formats as static text (the blocking-only `UnableToConnect`
-/// that embeds the URL is unreachable on these async paths), so echoing the
-/// message stays inside the ambient-log boundary. `HttpFormat` here means
-/// tungstenite could not parse the server's own handshake response after the
-/// connection was established — a runtime server fault, which keeps the
-/// generic `Io` mapping instead of blaming the caller's configuration.
+/// `validate_request_url` classifies every client-side request-construction
+/// failure before I/O, so a `Url` error reaching this function is a
+/// defense-in-depth catch (for example an exotic scheme rejected after the
+/// pre-check) and stays `InvalidConfig`: value- or build-determined, never a
+/// network outcome. Every reachable `UrlError` formats as static text (the
+/// blocking-only `UnableToConnect` that embeds the URL is unreachable on
+/// these async paths), so echoing the message stays inside the ambient-log
+/// boundary. `HttpFormat` here means tungstenite could not parse the
+/// server's own handshake response after the connection was established — a
+/// runtime server fault, which keeps the generic `Io` mapping instead of
+/// blaming the caller's configuration.
 fn map_connect_error(error: WebSocketError) -> SignalFishError {
     match &error {
         WebSocketError::Url(_) => SignalFishError::InvalidConfig {
@@ -90,8 +92,17 @@ fn map_request_config_error(error: WebSocketError) -> SignalFishError {
 /// Build the WebSocket handshake request from `url` to validate it before any
 /// network I/O, so unparseable URLs report `InvalidConfig` and post-connect
 /// `HttpFormat` server-response failures cannot be mislabeled as
-/// configuration errors.
+/// configuration errors. The `wss://` feature check mirrors tungstenite's
+/// lowercase-only scheme handling and moves the missing-`tls` failure before
+/// the TCP connect so the classification does not depend on network order.
 fn validate_request_url(url: &str) -> Result<(), SignalFishError> {
+    #[cfg(not(feature = "tls"))]
+    if url.starts_with("wss://") {
+        return Err(SignalFishError::InvalidConfig {
+            field: "url",
+            problem: "wss:// requires the opt-in `tls` feature".into(),
+        });
+    }
     use tokio_tungstenite::tungstenite::client::IntoClientRequest as _;
     url.into_client_request()
         .map_err(map_request_config_error)?;
@@ -1492,7 +1503,7 @@ mod tests {
         .expect_err("zero must not create a degenerate WebSocket codec");
         assert_eq!(
             error.to_string(),
-            "invalid configuration: max_inbound_message_size must be greater than zero or None"
+            "invalid configuration: max_inbound_message_size: must be greater than zero or None"
         );
     }
 
@@ -1670,6 +1681,37 @@ mod tests {
             !err.to_string().contains("not-a-valid-url"),
             "URL parse failures must not echo the caller's URL: {err}"
         );
+    }
+
+    #[tokio::test]
+    async fn unparseable_url_is_invalid_config_from_the_pre_connect_check() {
+        // A space makes `Uri::from_str` fail, which tungstenite classifies as
+        // `HttpFormat` — post-connect that would be a server fault mapped to
+        // `Io`, so this pin holds only while the pre-connect request
+        // construction classifies it as caller configuration.
+        let error = WebSocketTransport::connect("ws://exa mple.invalid")
+            .await
+            .expect_err("a URL that cannot be parsed must fail before I/O");
+        assert!(matches!(
+            error,
+            SignalFishError::InvalidConfig { field: "url", .. }
+        ));
+        assert!(
+            !error.to_string().contains("exa mple.invalid"),
+            "URL parse failures must not echo the caller's URL: {error}"
+        );
+    }
+
+    #[cfg(not(feature = "tls"))]
+    #[tokio::test]
+    async fn wss_url_without_the_tls_feature_is_invalid_config_before_io() {
+        let error = WebSocketTransport::connect("wss://example.invalid")
+            .await
+            .expect_err("wss:// without the tls feature must fail before I/O");
+        assert!(matches!(
+            error,
+            SignalFishError::InvalidConfig { field: "url", .. }
+        ));
     }
 
     #[tokio::test]

--- a/src/transports/websocket.rs
+++ b/src/transports/websocket.rs
@@ -76,7 +76,7 @@ fn map_connect_error(error: WebSocketError) -> SignalFishError {
     }
 }
 
-/// Classify client-side request-construction failures: an unparseable URL or
+/// Classify client-side request-construction failures: an unparsable URL or
 /// an otherwise unbuildable handshake request is caller configuration,
 /// rejected before any network I/O.
 fn map_request_config_error(error: WebSocketError) -> SignalFishError {
@@ -90,7 +90,7 @@ fn map_request_config_error(error: WebSocketError) -> SignalFishError {
 }
 
 /// Build the WebSocket handshake request from `url` to validate it before any
-/// network I/O, so unparseable URLs report `InvalidConfig` and post-connect
+/// network I/O, so unparsable URLs report `InvalidConfig` and post-connect
 /// `HttpFormat` server-response failures cannot be mislabeled as
 /// configuration errors. The `wss://` feature check mirrors tungstenite's
 /// lowercase-only scheme handling and moves the missing-`tls` failure before
@@ -1684,7 +1684,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn unparseable_url_is_invalid_config_from_the_pre_connect_check() {
+    async fn unparsable_url_is_invalid_config_from_the_pre_connect_check() {
         // A space makes `Uri::from_str` fail, which tungstenite classifies as
         // `HttpFormat` — post-connect that would be a server fault mapped to
         // `Io`, so this pin holds only while the pre-connect request
@@ -2273,7 +2273,7 @@ mod tests {
             .expect("malformed listener must have an address");
         let server_task = tokio::spawn(async move {
             let (mut tcp, _) = listener.accept().await.expect("server must accept offer");
-            // An unparseable status line makes tungstenite fail the handshake
+            // An unparsable status line makes tungstenite fail the handshake
             // with an `HttpFormat` error after the TCP connection exists —
             // a runtime server fault, not caller configuration.
             tcp.write_all(b"HTTP/1.1 099 Bogus\r\n\r\n")


### PR DESCRIPTION
## Why

Issue #179: two error-surface problems hurt diagnosis at runtime. Transport send/receive failures flattened their cause to an unstructured `String`, so `Error::source()` could not reach the root cause and programmatic handling was impossible. And misconfiguration wore an I/O costume — a typo'd URL or zero size limit surfaced as `Io`, pointing users at the network.

## What

- **Structured causes (breaking).** `SignalFishError::TransportSend` and `TransportReceive` now carry the backend's boxed original error as their `#[source]` cause instead of a `String`. `Display` text is unchanged. The native WebSocket keeps the full `tungstenite::Error` (whose chain reaches the underlying `std::io::Error`); custom transports box whatever error they produce.
- **Typed config errors (breaking).** New exhaustive `SignalFishError::InvalidConfig { field, problem }` replaces the `Io` costume for value-determined rejections, all decided before any network I/O: zero inbound-size limits, unparseable URLs, Emscripten interior-NUL URLs, `wss://` without the `tls` feature, and Godot's `ERR_INVALID_PARAMETER` URL faults. Engine- and network-determined failures (Godot `ERR_UNAVAILABLE`/`FAILED`, malformed server handshake responses, HTTP upgrade rejections) keep `Io`.
- **One redaction hardening found by the audit:** a boxed `std::ffi::NulError` embeds the whole frame byte vector in `Debug` — the Emscripten send path now boxes its Display text instead.

Both are breaking API additions targeted at the forthcoming 0.11 release; published 0.10 does not expose them.

## Verification

- `cargo fmt` / `cargo clippy --workspace --all-targets --all-features -- -D warnings` / `cargo test --workspace --all-features` clean; sparse-feature cells (tokio-runtime, polling-client, mesh, tls, websocket-without-tls) clean.
- New pins: `source()` reachability (direct and nested chains), `InvalidConfig` display, pre-connect URL classification (red/green against removing the check), wss-without-tls determinism, HTTP-rejection classification across all three token-binding modes, malformed server response stays `Io`, Godot URL-fault vs engine-fault split.
- Three-surface adversarial audit (round 16 of #126) plus two hostile review rounds and a convergence verifier: zero remaining findings.

Closes #179.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Breaking public API (`SignalFishError` variants and transport error payloads) affects every exhaustive match and error-handling path across WebSocket, WASM, and Godot integrations.
> 
> **Overview**
> **Breaking error-surface overhaul for 0.11:** transport failures and caller misconfiguration are classified and inspectable more accurately.
> 
> `TransportSend` and `TransportReceive` no longer flatten backend failures to a `String`. They box the original error as `#[source]`, so `Error::source()` can reach `tungstenite::Error` and underlying `io::Error` while **Display** stays the same; string details still work via `.into()`. All built-in and example transports (native WebSocket, Emscripten, Godot) were updated to `Box::new(error)` instead of `to_string()`.
> 
> A new **`InvalidConfig { field, problem }`** variant replaces dressing pre-connect mistakes as `SignalFishError::Io`. That covers zero inbound limits, unparsable URLs (with pre-I/O `validate_request_url` on native WebSocket), `wss://` without `tls`, Emscripten NUL URLs / zero queue size, and Godot `ERR_INVALID_PARAMETER` URL faults—while real network/engine failures (HTTP 403, malformed server handshake, Godot `FAILED`) remain **`Io`**.
> 
> Docs, skills, changelog, and tests were aligned; Emscripten text send boxes **`NulError`** display text only so `Debug` does not leak frame bytes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1426cad25b5a9725137a1e483aee39a90cc42f38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->