### PR TITLE
Close #186: spectator wire fixtures, deferred-send counts, close-path docs

### DIFF
--- a/.github/workflows/deep-safety.yml
+++ b/.github/workflows/deep-safety.yml
@@ -225,7 +225,11 @@ jobs:
           tool: cargo-mutants@26.2.0
 
       - name: Run mutation tests
-        run: cargo mutants --gitignore true --timeout 60 --no-shuffle -j 2 --file src/protocol.rs --file src/protocol/binary.rs --file src/terminal_drain.rs --file src/error_codes.rs --file src/error.rs
+        run: >-
+          cargo mutants --gitignore true --timeout 60 --no-shuffle -j 2
+          --file src/protocol.rs --file src/protocol/binary.rs
+          --file src/terminal_drain.rs --file src/error_codes.rs
+          --file src/error.rs
 
       - name: Upload mutation results
         if: always()

--- a/.github/workflows/deep-safety.yml
+++ b/.github/workflows/deep-safety.yml
@@ -225,7 +225,7 @@ jobs:
           tool: cargo-mutants@26.2.0
 
       - name: Run mutation tests
-        run: cargo mutants --gitignore true --timeout 60 --no-shuffle -j 2 --file src/protocol.rs --file src/error_codes.rs --file src/error.rs
+        run: cargo mutants --gitignore true --timeout 60 --no-shuffle -j 2 --file src/protocol.rs --file src/protocol/binary.rs --file src/terminal_drain.rs --file src/error_codes.rs --file src/error.rs
 
       - name: Upload mutation results
         if: always()

--- a/.llm/context.md
+++ b/.llm/context.md
@@ -73,7 +73,9 @@ the sole documented exception for the platform C API. Required WASM policy and
 terminal deletion failure intentionally leaks the small allocation instead of
 risking late-callback use-after-free. Change-scoped, scheduled, and manual
 Deep Safety runs Miri protocol tests, ThreadSanitizer, three raw-byte
-JSON/MessagePack fuzz targets, and focused mutation testing; required Clippy
+JSON/MessagePack fuzz targets plus the token-binding facade target, and
+focused mutation testing (protocol.rs, protocol/binary.rs,
+terminal_drain.rs, error_codes.rs, error.rs); required Clippy
 and WASM gates enforce compiler safety on every PR. Every member denies
 `unwrap_used` through `indexing_slicing`/`unreachable`, plus `arithmetic_side_effects`; the No
 Panics grep gate scans all members; release builds enable `overflow-checks` (debug-equivalent arithmetic).
@@ -105,7 +107,7 @@ Dependabot uses one root-workspace updater; minimum/latest Godot fixtures stay s
 | `src/webrtc.rs` | `WebRtcDriver` seam + `MeshController` (feature: `mesh`) |
 | `src/transports/websocket.rs` | WebSocket transport (feature: `transport-websocket`) |
 | `src/token_binding.rs` | Native WebSocket token-binding-v2 types, validation, canonicalization, and proof state (feature: `token-binding`) |
-| `crates/signal-fish-client-godot/src/lib.rs` | Godot 4.5 native/web `WebSocketPeer` adapter and its 39 fake-backend tests |
+| `crates/signal-fish-client-godot/src/lib.rs` | Godot 4.5 native/web `WebSocketPeer` adapter and its 43 fake-backend tests |
 
 ### Transport Trait
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The Godot adapter's `watermark_hits` and `backend_capacity_hits`
+  transport diagnostics now count each deferred send once, instead of once
+  per poll attempt that re-observed the same parked frame — so a frame held
+  across N polls no longer inflates the counters N-fold.
+- The `SignalFishClientApi` trait's diagnostic accessors (`send_capacity`,
+  `max_send_capacity`, `stats`, `snapshot`) are now `#[must_use]`, matching
+  the concrete drivers, so discarding them silently is a compile warning.
+
+### Fixed
+
+- The async driver's `transport_diagnostics()` sample now refreshes during
+  the post-send-failure terminal drain, as its per-receive-poll contract
+  documents, instead of freezing at the last pre-teardown value.
+
 ## [0.11.0] - 2026-08-28
 
 <!-- semver-checks: major -->

--- a/crates/signal-fish-client-godot/src/lib.rs
+++ b/crates/signal-fish-client-godot/src/lib.rs
@@ -629,7 +629,7 @@ impl GodotWebSocketTransport {
     /// Count one deferred send for the current caller frame. Repeated polls
     /// of the same parked frame re-enter `poll_send`, so the hit is recorded
     /// only on the first deferral of the episode and cleared when the frame
-    /// is accepted or leaves the slot.
+    /// is accepted, reported as a terminal send error, or leaves the slot.
     fn count_deferred_send(&mut self, select: impl FnOnce(&mut TransportDiagnostics) -> &mut u64) {
         if !self.deferred_counted {
             let counter = select(&mut self.diagnostics);
@@ -833,6 +833,9 @@ impl Transport for GodotWebSocketTransport {
                 Poll::Pending
             }
             BackendSendResult::Error(error) => {
+                // Terminal for the caller frame: close the deferral episode
+                // so the invariant does not depend on the teardown contract.
+                self.deferred_counted = false;
                 Poll::Ready(Err(SignalFishError::TransportSend(error.into())))
             }
         }
@@ -965,6 +968,9 @@ mod tests {
         configured_max_queued_packets: Rc<Cell<i32>>,
         connection_steps: Rc<RefCell<Vec<&'static str>>>,
         connect_error: Option<Error>,
+        /// Remaining `BackendSendResult::Capacity` refusals before sends are
+        /// accepted, for tests that must park a frame more than once.
+        capacity_refusals: usize,
     }
 
     impl FakeBackend {
@@ -989,6 +995,7 @@ mod tests {
                 configured_max_queued_packets: Rc::new(Cell::new(0)),
                 connection_steps: Rc::new(RefCell::new(Vec::new())),
                 connect_error: None,
+                capacity_refusals: 0,
             }
         }
     }
@@ -1041,6 +1048,10 @@ mod tests {
             if let Some(result) = self.send_result.take() {
                 return result;
             }
+            if self.capacity_refusals > 0 {
+                self.capacity_refusals = self.capacity_refusals.saturating_sub(1);
+                return BackendSendResult::Capacity;
+            }
             self.sent
                 .borrow_mut()
                 .push(TransportFrame::Text(text.to_string()));
@@ -1056,6 +1067,10 @@ mod tests {
         fn send_binary(&mut self, bytes: &[u8]) -> BackendSendResult {
             if let Some(result) = self.send_result.take() {
                 return result;
+            }
+            if self.capacity_refusals > 0 {
+                self.capacity_refusals = self.capacity_refusals.saturating_sub(1);
+                return BackendSendResult::Capacity;
             }
             self.sent
                 .borrow_mut()
@@ -1272,7 +1287,8 @@ mod tests {
     #[test]
     fn backend_capacity_result_park_counts_one_deferred_send_per_frame() {
         let mut backend = FakeBackend::new(PeerState::Open);
-        backend.send_result = Some(BackendSendResult::Capacity);
+        // The engine refuses the same frame twice before accepting it.
+        backend.capacity_refusals = 2;
         let mut transport = GodotWebSocketTransport::from_backend(Box::new(backend));
         let expected = TransportFrame::Text("retry me".to_string());
         let mut frame = Some(expected.clone());
@@ -1281,6 +1297,22 @@ mod tests {
             transport.poll_send(&mut context(), &mut frame),
             Poll::Pending
         ));
+        assert_eq!(transport.diagnostics().backend_capacity_hits, 1);
+
+        // The same frame refused again: still one deferred send.
+        assert!(matches!(
+            transport.poll_send(&mut context(), &mut frame),
+            Poll::Pending
+        ));
+        assert_eq!(frame, Some(expected.clone()));
+        assert_eq!(transport.diagnostics().backend_capacity_hits, 1);
+
+        // Refusal budget spent: the frame is accepted, episode closed.
+        assert!(matches!(
+            transport.poll_send(&mut context(), &mut frame),
+            Poll::Ready(Ok(()))
+        ));
+        assert!(frame.is_none());
         assert_eq!(transport.diagnostics().backend_capacity_hits, 1);
     }
 

--- a/crates/signal-fish-client-godot/src/lib.rs
+++ b/crates/signal-fish-client-godot/src/lib.rs
@@ -363,6 +363,10 @@ pub struct GodotWebSocketTransport {
     admission_watermark_violations: u64,
     one_frame_escape_frames: u64,
     one_frame_escape_bytes: u64,
+    /// The current caller frame's deferral is already counted, so polls that
+    /// re-observe the same parked state do not inflate the deferred-send
+    /// counters. Cleared when the frame is accepted (or the slot is empty).
+    deferred_counted: bool,
 }
 
 #[derive(Debug, Default)]
@@ -525,6 +529,7 @@ impl GodotWebSocketTransport {
             admission_watermark_violations: 0,
             one_frame_escape_frames: 0,
             one_frame_escape_bytes: 0,
+            deferred_counted: false,
         };
         transport.sample_cycle_at(Instant::now());
         transport
@@ -618,6 +623,18 @@ impl GodotWebSocketTransport {
                     .min(safe_native)
             }
             GodotBackpressurePolicy::NativeCapacity => safe_native,
+        }
+    }
+
+    /// Count one deferred send for the current caller frame. Repeated polls
+    /// of the same parked frame re-enter `poll_send`, so the hit is recorded
+    /// only on the first deferral of the episode and cleared when the frame
+    /// is accepted or leaves the slot.
+    fn count_deferred_send(&mut self, select: impl FnOnce(&mut TransportDiagnostics) -> &mut u64) {
+        if !self.deferred_counted {
+            let counter = select(&mut self.diagnostics);
+            *counter = counter.saturating_add(1);
+            self.deferred_counted = true;
         }
     }
 
@@ -738,6 +755,7 @@ impl Transport for GodotWebSocketTransport {
         }
 
         let Some(next_frame) = frame.as_ref() else {
+            self.deferred_counted = false;
             return Poll::Ready(Ok(()));
         };
         let next_bytes = match next_frame {
@@ -760,12 +778,11 @@ impl Transport for GodotWebSocketTransport {
         ) {
             AdmissionDecision::Admit => {}
             AdmissionDecision::NativeCapacity => {
-                self.diagnostics.backend_capacity_hits =
-                    self.diagnostics.backend_capacity_hits.saturating_add(1);
+                self.count_deferred_send(|diagnostics| &mut diagnostics.backend_capacity_hits);
                 return Poll::Pending;
             }
             AdmissionDecision::Watermark => {
-                self.diagnostics.watermark_hits = self.diagnostics.watermark_hits.saturating_add(1);
+                self.count_deferred_send(|diagnostics| &mut diagnostics.watermark_hits);
                 return Poll::Pending;
             }
         }
@@ -777,6 +794,7 @@ impl Transport for GodotWebSocketTransport {
         match result {
             BackendSendResult::Accepted => {
                 let _ = frame.take();
+                self.deferred_counted = false;
                 match accepted_admission_audit(current, next_bytes, watermark) {
                     AcceptedAdmissionAudit::WithinWatermark => {}
                     AcceptedAdmissionAudit::EmptyBufferEscape(bytes) => {
@@ -811,8 +829,7 @@ impl Transport for GodotWebSocketTransport {
                 Poll::Ready(Ok(()))
             }
             BackendSendResult::Capacity => {
-                self.diagnostics.backend_capacity_hits =
-                    self.diagnostics.backend_capacity_hits.saturating_add(1);
+                self.count_deferred_send(|diagnostics| &mut diagnostics.backend_capacity_hits);
                 Poll::Pending
             }
             BackendSendResult::Error(error) => {
@@ -1165,6 +1182,106 @@ mod tests {
         ));
         assert!(frame.is_none());
         assert_eq!(transport.diagnostics().accepted_frames, 1);
+    }
+
+    #[test]
+    fn watermark_park_across_repeated_polls_counts_one_deferred_send() {
+        let mut backend = FakeBackend::new(PeerState::Open);
+        backend.buffered = 32 * 1024 - 4;
+        // Two consecutive polls observe the same parked watermark state, then
+        // the buffer drains, the third poll admits the frame, and a fourth
+        // parks again for an independent send.
+        backend
+            .buffered_after_poll
+            .extend([32 * 1024 - 4, 32 * 1024 - 4, 0, 32 * 1024 - 7]);
+        let mut transport = GodotWebSocketTransport::from_backend(Box::new(backend));
+        let expected = TransportFrame::Binary(vec![9; 8]);
+        let mut frame = Some(expected.clone());
+
+        assert!(matches!(
+            transport.poll_send(&mut context(), &mut frame),
+            Poll::Pending
+        ));
+        assert_eq!(frame, Some(expected.clone()));
+        assert_eq!(transport.diagnostics().watermark_hits, 1);
+
+        // The same frame still parked: the deferral must not count again.
+        assert!(matches!(
+            transport.poll_send(&mut context(), &mut frame),
+            Poll::Pending
+        ));
+        assert_eq!(frame, Some(expected.clone()));
+        assert_eq!(transport.diagnostics().watermark_hits, 1);
+
+        // Once the frame is admitted, the episode ends.
+        assert!(matches!(
+            transport.poll_send(&mut context(), &mut frame),
+            Poll::Ready(Ok(()))
+        ));
+        assert!(frame.is_none());
+        assert_eq!(transport.diagnostics().watermark_hits, 1);
+
+        // A later, independent send counts as its own deferral (the accepted
+        // 8-byte frame left 8 buffered bytes; the sampled entry re-parks the
+        // buffer above the watermark for this 8-byte frame).
+        let mut second = Some(TransportFrame::Binary(vec![7; 8]));
+        assert!(matches!(
+            transport.poll_send(&mut context(), &mut second),
+            Poll::Pending
+        ));
+        assert_eq!(transport.diagnostics().watermark_hits, 2);
+    }
+
+    #[test]
+    fn native_capacity_park_across_repeated_polls_counts_one_deferred_send() {
+        let mut backend = FakeBackend::new(PeerState::Open);
+        backend.buffered = 8;
+        backend.capacity = 10;
+        backend.capacity_boundary = NativeCapacityBoundary::GreaterThan;
+        backend.buffered_after_poll.extend([8, 8, 0]);
+        let mut transport = GodotWebSocketTransport::from_backend_with_options(
+            Box::new(backend),
+            GodotWebSocketOptions {
+                backpressure_policy: GodotBackpressurePolicy::NativeCapacity,
+            },
+        );
+        let expected = TransportFrame::Text("abc".to_string());
+        let mut frame = Some(expected.clone());
+
+        assert!(matches!(
+            transport.poll_send(&mut context(), &mut frame),
+            Poll::Pending
+        ));
+        assert_eq!(transport.diagnostics().backend_capacity_hits, 1);
+
+        assert!(matches!(
+            transport.poll_send(&mut context(), &mut frame),
+            Poll::Pending
+        ));
+        assert_eq!(frame, Some(expected));
+        assert_eq!(transport.diagnostics().backend_capacity_hits, 1);
+
+        assert!(matches!(
+            transport.poll_send(&mut context(), &mut frame),
+            Poll::Ready(Ok(()))
+        ));
+        assert!(frame.is_none());
+        assert_eq!(transport.diagnostics().backend_capacity_hits, 1);
+    }
+
+    #[test]
+    fn backend_capacity_result_park_counts_one_deferred_send_per_frame() {
+        let mut backend = FakeBackend::new(PeerState::Open);
+        backend.send_result = Some(BackendSendResult::Capacity);
+        let mut transport = GodotWebSocketTransport::from_backend(Box::new(backend));
+        let expected = TransportFrame::Text("retry me".to_string());
+        let mut frame = Some(expected.clone());
+
+        assert!(matches!(
+            transport.poll_send(&mut context(), &mut frame),
+            Poll::Pending
+        ));
+        assert_eq!(transport.diagnostics().backend_capacity_hits, 1);
     }
 
     #[test]

--- a/scripts/check-no-panics.sh
+++ b/scripts/check-no-panics.sh
@@ -75,10 +75,10 @@ for dir in "${PROD_DIRS[@]}"; do
         #     content must start with optional whitespace and `//`.
         #   - Lines referencing the pattern inside a trailing comment. `//`
         #     only starts a comment at line start or after whitespace, so a
-        #     `//` inside a string literal (e.g. an "https://…" URL) is not
-        #     treated as one and cannot hide a real violation. The portable
-        #     BRE form also keeps the deny patterns (which use literal
-        #     parens) valid in basic grep.
+        #     colon-adjacent `//` (e.g. an "https://…" URL) is not treated as
+        #     one. Residual hole: whitespace inside a string literal can
+        #     still mask a violation later on the same line — clippy's deny
+        #     lints remain the authoritative backstop for that class.
         matches=$(grep -rn --include='*.rs' "$pattern" "$dir" \
             | grep -v '^[^:]*:[0-9]*:[[:space:]]*//' \
             | grep -v '[[:space:]]//.*'"$pattern" \

--- a/scripts/check-no-panics.sh
+++ b/scripts/check-no-panics.sh
@@ -69,11 +69,19 @@ for dir in "${PROD_DIRS[@]}"; do
 
     for pattern in "${PATTERNS[@]}"; do
         # Find violations, filtering out:
-        #   - Comment-only lines (// ...)
-        #   - Lines referencing the pattern inside comments
+        #   - Comment-only and doc-comment lines (`// …`, `/// …`). grep -rn
+        #     prefixes every hit with `path:line:`, so the filter is
+        #     prefix-aware: `^[^:]*:[0-9]*:` skips the location, then the
+        #     content must start with optional whitespace and `//`.
+        #   - Lines referencing the pattern inside a trailing comment. `//`
+        #     only starts a comment at line start or after whitespace, so a
+        #     `//` inside a string literal (e.g. an "https://…" URL) is not
+        #     treated as one and cannot hide a real violation. The portable
+        #     BRE form also keeps the deny patterns (which use literal
+        #     parens) valid in basic grep.
         matches=$(grep -rn --include='*.rs' "$pattern" "$dir" \
-            | grep -v '^[[:space:]]*//' \
-            | grep -v '//.*'"$pattern" \
+            | grep -v '^[^:]*:[0-9]*:[[:space:]]*//' \
+            | grep -v '[[:space:]]//.*'"$pattern" \
             || true)
 
         if [ -z "$matches" ]; then

--- a/src/client.rs
+++ b/src/client.rs
@@ -24,6 +24,15 @@
 //!   the transport gracefully under [`shutdown_timeout`](SignalFishConfig::shutdown_timeout),
 //!   and deliver the terminal `Disconnected` best-effort (a receiver that
 //!   outlives the loop also observes the event channel closing).
+//! - **Terminal inbound frames** are not guaranteed delivery once the loop is
+//!   tearing down, and the policy differs by trigger: after a terminal
+//!   outbound send failure the loop still processes the frames that are
+//!   already immediately ready from the backend (bounded by the standard
+//!   64-frame / 64 KiB driver work budget and the shared teardown budget),
+//!   while after a peer close or receive error no further inbound frames are
+//!   read at all. The polling driver discards ready inbound frames during
+//!   close instead of processing them — the same client-visible outcome
+//!   (late frames are not delivered) with different observable frame counts.
 //! - **Commands** go through a bounded queue and queue admission is never
 //!   silent: the synchronous send methods fail fast with
 //!   [`SignalFishError::SendBufferFull`] when it is full, and the
@@ -1574,7 +1583,9 @@ impl SignalFishClient {
     /// loop-cycle start and each pending-send or receive poll — so a watermark
     /// or capacity hit that parks an in-flight send is visible to this
     /// accessor while backpressure is still in flight, not only at the next
-    /// wakeup. This mirrors the polling driver's
+    /// wakeup. After the loop exits (terminal disconnect or shutdown), the
+    /// sample stops refreshing and this accessor keeps reporting the last
+    /// observed values. This mirrors the polling driver's
     /// [`transport_diagnostics`](crate::polling_client::SignalFishPollingClient::transport_diagnostics),
     /// which reads its caller-owned transport synchronously. Use these
     /// counters to tell command-queue congestion

--- a/src/client.rs
+++ b/src/client.rs
@@ -2201,6 +2201,12 @@ async fn finish_send_failure(
             ))
         })
         .await;
+        // Each drain step is a receive poll, so keep the sampled transport
+        // diagnostics current here too: backend-owned buffering (drained
+        // inbound frames) released during this terminal drain must be
+        // visible to `transport_diagnostics()` exactly as the per-poll
+        // refresh contract promises.
+        lock_core(state).record_transport_diagnostics(transport.diagnostics());
         let ReadyFrameDrainPoll::Frame {
             frame,
             budget_reached,

--- a/src/client_api.rs
+++ b/src/client_api.rs
@@ -78,12 +78,16 @@ pub trait SignalFishClientApi {
     /// Report data-path transport status.
     fn report_transport_status(&mut self, transport: TransportKind, connected: bool) -> Result<()>;
     /// Remaining command-queue capacity.
+    #[must_use = "this diagnostic view is discarded if not used"]
     fn send_capacity(&self) -> usize;
     /// Configured command-queue capacity.
+    #[must_use = "this diagnostic view is discarded if not used"]
     fn max_send_capacity(&self) -> usize;
     /// Cumulative traffic statistics.
+    #[must_use = "this diagnostic view is discarded if not used"]
     fn stats(&self) -> ClientStats;
     /// Coherent connection and room snapshot.
+    #[must_use = "this diagnostic view is discarded if not used"]
     fn snapshot(&self) -> ClientSnapshot;
 
     /// Server-confirmed local role in the current room.

--- a/src/polling_client.rs
+++ b/src/polling_client.rs
@@ -980,7 +980,8 @@ impl<T: Transport> SignalFishPollingClient<T> {
     /// While the close is in flight, inbound frames that are already buffered
     /// or immediately ready are drained and **discarded** — they are no
     /// longer decoded, processed, or delivered as events, and the drain
-    /// itself is bounded by the configured receive work budget. Frames that
+    /// itself is bounded by the configured receive work budget (a frame that
+    /// crosses the byte budget is still drained). Frames that
     /// arrive later stay unread in the backend. (The async driver instead
     /// processes immediately-ready frames through the core after a terminal
     /// send failure and reads none after a peer close, so the same

--- a/src/polling_client.rs
+++ b/src/polling_client.rs
@@ -963,6 +963,16 @@ impl<T: Transport> SignalFishPollingClient<T> {
     /// under the normal work budget before starting the transport close.
     /// [`SignalFishConfig::shutdown_timeout`] bounds the complete operation.
     ///
+    /// While the close is in flight, inbound frames that are already buffered
+    /// or immediately ready are drained and **discarded** — they are no
+    /// longer decoded, processed, or delivered as events, and the drain
+    /// itself is bounded by the configured receive work budget. Frames that
+    /// arrive later stay unread in the backend. (The async driver instead
+    /// processes immediately-ready frames through the core after a terminal
+    /// send failure and reads none after a peer close, so the same
+    /// client-visible outcome — late frames are not delivered — is reached
+    /// with different observable frame counts.)
+    ///
     /// Unlike the async driver's `shutdown()`, `close` emits **no** terminal
     /// `Disconnected` event and no application events at all: observe
     /// completion through [`snapshot`](Self::snapshot) instead of waiting on

--- a/src/polling_client.rs
+++ b/src/polling_client.rs
@@ -56,12 +56,24 @@ const DEFAULT_POLL_BYTES: usize = DEFAULT_DRIVER_WORK_BYTES;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PollingWorkBudget {
     /// Maximum outbound ownership transfers per poll.
+    ///
+    /// Zero values clamp up to one: a poll always makes progress, it never
+    /// refuses all work.
     pub send_frames: usize,
     /// Maximum outbound payload bytes begun per poll.
+    ///
+    /// Zero values clamp up to one: a poll always makes progress, it never
+    /// refuses all work.
     pub send_bytes: usize,
     /// Maximum inbound frames processed per poll.
+    ///
+    /// Zero values clamp up to one: a poll always makes progress, it never
+    /// refuses all work.
     pub receive_frames: usize,
     /// Maximum inbound payload bytes processed per poll.
+    ///
+    /// Zero values clamp up to one: a poll always makes progress, it never
+    /// refuses all work.
     pub receive_bytes: usize,
 }
 
@@ -113,9 +125,11 @@ pub struct PollingStats {
     pub current_queue_depth: u64,
     /// Highest observed client-owned outbound depth.
     pub peak_queue_depth: u64,
-    /// Polls that stopped because the send frame or byte budget was exhausted.
+    /// Driver cycles that stopped because the send frame or byte budget was
+    /// exhausted (caller polls and close-time flush steps).
     pub send_budget_exhaustions: u64,
-    /// Polls that stopped because the receive frame or byte budget was exhausted.
+    /// Driver cycles that stopped because the receive frame or byte budget
+    /// was exhausted (caller polls and close-time drain steps).
     pub receive_budget_exhaustions: u64,
     /// Commands abandoned by close policy or close-deadline expiry, plus
     /// dequeue-time serialization failures.

--- a/src/protocol/binary.rs
+++ b/src/protocol/binary.rs
@@ -416,4 +416,42 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn debug_impls_redact_payload_bytes_and_report_lengths() {
+        let from_player = PlayerId::from_u128(PLAYER_ID);
+        // 0xDE 0xAD 0xBE 0xEF never appears in a Debug string; only the
+        // payload length may be shown (ambient-log redaction contract).
+        let payload = vec![0xde, 0xad, 0xbe, 0xef];
+
+        let v3 = V3BinaryGameDataFrame {
+            from_player,
+            encoding: GameDataEncoding::Json,
+            payload: payload.clone(),
+            seq: 7,
+            epoch: 2,
+        };
+        let v3_debug = format!("{v3:?}");
+        assert!(
+            v3_debug.starts_with("V3BinaryGameDataFrame {"),
+            "{v3_debug}"
+        );
+        assert!(v3_debug.contains("payload_bytes: 4"), "{v3_debug}");
+        assert!(v3_debug.contains("seq: 7"), "{v3_debug}");
+        assert!(v3_debug.contains("epoch: 2"), "{v3_debug}");
+        assert!(!v3_debug.contains("222"), "{v3_debug}");
+
+        let v2 = V2BinaryGameDataFrame {
+            from_player,
+            encoding: GameDataEncoding::MessagePack,
+            payload,
+        };
+        let v2_debug = format!("{v2:?}");
+        assert!(
+            v2_debug.starts_with("V2BinaryGameDataFrame {"),
+            "{v2_debug}"
+        );
+        assert!(v2_debug.contains("payload_bytes: 4"), "{v2_debug}");
+        assert!(!v2_debug.contains("222"), "{v2_debug}");
+    }
 }

--- a/src/terminal_drain.rs
+++ b/src/terminal_drain.rs
@@ -111,7 +111,7 @@ pub(crate) fn peer_close_reason<T: Transport + ?Sized>(transport: &T) -> Option<
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, clippy::indexing_slicing)]
+#[allow(clippy::expect_used, clippy::indexing_slicing, clippy::panic)]
 mod tests {
     use super::*;
     use crate::transport::TransportCloseInfo;
@@ -274,7 +274,7 @@ mod tests {
         assert!(close_reason(&locally_closed).is_some());
         assert_eq!(peer_close_reason(&locally_closed), None);
 
-        let mut open = StubDrainTransport::with_frames(Vec::new());
+        let open = StubDrainTransport::with_frames(Vec::new());
         assert_eq!(close_reason(&open), None);
         assert_eq!(peer_close_reason(&open), None);
     }

--- a/src/terminal_drain.rs
+++ b/src/terminal_drain.rs
@@ -111,9 +111,11 @@ pub(crate) fn peer_close_reason<T: Transport + ?Sized>(transport: &T) -> Option<
 }
 
 #[cfg(test)]
+#[allow(clippy::expect_used, clippy::indexing_slicing)]
 mod tests {
     use super::*;
     use crate::transport::TransportCloseInfo;
+    use std::task::{Context, Poll};
 
     #[test]
     fn close_reason_labels_match_the_reported_initiator() {
@@ -142,5 +144,138 @@ mod tests {
         for (context, info, expected) in cases {
             assert_eq!(format_close_reason(info), expected, "{context}");
         }
+    }
+
+    #[test]
+    fn standard_driver_budget_is_the_documented_64_frames_64_kib() {
+        assert_eq!(DEFAULT_DRIVER_WORK_FRAMES, 64);
+        assert_eq!(DEFAULT_DRIVER_WORK_BYTES, 65_536);
+        let standard = ReadyFrameDrainBudget::standard();
+        assert_eq!(standard.frames, 64);
+        assert_eq!(standard.bytes, 65_536);
+        let custom = ReadyFrameDrainBudget::new(3, 9);
+        assert_eq!(custom.frames, 3);
+        assert_eq!(custom.bytes, 9);
+    }
+
+    /// Minimal transport: a scripted receive queue plus close metadata.
+    struct StubDrainTransport {
+        frames: std::vec::Vec<Option<Result<TransportFrame, SignalFishError>>>,
+        close: Option<TransportCloseInfo>,
+    }
+
+    impl StubDrainTransport {
+        fn with_frames(frames: Vec<TransportFrame>) -> Self {
+            Self {
+                frames: frames.into_iter().map(|frame| Some(Ok(frame))).collect(),
+                close: None,
+            }
+        }
+    }
+
+    impl Transport for StubDrainTransport {
+        fn poll_send(
+            &mut self,
+            _cx: &mut Context<'_>,
+            _frame: &mut Option<TransportFrame>,
+        ) -> Poll<Result<(), SignalFishError>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_recv(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Option<Result<TransportFrame, SignalFishError>>> {
+            Poll::Ready(self.frames.pop().flatten())
+        }
+
+        fn poll_close(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), SignalFishError>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn abort(&mut self) {}
+
+        fn close_info(&self) -> Option<TransportCloseInfo> {
+            self.close.clone()
+        }
+    }
+
+    fn noop_context() -> Context<'static> {
+        let waker = std::task::Waker::noop();
+        Context::from_waker(waker)
+    }
+
+    #[test]
+    fn frame_budget_flags_reached_on_the_exact_last_admitted_frame() {
+        let mut transport = StubDrainTransport::with_frames(vec![
+            TransportFrame::Text("1".into()),
+            TransportFrame::Text("2".into()),
+            TransportFrame::Text("3".into()),
+        ]);
+        let mut drain = ReadyFrameDrain::new(None, ReadyFrameDrainBudget::new(3, 1_000));
+        let mut cx = noop_context();
+        let mut drained = 0;
+        for expected_reached in [false, false, true] {
+            let budget_reached = match drain.poll_next(&mut transport, &mut cx, false) {
+                ReadyFrameDrainPoll::Frame { budget_reached, .. } => budget_reached,
+                ReadyFrameDrainPoll::Pending => panic!("transport unexpectedly pending"),
+                ReadyFrameDrainPoll::Closed => panic!("transport unexpectedly closed"),
+                ReadyFrameDrainPoll::ReceiveFailed(_) => panic!("unexpected receive failure"),
+                ReadyFrameDrainPoll::DeadlineReached => panic!("unexpected deadline"),
+            };
+            assert_eq!(budget_reached, expected_reached);
+            drained += 1;
+        }
+        assert_eq!(drained, 3);
+    }
+
+    #[test]
+    fn byte_budget_counts_exact_frame_payload_lengths() {
+        let mut transport = StubDrainTransport::with_frames(vec![
+            TransportFrame::Text("abcd".into()),
+            TransportFrame::Binary(vec![9, 9, 9, 9]),
+        ]);
+        // Byte budget 7: the 4-byte text frame stays under it, the second
+        // 4-byte frame crosses it (8 >= 7) and must be flagged.
+        let mut drain = ReadyFrameDrain::new(None, ReadyFrameDrainBudget::new(1_000, 7));
+        let mut cx = noop_context();
+        let first_reached = match drain.poll_next(&mut transport, &mut cx, false) {
+            ReadyFrameDrainPoll::Frame { budget_reached, .. } => budget_reached,
+            _ => panic!("expected the first frame"),
+        };
+        assert!(!first_reached, "4 bytes must stay under a 7-byte budget");
+        let second_reached = match drain.poll_next(&mut transport, &mut cx, false) {
+            ReadyFrameDrainPoll::Frame { budget_reached, .. } => budget_reached,
+            _ => panic!("expected the second frame"),
+        };
+        assert!(second_reached, "8 total bytes must cross the 7-byte budget");
+    }
+
+    #[test]
+    fn close_reason_and_peer_filter_read_transport_metadata() {
+        let peer_info = TransportCloseInfo {
+            code: Some(1000),
+            reason: Some("done".into()),
+            clean: Some(true),
+            initiated_by_peer: true,
+        };
+        let local_info = TransportCloseInfo {
+            initiated_by_peer: false,
+            ..peer_info.clone()
+        };
+
+        let mut peer_closed = StubDrainTransport::with_frames(Vec::new());
+        peer_closed.close = Some(peer_info);
+        assert!(close_reason(&peer_closed).is_some());
+        assert!(peer_close_reason(&peer_closed).is_some());
+
+        let mut locally_closed = StubDrainTransport::with_frames(Vec::new());
+        locally_closed.close = Some(local_info);
+        assert!(close_reason(&locally_closed).is_some());
+        assert_eq!(peer_close_reason(&locally_closed), None);
+
+        let mut open = StubDrainTransport::with_frames(Vec::new());
+        assert_eq!(close_reason(&open), None);
+        assert_eq!(peer_close_reason(&open), None);
     }
 }

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -71,8 +71,9 @@ impl std::fmt::Debug for TransportCloseInfo {
 /// Publishing is optional per backend: the built-in native WebSocket and
 /// Emscripten transports report the all-default view (zero buffered bytes and
 /// counters), while the Godot adapter populates every field. A zero
-/// `effective_watermark_bytes` always means "no watermark published", never
-/// "zero watermark".
+/// `effective_watermark_bytes` means "no watermark published" for backends
+/// that do not track one; the Godot adapter can also publish a genuine
+/// configured zero (a fixed 0-byte watermark is strict stop-and-wait).
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct TransportDiagnostics {
     /// Bytes currently buffered by the transport backend.
@@ -85,7 +86,9 @@ pub struct TransportDiagnostics {
     /// Always `0` for backends that do not publish diagnostics (the built-in
     /// native WebSocket and Emscripten transports).
     pub peak_buffered_bytes: u64,
-    /// Current admission watermark. `0` means the transport does not publish one.
+    /// Current admission watermark. Backends that publish no watermark report
+    /// `0`; so does a Godot adapter configured with a fixed 0-byte (strict
+    /// stop-and-wait) watermark.
     pub effective_watermark_bytes: u64,
     /// Frames accepted by the backend.
     pub accepted_frames: u64,
@@ -93,12 +96,14 @@ pub struct TransportDiagnostics {
     pub accepted_bytes: u64,
     /// Sends deferred by the configured admission watermark. One hit per
     /// deferred send: repeated polls that re-observe the same parked frame do
-    /// not count again, while a later independent send does.
+    /// not count again, while a later independent send does. A send deferred
+    /// by multiple mechanisms records only its first mechanism.
     pub watermark_hits: u64,
     /// Sends deferred because the backend reported or approached native
     /// capacity. One hit per deferred send: repeated polls that re-observe
     /// the same parked frame do not count again, while a later independent
-    /// send does.
+    /// send does. A send deferred by multiple mechanisms records only its
+    /// first mechanism.
     pub backend_capacity_hits: u64,
 }
 

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -79,9 +79,14 @@ pub struct TransportDiagnostics {
     pub accepted_frames: u64,
     /// Payload bytes accepted by the backend.
     pub accepted_bytes: u64,
-    /// Sends deferred by the configured admission watermark.
+    /// Sends deferred by the configured admission watermark. One hit per
+    /// deferred send: repeated polls that re-observe the same parked frame do
+    /// not count again, while a later independent send does.
     pub watermark_hits: u64,
-    /// Sends deferred because the backend reported or approached native capacity.
+    /// Sends deferred because the backend reported or approached native
+    /// capacity. One hit per deferred send: repeated polls that re-observe
+    /// the same parked frame do not count again, while a later independent
+    /// send does.
     pub backend_capacity_hits: u64,
 }
 

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -67,11 +67,23 @@ impl std::fmt::Debug for TransportCloseInfo {
 ///
 /// Counters are cumulative and saturating. Byte values describe backend-owned
 /// buffering, not the polling client's command queue or peer delivery.
+///
+/// Publishing is optional per backend: the built-in native WebSocket and
+/// Emscripten transports report the all-default view (zero buffered bytes and
+/// counters), while the Godot adapter populates every field. A zero
+/// `effective_watermark_bytes` always means "no watermark published", never
+/// "zero watermark".
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct TransportDiagnostics {
     /// Bytes currently buffered by the transport backend.
+    ///
+    /// Always `0` for backends that do not publish diagnostics (the built-in
+    /// native WebSocket and Emscripten transports).
     pub current_buffered_bytes: u64,
     /// Highest observed backend-buffered byte count.
+    ///
+    /// Always `0` for backends that do not publish diagnostics (the built-in
+    /// native WebSocket and Emscripten transports).
     pub peak_buffered_bytes: u64,
     /// Current admission watermark. `0` means the transport does not publish one.
     pub effective_watermark_bytes: u64,
@@ -202,6 +214,10 @@ pub trait Transport {
     }
 
     /// Return transport-owned buffering and admission diagnostics.
+    ///
+    /// The default returns the all-default view; backends that do not track
+    /// buffering (the built-in native WebSocket and Emscripten transports)
+    /// keep it. See [`TransportDiagnostics`] for field semantics.
     fn diagnostics(&self) -> TransportDiagnostics {
         TransportDiagnostics::default()
     }

--- a/tests/wire_golden_tests.rs
+++ b/tests/wire_golden_tests.rs
@@ -262,3 +262,34 @@ fn v3_signal_payload_is_externally_tagged_in_samples() {
     }
     assert!(found, "expected at least one Signal line in the v3 samples");
 }
+
+/// Hand-built spectator server-message wire fixtures.
+///
+/// The upstream server publishes no `SpectatorJoined`/`SpectatorLeft` (or
+/// related) sample lines, so the vendored `.jsonl` corpus is blind to the
+/// spectator lifecycle: a serde-shape drift there could never fail the golden
+/// conformance layer (round-20 finding F1 — a schema-optional `room_id`
+/// quarantining clients — is exactly the class this blindness allowed).
+///
+/// These fixtures are hand-built to the **vendored AsyncAPI authority**
+/// (`tests/server-spec/signal-fish-protocol.asyncapi.yaml`, checksum-pinned):
+/// `SpectatorJoined` oneOf branches (V2/V3/empty-room), `SpectatorJoinFailed`,
+/// `SpectatorLeft` (including the schema-optional `room_id` omission),
+/// `NewSpectatorJoined`, and `SpectatorDisconnected`. Every line must
+/// deserialize into `ServerMessage` and round-trip to a semantically
+/// identical JSON object, exactly like the complete v3 samples.
+#[test]
+fn spectator_server_wire_fixtures_conform() {
+    const SPECTATOR_SERVER_MESSAGES: &str = r#"
+{"type": "SpectatorJoined", "data": {"room_id": "11111111-1111-1111-1111-111111111111", "room_code": "ABC123", "spectator_id": "00000000-0000-0000-0000-0000000000c1", "game_name": "test_game", "current_players": [{"id": "00000000-0000-0000-0000-00000000000a", "name": "Alice", "is_authority": true, "is_ready": false, "connected_at": "2024-01-02T03:04:05Z", "epoch": 1, "seq": 42}], "current_spectators": [{"id": "00000000-0000-0000-0000-0000000000c1", "name": "Observer", "connected_at": "2024-01-02T03:06:07Z"}], "lobby_state": "waiting", "reason": "joined"}}
+{"type": "SpectatorJoined", "data": {"room_id": "11111111-1111-1111-1111-111111111111", "room_code": "ABC123", "spectator_id": "00000000-0000-0000-0000-0000000000c1", "game_name": "test_game", "current_players": [{"id": "00000000-0000-0000-0000-00000000000a", "name": "Alice", "is_authority": true, "is_ready": false, "connected_at": "2024-01-02T03:04:05Z"}], "current_spectators": [{"id": "00000000-0000-0000-0000-0000000000c1", "name": "Observer", "connected_at": "2024-01-02T03:06:07Z"}], "lobby_state": "lobby"}}
+{"type": "SpectatorJoined", "data": {"room_id": "11111111-1111-1111-1111-111111111111", "room_code": "ABC123", "spectator_id": "00000000-0000-0000-0000-0000000000c1", "game_name": "test_game", "current_players": [], "current_spectators": [{"id": "00000000-0000-0000-0000-0000000000c1", "name": "Observer", "connected_at": "2024-01-02T03:06:07Z"}], "lobby_state": "waiting", "reason": "joined"}}
+{"type": "SpectatorJoinFailed", "data": {"reason": "room is full", "error_code": "TOO_MANY_SPECTATORS"}}
+{"type": "SpectatorJoinFailed", "data": {"reason": "spectators are not allowed in this room"}}
+{"type": "SpectatorLeft", "data": {"room_id": "11111111-1111-1111-1111-111111111111", "room_code": "ABC123", "reason": "voluntary_leave", "current_spectators": [{"id": "00000000-0000-0000-0000-0000000000c2", "name": "Second", "connected_at": "2024-01-02T03:06:08Z"}]}}
+{"type": "SpectatorLeft", "data": {"reason": "removed", "current_spectators": []}}
+{"type": "NewSpectatorJoined", "data": {"spectator": {"id": "00000000-0000-0000-0000-0000000000c2", "name": "Second", "connected_at": "2024-01-02T03:06:08Z"}, "current_spectators": [{"id": "00000000-0000-0000-0000-0000000000c1", "name": "Observer", "connected_at": "2024-01-02T03:06:07Z"}, {"id": "00000000-0000-0000-0000-0000000000c2", "name": "Second", "connected_at": "2024-01-02T03:06:08Z"}], "reason": "joined"}}
+{"type": "SpectatorDisconnected", "data": {"spectator_id": "00000000-0000-0000-0000-0000000000c2", "reason": "disconnected", "current_spectators": [{"id": "00000000-0000-0000-0000-0000000000c1", "name": "Observer", "connected_at": "2024-01-02T03:06:07Z"}]}}
+"#;
+    assert_conformance::<ServerMessage>("spectator-server-fixtures", SPECTATOR_SERVER_MESSAGES);
+}


### PR DESCRIPTION
Closes #186.

Round 20 of the correctness audit left four low-severity follow-ups (issue #186), and the recurring audit (#126) continued with round 21 over three never-audited surfaces. This PR closes the follow-ups and lands round 21's fixes.

## Issue #186 follow-ups

- **Spectator wire fixtures.** The vendored server samples contain no spectator server messages, so wire drift in the spectator lifecycle could never fail the golden conformance tests (the blindness that caused round 20's one real bug). Added hand-built fixtures for all five spectator server messages — including the schema-optional `room_id`-omitted case — each round-trip-pinned against the vendored, checksummed protocol spec.
- **Deferred-send diagnostics.** The Godot adapter counted a watermark/capacity deferral once per poll attempt, so a frame parked across N polls inflated `watermark_hits`/`backend_capacity_hits` N-fold. Each deferred send now counts exactly once, with red/green pins for all three deferral mechanisms.
- **Close-path documentation.** Both drivers now document what happens to inbound frames during close (ready frames are drained and dropped, not delivered — with the drivers' different observable counts explained), and `transport_diagnostics()` documents that its sample freezes once the transport loop exits.

## Audit round 21

**Released-artifact integrity: zero findings.** The 0.11.0 release chain (tag → packaged bytes → crates.io → release assets → attestations → docs.rs → semver diff vs 0.10.0 → vendored protocol authorities) was verified end-to-end and is byte-faithful.

Fixes landed:

- **Mutation testing silently missed two modules.** The Deep Safety mutation lane's file list predated `src/protocol/binary.rs` (the MessagePack decoder) and `src/terminal_drain.rs`; both are now mutated.
- **The No-Panics grep gate could be evaded.** Its comment filter treated any `//` as a comment, so a real violation like `"https://…".unwrap()` on a line with a URL was silently dropped. The filter now anchors comments properly; verified red/green with a planted violation.
- **Async diagnostics froze during the terminal drain.** `transport_diagnostics()` now refreshes per drain poll, matching its documented per-receive-poll contract.
- **Doc accuracy:** work-budget zero-clamp behavior, budget-exhaustion counter wording, which built-in transports publish diagnostics, and `#[must_use]` on the `SignalFishClientApi` trait's diagnostic accessors (matching the concrete drivers).

## Verification

`cargo fmt`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, and `cargo test --workspace --all-features` clean (23/23 suites, zero failures); `check-no-panics.sh` and shell-portability suites green; two-round adversarial review converged to zero findings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly diagnostics, documentation, conformance tests, and CI gates; the async drain change only updates sampled diagnostics during an existing teardown path.
> 
> **Overview**
> Closes audit follow-ups (#186) and round-21 hardening: **spectator server wire** is now covered by hand-built golden fixtures (including schema-optional `room_id` omission) so lifecycle messages cannot drift unseen; **Godot transport diagnostics** count `watermark_hits` / `backend_capacity_hits` once per parked send, not once per re-poll.
> 
> The **async driver** refreshes `transport_diagnostics()` on each step of the post–send-failure ready-frame drain so buffering changes during teardown stay visible. **`SignalFishClientApi`** diagnostic getters are **`#[must_use]`** like the concrete clients.
> 
> **Docs and CI:** close/teardown inbound-frame behavior is spelled out for async vs polling (process vs discard ready frames, same “late frames not delivered” outcome); Deep Safety **mutation** now includes `protocol/binary.rs` and `terminal_drain.rs`; **No-Panics** grep skips real `//` comments without treating `https://` as a comment. Tests cover drain budgets, binary `Debug` redaction, and the deferral counting fixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07847a9b0ecbec28810ef6f1e0c012a4defdd5c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->