### PR TITLE
Unbrick Prepare Release for the 0.11 release

### DIFF
--- a/.llm/skills/crate-publishing/SKILL.md
+++ b/.llm/skills/crate-publishing/SKILL.md
@@ -274,9 +274,12 @@ standard version-sync locations, this release introduced new files to keep in
 mind on future bumps:
 
 - `tests/wire-samples/PROVENANCE.toml` — its `synced` date is human-maintained
-  (refresh at release; see [protocol-wire-conformance](../protocol-wire-conformance/SKILL.md)).
-- `tests/token-binding/PROVENANCE.toml` — release preparation refreshes its
-  `synced` date with the other pinned Server 0.7 corpora.
+  upstream-refresh provenance (refresh only when re-syncing the samples; see
+  [protocol-wire-conformance](../protocol-wire-conformance/SKILL.md));
+  release preparation never rewrites it.
+- `tests/token-binding/PROVENANCE.toml` — its `synced` date is
+  upstream-refresh provenance maintained in the same commit as vector
+  changes; release preparation never rewrites it.
 - New skills: `protocol-versioning-and-negotiation.md`, `webrtc-mesh-signaling.md`,
   `../protocol-wire-conformance/SKILL.md` (auto-indexed; no version literal).
 - New feature `mesh` (pure-std, zero deps). Concrete WebRTC backends (str0m,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -318,6 +318,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed the Prepare Release blocker that would fail every future release run:
+  the compatibility manifest now carries both a release-stamped top-level
+  `synced` date and real upstream-refresh dates under `[protocol_authority]`,
+  but the release tooling still required exactly one `synced` date in the
+  whole file. Releases now stamp only the top-level date and never rewrite
+  section-level upstream provenance (including the vendored PROVENANCE.toml
+  files), and a checkout-level guard catches inventory drift in tests instead
+  of on release day.
+- The published model-context page (`llms.txt`) now tracks the release
+  version automatically instead of advertising a stale crate version after
+  each release.
+- Release-version notes in the README and the getting-started and client
+  guides no longer embed the next version number, so release preparation can
+  no longer rewrite them into stale claims.
 - Fixed the native WebSocket send path flattening its error cause: a
   synchronous `start_send` rejection (the classic oversized-outbound-message
   refusal) boxed the formatted text instead of the backend's original

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -329,9 +329,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The published model-context page (`llms.txt`) now tracks the release
   version automatically instead of advertising a stale crate version after
   each release.
-- Release-version notes in the README and the getting-started and client
-  guides no longer embed the next version number, so release preparation can
-  no longer rewrite them into stale claims.
+- Release-version notes in the README and the mesh, getting-started, and
+  client guides no longer embed the next version number or enumerate
+  unreleased features, so release preparation can no longer rewrite them
+  into stale claims; they point at the changelog instead.
 - Fixed the native WebSocket send path flattening its error cause: a
   synchronous `start_send` rejection (the classic oversized-outbound-message
   refusal) boxed the formatted text instead of the backend's original

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Set `SIGNAL_FISH_URL` to use a server other than
 `ws://localhost:3536/v2/ws`.
 
 The published `0.10.0` crate is the stable release. This branch also documents
-unreleased changes planned for 0.11. Use the [0.10.0 API
+unreleased changes ahead of the next release. Use the [0.10.0 API
 docs](https://docs.rs/signal-fish-client/0.10.0/) for the published surface, or
 see the
 [changelog](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/blob/main/CHANGELOG.md)

--- a/docs/client.md
+++ b/docs/client.md
@@ -10,8 +10,9 @@ game-loop-driven alternative.
 
 !!! note "Published crate versus this guide"
     The stable crates.io release is **0.10.0**. This guide tracks the current
-    `main` branch, including polling budgets, close policies, queue-age
-    diagnostics, and adaptive Godot admission added after 0.10.0. Use the
+    `main` branch, which may include additions that have not reached a release
+    yet, such as polling budgets, close policies, queue-age diagnostics, and
+    adaptive Godot admission. Use the
     [0.10.0 API docs](https://docs.rs/signal-fish-client/0.10.0/) for the
     published surface, or a `git` dependency on `main` for the unreleased APIs.
 

--- a/docs/client.md
+++ b/docs/client.md
@@ -11,8 +11,8 @@ game-loop-driven alternative.
 !!! note "Published crate versus this guide"
     The stable crates.io release is **0.10.0**. This guide tracks the current
     `main` branch, which may include additions that have not reached a release
-    yet, such as polling budgets, close policies, queue-age diagnostics, and
-    adaptive Godot admission. Use the
+    yet; the [changelog](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/blob/main/CHANGELOG.md)
+    lists what is new. Use the
     [0.10.0 API docs](https://docs.rs/signal-fish-client/0.10.0/) for the
     published surface, or a `git` dependency on `main` for the unreleased APIs.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -32,7 +32,9 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 !!! note "Published release and main"
     **0.10.0** is the current crates.io release. This guide follows unreleased
     `main`, which may include breaking APIs that have not reached a release
-    yet. Use the [0.10.0
+    yet; the
+    [changelog](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/blob/main/CHANGELOG.md)
+    says which release added them. Use the [0.10.0
     docs.rs pages](https://docs.rs/signal-fish-client/0.10.0/) with the versioned
     dependency above. To evaluate unreleased changes, use:
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -31,7 +31,8 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 
 !!! note "Published release and main"
     **0.10.0** is the current crates.io release. This guide follows unreleased
-    `main`, which includes breaking APIs planned for 0.11. Use the [0.10.0
+    `main`, which may include breaking APIs that have not reached a release
+    yet. Use the [0.10.0
     docs.rs pages](https://docs.rs/signal-fish-client/0.10.0/) with the versioned
     dependency above. To evaluate unreleased changes, use:
 

--- a/docs/mesh-guide.md
+++ b/docs/mesh-guide.md
@@ -14,8 +14,10 @@ drive the whole handshake for you.
     signal-fish-client = { git = "https://github.com/Ambiguous-Interactive/signal-fish-client-rust", features = ["mesh"] }
     ```
 
-    The generation-bearing Server 0.7 APIs in this guide target the forthcoming
-    breaking 0.11 release. Published 0.10.0 does not contain them.
+    The generation-bearing Server 0.7 APIs in this guide may not have reached
+    the published crates.io release yet; the
+    [changelog](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/blob/main/CHANGELOG.md)
+    says which release added them. The current release is 0.10.0.
 
 ---
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -74,7 +74,8 @@ members set `version.workspace = true`. Preparation discovers crates through
 `cargo metadata`, verifies internal publishable dependencies inherit through
 `workspace = true`, updates the shared version and exact workspace
 requirements by manifest key (including renamed dependencies), then updates
-locks, documentation references, provenance, and the changelog. It fails
+locks, documentation references, the compatibility manifest's release-sync
+date, and the changelog. It fails
 before writing if the workspace graph, inventory, or `[Unreleased]` section is
 invalid. Release intent is deterministic: a `**Breaking:**` entry selects a
 major bump (or a pre-1.0 minor bump); Added, Changed, Deprecated, or Removed

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -683,15 +683,23 @@ def prepare(
             if lock.count(marker) != 1:
                 raise ReleaseError(f"{relative} has no unique locked {package} {old}")
     compatibility_text = (root / "tests/compatibility.toml").read_text(encoding="utf-8")
+    # Only the top-level table carries the release-stamped identity. Section
+    # tables ([protocol_authority] and the vendored PROVENANCE.toml files) hold
+    # real upstream-refresh provenance and must never be rewritten by a release.
+    compatibility_header = compatibility_text.partition("\n[")[0]
     if (
-        len(re.findall(r'^client_version = "[^"]+"$', compatibility_text, re.MULTILINE))
+        len(
+            re.findall(
+                r'^client_version = "[^"]+"$',
+                compatibility_header,
+                re.MULTILINE,
+            )
+        )
         != 1
     ):
-        raise ReleaseError("tests/compatibility.toml has no unique client_version")
-    # Only the top-level table carries the release-sync date. Section tables
-    # ([protocol_authority] and the vendored PROVENANCE.toml files) hold real
-    # upstream-refresh provenance and must never be rewritten by a release.
-    compatibility_header = compatibility_text.partition("\n[")[0]
+        raise ReleaseError(
+            "tests/compatibility.toml has no unique top-level client_version"
+        )
     if (
         len(
             re.findall(
@@ -729,13 +737,17 @@ def prepare(
         replace_required(root / relative, old, new)
     compatibility = root / "tests/compatibility.toml"
     header, separator, sections = compatibility_text.partition("\n[")
-    header = re.sub(
+    header, count = re.subn(
         r'^client_version = "[^"]+"$',
         f'client_version = "{new}"',
         header,
         count=1,
         flags=re.MULTILINE,
     )
+    if count != 1:
+        raise ReleaseError(
+            "tests/compatibility.toml has no unique top-level client_version"
+        )
     header, count = re.subn(
         r'^synced = "[0-9]{4}-[0-9]{2}-[0-9]{2}"$',
         f'synced = "{date}"',

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -30,14 +30,9 @@ VERSION_FILES = (
     "docs/mesh-guide.md",
     "docs/protocol.md",
     "docs/wasm.md",
+    "llms.txt",
     ".llm/context.md",
     ".llm/skills/crate-publishing/SKILL.md",
-)
-PROVENANCE_FILES = (
-    "tests/compatibility.toml",
-    "tests/server-spec/PROVENANCE.toml",
-    "tests/token-binding/PROVENANCE.toml",
-    "tests/wire-samples/PROVENANCE.toml",
 )
 CHANGELOG_CATEGORIES = (
     "Added",
@@ -693,17 +688,23 @@ def prepare(
         != 1
     ):
         raise ReleaseError("tests/compatibility.toml has no unique client_version")
-    for relative in PROVENANCE_FILES:
-        provenance = (root / relative).read_text(encoding="utf-8")
-        if (
-            len(
-                re.findall(
-                    r'^synced = "[0-9]{4}-[0-9]{2}-[0-9]{2}"$', provenance, re.MULTILINE
-                )
+    # Only the top-level table carries the release-sync date. Section tables
+    # ([protocol_authority] and the vendored PROVENANCE.toml files) hold real
+    # upstream-refresh provenance and must never be rewritten by a release.
+    compatibility_header = compatibility_text.partition("\n[")[0]
+    if (
+        len(
+            re.findall(
+                r'^synced = "[0-9]{4}-[0-9]{2}-[0-9]{2}"$',
+                compatibility_header,
+                re.MULTILINE,
             )
-            != 1
-        ):
-            raise ReleaseError(f"{relative} has no unique synced date")
+        )
+        != 1
+    ):
+        raise ReleaseError(
+            "tests/compatibility.toml has no unique top-level synced date"
+        )
     changelog_text = (root / "CHANGELOG.md").read_text(encoding="utf-8")
     unreleased_start = changelog_text.find("## [Unreleased]")
     next_release = changelog_text.find(
@@ -727,28 +728,24 @@ def prepare(
     for relative in VERSION_FILES:
         replace_required(root / relative, old, new)
     compatibility = root / "tests/compatibility.toml"
-    text = compatibility_text
-    text = re.sub(
+    header, separator, sections = compatibility_text.partition("\n[")
+    header = re.sub(
         r'^client_version = "[^"]+"$',
         f'client_version = "{new}"',
-        text,
+        header,
         count=1,
         flags=re.MULTILINE,
     )
-    compatibility.write_text(text, encoding="utf-8")
-    for relative in PROVENANCE_FILES:
-        path = root / relative
-        provenance = path.read_text(encoding="utf-8")
-        provenance, count = re.subn(
-            r'^synced = "[0-9]{4}-[0-9]{2}-[0-9]{2}"$',
-            f'synced = "{date}"',
-            provenance,
-            count=1,
-            flags=re.MULTILINE,
-        )
-        if count != 1:
-            raise ReleaseError(f"{relative} has no unique synced date")
-        path.write_text(provenance, encoding="utf-8")
+    header, count = re.subn(
+        r'^synced = "[0-9]{4}-[0-9]{2}-[0-9]{2}"$',
+        f'synced = "{date}"',
+        header,
+        count=1,
+        flags=re.MULTILINE,
+    )
+    if count != 1:
+        raise ReleaseError("tests/compatibility.toml has no unique top-level synced date")
+    compatibility.write_text(header + separator + sections, encoding="utf-8")
     cut_changelog(root / "CHANGELOG.md", old, new, date, breaking)
     return new
 

--- a/scripts/test_release.py
+++ b/scripts/test_release.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import importlib.util
+import re
 import tempfile
 import unittest
 from pathlib import Path
@@ -222,12 +223,12 @@ class PreparationTests(unittest.TestCase):
             path = self.root / relative
             path.parent.mkdir(parents=True, exist_ok=True)
             path.write_text("release 1.2.3\n", encoding="utf-8")
-        for relative in release.PROVENANCE_FILES:
-            path = self.root / relative
-            path.parent.mkdir(parents=True, exist_ok=True)
-            path.write_text(
-                'client_version = "1.2.3"\nsynced = "2020-01-01"\n', encoding="utf-8"
-            )
+        (self.root / "tests").mkdir()
+        (self.root / "tests/compatibility.toml").write_text(
+            'client_version = "1.2.3"\nsynced = "2020-01-01"\n\n'
+            '[protocol_authority]\ncommit = "abc"\nsynced = "2020-01-02"\n',
+            encoding="utf-8",
+        )
         for relative in release.LOCKSTEP_LOCKFILES:
             path = self.root / relative
             path.parent.mkdir(parents=True, exist_ok=True)
@@ -265,9 +266,25 @@ class PreparationTests(unittest.TestCase):
             encoding="utf-8"
         )
         self.assertIn('client_version = "1.3.0"', compatibility)
-        self.assertIn('synced = "2026-07-13"', compatibility)
+        # Only the top-level release-sync date is stamped; upstream provenance
+        # dates ([protocol_authority] and vendored PROVENANCE.toml files) are
+        # never rewritten by a release.
+        self.assertEqual(compatibility.count('synced = "2026-07-13"'), 1)
+        self.assertEqual(compatibility.count('synced = "2020-01-02"'), 1)
         self.assertEqual(release.previous_version(self.root, "1.3.0"), "1.2.3")
         self.assertEqual(release.semver_policy(self.root, "1.3.0"), "minor")
+
+    def test_prepare_requires_unique_top_level_synced_date(self) -> None:
+        path = self.root / "tests/compatibility.toml"
+        path.write_text(
+            'client_version = "1.2.3"\nsynced = "2020-01-01"\n'
+            'synced = "2020-01-05"\n\n'
+            '[protocol_authority]\ncommit = "abc"\nsynced = "2020-01-02"\n',
+            encoding="utf-8",
+        )
+        with self.assertRaisesRegex(release.ReleaseError, "top-level synced date"):
+            release.prepare(self.root, "minor", "2026-07-13", allow_dirty=True)
+        self.assertEqual(release.package_version(self.root), "1.2.3")
 
     def test_release_intent_derives_minor_from_added_entries(self) -> None:
         intent = release.release_intent(self.root)
@@ -857,6 +874,24 @@ class WorkflowPolicyTests(unittest.TestCase):
                     path.read_text(encoding="utf-8"),
                     f"{relative} does not mention workspace version {version}",
                 )
+
+    def test_compatibility_top_level_synced_matches_this_checkout(self) -> None:
+        # Guards the release-day synced inventory against drift like #133
+        # adding a section-level synced date to tests/compatibility.toml,
+        # which made every Prepare Release run fail before writing anything.
+        # Prepare stamps exactly one top-level synced date; section tables
+        # hold upstream provenance and may carry their own dates.
+        root = Path(__file__).resolve().parents[1]
+        text = (root / "tests/compatibility.toml").read_text(encoding="utf-8")
+        header = text.partition("\n[")[0]
+        dates = re.findall(
+            r'^synced = "[0-9]{4}-[0-9]{2}-[0-9]{2}"$', header, re.MULTILINE
+        )
+        self.assertEqual(
+            len(dates),
+            1,
+            "tests/compatibility.toml must have exactly one top-level synced date",
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/test_release.py
+++ b/scripts/test_release.py
@@ -274,17 +274,30 @@ class PreparationTests(unittest.TestCase):
         self.assertEqual(release.previous_version(self.root, "1.3.0"), "1.2.3")
         self.assertEqual(release.semver_policy(self.root, "1.3.0"), "minor")
 
-    def test_prepare_requires_unique_top_level_synced_date(self) -> None:
+    def test_prepare_requires_top_level_identity_in_header_table(self) -> None:
         path = self.root / "tests/compatibility.toml"
-        path.write_text(
-            'client_version = "1.2.3"\nsynced = "2020-01-01"\n'
-            'synced = "2020-01-05"\n\n'
-            '[protocol_authority]\ncommit = "abc"\nsynced = "2020-01-02"\n',
-            encoding="utf-8",
-        )
-        with self.assertRaisesRegex(release.ReleaseError, "top-level synced date"):
-            release.prepare(self.root, "minor", "2026-07-13", allow_dirty=True)
-        self.assertEqual(release.package_version(self.root), "1.2.3")
+        cases = {
+            "duplicate top-level synced": (
+                'client_version = "1.2.3"\nsynced = "2020-01-01"\n'
+                'synced = "2020-01-05"\n\n'
+                '[protocol_authority]\ncommit = "abc"\nsynced = "2020-01-02"\n'
+            ),
+            "client_version only in a section": (
+                'synced = "2020-01-01"\n\n'
+                '[protocol_authority]\ncommit = "abc"\n'
+                'client_version = "1.2.3"\nsynced = "2020-01-02"\n'
+            ),
+        }
+        for name, content in cases.items():
+            with self.subTest(case=name):
+                path.write_text(content, encoding="utf-8")
+                with self.assertRaisesRegex(
+                    release.ReleaseError, "top-level"
+                ):
+                    release.prepare(
+                        self.root, "minor", "2026-07-13", allow_dirty=True
+                    )
+                self.assertEqual(release.package_version(self.root), "1.2.3")
 
     def test_release_intent_derives_minor_from_added_entries(self) -> None:
         intent = release.release_intent(self.root)
@@ -875,15 +888,25 @@ class WorkflowPolicyTests(unittest.TestCase):
                     f"{relative} does not mention workspace version {version}",
                 )
 
-    def test_compatibility_top_level_synced_matches_this_checkout(self) -> None:
-        # Guards the release-day synced inventory against drift like #133
+    def test_compatibility_top_level_identity_matches_this_checkout(self) -> None:
+        # Guards the release-day identity inventory against drift like #133
         # adding a section-level synced date to tests/compatibility.toml,
         # which made every Prepare Release run fail before writing anything.
-        # Prepare stamps exactly one top-level synced date; section tables
-        # hold upstream provenance and may carry their own dates.
+        # Prepare stamps exactly one top-level client_version and synced
+        # date; section tables hold upstream provenance and may carry their
+        # own synced dates.
         root = Path(__file__).resolve().parents[1]
         text = (root / "tests/compatibility.toml").read_text(encoding="utf-8")
         header = text.partition("\n[")[0]
+        client_versions = re.findall(
+            r'^client_version = "[^"]+"$', header, re.MULTILINE
+        )
+        self.assertEqual(
+            len(client_versions),
+            1,
+            "tests/compatibility.toml must have exactly one top-level "
+            "client_version",
+        )
         dates = re.findall(
             r'^synced = "[0-9]{4}-[0-9]{2}-[0-9]{2}"$', header, re.MULTILINE
         )


### PR DESCRIPTION
## Why

The round-18 paranoid-audit release-readiness surface (#126) found that every future **Prepare Release** run — including the upcoming 0.11 release — fails closed before writing anything. #133 gave the compatibility manifest a second, section-level `synced` date (real upstream-refresh provenance), but release tooling still demanded exactly one `synced` date per file. Worse, the old stamping loop rewrote the *first* `synced` date it found, which would have falsified the vendored PROVENANCE files' upstream dates and broken the manifest parity test mid-release.

## How

- Releases now stamp exactly the compatibility manifest's **top-level** `synced` date and never rewrite section-level upstream provenance. Both identity checks (`client_version`, `synced`) are scoped to the top-level table and fail closed before any write.
- A new checkout-level guard test catches identity-inventory drift in tests instead of on release day, with red/green unit tests for both failure shapes.
- `llms.txt` joins the version-file inventory, so the published model-context page tracks each release instead of advertising a stale crate version.
- The README and the mesh, getting-started, and client guides no longer embed the next version number or enumerate unreleased features; they hedge and point at the changelog, so release preparation can no longer rewrite them into stale claims.

## Evidence

- Full `prepare minor --breaking` simulation on this branch produces the exact expected 0.11.0 inventory (changelog cut with major semver policy, all version files, lockstep lockfiles, manifest identity) and the Rust compatibility parity test passes on the simulated post-release tree.
- Four adversarial review rounds converged to zero findings.
- Local: fmt/clippy clean, 23/23 Rust test suites, 52/52 release-tooling tests, pre-commit 16/16.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release automation and manifest invariants that gate every future publish; mistakes could ship wrong provenance or still block releases, but scope is tooling/docs with strong tests rather than runtime client code.
> 
> **Overview**
> **Prepare Release** was failing because `tests/compatibility.toml` gained section-level `synced` dates (upstream protocol provenance) while `release.py` still required exactly one `synced` per file and would rewrite the first match—risking falsified vendored **PROVENANCE.toml** dates.
> 
> Release preparation now updates only the **top-level** `client_version` and release-stamped `synced` in `tests/compatibility.toml`, leaves `[protocol_authority]` and vendored provenance files untouched, and drops the old `PROVENANCE_FILES` rewrite loop. Validation and unit tests enforce unique top-level identity; a new checkout-level test catches manifest drift before release day.
> 
> **`llms.txt`** is included in the version-file inventory so the model-context page tracks each release. README and the client, getting-started, and mesh guides no longer name the next version or list unreleased features—they defer to the changelog so bumps cannot leave stale claims. Publishing skill notes and `docs/releasing.md` document the split between release-sync and upstream-refresh provenance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 542471e270e749f671e67e6f66907b565720c452. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->