### PR TITLE
Round 22 audit: honest sparse CI cells and harness fidelity pins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,20 +77,32 @@ jobs:
       matrix:
         include:
           - name: default
+            scope: "--workspace"
             flags: ""
           - name: all-features
+            scope: "--workspace"
             flags: "--all-features"
+          # Sparse cells scope to the core package: `--workspace` would pull
+          # in the Godot adapter, whose dependency edge force-enables the
+          # core `polling-client` feature and silently unifies every isolated
+          # state the cell names.
           - name: token-binding-no-tls
+            scope: "-p signal-fish-client"
             flags: "--no-default-features --features token-binding"
           - name: no-default-features
+            scope: "-p signal-fish-client"
             flags: "--no-default-features"
           - name: polling-client-only
+            scope: "-p signal-fish-client"
             flags: "--no-default-features --features polling-client"
           - name: mesh-only
+            scope: "-p signal-fish-client"
             flags: "--no-default-features --features mesh"
           - name: tokio-runtime-only
+            scope: "-p signal-fish-client"
             flags: "--no-default-features --features tokio-runtime"
           - name: tls-only
+            scope: "-p signal-fish-client"
             flags: "--no-default-features --features tls"
     steps:
       - name: Checkout repository
@@ -102,7 +114,7 @@ jobs:
       - name: Cache Cargo artifacts
         uses: Swatinem/rust-cache@v2.9.2
       - name: Run Clippy
-        run: cargo clippy --workspace --all-targets ${{ matrix.flags }} -- -D warnings
+        run: cargo clippy ${{ matrix.scope }} --all-targets ${{ matrix.flags }} -- -D warnings
 
   # ──────────────────────────────────────────────────────────────
   # Tests — run across feature combinations
@@ -117,20 +129,32 @@ jobs:
       matrix:
         include:
           - name: default
+            scope: "--workspace"
             flags: ""
           - name: all-features
+            scope: "--workspace"
             flags: "--all-features"
+          # Sparse cells scope to the core package: `--workspace` would pull
+          # in the Godot adapter, whose dependency edge force-enables the
+          # core `polling-client` feature and silently unifies every isolated
+          # state the cell names.
           - name: token-binding-no-tls
+            scope: "-p signal-fish-client"
             flags: "--no-default-features --features token-binding"
           - name: no-default-features
+            scope: "-p signal-fish-client"
             flags: "--no-default-features"
           - name: polling-client-only
+            scope: "-p signal-fish-client"
             flags: "--no-default-features --features polling-client"
           - name: mesh-only
+            scope: "-p signal-fish-client"
             flags: "--no-default-features --features mesh"
           - name: tokio-runtime-only
+            scope: "-p signal-fish-client"
             flags: "--no-default-features --features tokio-runtime"
           - name: tls-only
+            scope: "-p signal-fish-client"
             flags: "--no-default-features --features tls"
     steps:
       - name: Checkout repository
@@ -140,7 +164,7 @@ jobs:
       - name: Cache Cargo artifacts
         uses: Swatinem/rust-cache@v2.9.2
       - name: Run tests
-        run: cargo test --workspace ${{ matrix.flags }}
+        run: cargo test ${{ matrix.scope }} ${{ matrix.flags }}
 
   # ──────────────────────────────────────────────────────────────
   # Pinned server compatibility E2E — generation-less 0.4, Server 0.7 mesh,

--- a/.llm/context.md
+++ b/.llm/context.md
@@ -348,7 +348,7 @@ an inherited workspace dependency, `default-features = false`, and
 `godot = ">=0.4.5, <0.6"` with no-thread WASM and lazy-function-table support.
 Its minimum 0.4.5 and latest 0.5.4 standalone fixtures must each lock exactly
 one `godot` and one version of every `godot-*` family crate.
-Tests additionally use full-featured `tokio` and `tracing-subscriber`.
+Core tests additionally use full-featured `tokio` and `tracing-subscriber` (the adapter suite has no dev-dependencies).
 
 ## Key Design Decisions
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -2863,9 +2863,10 @@ mod tests {
                         // Authoritative exits (removed, disconnected,
                         // room-closed) are server-initiated and must be
                         // deliverable without a matching client command;
-                        // only voluntary answers stay gated. Mirrors the
-                        // core's `spectator_exit_is_authoritative`. An
-                        // absent reason field stays gated (voluntary face).
+                        // the command-answer faces (absent reason,
+                        // `voluntary_leave`, `joined`) stay gated. Mirrors
+                        // the core's `spectator_exit_is_authoritative`
+                        // partition.
                         let reason = parsed
                             .get("data")
                             .and_then(|data| data.get("reason"))

--- a/src/client_core.rs
+++ b/src/client_core.rs
@@ -2599,6 +2599,10 @@ mod tests {
     }
 
     fn protocol_info(version: Option<u16>) -> ServerMessage {
+        // Server-sendable shapes only: a v2 connection's ProtocolInfo omits
+        // all five v3 fields including `protocol_version` itself (vendored
+        // AsyncAPI), so versions below 3 produce exactly the `None` shape.
+        let v3_fields = version.filter(|version| *version >= 3);
         ServerMessage::ProtocolInfo(ProtocolInfoPayload {
             platform: None,
             sdk_version: None,
@@ -2608,11 +2612,11 @@ mod tests {
             notes: None,
             game_data_formats: vec![GameDataEncoding::Json],
             player_name_rules: None,
-            protocol_version: version,
-            min_protocol_version: version.map(|_| 2),
-            max_protocol_version: version,
-            transports: version.map(|_| vec![MessageTransport::Websocket]),
-            max_outbound_message_size: version.map(|_| 8 * 1024 * 1024),
+            protocol_version: v3_fields,
+            min_protocol_version: v3_fields.map(|_| 2),
+            max_protocol_version: v3_fields,
+            transports: v3_fields.map(|_| vec![MessageTransport::Websocket]),
+            max_outbound_message_size: v3_fields.map(|_| 8 * 1024 * 1024),
         })
     }
 
@@ -5880,6 +5884,46 @@ mod tests {
             let mut relay = plan(Topology::Relay, TransportKind::Relay);
             relay.generation = Some(SessionGeneration::from_u128(5));
             let _ = process(&mut core, ServerMessage::SessionPlan(Box::new(relay)));
+
+            let outcome = process(
+                &mut core,
+                ServerMessage::Signal {
+                    from: PlayerId::from_u128(PEER),
+                    generation: Some(SessionGeneration::from_u128(GENERATION)),
+                    signal: serde_json::json!({"Offer": "late"}),
+                },
+            );
+            assert!(outcome.events.is_empty(), "{policy:?}");
+            assert!(!outcome.disconnect, "{policy:?}");
+            assert!(!core.snapshot().quarantined, "{policy:?}");
+        }
+    }
+
+    /// Same-generation WebRtc→relay replan: peers dropped by the replacement
+    /// hold no authority under the still-live generation, so their in-flight
+    /// same-generation signals must stay benign (retired at replacement,
+    /// which reads the pre-replacement transport), not lifecycle violations.
+    #[test]
+    fn same_generation_relay_replan_retires_dropped_webrtc_plan_peers() {
+        for policy in [
+            ProtocolViolationPolicy::Quarantine,
+            ProtocolViolationPolicy::Disconnect,
+            ProtocolViolationPolicy::Observe,
+        ] {
+            let mut core = v3_room(policy);
+            let _ = process(
+                &mut core,
+                ServerMessage::SessionPlan(Box::new(plan(Topology::Mesh, TransportKind::WebRtc))),
+            );
+            // The relay replacement keeps the current generation.
+            let _ = process(
+                &mut core,
+                ServerMessage::SessionPlan(Box::new(plan(Topology::Relay, TransportKind::Relay))),
+            );
+            assert_eq!(
+                core.snapshot().session_generation,
+                Some(SessionGeneration::from_u128(GENERATION))
+            );
 
             let outcome = process(
                 &mut core,

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -1976,6 +1976,54 @@ mod ci_workflow_policy {
         }
     }
 
+    /// The six sparse matrix rows must scope to the core package. With
+    /// `--workspace`, the Godot adapter member's dependency edge
+    /// force-enables the core `polling-client` feature, so the feature
+    /// unifier silently compiles a state different from the one every sparse
+    /// row name claims (round-22 audit). The pin is per-cell: each row's
+    /// `scope` must sit directly above its `flags`, so swapping scopes
+    /// between rows or dropping a `scope` key fails here.
+    #[test]
+    fn sparse_matrix_rows_scope_the_core_package() {
+        const CORE_SCOPE: &str = "-p signal-fish-client";
+        /// (flags, scope) for every matrix row, wide rows first.
+        const ROWS: [(&str, &str); 8] = [
+            ("", "--workspace"),
+            ("--all-features", "--workspace"),
+            ("--no-default-features --features token-binding", CORE_SCOPE),
+            ("--no-default-features", CORE_SCOPE),
+            (
+                "--no-default-features --features polling-client",
+                CORE_SCOPE,
+            ),
+            ("--no-default-features --features mesh", CORE_SCOPE),
+            ("--no-default-features --features tokio-runtime", CORE_SCOPE),
+            ("--no-default-features --features tls", CORE_SCOPE),
+        ];
+        let contents = ci_contents();
+        for job_name in ["clippy", "test"] {
+            let job = extract_job_block(&contents, job_name)
+                .unwrap_or_else(|| panic!("ci.yml must define the {job_name} job"));
+            for (flags, scope) in ROWS {
+                assert!(
+                    job.contains(&format!(
+                        "scope: \"{scope}\"\n            flags: \"{flags}\""
+                    )),
+                    "ci.yml {job_name} matrix row for flags \"{flags}\" must carry scope \"{scope}\""
+                );
+            }
+            let expected_run = if job_name == "clippy" {
+                "cargo clippy ${{ matrix.scope }} --all-targets ${{ matrix.flags }} -- -D warnings"
+            } else {
+                "cargo test ${{ matrix.scope }} ${{ matrix.flags }}"
+            };
+            assert!(
+                job.contains(expected_run),
+                "ci.yml {job_name} run line must honor the per-row scope: {expected_run}"
+            );
+        }
+    }
+
     #[test]
     fn semver_tool_supports_the_stable_rustdoc_format() {
         for path in [

--- a/tests/client_tests.rs
+++ b/tests/client_tests.rs
@@ -18,7 +18,8 @@ mod common;
 use std::collections::VecDeque;
 
 use signal_fish_client::protocol::{
-    ClientMessage, ConnectionInfo, GameDataEncoding, RelayTransport, ServerMessage, TransportKind,
+    ClientMessage, ConnectionInfo, GameDataEncoding, RelayTransport, ServerMessage,
+    SpectatorStateChangeReason, TransportKind,
 };
 use signal_fish_client::transport::TransportFrame;
 use signal_fish_client::{
@@ -37,8 +38,8 @@ use common::{
     authenticated_json, authority_response_json, error_json, finalized_reconnected_json,
     game_data_json, new_peer_json, peer_transport_status_json, player_left_json, pong_json,
     protocol_info_json, reconnected_json, room_joined_json, room_left_json, session_plan_json,
-    signal_json, spectator_joined_json, spectator_left_json, wait_for_sent_len, MockTransport,
-    RecordingCloseTransport,
+    signal_json, spectator_joined_json, spectator_left_json, spectator_left_json_with_reason,
+    wait_for_sent_len, MockTransport, RecordingCloseTransport,
 };
 use std::time::Duration;
 
@@ -498,6 +499,59 @@ async fn spectator_join_and_leave_flow() {
     assert!(client.current_room_code().await.is_none());
 
     client.shutdown().await;
+}
+
+/// Authoritative spectator exits (`removed` / `disconnected` / `room_closed`)
+/// are server-initiated: the shared mock must deliver them without any
+/// matching `LeaveSpectator` command. Before the round-22 gate alignment this
+/// deadlocked the shared mock (the frame stayed gated forever), while the
+/// async driver's own mock delivered them — the four harness gates disagreed.
+#[tokio::test]
+async fn authoritative_spectator_exit_is_delivered_without_a_voluntary_leave() {
+    for (label, reason) in [
+        ("removed", SpectatorStateChangeReason::Removed),
+        ("disconnected", SpectatorStateChangeReason::Disconnected),
+        ("room_closed", SpectatorStateChangeReason::RoomClosed),
+    ] {
+        let (mut client, mut events, sent, _closed) = start_client(vec![
+            Some(Ok(authenticated_json())),
+            Some(Ok(protocol_info_json(None))),
+            Some(Ok(spectator_joined_json())),
+            Some(Ok(spectator_left_json_with_reason(Some(reason)))),
+        ])
+        .await;
+
+        drain_until_authenticated(&mut events).await;
+        drain_until_protocol_info(&mut events).await;
+        let ev = events.recv().await.expect("event");
+        assert!(
+            matches!(ev, SignalFishEvent::SpectatorJoined { .. }),
+            "{label}: expected SpectatorJoined, got {ev:?}"
+        );
+
+        // No voluntary leave is issued: the authoritative exit must arrive on
+        // its own and clear the room-scoped state.
+        let ev = tokio::time::timeout(Duration::from_secs(2), events.recv())
+            .await
+            .unwrap_or_else(|_| panic!("{label}: authoritative SpectatorLeft was never delivered"))
+            .expect("event");
+        assert!(
+            matches!(ev, SignalFishEvent::SpectatorLeft { .. }),
+            "{label}: expected SpectatorLeft, got {ev:?}"
+        );
+        assert!(client.current_room_id().await.is_none());
+        assert!(
+            !sent
+                .lock()
+                .unwrap()
+                .iter()
+                .any(|m| serde_json::from_str::<ClientMessage>(m)
+                    .is_ok_and(|cm| matches!(cm, ClientMessage::LeaveSpectator))),
+            "{label}: no LeaveSpectator may be sent for an authoritative exit"
+        );
+
+        client.shutdown().await;
+    }
 }
 
 // ════════════════════════════════════════════════════════════════════

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -20,7 +20,7 @@ use signal_fish_client::protocol::SpectatorJoinedPayload;
 use signal_fish_client::protocol::{
     GameDataEncoding, LobbyState, PlayerId, PlayerInfo, ProtocolInfoPayload, RateLimitInfo,
     ReconnectedPayload, ReplayStatus, RoomJoinedPayload, SenderWatermark, ServerMessage,
-    SessionPeer, SessionPlanPayload, Topology, TransportKind,
+    SessionPeer, SessionPlanPayload, SpectatorStateChangeReason, Topology, TransportKind,
 };
 use signal_fish_client::transport::TransportFrame;
 use signal_fish_client::{ClientMessage, SignalFishError, Transport};
@@ -132,7 +132,21 @@ impl Transport for MockTransport {
                 ServerMessage::SpectatorJoined(_) | ServerMessage::SpectatorJoinFailed { .. } => {
                     Some(3)
                 }
-                ServerMessage::SpectatorLeft { .. } => Some(4),
+                // Authoritative exits (removed, disconnected, room-closed)
+                // are server-initiated and must be deliverable without a
+                // matching client command; the command-answer faces (absent
+                // reason, `voluntary_leave`, `joined`) stay gated. Mirrors
+                // the async driver's test mock and the core's
+                // `spectator_exit_is_authoritative` partition.
+                ServerMessage::SpectatorLeft {
+                    reason:
+                        None
+                        | Some(
+                            SpectatorStateChangeReason::VoluntaryLeave
+                            | SpectatorStateChangeReason::Joined,
+                        ),
+                    ..
+                } => Some(4),
                 _ => None,
             }
         });
@@ -290,10 +304,16 @@ pub fn spectator_joined_json() -> String {
 
 /// Returns the JSON string for a `SpectatorLeft` server message.
 pub fn spectator_left_json() -> String {
+    spectator_left_json_with_reason(None)
+}
+
+/// Returns the JSON string for a `SpectatorLeft` server message carrying the
+/// given state-change reason (`None` models the voluntary/absent-reason face).
+pub fn spectator_left_json_with_reason(reason: Option<SpectatorStateChangeReason>) -> String {
     serde_json::to_string(&ServerMessage::SpectatorLeft {
         room_id: Some(uuid::Uuid::from_u128(300)),
         room_code: Some("SPEC1".into()),
-        reason: None,
+        reason,
         current_spectators: vec![],
     })
     .expect("spectator_left_json serialization")
@@ -365,9 +385,13 @@ pub fn game_data_json(from_player: uuid::Uuid, data: serde_json::Value) -> Strin
 
 // ── Protocol v3 fixtures ────────────────────────────────────────────
 
-/// Builds a `ProtocolInfoPayload` with the given negotiated version (min 2 /
-/// max 3 when the version is set; all version fields omitted for `None`).
+/// Builds a `ProtocolInfoPayload` with the given negotiated version. Versions
+/// `>= 3` stamp all five v3 fields; versions below 3 — like `None` — produce
+/// the v2 shape with every v3 field (including `protocol_version` itself)
+/// omitted, matching the vendored AsyncAPI ("absent on negotiated v2
+/// connections") so every emitted shape is server-sendable.
 pub fn protocol_info_payload(protocol_version: Option<u16>) -> ProtocolInfoPayload {
+    let v3_fields = protocol_version.filter(|version| *version >= 3);
     ProtocolInfoPayload {
         platform: None,
         sdk_version: None,
@@ -377,12 +401,12 @@ pub fn protocol_info_payload(protocol_version: Option<u16>) -> ProtocolInfoPaylo
         notes: None,
         game_data_formats: vec![GameDataEncoding::Json, GameDataEncoding::MessagePack],
         player_name_rules: None,
-        protocol_version,
-        min_protocol_version: protocol_version.map(|_| 2),
-        max_protocol_version: protocol_version.map(|version| version.max(3)),
-        transports: protocol_version
+        protocol_version: v3_fields,
+        min_protocol_version: v3_fields.map(|_| 2),
+        max_protocol_version: v3_fields.map(|version| version.max(3)),
+        transports: v3_fields
             .map(|_| vec![signal_fish_client::protocol::MessageTransport::Websocket]),
-        max_outbound_message_size: protocol_version.map(|_| 8 * 1024 * 1024),
+        max_outbound_message_size: v3_fields.map(|_| 8 * 1024 * 1024),
     }
 }
 

--- a/tests/negotiation_robustness_tests.rs
+++ b/tests/negotiation_robustness_tests.rs
@@ -95,6 +95,12 @@ async fn drain_until_violation(rx: &mut tokio::sync::mpsc::Receiver<SignalFishEv
 
 /// Build a `Reconnected` JSON whose `missed_events` is an arbitrary list.
 fn reconnected_with_missed(missed: Vec<ServerMessage>) -> String {
+    reconnected_with(missed, ReplayStatus::Complete)
+}
+
+/// Build a `Reconnected` JSON with an arbitrary `missed_events` list and
+/// caller-chosen `replay` status.
+fn reconnected_with(missed: Vec<ServerMessage>, replay: ReplayStatus) -> String {
     let payload = ReconnectedPayload {
         room_id: uuid::Uuid::from_u128(100),
         room_code: "RECON1".into(),
@@ -122,7 +128,7 @@ fn reconnected_with_missed(missed: Vec<ServerMessage>) -> String {
         current_spectators: vec![],
         ice_servers: vec![],
         missed_events: missed,
-        replay: Some(ReplayStatus::Complete),
+        replay: Some(replay),
         sender_watermarks: [200, 9]
             .into_iter()
             .map(|id| SenderWatermark {
@@ -191,6 +197,57 @@ async fn reconnect_rejects_protocol_info_without_downgrading_active_v3() {
     );
     assert!(client.supports_mesh());
     client.shutdown().await;
+}
+
+/// The vendored AsyncAPI pins exactly three `ReplayStatus` wire tokens
+/// (`complete` / `truncated` / `unavailable`). Every value must decode and
+/// surface verbatim on the `Reconnected` event; previously only `complete`
+/// was ever exercised anywhere.
+#[tokio::test]
+async fn reconnected_replay_status_decodes_and_surfaces_every_wire_value() {
+    for (status, token) in [
+        (ReplayStatus::Complete, "complete"),
+        (ReplayStatus::Truncated, "truncated"),
+        (ReplayStatus::Unavailable, "unavailable"),
+    ] {
+        // Wire token, both directions.
+        assert_eq!(
+            serde_json::to_string(&status)
+                .expect("ReplayStatus always serializes")
+                .as_str(),
+            format!("\"{token}\""),
+            "serialize direction for {token}"
+        );
+        assert_eq!(
+            serde_json::from_str::<ReplayStatus>(&format!("\"{token}\"")).ok(),
+            Some(status),
+            "decode direction for {token}"
+        );
+
+        let (mut client, mut events, _sent, _closed) = start_client(vec![
+            Some(Ok(authenticated_json())),
+            Some(Ok(protocol_info_json(Some(3)))),
+            Some(Ok(reconnected_with(vec![], status))),
+        ]);
+        drain_until_authenticated(&mut events).await;
+        drain_until_protocol_info(&mut events).await;
+        client
+            .reconnect(
+                uuid::Uuid::from_u128(200),
+                uuid::Uuid::from_u128(100),
+                "submitted-token".into(),
+            )
+            .expect("authenticated reconnect must queue");
+        let event = tokio::time::timeout(std::time::Duration::from_secs(2), events.recv())
+            .await
+            .expect("timed out waiting for the Reconnected event")
+            .expect("event channel closed");
+        assert!(
+            matches!(&event, SignalFishEvent::Reconnected { replay: Some(replay), .. } if *replay == status),
+            "expected replay {status:?} ({token}), got {event:?}"
+        );
+        client.shutdown().await;
+    }
 }
 
 /// Multiple replayed negotiation messages are rejected as one invalid reconnect.


### PR DESCRIPTION
## Why

Issue #126's recurring paranoid-audit rounds exist because the bugs that slip through are the ones nobody thinks to look at. Round 22 pointed four independent adversarial agents at surfaces never audited before: the session-plan acceptance pipeline, the test-mock fidelity against the vendored server authority, manifest/CI-matrix truthfulness, and the async↔polling public-API parity matrix.

The session-plan pipeline and the public API came back **clean** (every candidate defect mechanically refuted). What the round did find were places where our safety nets were quietly lying to us — CI cells that didn't test what their names claim, a test harness gate that disagreed with its three siblings, and a wire value space two-thirds untested.

## What changed

1. **Sparse CI cells now test the states they name.** Every `--no-default-features` clippy/test cell ran `--workspace`, which pulls in the Godot adapter and silently force-enables the core's `polling-client` — so `mesh-only`, `tokio-runtime-only`, etc. never compiled their isolated states. Cells now run `-p signal-fish-client`; all six honest states were verified clean locally before the change, and a per-cell pin (fails on the old workflow, catches scope swaps) guards the property.
2. **The last harness gate aligned.** Round 20 made three test mocks deliver authoritative spectator exits without a matching client command; the shared `tests/common` gate was missed and would have deadlocked the first future test through it. Now byte-consistent with the others, with a red/green test covering all three authoritative reasons.
3. **All three `ReplayStatus` values pinned.** `truncated`/`unavailable` were never constructed, decoded, or asserted anywhere; a data-driven test now covers wire tokens (both directions) and event passthrough.
4. **Test helpers emit only server-sendable shapes.** The v2 branch of both `protocol_info` helpers included v3-only fields the vendored AsyncAPI says are absent on v2 connections — a laundering trap for future fixtures.
5. **context.md**: corrected a false claim that the Godot adapter's tests use dev-dependencies (it has none).

## Verification

- Mandatory workflow clean (fmt, clippy `-D warnings` all-features, 23/23 test suites).
- All six isolated core feature states: clippy + full test suites pass.
- Red/green proven for both behavioral pins (gate revert and workflow revert each fail their new test).
- Hostile review + convergence verifier closed all findings; zero production defects this round.
- Nothing user-visible (CI/test/harness work only) → no changelog entry per policy.

Refs: #126 (round 22). Follow-up filed: #190.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI configuration, test mocks/fixtures, and new tests; no production client protocol or API behavior is modified.
> 
> **Overview**
> **CI honesty for isolated feature builds:** Clippy and test matrix rows that claim `--no-default-features` / single-feature builds now run `cargo … -p signal-fish-client` instead of `--workspace`, so the Godot adapter no longer force-enables `polling-client` and falsifies those cells. A `ci_config_tests` guard pins each row’s `scope` next to its `flags` and the updated run lines.
> 
> **Test harness and fixture fidelity:** The shared `tests/common` mock (and the async driver’s in-crate mock) now gate `SpectatorLeft` like the core’s authoritative vs voluntary partition—authoritative `removed` / `disconnected` / `room_closed` exits deliver without a matching `LeaveSpectator`. New integration tests cover those paths. `protocol_info` test helpers omit all v3-only fields when negotiated version is below 3 (AsyncAPI v2 shape).
> 
> **Additional coverage:** `ReplayStatus` wire tokens (`complete` / `truncated` / `unavailable`) are exercised decode/serialize and on `Reconnected` events; a core unit test pins benign handling of same-generation WebRTC signals after a WebRtc→relay replan. `.llm/context.md` clarifies that only core tests use tokio/tracing-subscriber dev-deps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83233f48d3e5d9ff7a195523cd5d7bfd81a2cc05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->