### PR TITLE
Round 20 audit: schema-valid spectator exits, correlated fence release

### DIFF
--- a/.llm/skills/transport-abstraction/SKILL.md
+++ b/.llm/skills/transport-abstraction/SKILL.md
@@ -93,7 +93,10 @@ The caller owns `frame: Option<TransportFrame>` until the transport takes it.
 - If a transport returns `Pending` after taking a frame, it must retain all
   state needed to finish that exact accepted operation across later polls.
 - Repeated polls while that send is pending must not accept a replacement frame,
-  restart the write, or duplicate bytes.
+  restart the write, or duplicate bytes. Passing `Some(replacement)` while a
+  send is retained is outside the contract: built-in drivers never do it, and a
+  backend's behavior in that case is unspecified (the native WebSocket leaves
+  the replacement untouched and reports the retained operation).
 - `None` means no new frame. If no retained write exists, return `Ready(Ok(()))`.
 
 For a buffered sink, the usual state machine is:
@@ -123,7 +126,10 @@ If `poll_recv` consumes partial input before returning `Pending`, that partial
 input must remain in the transport. A later poll must continue it rather than
 lose it. When a real async waker is supplied, register or forward it so the
 async client wakes when progress becomes possible. A frame-loop polling client
-uses a noop waker and simply polls again next tick.
+uses a noop waker and simply polls again next tick. A polling-only backend (the
+Emscripten transport) may rely on that noop-waker contract and skip waker
+registration entirely; it must not be wrapped by the async driver, which
+requires a working waker.
 
 ## Close Contract
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -318,6 +318,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Accepted authoritative `SpectatorLeft` frames that omit the optional
+  `room_id` (server removal, spectator disconnect, or room close). The wire
+  authority marks the field optional, but the client required it and latched
+  quarantine on a schema-valid exit under the default policy; a named room
+  must still match the current one.
+- Corrected published documentation that reversed actual behavior or
+  misdescribed the API: the mesh guide now states that an empty `SessionPlan`
+  clears pre-gathered ICE servers (plans replace the list wholesale, they
+  never merge), the spectator-leaves event and protocol tables describe
+  authoritative exits, the `DecodeFailed.raw_prefix` field documents that
+  it carries verbatim frame content, and the events and web/Godot guides no
+  longer fabricate a lobby ready-count denominator or silently swallow
+  command errors in example sketches.
 - Fixed the release tooling's remaining fence-blind spots: release
   preparation, the changelog cut, semver-policy derivation, the previous
   baseline lookup, and release-notes extraction now track CommonMark fenced

--- a/docs/events.md
+++ b/docs/events.md
@@ -344,10 +344,8 @@ details.
 ```rust,ignore
 match event {
     SignalFishEvent::LobbyStateChanged { lobby_state, ready_players, all_ready } => {
-        println!("Lobby: {lobby_state:?}, {}/{} ready",
-            ready_players.len(),
-            ready_players.len() + if all_ready { 0 } else { 1 }
-        );
+        println!("Lobby: {lobby_state:?}, {} player(s) ready{}", ready_players.len(),
+            if all_ready { " (all ready)" } else { "" });
     }
     SignalFishEvent::GameStarting { peer_connections } => {
         println!("Game starting with {} peers", peer_connections.len());
@@ -560,7 +558,7 @@ full spectator lifecycle.
 |---------|------------|-------------|
 | `SpectatorJoined` | `room_id`, `spectator_id`, `current_players`, `current_spectators`, … | Successfully joined a room as a spectator. |
 | `SpectatorJoinFailed` | `reason: String`, `error_code: Option<ErrorCode>` | Failed to join as a spectator. |
-| `SpectatorLeft` | `room_id: Option<RoomId>`, `room_code: Option<String>`, `reason`, `current_spectators` | Successfully left spectator mode. |
+| `SpectatorLeft` | `room_id: Option<RoomId>`, `room_code: Option<String>`, `reason`, `current_spectators` | The spectator left the room: either the answer to this client's admitted voluntary leave, or an authoritative exit (server removal, spectator disconnect, or room close). |
 | `NewSpectatorJoined` | `spectator: SpectatorInfo`, `current_spectators`, `reason` | Another spectator joined the room. |
 | `SpectatorDisconnected` | `spectator_id: PlayerId`, `reason`, `current_spectators` | Another spectator disconnected. |
 

--- a/docs/mesh-guide.md
+++ b/docs/mesh-guide.md
@@ -258,8 +258,9 @@ To shorten the time-to-connect, the server can deliver STUN/TURN servers
 the lobby wait — so your WebRTC stack can begin gathering candidates before the
 `SessionPlan` arrives. Feed these into `set_ice_servers` as soon as you get them
 (`MeshController` does this for you). When the `SessionPlan` later carries its own
-`ice_servers`, those supersede the pre-gathered set; an empty plan keeps the
-pre-gathered ones.
+`ice_servers`, those supersede the pre-gathered set; an empty plan
+authoritatively clears the pre-gathered set — plans replace the ICE list
+wholesale, they never merge with it.
 
 ---
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -635,7 +635,7 @@ pub enum ServerMessage { /* ... */ }
 | `PlayerReconnected` | Another player reconnected. |
 | `SpectatorJoined` | Successfully joined as a spectator. |
 | `SpectatorJoinFailed` | Failed to join as a spectator. |
-| `SpectatorLeft` | Successfully left spectator mode. |
+| `SpectatorLeft` | The spectator left the room: an answer to an admitted voluntary leave, or an authoritative exit (`reason`: `removed`, `disconnected`, or `room_closed`). Room identity fields are optional on the wire; a named room must match the current one. |
 | `RoomOperationResult` | **(negotiated v3)** Echoes the exact UUID and carries an operation-specific terminal result or `OperationFailed`. |
 | `NewSpectatorJoined` | Another spectator joined the room. |
 | `SpectatorDisconnected` | Another spectator disconnected. |

--- a/docs/wasm.md
+++ b/docs/wasm.md
@@ -391,7 +391,9 @@ processes incoming messages up to the configured work budget, then returns a
 for event in client.poll() {
     match event {
         SignalFishEvent::Authenticated { .. } => {
-            client.join_room(JoinRoomParams::new("my-game", "Player1")).ok();
+            if let Err(e) = client.join_room(JoinRoomParams::new("my-game", "Player1")) {
+                eprintln!("join_room refused: {e}");
+            }
         }
         SignalFishEvent::RoomJoined { room_code, .. } => {
             // You are in the room
@@ -584,11 +586,15 @@ impl INode for SignalFishNode {
                     godot_print!("Authenticated as {}", app_name);
                     let params = JoinRoomParams::new("my-game", "GodotPlayer")
                         .with_max_players(4);
-                    client.join_room(params).ok();
+                    if let Err(e) = client.join_room(params) {
+                        godot_print!("join_room refused: {e}");
+                    }
                 }
                 SignalFishEvent::RoomJoined { room_code, player_id, .. } => {
                     godot_print!("Joined room {} as {}", room_code, player_id);
-                    client.set_ready().ok();
+                    if let Err(e) = client.set_ready() {
+                        godot_print!("set_ready refused: {e}");
+                    }
                 }
                 SignalFishEvent::GameData { from_player, data, .. } => {
                     godot_print!("Game data from {}: {}", from_player, data);

--- a/src/client.rs
+++ b/src/client.rs
@@ -2626,7 +2626,8 @@ async fn emit_event_or_shutdown(
 mod tests {
     use super::*;
     use crate::protocol::{
-        LobbyState, RateLimitInfo, RoomJoinedPayload, ROOM_OPERATION_IDS_CAPABILITY,
+        LobbyState, RateLimitInfo, RoomJoinedPayload, RoomOperationRequest,
+        ROOM_OPERATION_IDS_CAPABILITY,
     };
     use std::collections::VecDeque;
     use std::future::Future;
@@ -2834,37 +2835,65 @@ mod tests {
                 let Some(Ok(json)) = item else {
                     return None;
                 };
-                let message_type = serde_json::from_str::<serde_json::Value>(json)
-                    .ok()?
-                    .get("type")?
-                    .as_str()?
-                    .to_owned();
+                let parsed = serde_json::from_str::<serde_json::Value>(json).ok()?;
+                let message_type = parsed.get("type")?.as_str()?.to_owned();
                 match message_type.as_str() {
                     "RoomJoined" | "RoomJoinFailed" => Some(0),
                     "RoomLeft" => Some(1),
                     "Reconnected" | "ReconnectionFailed" => Some(2),
                     "SpectatorJoined" | "SpectatorJoinFailed" => Some(3),
-                    "SpectatorLeft" => Some(4),
+                    "SpectatorLeft" => {
+                        // Authoritative exits (removed, disconnected,
+                        // room-closed) are server-initiated and must be
+                        // deliverable without a matching client command;
+                        // only voluntary answers stay gated. Mirrors the
+                        // core's `spectator_exit_is_authoritative`. An
+                        // absent reason field stays gated (voluntary face).
+                        let reason = parsed
+                            .get("data")
+                            .and_then(|data| data.get("reason"))
+                            .and_then(|reason| reason.as_str())
+                            .map(str::to_owned);
+                        match reason.as_deref() {
+                            Some("room_closed" | "removed" | "disconnected") => None,
+                            _ => Some(4),
+                        }
+                    }
                     _ => None,
                 }
             });
             if let Some(kind) = response_kind {
+                // Counts both wire shapes of a directed room operation: the
+                // legacy unwrapped command and the correlated
+                // `RoomOperation` envelope sent after `room_operation_ids`
+                // negotiation.
+                fn directed_operation_kind(message: &ClientMessage) -> Option<usize> {
+                    match message {
+                        ClientMessage::JoinRoom { .. } => Some(0),
+                        ClientMessage::LeaveRoom => Some(1),
+                        ClientMessage::Reconnect { .. } => Some(2),
+                        ClientMessage::JoinAsSpectator { .. } => Some(3),
+                        ClientMessage::LeaveSpectator => Some(4),
+                        ClientMessage::RoomOperation { operation, .. } => {
+                            match operation.as_ref() {
+                                RoomOperationRequest::JoinRoom { .. } => Some(0),
+                                RoomOperationRequest::LeaveRoom => Some(1),
+                                RoomOperationRequest::Reconnect { .. } => Some(2),
+                                RoomOperationRequest::JoinAsSpectator { .. } => Some(3),
+                                RoomOperationRequest::LeaveSpectator => Some(4),
+                            }
+                        }
+                        _ => None,
+                    }
+                }
                 let sent_count = self
                     .sent
                     .lock()
                     .unwrap()
                     .iter()
                     .filter(|json| {
-                        serde_json::from_str::<ClientMessage>(json).is_ok_and(
-                            |message| match kind {
-                                0 => matches!(message, ClientMessage::JoinRoom { .. }),
-                                1 => matches!(message, ClientMessage::LeaveRoom),
-                                2 => matches!(message, ClientMessage::Reconnect { .. }),
-                                3 => matches!(message, ClientMessage::JoinAsSpectator { .. }),
-                                4 => matches!(message, ClientMessage::LeaveSpectator),
-                                _ => false,
-                            },
-                        )
+                        serde_json::from_str::<ClientMessage>(json)
+                            .is_ok_and(|message| directed_operation_kind(&message) == Some(kind))
                     })
                     .count();
                 if sent_count <= self.delivered_room_responses[kind] {
@@ -6521,6 +6550,76 @@ mod tests {
         assert!(client.current_room_code().await.is_none());
 
         client.shutdown().await;
+    }
+
+    /// The wire authority leaves `room_id` optional on `SpectatorLeft`
+    /// (vendored AsyncAPI: no `required` on the data object), so an
+    /// authoritative exit from the current room may omit the identity. A
+    /// named room must still match: that mismatch stays a violation.
+    #[tokio::test]
+    async fn authoritative_spectator_left_accepts_optional_room_identity() {
+        use crate::protocol::SpectatorStateChangeReason;
+        let authoritative_without_room_id = serde_json::to_string(&ServerMessage::SpectatorLeft {
+            room_id: None,
+            room_code: None,
+            reason: Some(SpectatorStateChangeReason::RoomClosed),
+            current_spectators: vec![],
+        })
+        .unwrap();
+        let mismatched_room_id = serde_json::to_string(&ServerMessage::SpectatorLeft {
+            room_id: Some(uuid::Uuid::from_u128(999)),
+            room_code: None,
+            reason: Some(SpectatorStateChangeReason::RoomClosed),
+            current_spectators: vec![],
+        })
+        .unwrap();
+
+        for (name, frame, accepted) in [
+            ("omitted room_id", authoritative_without_room_id, true),
+            ("mismatched room_id", mismatched_room_id, false),
+        ] {
+            let (transport, _sent, _closed) = MockTransport::new(vec![
+                Some(Ok(authenticated_json())),
+                Some(Ok(protocol_info_v2_json())),
+                Some(Ok(spectator_joined_json())),
+                Some(Ok(frame)),
+            ]);
+            let config = SignalFishConfig::new("mb_test");
+            let (mut client, mut events) = SignalFishClient::start(transport, config);
+
+            enter_scripted_spectator_room(&mut client, &mut events).await;
+            let ev = events.recv().await.unwrap();
+            if accepted {
+                assert!(
+                    matches!(ev, SignalFishEvent::SpectatorLeft { .. }),
+                    "{name}: expected a SpectatorLeft event, got {ev:?}"
+                );
+                assert!(
+                    client.current_room_id().await.is_none(),
+                    "{name}: the authoritative exit must clear room membership"
+                );
+                assert!(
+                    !client.snapshot().quarantined,
+                    "{name}: a schema-valid authoritative exit must not quarantine"
+                );
+            } else {
+                assert!(
+                    matches!(ev, SignalFishEvent::ProtocolViolation { .. }),
+                    "{name}: expected a ProtocolViolation event, got {ev:?}"
+                );
+                assert_eq!(
+                    client.current_room_id().await,
+                    Some(uuid::Uuid::from_u128(300)),
+                    "{name}: a rejected exit must not clear room membership"
+                );
+                assert!(
+                    client.snapshot().quarantined,
+                    "{name}: a mismatched authoritative identity must quarantine"
+                );
+            }
+
+            client.shutdown().await;
+        }
     }
 
     #[tokio::test]

--- a/src/client_core.rs
+++ b/src/client_core.rs
@@ -1126,6 +1126,9 @@ impl ClientCore {
     /// Unreachable while every `ClientMessage` field serializes infallibly,
     /// but one fallible field away from a permanent `RoomOperationPending` in
     /// both drivers, so the fence is released instead of asserted away.
+    /// Matching is by operation kind only: at most one fence exists at a
+    /// time, so a same-kind message — wrapped or not — can only be the
+    /// command that armed it, never a competing operation.
     pub(crate) fn dequeue_serialization_failed(&mut self, message: &ClientMessage) {
         let kind = match message {
             ClientMessage::JoinRoom { .. } => PendingRoomOperation::JoinPlayer,
@@ -1133,6 +1136,13 @@ impl ClientCore {
             ClientMessage::Reconnect { .. } => PendingRoomOperation::ReconnectPlayer,
             ClientMessage::JoinAsSpectator { .. } => PendingRoomOperation::JoinSpectator,
             ClientMessage::LeaveSpectator => PendingRoomOperation::LeaveSpectator,
+            ClientMessage::RoomOperation { operation, .. } => match operation.as_ref() {
+                RoomOperationRequest::JoinRoom { .. } => PendingRoomOperation::JoinPlayer,
+                RoomOperationRequest::LeaveRoom => PendingRoomOperation::LeavePlayer,
+                RoomOperationRequest::Reconnect { .. } => PendingRoomOperation::ReconnectPlayer,
+                RoomOperationRequest::JoinAsSpectator { .. } => PendingRoomOperation::JoinSpectator,
+                RoomOperationRequest::LeaveSpectator => PendingRoomOperation::LeaveSpectator,
+            },
             _ => return,
         };
         if self
@@ -1417,7 +1427,10 @@ impl ClientCore {
                         | crate::protocol::SpectatorStateChangeReason::Removed
                         | crate::protocol::SpectatorStateChangeReason::RoomClosed,
                     ) => {
-                        if *room_id != self.snapshot.room_id {
+                        // The wire authority leaves `room_id` optional; an
+                        // authoritative exit from the current room need not
+                        // repeat its identity, but a named room must match.
+                        if room_id.is_some_and(|room_id| Some(room_id) != self.snapshot.room_id) {
                             return Err(
                                 "lifecycle violation: authoritative SpectatorLeft must identify the current room"
                                     .into(),
@@ -4533,20 +4546,39 @@ mod tests {
         assert_lifecycle_violation_containing(&outcome, "joined reason");
         assert_eq!(invalid.room_role(), Some(RoomRole::Spectator));
 
-        for room_id in [None, Some(RoomId::from_u128(999))] {
-            let mut invalid = v3_spectator(ProtocolViolationPolicy::Observe);
-            let outcome = process(
-                &mut invalid,
-                ServerMessage::SpectatorLeft {
-                    room_id,
-                    room_code: None,
-                    reason: Some(crate::protocol::SpectatorStateChangeReason::RoomClosed),
-                    current_spectators: vec![],
-                },
-            );
-            assert_lifecycle_violation_containing(&outcome, "identify the current room");
-            assert_eq!(invalid.room_role(), Some(RoomRole::Spectator));
-        }
+        // The wire authority leaves `room_id` optional: an authoritative exit
+        // from the current room may omit the identity, while a named room
+        // must still match.
+        let mut omitted_identity = v3_spectator(ProtocolViolationPolicy::Observe);
+        let outcome = process(
+            &mut omitted_identity,
+            ServerMessage::SpectatorLeft {
+                room_id: None,
+                room_code: None,
+                reason: Some(crate::protocol::SpectatorStateChangeReason::RoomClosed),
+                current_spectators: vec![],
+            },
+        );
+        assert!(matches!(
+            outcome.events.as_slice(),
+            [SignalFishEvent::SpectatorLeft { .. }]
+        ));
+        assert!(!outcome.disconnect);
+        assert_eq!(omitted_identity.room_role(), None);
+        assert!(!omitted_identity.snapshot().quarantined);
+
+        let mut mismatched_identity = v3_spectator(ProtocolViolationPolicy::Observe);
+        let outcome = process(
+            &mut mismatched_identity,
+            ServerMessage::SpectatorLeft {
+                room_id: Some(RoomId::from_u128(999)),
+                room_code: None,
+                reason: Some(crate::protocol::SpectatorStateChangeReason::RoomClosed),
+                current_spectators: vec![],
+            },
+        );
+        assert_lifecycle_violation_containing(&outcome, "identify the current room");
+        assert_eq!(mismatched_identity.room_role(), Some(RoomRole::Spectator));
     }
 
     #[test]
@@ -6557,13 +6589,13 @@ mod tests {
             ),
         ];
 
-        for (name, operation, message) in cases {
+        for (name, operation, message) in cases.iter() {
             let mut core = ClientCore::new(
                 Some(GameDataEncoding::Json),
                 ProtocolViolationPolicy::Observe,
                 true,
             );
-            core.record_admission(ClientCore::admission_for(&operation));
+            core.record_admission(ClientCore::admission_for(operation));
             assert!(
                 core.pending_room_operation.is_some(),
                 "{name}: admission must arm the fence"
@@ -6572,7 +6604,7 @@ mod tests {
                 assert_eq!(core.pending_reconnects.len(), 1);
             }
 
-            core.dequeue_serialization_failed(&message);
+            core.dequeue_serialization_failed(message);
             assert!(
                 core.pending_room_operation.is_none(),
                 "{name}: dequeue failure must release the fence"
@@ -6583,11 +6615,70 @@ mod tests {
             );
             // A mismatched message kind must never release someone else's
             // fence.
-            core.record_admission(ClientCore::admission_for(&operation));
+            core.record_admission(ClientCore::admission_for(operation));
             core.dequeue_serialization_failed(&ClientMessage::Ping);
             assert!(
                 core.pending_room_operation.is_some(),
                 "{name}: an unrelated message must not release the fence"
+            );
+        }
+
+        // After `room_operation_ids` negotiation the same five operations are
+        // enqueued wrapped in a correlated `RoomOperation` envelope; a
+        // dequeue-time serialization failure of that envelope must release
+        // the fence exactly like the unwrapped shapes above.
+        for (name, operation, unwrapped) in cases.iter().map(|(n, o, m)| (n, o, m.clone())) {
+            let operation_id = RoomOperationId::from_u128(0xaaaa);
+            let envelope = correlate_room_operation(unwrapped, operation_id);
+
+            // Negotiated mode, with the fence carrying the same operation id
+            // the envelope was built with — the exact state
+            // `prepare_with_admission` produces.
+            let mut core = ClientCore::new_with_room_operation_ids(
+                Some(GameDataEncoding::Json),
+                ProtocolViolationPolicy::Observe,
+                true,
+                true,
+            );
+            core.record_admission(ClientCore::admission_for(operation));
+            if let Some(pending) = core.pending_room_operation.as_mut() {
+                pending.operation_id = Some(operation_id);
+            }
+            assert!(
+                core.pending_room_operation.is_some(),
+                "{name}: correlated admission must arm the fence"
+            );
+
+            core.dequeue_serialization_failed(&envelope);
+            assert!(
+                core.pending_room_operation.is_none(),
+                "{name}: a correlated dequeue failure must release the fence"
+            );
+            assert!(
+                core.pending_reconnects.is_empty(),
+                "{name}: correlated reconnect bookkeeping must be released with the fence"
+            );
+
+            // The kind match is still exact for envelopes.
+            core.record_admission(ClientCore::admission_for(operation));
+            let unrelated = correlate_room_operation(
+                match operation {
+                    ClientOperation::JoinRoom(_) => ClientMessage::LeaveRoom,
+                    _ => ClientMessage::JoinRoom {
+                        game_name: "other".into(),
+                        player_name: "local".into(),
+                        room_code: None,
+                        max_players: None,
+                        supports_authority: None,
+                        relay_transport: None,
+                    },
+                },
+                RoomOperationId::from_u128(0xbbbb),
+            );
+            core.dequeue_serialization_failed(&unrelated);
+            assert!(
+                core.pending_room_operation.is_some(),
+                "{name}: a different correlated operation must not release the fence"
             );
         }
     }

--- a/src/event.rs
+++ b/src/event.rs
@@ -116,6 +116,11 @@ pub enum SignalFishEvent {
         error: String,
         /// The raw frame text, truncated to at most
         /// [`DECODE_FAILED_RAW_PREFIX_MAX`] bytes on a UTF-8 boundary.
+        ///
+        /// This is verbatim frame content and can include sensitive data the
+        /// frame carried (for example SDP inside a signal relay). [`Debug`]
+        /// formatting of this event redacts it; treat the field itself as
+        /// diagnostic-only and never log it verbatim.
         raw_prefix: String,
     },
 
@@ -475,7 +480,9 @@ pub enum SignalFishEvent {
         error_code: Option<ErrorCode>,
     },
 
-    /// Successfully left spectator mode.
+    /// The spectator left the room: either the answer to this client's
+    /// admitted voluntary leave, or an authoritative exit (server removal,
+    /// spectator disconnect, or room close).
     SpectatorLeft {
         /// Room identifier, if available.
         room_id: Option<RoomId>,

--- a/src/polling_client.rs
+++ b/src/polling_client.rs
@@ -1552,6 +1552,7 @@ mod tests {
     use proptest::{prop_assert, prop_assert_eq};
 
     use super::*;
+    use crate::protocol::RoomOperationRequest;
     use crate::protocol::ServerMessage;
     use crate::transport::TransportFrame;
 
@@ -1625,9 +1626,16 @@ mod tests {
                 )
             });
             let reconnect_was_sent = self.sent.iter().any(|json| {
-                matches!(
-                    serde_json::from_str::<ClientMessage>(json),
-                    Ok(ClientMessage::Reconnect { .. })
+                serde_json::from_str::<ClientMessage>(json).is_ok_and(
+                    // Correlated envelopes count as their inner
+                    // operation, mirroring the wire in negotiated mode.
+                    |message| match message {
+                        ClientMessage::Reconnect { .. } => true,
+                        ClientMessage::RoomOperation { operation, .. } => {
+                            matches!(operation.as_ref(), RoomOperationRequest::Reconnect { .. })
+                        }
+                        _ => false,
+                    },
                 )
             });
             if reconnect_response_is_gated && !reconnect_was_sent {

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1104,7 +1104,9 @@ pub enum ServerMessage {
         #[serde(skip_serializing_if = "Option::is_none")]
         error_code: Option<ErrorCode>,
     },
-    /// Successfully left spectator mode.
+    /// The spectator left the room: an answer to an admitted voluntary
+    /// leave, or an authoritative exit (`removed`, `disconnected`, or
+    /// `room_closed`).
     SpectatorLeft {
         #[serde(skip_serializing_if = "Option::is_none")]
         room_id: Option<RoomId>,

--- a/src/transports/websocket.rs
+++ b/src/transports/websocket.rs
@@ -8,7 +8,10 @@
 //!
 //! Connections disable Nagle's algorithm (`TCP_NODELAY`) by default for low
 //! latency and reject inbound frames or assembled messages larger than 8 MiB;
-//! see [`WebSocketConnectOptions`] to override either policy.
+//! see [`WebSocketConnectOptions`] to override either policy. Both policies
+//! apply to connections this type dials — a post-handshake
+//! [`from_stream`](WebSocketTransport::from_stream) connection applies neither
+//! and preserves caller-owned policy.
 //!
 //! # Feature gate
 //!

--- a/src/webrtc.rs
+++ b/src/webrtc.rs
@@ -633,7 +633,7 @@ mod controller {
         /// or topology change reassigned who offers) has its handshake cleanly
         /// restarted in the new role: leaving the stale role in place would let
         /// the two sides glare (both offer) or stall (both wait), because the SDK
-        /// obeys the server verbatim and runs no perfect-negotiation rollback. A
+        /// obeys the server verbatim and runs no perfect-negotiation rollback.
         /// Generation changes are hard handshake barriers: every retained peer is
         /// rebuilt even when its role is unchanged. Within one generation, a known
         /// peer whose role is unchanged keeps its live connection untouched.
@@ -1318,16 +1318,32 @@ mod tests {
             let expected_command_was_sent = expected_command.is_none_or(|expected| {
                 self.sent.lock().unwrap().iter().any(|json| {
                     serde_json::from_str::<crate::protocol::ClientMessage>(json).is_ok_and(
+                        // Correlated envelopes count as their inner
+                        // operation, mirroring the wire in negotiated mode.
                         |message| {
-                            matches!(
-                                (expected, message),
-                                ("JoinRoom", crate::protocol::ClientMessage::JoinRoom { .. })
-                                    | (
-                                        "Reconnect",
-                                        crate::protocol::ClientMessage::Reconnect { .. }
-                                    )
-                                    | ("LeaveRoom", crate::protocol::ClientMessage::LeaveRoom)
-                            )
+                            let sent_kind = match &message {
+                                crate::protocol::ClientMessage::JoinRoom { .. } => Some("JoinRoom"),
+                                crate::protocol::ClientMessage::Reconnect { .. } => {
+                                    Some("Reconnect")
+                                }
+                                crate::protocol::ClientMessage::LeaveRoom => Some("LeaveRoom"),
+                                crate::protocol::ClientMessage::RoomOperation {
+                                    operation, ..
+                                } => match operation.as_ref() {
+                                    crate::protocol::RoomOperationRequest::JoinRoom { .. } => {
+                                        Some("JoinRoom")
+                                    }
+                                    crate::protocol::RoomOperationRequest::Reconnect { .. } => {
+                                        Some("Reconnect")
+                                    }
+                                    crate::protocol::RoomOperationRequest::LeaveRoom => {
+                                        Some("LeaveRoom")
+                                    }
+                                    _ => None,
+                                },
+                                _ => None,
+                            };
+                            sent_kind == Some(expected)
                         },
                     )
                 })


### PR DESCRIPTION
## Why

Issue #126's recurring correctness-audit ask continued with round 20 over four never-audited surfaces (spectator lifecycle end-to-end, `PeerSignal` wire fidelity, `from_stream`/`Transport` default-method contracts, and documentation behavioral fidelity), each audited by an independent adversarial agent. Two real defects and a set of documentation reversals survived 19 prior rounds; this PR fixes them all at the class level.

## What changed

**Production**
- **Schema-valid authoritative `SpectatorLeft` frames no longer quarantine the client.** The vendored wire authority marks `room_id` optional, but the client required it on authoritative exits (server removal, spectator disconnect, room close) and latched quarantine on a conforming frame. An omitted identity is now accepted; a *named* room must still match the current one, and that mismatch still violates. Pinned red/green at the shared core and end-to-end in the async driver (the test mock learned to deliver server-initiated exits, which no fixture could previously exercise).
- **Negotiated room-operation fences release on dequeue-serialization failure.** The fence-release safety net classified only the five legacy command shapes; after `room_operation_ids` negotiation the same commands ride a correlated `RoomOperation` envelope, which fell through and would have wedged every later room command behind `RoomOperationPending` in both drivers. Latent (serialization is infallible today), fixed at the one shared seam. The same envelope-blindness was swept out of all three test-harness response gates.

**Docs**
- The mesh guide no longer reverses actual behavior: an empty `SessionPlan` **clears** pre-gathered ICE servers (plans replace the list wholesale; pinned by existing tests it previously contradicted).
- `SpectatorLeft` rustdoc and guide tables now describe both faces (voluntary answer or authoritative exit); `DecodeFailed.raw_prefix` documents that it carries verbatim frame content; the WebSocket module doc scopes the Nagle/8 MiB defaults to dialed connections (`from_stream` preserves caller policy).
- Example sketches no longer fabricate a lobby ready-count denominator or silently `.ok()` away command refusals.

## Verification

- Mandatory workflow clean: fmt, clippy `-D warnings` (all targets/features), 1042 tests / 23 suites, zero failures.
- Both production fixes proven red against parent behavior, then green.
- Two hostile reviewers + a convergence verifier closed all findings (including a gate-regression the existing suite caught mid-review) to zero open items.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes spectator exit validation and room-operation fence release in shared core paths used by both drivers; behavior is pinned by new tests but affects membership and quarantine on server-initiated spectator teardown.
> 
> **Overview**
> Fixes **spectator lifecycle** handling so schema-valid authoritative `SpectatorLeft` messages no longer quarantine the client when `room_id` is omitted on the wire. **`client_core`** now only rejects authoritative exits when a **present** `room_id` does not match the current room; voluntary leaves still require the pending-operation fence. Docs and event/protocol rustdoc describe voluntary vs authoritative exits.
> 
> Fixes a latent **room-operation fence** bug after **`room_operation_ids`** negotiation: **`dequeue_serialization_failed`** (and async/polling/WebRTC test mocks) treat correlated **`RoomOperation`** envelopes like the legacy five commands so a dequeue-time serialization failure cannot leave **`RoomOperationPending`** wedged forever.
> 
> Documentation-only updates clarify transport send/receive contracts (replacement frames while a send is retained; Emscripten noop-waker), mesh **ICE** list replacement (empty `SessionPlan` clears pre-gather), **`DecodeFailed.raw_prefix`** sensitivity, WebSocket dial vs **`from_stream`** policy, and wasm/Godot examples that log command errors instead of swallowing them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6716c1df6917a82f68317fbd21677affdbca006a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->