### PR TITLE
Prepare release 0.11.0

### DIFF
--- a/.llm/context.md
+++ b/.llm/context.md
@@ -4,7 +4,7 @@
 
 - **Company:** Ambiguous Interactive
 - **Crates:** `signal-fish-client` (core) and `signal-fish-client-godot` (adapter)
-- **Version:** 0.10.0 lockstep across both crates
+- **Version:** 0.11.0 lockstep across both crates
 - **Edition:** 2021
 - **MSRV:** Rust 1.87.0 for core; Rust 1.94.0 for the Godot adapter
 - **License:** MIT

--- a/.llm/skills/crate-publishing/SKILL.md
+++ b/.llm/skills/crate-publishing/SKILL.md
@@ -38,10 +38,10 @@ The workspace owns the lockstep version and exact internal requirement:
 
 ```toml
 [workspace.package]
-version = "0.10.0"
+version = "0.11.0"
 
 [workspace.dependencies]
-signal-fish-client = { version = "=0.10.0", path = ".", default-features = false }
+signal-fish-client = { version = "=0.11.0", path = ".", default-features = false }
 ```
 
 The adapter inherits that version and dependency, uses Rust 1.94.0, and has its

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-08-28
+
+<!-- semver-checks: major -->
+
 ### Added
 
 - Added the 0.11 migration guide (`docs/migration-0.11.md`, linked from the
@@ -1188,7 +1192,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - After: `SignalFishError::ServerError { message, error_code }` where `error_code` is `Option<ErrorCode>`
   - Recommended handling: `match error_code { Some(code) => ..., None => ... }`
 
-[Unreleased]: https://github.com/Ambiguous-Interactive/signal-fish-client-rust/compare/v0.10.0...HEAD
+[Unreleased]: https://github.com/Ambiguous-Interactive/signal-fish-client-rust/compare/v0.11.0...HEAD
+[0.11.0]: https://github.com/Ambiguous-Interactive/signal-fish-client-rust/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/Ambiguous-Interactive/signal-fish-client-rust/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/Ambiguous-Interactive/signal-fish-client-rust/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/Ambiguous-Interactive/signal-fish-client-rust/compare/v0.6.0...v0.8.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -906,7 +906,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-fish-client"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "base64",
  "futures-util",
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "signal-fish-client-godot"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "godot",
  "signal-fish-client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,10 +169,10 @@ members = ["crates/signal-fish-client-godot", "tools/perf-lab"]
 resolver = "2"
 
 [workspace.package]
-version = "0.10.0"
+version = "0.11.0"
 
 [workspace.dependencies]
-signal-fish-client = { version = "=0.10.0", path = ".", default-features = false }
+signal-fish-client = { version = "=0.11.0", path = ".", default-features = false }
 
 # Release builds validate under the same arithmetic semantics as every debug
 # test, fuzz, and Miri run: integer overflow aborts loudly instead of wrapping

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Add the client and Tokio:
 
 ```toml
 [dependencies]
-signal-fish-client = "0.10.0"
+signal-fish-client = "0.11.0"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ```
 
@@ -77,9 +77,9 @@ cargo run --example basic_lobby
 Set `SIGNAL_FISH_URL` to use a server other than
 `ws://localhost:3536/v2/ws`.
 
-The published `0.10.0` crate is the stable release. This branch also documents
-unreleased changes ahead of the next release. Use the [0.10.0 API
-docs](https://docs.rs/signal-fish-client/0.10.0/) for the published surface, or
+The published `0.11.0` crate is the stable release. This branch also documents
+unreleased changes ahead of the next release. Use the [0.11.0 API
+docs](https://docs.rs/signal-fish-client/0.11.0/) for the published surface, or
 see the
 [changelog](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/blob/main/CHANGELOG.md)
 before depending on `main`.

--- a/docs/client.md
+++ b/docs/client.md
@@ -9,11 +9,11 @@ For WebAssembly environments without an async runtime,
 game-loop-driven alternative.
 
 !!! note "Published crate versus this guide"
-    The stable crates.io release is **0.10.0**. This guide tracks the current
+    The stable crates.io release is **0.11.0**. This guide tracks the current
     `main` branch, which may include additions that have not reached a release
     yet; the [changelog](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/blob/main/CHANGELOG.md)
     lists what is new. Use the
-    [0.10.0 API docs](https://docs.rs/signal-fish-client/0.10.0/) for the
+    [0.11.0 API docs](https://docs.rs/signal-fish-client/0.11.0/) for the
     published surface, or a `git` dependency on `main` for the unreleased APIs.
 
 ---
@@ -81,7 +81,7 @@ use signal_fish_client::{GameDataEncoding, SignalFishConfig};
 
 let config = SignalFishConfig {
     app_id: "mb_app_abc123".into(),
-    sdk_version: Some("0.10.0".into()),
+    sdk_version: Some("0.11.0".into()),
     platform: Some("rust".into()),
     game_data_format: Some(GameDataEncoding::Json),
     ..SignalFishConfig::new("mb_app_abc123")

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -23,19 +23,19 @@ The equivalent manifest entries are:
 
 ```toml
 [dependencies]
-signal-fish-client = "0.10.0"
+signal-fish-client = "0.11.0"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ```
 
 `signal-fish-client` enables its built-in WebSocket transport by default.
 
 !!! note "Published release and main"
-    **0.10.0** is the current crates.io release. This guide follows unreleased
+    **0.11.0** is the current crates.io release. This guide follows unreleased
     `main`, which may include breaking APIs that have not reached a release
     yet; the
     [changelog](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/blob/main/CHANGELOG.md)
-    says which release added them. Use the [0.10.0
-    docs.rs pages](https://docs.rs/signal-fish-client/0.10.0/) with the versioned
+    says which release added them. Use the [0.11.0
+    docs.rs pages](https://docs.rs/signal-fish-client/0.11.0/) with the versioned
     dependency above. To evaluate unreleased changes, use:
 
     ```toml

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,9 +20,9 @@ polling client that runs inside your game loop.
 [View on GitHub](https://github.com/Ambiguous-Interactive/signal-fish-client-rust){ .md-button .sf-home-action }
 
 !!! note "Release status"
-    **0.10.0** is the current crates.io release and supports Rust **1.87.0** or
-    newer. This site follows unreleased `main`; use the [0.10.0 API
-    docs](https://docs.rs/signal-fish-client/0.10.0/) for the published surface.
+    **0.11.0** is the current crates.io release and supports Rust **1.87.0** or
+    newer. This site follows unreleased `main`; use the [0.11.0 API
+    docs](https://docs.rs/signal-fish-client/0.11.0/) for the published surface.
 
 ## Get connected
 

--- a/docs/mesh-guide.md
+++ b/docs/mesh-guide.md
@@ -17,7 +17,7 @@ drive the whole handshake for you.
     The generation-bearing Server 0.7 APIs in this guide may not have reached
     the published crates.io release yet; the
     [changelog](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/blob/main/CHANGELOG.md)
-    says which release added them. The current release is 0.10.0.
+    says which release added them. The current release is 0.11.0.
 
 ---
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -702,7 +702,7 @@ Every message on the wire is a JSON object with two top-level keys:
         "type": "Authenticate",
         "data": {
             "app_id": "mb_app_abc123",
-            "sdk_version": "0.10.0"
+            "sdk_version": "0.11.0"
         }
     }
     ```

--- a/docs/wasm.md
+++ b/docs/wasm.md
@@ -134,7 +134,7 @@ signal-fish-client = { git = "https://github.com/Ambiguous-Interactive/signal-fi
 
 These snippets use `main` because the ownership, bounded-work, and admission
 guarantees documented below are listed under `Unreleased`. Use the published
-`0.10.0` dependency with its [versioned API docs](https://docs.rs/signal-fish-client/0.10.0/)
+`0.11.0` dependency with its [versioned API docs](https://docs.rs/signal-fish-client/0.11.0/)
 when you do not need those fixes yet.
 
 The adapter supports godot-rust 0.4.5 through 0.5.x and requires Rust 1.94 or

--- a/llms.txt
+++ b/llms.txt
@@ -10,7 +10,7 @@ the raw Emscripten transport is only for custom hosts
 that explicitly link Emscripten's WebSocket library.
 
 The GitHub Pages documentation tracks the unreleased `main` branch. Install
-`signal-fish-client = "0.10.0"` for the current crates.io release; use the
+`signal-fish-client = "0.11.0"` for the current crates.io release; use the
 repository git dependency when evaluating APIs and fixes listed under
 `Unreleased` until the next crate version is published.
 

--- a/tests/compatibility.toml
+++ b/tests/compatibility.toml
@@ -1,9 +1,9 @@
 # Canonical client/server protocol compatibility binding.
-client_version = "0.10.0"
+client_version = "0.11.0"
 server_version = "0.7.0"
 server_tag = "v0.7.0"
 server_commit = "3f7f43d4cd4b3cc7f8fb893220dc35c9b1fad333"
-synced = "2026-08-16"
+synced = "2026-08-28"
 
 [protocol_authority]
 commit = "5de9105e4c269a29919ae29880f5b67fc8d630c3"

--- a/tests/godot-compat-min/Cargo.lock
+++ b/tests/godot-compat-min/Cargo.lock
@@ -497,7 +497,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-fish-client"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "rmp",
  "rmp-serde",
@@ -512,7 +512,7 @@ dependencies = [
 
 [[package]]
 name = "signal-fish-client-godot"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "godot",
  "signal-fish-client",

--- a/tests/godot-web-smoke/Cargo.lock
+++ b/tests/godot-web-smoke/Cargo.lock
@@ -539,7 +539,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-fish-client"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "rmp",
  "rmp-serde",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "signal-fish-client-godot"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "godot",
  "signal-fish-client",


### PR DESCRIPTION
Mechanical release preparation generated by the **Prepare Release** workflow from a fully green `main` (`b504e68`).

- Bumps the single workspace version `0.10.0` → `0.11.0` (minor, breaking → major semver policy) and stamps every version reference in lockstep (manifests, all three lockfiles, docs, `llms.txt`, compatibility manifest sync dates).
- Cuts `[Unreleased]` into `## [0.11.0] - 2026-08-28` with its compare link.

The workflow validated this exact tree before pushing: release intent derivation, workspace/lockstep inventory, changelog cut, and the full mandatory verification (fmt, clippy `-D warnings`, all suites) pass on this commit.

Merge after every required check is green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and documentation metadata only; runtime behavior is unchanged in this diff and ships only after merge and the separate Release workflow.
> 
> **Overview**
> **Prepare Release** mechanical cut for **0.11.0**: the workspace lockstep version moves **0.10.0 → 0.11.0** for `signal-fish-client` and `signal-fish-client-godot`, with matching exact workspace dependency pins and updates across root and Godot fixture **Cargo.lock** files.
> 
> **CHANGELOG** promotes the former `[Unreleased]` notes into **`## [0.11.0] - 2026-08-28`** (marked **major** for semver policy) and refreshes compare links; **`[Unreleased]`** is left empty for the next cycle.
> 
> Consumer-facing references are stamped to **0.11.0** in **README**, site docs, **`llms.txt`**, agent publishing context, and **`tests/compatibility.toml`** (`client_version` plus **`synced`** **2026-08-28**). No `src/` or behavioral changes appear in this diff—the release bundles the breaking API/error-surface work already documented in the cut changelog (e.g. boxed transport errors, `InvalidConfig`, room auth gates, token binding, v3 room-operation IDs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a641fff46664de7772ba3e7b5e3b5c1e03e42c6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->