### PR TITLE
Add the 0.11 migration guide (+ one structured-cause fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added the 0.11 migration guide (`docs/migration-0.11.md`, linked from the
+  site navigation and the errors and related guides) covering the breaking
+  error-surface changes: the boxed transport error causes and the new
+  `SignalFishError::InvalidConfig` reclassifications.
 - Added root re-exports for the `PlayerId` and `RoomId` identity aliases that
   appear throughout the client API (`reconnect`, `send_signal`,
   `ClientSnapshot`), so typed helpers no longer need a deep
@@ -314,6 +318,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed the native WebSocket send path flattening its error cause: a
+  synchronous `start_send` rejection (the classic oversized-outbound-message
+  refusal) boxed the formatted text instead of the backend's original
+  `tungstenite::Error`, so `Error::source()` could not reach the root cause
+  on that one path. The structured cause now survives the frame-restoration
+  classification; `Display` text, retryability, and exact frame restoration
+  are unchanged.
 - Fixed misleading token-binding connect errors for HTTP upgrade rejections:
   a non-101 response (404 wrong path, 401/403 rejected auth, 500, ...) on an
   `Optional` or `Required` token-binding connect was reported as

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -487,6 +487,10 @@ directly from client methods as `Result<(), SignalFishError>`.
 | `InvalidConfig { field, problem }` | A configuration value was rejected because it is unusable (zero size limit, unparsable URL, `wss://` without the `tls` feature); correcting the value is required, retrying is not enough. |
 | `Io(std::io::Error)` | An underlying I/O error occurred. |
 
+Upgrading from 0.10? The transport error payloads and the `InvalidConfig`
+reclassification are breaking; see [the 0.11
+migration](migration-0.11.md#structured-transport-error-causes).
+
 ### Server-Side: `ErrorCode`
 
 `ErrorCode` is a 54-variant enum that arrives inside events. The post-0.7

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -46,6 +46,11 @@ exhaustive public enum:
 | `InvalidConfig` | `field: &'static str`, `problem: String` | A caller-supplied configuration value was rejected because the value itself is unusable, before any network I/O: a zero inbound-size limit, a URL that cannot be parsed into a WebSocket request, a URL containing interior NUL bytes (Emscripten), or `wss://` without the opt-in `tls` feature. The failure is determined by the value or the build, not by a network outcome — retrying without correcting it keeps failing. |
 | `Io` | `std::io::Error` | An I/O error occurred. Implements `From<std::io::Error>`. |
 
+Upgrading from 0.10? The transport error payloads and the `InvalidConfig`
+reclassification are breaking; see [the 0.11
+migration](migration-0.11.md#structured-transport-error-causes) for
+before/after examples.
+
 Local validation has stable precedence: connection state, server-confirmed
 authentication for directed room operations, an admitted pending room
 transition, membership/role, authority, protocol version, format/session plan,

--- a/docs/migration-0.11.md
+++ b/docs/migration-0.11.md
@@ -1,0 +1,117 @@
+# Migrating from 0.10 to 0.11
+
+Version 0.11 makes runtime failures easier to diagnose. Transport send and
+receive errors keep the backend's original error instead of a flattened
+`String`, and misconfiguration is reported as a typed `InvalidConfig` error
+instead of wearing an I/O costume. This guide covers these two error-surface
+changes; the release's other breaking changes are listed at the end.
+
+## Structured transport error causes
+
+`SignalFishError::TransportSend` and `SignalFishError::TransportReceive` now
+carry a boxed original error (`Box<dyn Error + Send + Sync>`) as their
+`#[source]` cause instead of a `String`:
+
+```diff
+-Err(SignalFishError::TransportSend(message)) => {
++Err(SignalFishError::TransportSend(cause)) => {
+     eprintln!("Transport send failed: {cause}");
+ }
+```
+
+Log lines need no change: `Display` is byte-identical to 0.10 because the
+boxed cause's own message replaces the old flattened text. Simple bindings
+like the one above keep compiling.
+
+What breaks is code that relied on the payload being a `String` — for example
+`message.as_str()`, storing it in a `Vec<String>`, or matching on string
+content. For programmatic handling, walk the cause chain with
+`Error::source()`. The built-in native WebSocket boxes the backend's own
+`tungstenite::Error`, whose chain reaches the underlying `std::io::Error`
+when there is one:
+
+```rust,ignore
+use std::error::Error as _;
+
+match client.send_game_data(payload) {
+    Ok(()) => {}
+    Err(err) => {
+        eprintln!("send failed: {err}");
+        // New in 0.11: reach the root cause for programmatic handling.
+        let mut source = err.source();
+        while let Some(cause) = source {
+            if let Some(io) = cause.downcast_ref::<std::io::Error>() {
+                eprintln!("root cause: {} ({:?})", io, io.kind());
+            }
+            source = cause.source();
+        }
+    }
+}
+```
+
+Custom transports box whatever error they produce — an `io::Error`, a typed
+backend error, or a plain string detail. Constructing from a string keeps
+working through `.into()`:
+
+```rust,ignore
+Err(SignalFishError::TransportSend(
+    "this text-only loopback does not accept binary frames".into(),
+))
+```
+
+When a backend error's own `Debug` would embed application payload bytes,
+box its `Display` text instead so ambient logs stay redacted.
+
+## Typed configuration errors
+
+The new exhaustive variant
+`SignalFishError::InvalidConfig { field, problem }` reports caller-supplied
+values rejected before any network I/O. Exhaustive `SignalFishError` matches
+must add the arm:
+
+```rust,ignore
+match error {
+    SignalFishError::InvalidConfig { field, problem } => {
+        // The value itself is unusable; retrying without correcting it
+        // keeps failing.
+        eprintln!("invalid configuration: {field}: {problem}");
+    }
+    // ... remaining arms unchanged
+}
+```
+
+Each rejected value in this table returns `InvalidConfig` where 0.11
+development builds surfaced `Io` (with `ErrorKind::InvalidInput` or
+`ErrorKind::Other`); the zero-limit options themselves are also new in this
+release. Code matching `Io` around connect-time validation should match
+`InvalidConfig` instead:
+
+| Rejected value | Where |
+|----------------|-------|
+| Zero `max_inbound_message_size` | Native `WebSocketTransport` options |
+| Zero `max_inbound_queue_bytes` | Emscripten `EmscriptenWebSocketConnectOptions` |
+| URL that cannot be parsed into a WebSocket request | Native transport (checked before I/O) and Godot adapter (`ERR_INVALID_PARAMETER`) |
+| URL containing interior NUL bytes | Emscripten transport |
+| `wss://` URL without the opt-in `tls` feature | Native transport |
+
+Failures determined by the engine or the network keep the `Io`
+classification: Godot's `ERR_UNAVAILABLE`/`FAILED` engine faults, malformed
+server handshake responses, and HTTP upgrade rejections. The split is
+deliberate — `InvalidConfig` means "the value is wrong on its face", while
+`Io` still means "something outside your configuration failed".
+
+## Other 0.11 breaking changes
+
+The 0.11 window deliberately bundles further breaking changes that have their
+own migration notes:
+
+- Custom transports must implement `abort` explicitly; see
+  [Migrating custom transports for 0.11](transport.md#migrating-custom-transports-for-011).
+- `supports_mesh()` semantics and the new exhaustive `ClientSnapshot` fields;
+  see [the 0.11 capability-versus-active-plan
+  migration](protocol-versioning.md#011-migration-capability-versus-active-plan).
+- The remaining API additions — pre-authentication refusals, token-binding
+  connect options, generation-bound driver signaling, and the new error
+  variants behind exhaustive matches — are enumerated under `CHANGELOG.md`'s
+  `[Unreleased]` **Breaking** bullets and in the
+  [errors guide](errors.md) variant table.

--- a/docs/protocol-versioning.md
+++ b/docs/protocol-versioning.md
@@ -160,6 +160,8 @@ from `true` to `false`. It never guarantees that the server selected P2P.
 `session_transport`, so 0.11 consumers constructing snapshots must initialize
 both fields. Routing code should read those fields from one `snapshot()` (or use
 `is_p2p_active()` for a one-value query); do not substitute `supports_mesh()`.
+For the release's other error-surface changes, see
+[Migrating 0.10 to 0.11](migration-0.11.md).
 
 ---
 

--- a/docs/transport.md
+++ b/docs/transport.md
@@ -182,6 +182,8 @@ Because `abort` can run from `Drop` during unwinding, it must never panic. If an
 external cleanup API fails, keep callback backing storage alive rather than
 risk use-after-free, and make later `abort` or `Drop` retries safe.
 `examples/custom_transport.rs` shows a complete channel-backed implementation.
+For the release's other error-surface changes, see
+[Migrating 0.10 to 0.11](migration-0.11.md).
 
 ## Receiving
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -156,5 +156,6 @@ nav:
       - WebSocket Token Binding: token-binding.md
       - Migrating 0.7 to 0.8: migration-0.8.md
       - Migrating 0.8 to 0.9: migration-0.9.md
+      - Migrating 0.10 to 0.11: migration-0.11.md
       - Release Operations: releasing.md
       - Brand & Font Attribution: attributions.md

--- a/src/transports/websocket.rs
+++ b/src/transports/websocket.rs
@@ -1133,14 +1133,15 @@ where
                 Pin::new(stream).start_send(message)
             };
             if let Err(error) = send_result {
-                let detail = error.to_string();
-                let retryable = if let WebSocketError::WriteBufferFull(message) = error {
+                // Classify by reference so the original backend error stays
+                // intact: `TransportSend` boxes it as the `#[source]` cause.
+                let retryable = if let WebSocketError::WriteBufferFull(message) = &error {
                     let restored = if token_binding_active {
                         // The exact original remains in the caller slot. Never
                         // restore the protected envelope or a retry would wrap it twice.
                         true
                     } else {
-                        match *message {
+                        match message.as_ref() {
                             Message::Text(text) => {
                                 *frame = Some(TransportFrame::Text(text.to_string()));
                                 true
@@ -1155,16 +1156,19 @@ where
                                 };
 
                                 match frame_data.header().opcode {
-                                    OpCode::Data(Data::Text) => match frame_data.into_text() {
-                                        Ok(text) => {
-                                            *frame = Some(TransportFrame::Text(text.to_string()));
-                                            true
+                                    OpCode::Data(Data::Text) => {
+                                        match frame_data.clone().into_text() {
+                                            Ok(text) => {
+                                                *frame =
+                                                    Some(TransportFrame::Text(text.to_string()));
+                                                true
+                                            }
+                                            Err(_) => false,
                                         }
-                                        Err(_) => false,
-                                    },
+                                    }
                                     OpCode::Data(Data::Binary) => {
                                         *frame = Some(TransportFrame::Binary(
-                                            frame_data.into_payload().to_vec(),
+                                            frame_data.payload().to_vec(),
                                         ));
                                         true
                                     }
@@ -1181,7 +1185,7 @@ where
                 if !retryable {
                     self.mark_send_failed();
                 }
-                return Poll::Ready(Err(SignalFishError::TransportSend(detail.into())));
+                return Poll::Ready(Err(SignalFishError::TransportSend(Box::new(error))));
             }
             if token_binding_active {
                 let _accepted_original = frame.take();
@@ -3087,6 +3091,16 @@ mod tests {
             assert!(!state.closed, "a per-message refusal is retryable");
             assert!(!state.send_failed, "the restored frame may be retried");
             assert!(!state.send_started);
+            // The structured backend cause survives the frame-restoration
+            // classification, so programmatic handling can still reach the
+            // exact `tungstenite::Error` (here `WriteBufferFull`).
+            let Poll::Ready(Err(SignalFishError::TransportSend(cause))) = result else {
+                panic!("the write-buffer refusal must surface as TransportSend");
+            };
+            assert!(matches!(
+                cause.downcast_ref::<WebSocketError>(),
+                Some(WebSocketError::WriteBufferFull(_))
+            ));
         }
     }
 


### PR DESCRIPTION
Closes #181.

## Why

PR #180 broke the error surface for the 0.11 release (boxed transport error causes, typed `InvalidConfig`), and issue #181 asks for the per-release migration guide so users can upgrade their code confidently.

## What

- **New `docs/migration-0.11.md`**: before/after match arms for the boxed `TransportSend`/`TransportReceive` causes (Display text unchanged, log lines need no change), a `source()` cause-chain example reaching the underlying `io::Error`, the `.into()` path for custom transports, and the exhaustive `InvalidConfig` arm with the exact list of reclassifications — plus what deliberately stays `Io`. A closing section links the release's other breaking-change migration notes (custom-transport `abort`, `supports_mesh()`/`ClientSnapshot`) so the guide cannot be read as the complete break set.
- **Wiring**: site-nav entry after the existing migration guides, cross-references from the errors and concepts guides, and reciprocal links from the two existing 0.11 migration sections.
- **One production fix found by the audit**: the native WebSocket's synchronous `start_send` rejection still boxed a flattened string, so `Error::source()` could not reach the root cause on exactly the classic oversized-outbound-message refusal. It now boxes the original `tungstenite::Error`; Display text, retryability, and exact frame restoration are unchanged, pinned by a new downcast assertion.

## Verification

- `cargo fmt` / `cargo clippy --workspace --all-targets --all-features -- -D warnings` / `cargo test --workspace --all-features` clean.
- New assertion verified red against the old construction and green with the fix.
- Every guide claim checked against `v0.10.0` and current sources; adversarial review rounds converged to zero findings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly documentation; the WebSocket change only improves error cause chaining on an existing send-failure path without altering user-visible messages or retry semantics.
> 
> **Overview**
> Adds **`docs/migration-0.11.md`** for the 0.10→0.11 break: boxed **`TransportSend`/`TransportReceive`** causes (with **`Error::source()`** examples and string **`.into()`** for custom transports) and the new **`InvalidConfig`** arm plus which connect-time failures moved out of **`Io`**. The guide links to the other 0.11 migration notes so it is not treated as the full break list.
> 
> **Docs wiring:** **`CHANGELOG`** entry, MkDocs nav item, and upgrade callouts in **`errors.md`**, **`concepts.md`**, **`protocol-versioning.md`**, and **`transport.md`**.
> 
> **Runtime fix:** On native WebSocket synchronous **`start_send`** failure (including **`WriteBufferFull`**), **`TransportSend`** now boxes the original **`tungstenite::Error`** instead of a flattened string, matching the rest of 0.11; **`Display`**, retryability, and frame restoration stay the same. A unit test downcasts the cause to **`WebSocketError::WriteBufferFull`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38ce6956dc82fb9e62d20e5142873d2b27a40954. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->