### PR TITLE
audit!: live GoingAway + spectator E2E cells; harden v2 dialect and rate limits (#190)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,6 +212,12 @@ jobs:
           - server_version: "0.7.0"
             server_sha256: "70c6d12ac77843038c96d374a91225825c685cbf65fd7bedfd26b08d4003af7e"
             test_name: e2e_server_070_rejects_invalid_client_fingerprint_proofs
+          - server_version: "0.7.0"
+            server_sha256: "70c6d12ac77843038c96d374a91225825c685cbf65fd7bedfd26b08d4003af7e"
+            test_name: e2e_server_070_going_away_close_4000
+          - server_version: "0.7.0"
+            server_sha256: "70c6d12ac77843038c96d374a91225825c685cbf65fd7bedfd26b08d4003af7e"
+            test_name: e2e_server_070_spectator_live_smoke
           - server_version: "0.4.0"
             server_sha256: "971410b9503dd2f0c9f69c8a0a97e043e3979c79bf3d305e2ad03e21da8584e9"
             test_name: e2e_server_040_generationless_mesh_signal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Breaking:** `RateLimitInfo`'s `per_minute`, `per_hour`, and `per_day`
+  fields are now `u64` instead of `u32`. The protocol authority types these
+  limits as unbounded integers, and a value above `u32::MAX` previously
+  failed to decode the entire required `Authenticated` frame, silently
+  preventing authentication. Update any code that assigned these fields
+  with a literal or cast that assumed `u32`.
 - The Godot adapter's `watermark_hits` and `backend_capacity_hits`
   transport diagnostics now count each deferred send once, instead of once
   per poll attempt that re-observed the same parked frame — so a frame held
@@ -22,6 +28,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The async driver's `transport_diagnostics()` sample now refreshes during
   the post-send-failure terminal drain, as its per-receive-poll contract
   documents, instead of freezing at the last pre-teardown value.
+- A protocol-v2 `RoomJoined` that exposes protocol-v3-only metadata
+  (a `reconnection_token` or non-empty `ice_servers`) is now rejected as a
+  lifecycle violation under the violation policy, matching the existing
+  `Reconnected` guard; previously the token surfaced in `snapshot()`.
+- Corrected published documentation for `set_ready()`: the wire
+  `PlayerReady` message **toggles** readiness, so a repeated call un-readies
+  the player. Both drivers' docs, the client/getting-started/protocol
+  guides, and the lobby example now say to call it exactly once per room
+  membership.
 
 ## [0.11.0] - 2026-08-28
 

--- a/docs/client.md
+++ b/docs/client.md
@@ -235,7 +235,9 @@ The server will broadcast a player-left event to remaining room members.
 
 #### `set_ready`
 
-Signal readiness to start the game in the lobby.
+Signal readiness to start the game in the lobby. Each call **toggles**
+readiness, so call it once per room membership — a repeated call flips the
+player back to not-ready.
 
 ```rust,ignore
 fn set_ready(&mut self) -> Result<()>
@@ -861,7 +863,7 @@ configured capacity.
 |---|---|
 | `join_room(params: JoinRoomParams)` | Join or create a room. |
 | `leave_room()` | Leave the current room. |
-| `set_ready()` | Signal readiness in the lobby; this does not start the game. |
+| `set_ready()` | Signal readiness in the lobby; this does not start the game. Each call **toggles** readiness, so call it once per room membership. |
 | `start_game()` | Explicitly request game start after all players are ready. |
 | `send_game_data(data: serde_json::Value)` | Send protocol-reliable JSON game data. |
 | `send_game_data_with_delivery(data, delivery)` | Select a protocol-v3 JSON delivery class. |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -103,7 +103,8 @@ silently dropping events.
 
 Most games continue with these events and commands:
 
-1. On `RoomJoined`, call `set_ready()` when the local player is ready.
+1. On `RoomJoined`, call `set_ready()` once when the local player is ready
+   (the wire message toggles readiness, so a second call would un-ready you).
 2. Observe `LobbyStateChanged` and authority events.
 3. Call `start_game()` once the server's room rules allow it.
 4. Exchange JSON game data after `GameStarting`. Binary frames require

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -345,17 +345,17 @@ Rate-limit information returned after authentication.
 
 ```rust,ignore
 pub struct RateLimitInfo {
-    pub per_minute: u32,
-    pub per_hour: u32,
-    pub per_day: u32,
+    pub per_minute: u64,
+    pub per_hour: u64,
+    pub per_day: u64,
 }
 ```
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `per_minute` | `u32` | Maximum requests allowed per minute. |
-| `per_hour` | `u32` | Maximum requests allowed per hour. |
-| `per_day` | `u32` | Maximum requests allowed per day. |
+| `per_minute` | `u64` | Maximum requests allowed per minute. |
+| `per_hour` | `u64` | Maximum requests allowed per hour. |
+| `per_day` | `u64` | Maximum requests allowed per day. |
 
 ---
 
@@ -582,7 +582,7 @@ pub enum ClientMessage { /* ... */ }
 | `LeaveRoom` | Leave the current room. |
 | `GameData` | Send arbitrary JSON game data to other players. |
 | `AuthorityRequest` | Request to become (or yield) the room authority. |
-| `PlayerReady` | Signal readiness to start the game. |
+| `PlayerReady` | Toggle lobby readiness (call once per room membership). |
 | `ProvideConnectionInfo` | Provide your P2P connection info to peers. |
 | `Ping` | Heartbeat to keep the connection alive. |
 | `Reconnect` | Reconnect to a room after a disconnection. |

--- a/examples/basic_lobby.rs
+++ b/examples/basic_lobby.rs
@@ -113,7 +113,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         // readiness and one-shot start latch for the fresh room.
                         lobby_start.reset_for_room(room_supports_authority, locally_authority);
 
-                        // Mark ourselves as ready.
+                        // Mark ourselves as ready. `PlayerReady` toggles, and a
+                        // fresh RoomJoined starts unready, so one call per join
+                        // is correct — never retry it on later updates.
                         client.set_ready()?;
                         tracing::info!("Set ready");
                     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -1128,6 +1128,11 @@ impl SignalFishClient {
 
     /// Signal readiness to start the game in the lobby.
     ///
+    /// The wire `PlayerReady` message **toggles** readiness (per the protocol
+    /// authority), so call this exactly once per room membership: a repeated
+    /// call flips the player back to not-ready. A fresh `RoomJoined` starts
+    /// unready, so one call per join is correct.
+    ///
     /// # Errors
     ///
     /// Returns [`SignalFishError::NotInRoom`] outside a room,

--- a/src/client_api.rs
+++ b/src/client_api.rs
@@ -36,6 +36,9 @@ pub trait SignalFishClientApi {
     /// Send opaque binary game data.
     fn send_binary_game_data(&mut self, payload: Vec<u8>) -> Result<()>;
     /// Mark the local player ready.
+    ///
+    /// The wire `PlayerReady` message toggles readiness: call exactly once
+    /// per room membership, since a repeated call un-readies the player.
     fn set_ready(&mut self) -> Result<()>;
     /// Request the protocol-v2 game start.
     fn start_game(&mut self) -> Result<()>;

--- a/src/client_core.rs
+++ b/src/client_core.rs
@@ -1391,6 +1391,17 @@ impl ClientCore {
                     PendingRoomOperation::JoinPlayer,
                     "RoomJoined",
                 )?;
+                if self
+                    .snapshot
+                    .negotiated_protocol_version
+                    .is_none_or(|version| version < 3)
+                    && (payload.reconnection_token.is_some() || !payload.ice_servers.is_empty())
+                {
+                    return Err(
+                        "lifecycle violation: v2 RoomJoined exposed v3 token or ICE-server metadata"
+                            .into(),
+                    );
+                }
                 validate_local_player_snapshot(
                     payload.player_id,
                     payload.is_authority,
@@ -2720,6 +2731,9 @@ mod tests {
             player.epoch = None;
             player.seq = None;
         }
+        // The v2 dialect carries no v3-only room metadata.
+        payload.reconnection_token = None;
+        payload.ice_servers = Vec::new();
         ServerMessage::RoomJoined(payload)
     }
 
@@ -3187,7 +3201,7 @@ mod tests {
         let outcome = process(
             &mut legacy,
             ServerMessage::RoomJoined(roster_duplicate_room_joined_payload(room_joined_payload(
-                room_joined(),
+                room_joined_v2(),
             ))),
         );
         assert!(matches!(

--- a/src/polling_client.rs
+++ b/src/polling_client.rs
@@ -549,6 +549,11 @@ impl<T: Transport> SignalFishPollingClient<T> {
 
     /// Signal readiness to start the game.
     ///
+    /// The wire `PlayerReady` message **toggles** readiness (per the protocol
+    /// authority), so call this exactly once per room membership: a repeated
+    /// call flips the player back to not-ready. A fresh `RoomJoined` starts
+    /// unready, so one call per join is correct.
+    ///
     /// # Errors
     ///
     /// Returns [`SignalFishError::NotInRoom`],

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -403,11 +403,15 @@ pub struct PeerConnectionInfo {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RateLimitInfo {
     /// Requests allowed per minute.
-    pub per_minute: u32,
+    ///
+    /// The protocol authority leaves these limits unbounded integers, so they
+    /// are `u64`: a hostile or absurd `Authenticated` rate-limit value must
+    /// not be able to break authentication.
+    pub per_minute: u64,
     /// Requests allowed per hour.
-    pub per_hour: u32,
+    pub per_hour: u64,
     /// Requests allowed per day.
-    pub per_day: u32,
+    pub per_day: u64,
 }
 
 /// Describes negotiated protocol capabilities for a specific SDK.

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -1661,6 +1661,16 @@ mod ci_workflow_policy {
                 "e2e_server_070_rejects_invalid_client_fingerprint_proofs",
             ),
             (
+                "signal-fish-server-v0.7.0-x86_64-unknown-linux-gnu.tar.gz",
+                "0.7.0",
+                "e2e_server_070_going_away_close_4000",
+            ),
+            (
+                "signal-fish-server-v0.7.0-x86_64-unknown-linux-gnu.tar.gz",
+                "0.7.0",
+                "e2e_server_070_spectator_live_smoke",
+            ),
+            (
                 "signal-fish-server-v0.4.0-x86_64-unknown-linux-gnu.tar.gz",
                 "0.4.0",
                 "e2e_server_040_generationless_mesh_signal",

--- a/tests/polling_parity_tests.rs
+++ b/tests/polling_parity_tests.rs
@@ -32,11 +32,11 @@ use signal_fish_client::polling_client::{
 };
 use signal_fish_client::protocol::{
     ClientMessage, ConnectionInfo, DeliveryClass, DeliveryCountersByClass, DeliveryGap,
-    DeliveryGapReason, DeliveryReportPayload, GameDataEncoding, LatestDeliveryCounters, LobbyState,
-    PlayerId, PlayerInfo, ProtocolInfoPayload, ReconnectedPayload, ReliableDeliveryCounters,
-    ReplayStatus, RoomJoinedPayload, RoomOperationRequest, RoomOperationResult, SenderWatermark,
-    ServerMessage, SpectatorJoinedPayload, Topology, TransportKind, V2BinaryGameDataFrame,
-    V3BinaryGameDataFrame,
+    DeliveryGapReason, DeliveryReportPayload, GameDataEncoding, IceServer, LatestDeliveryCounters,
+    LobbyState, PlayerId, PlayerInfo, ProtocolInfoPayload, ReconnectedPayload,
+    ReliableDeliveryCounters, ReplayStatus, RoomJoinedPayload, RoomOperationRequest,
+    RoomOperationResult, SenderWatermark, ServerMessage, SpectatorJoinedPayload, Topology,
+    TransportKind, V2BinaryGameDataFrame, V3BinaryGameDataFrame,
 };
 use signal_fish_client::transport::TransportFrame;
 use signal_fish_client::{ClientStats, ErrorCode, ProtocolViolationPolicy, RoomRole};
@@ -2880,6 +2880,25 @@ fn finalized_v2_room_frame() -> TransportFrame {
     })))
 }
 
+/// A v2 room baseline that a nonconforming server decorated with v3-only
+/// fields (the schema's v2 branch forbids both).
+fn v2_room_frame_with_v3_metadata(
+    reconnection_token: Option<String>,
+    ice_servers: Vec<IceServer>,
+) -> TransportFrame {
+    let mut message = match finalized_v2_room_frame() {
+        TransportFrame::Text(message) => serde_json::from_str::<ServerMessage>(&message)
+            .expect("v2 room fixture must round-trip"),
+        TransportFrame::Binary(_) => unreachable!("room baseline must be text"),
+    };
+    let ServerMessage::RoomJoined(payload) = &mut message else {
+        unreachable!("v2 room fixture is a RoomJoined")
+    };
+    payload.reconnection_token = reconnection_token;
+    payload.ice_servers = ice_servers;
+    text_server_frame(message)
+}
+
 fn spectator_accountability_prefix(player_id: PlayerId) -> Vec<TransportFrame> {
     let spectator_joined = ServerMessage::SpectatorJoined(Box::new(SpectatorJoinedPayload {
         room_id: uuid::Uuid::from_u128(201),
@@ -3207,6 +3226,44 @@ async fn delayed_duplicate_exit_does_not_consume_rejoin_fence_in_either_driver()
 }
 
 #[tokio::test]
+async fn spectators_receive_lobby_and_game_starting_events() {
+    // Spectator membership passes the same lifecycle gate as players, so both
+    // lobby-machinery events must be delivered to a spectator on both drivers.
+    let frames = spectator_accountability_prefix(uuid::Uuid::from_u128(365))
+        .into_iter()
+        .chain([
+            text_server_frame(ServerMessage::LobbyStateChanged {
+                lobby_state: LobbyState::Lobby,
+                ready_players: vec![uuid::Uuid::from_u128(365)],
+                all_ready: false,
+            }),
+            text_server_frame(ServerMessage::GameStarting {
+                peer_connections: vec![],
+            }),
+        ])
+        .collect();
+    let events = assert_frame_trace_parity(frames, SignalFishConfig::new("app").enable_v3()).await;
+    assert!(
+        events
+            .iter()
+            .any(|event| event.starts_with("LobbyStateChanged|")),
+        "the spectator must receive LobbyStateChanged: {events:?}"
+    );
+    assert!(
+        events
+            .iter()
+            .any(|event| event.starts_with("GameStarting|")),
+        "the spectator must receive GameStarting: {events:?}"
+    );
+    assert!(
+        events
+            .iter()
+            .all(|event| !event.starts_with("ProtocolViolation")),
+        "spectator receipt of both events must not violate lifecycle: {events:?}"
+    );
+}
+
+#[tokio::test]
 async fn authoritative_spectator_exit_absorbs_overtaken_leave_with_driver_parity() {
     let mut frames = spectator_accountability_prefix(uuid::Uuid::from_u128(365));
     frames.push(text_server_frame(ServerMessage::SpectatorLeft {
@@ -3395,6 +3452,55 @@ async fn lifecycle_plan_and_signal_matrix_has_complete_driver_parity() {
             "PlayerLeft",
         ),
         (
+            "lobby-pre-room",
+            vec![
+                TransportFrame::Text(AUTH.into()),
+                TransportFrame::Text(PI_V3.into()),
+                text_server_frame(ServerMessage::LobbyStateChanged {
+                    lobby_state: LobbyState::Lobby,
+                    ready_players: vec![],
+                    all_ready: false,
+                }),
+            ],
+            "LobbyStateChanged",
+        ),
+        (
+            "game-starting-pre-room",
+            vec![
+                TransportFrame::Text(AUTH.into()),
+                TransportFrame::Text(PI_V3.into()),
+                text_server_frame(ServerMessage::GameStarting {
+                    peer_connections: vec![],
+                }),
+            ],
+            "GameStarting",
+        ),
+        (
+            "v2-room-token",
+            vec![
+                TransportFrame::Text(AUTH.into()),
+                TransportFrame::Text(PI_V2.into()),
+                v2_room_frame_with_v3_metadata(Some("v2-must-not-carry-tokens".into()), vec![]),
+            ],
+            "RoomJoined",
+        ),
+        (
+            "v2-room-ice-servers",
+            vec![
+                TransportFrame::Text(AUTH.into()),
+                TransportFrame::Text(PI_V2.into()),
+                v2_room_frame_with_v3_metadata(
+                    None,
+                    vec![IceServer {
+                        urls: vec!["stun:stun.l.google.com:19302".into()],
+                        username: None,
+                        credential: None,
+                    }],
+                ),
+            ],
+            "RoomJoined",
+        ),
+        (
             "delivery-report-pre-room",
             vec![
                 TransportFrame::Text(AUTH.into()),
@@ -3432,6 +3538,36 @@ async fn lifecycle_plan_and_signal_matrix_has_complete_driver_parity() {
                 .chain(std::iter::once(mixed_coalesced_unsupported_report(peer)))
                 .collect(),
             "DeliveryReport",
+        ),
+        (
+            "lobby-post-leave",
+            binary_accountability_prefix(peer)
+                .iter()
+                .cloned()
+                .chain(std::iter::once(text_server_frame(ServerMessage::RoomLeft)))
+                .chain(std::iter::once(text_server_frame(
+                    ServerMessage::LobbyStateChanged {
+                        lobby_state: LobbyState::Lobby,
+                        ready_players: vec![],
+                        all_ready: false,
+                    },
+                )))
+                .collect(),
+            "LobbyStateChanged",
+        ),
+        (
+            "game-starting-post-leave",
+            binary_accountability_prefix(peer)
+                .iter()
+                .cloned()
+                .chain(std::iter::once(text_server_frame(ServerMessage::RoomLeft)))
+                .chain(std::iter::once(text_server_frame(
+                    ServerMessage::GameStarting {
+                        peer_connections: vec![],
+                    },
+                )))
+                .collect(),
+            "GameStarting",
         ),
         (
             "noncanonical-plan",

--- a/tests/protocol_tests.rs
+++ b/tests/protocol_tests.rs
@@ -1628,6 +1628,40 @@ fn fixture_authenticated_from_server() {
 }
 
 #[test]
+fn fixture_authenticated_rate_limits_are_unbounded_integers() {
+    // The authority (AsyncAPI `RateLimitInfo`) types the limits as plain
+    // unbounded integers: a value above u32::MAX must decode instead of
+    // breaking the whole required `Authenticated` frame.
+    for (field, value) in [
+        ("per_minute", u32::MAX as u64 + 1),
+        ("per_hour", 5_000_000_000),
+        ("per_day", u64::MAX),
+    ] {
+        let limits = [
+            ("per_minute", if field == "per_minute" { value } else { 1 }),
+            ("per_hour", if field == "per_hour" { value } else { 2 }),
+            ("per_day", if field == "per_day" { value } else { 3 }),
+        ]
+        .map(|(name, limit)| format!(r#""{name}":{limit}"#))
+        .join(",");
+        let json = format!(
+            r#"{{"type":"Authenticated","data":{{"app_name":"app","rate_limits":{{{limits}}}}}}}"#
+        );
+        let ServerMessage::Authenticated { rate_limits, .. } =
+            serde_json::from_str(&json).expect("unbounded rate-limit integers must decode")
+        else {
+            panic!("expected Authenticated");
+        };
+        let decoded = match field {
+            "per_minute" => rate_limits.per_minute,
+            "per_hour" => rate_limits.per_hour,
+            _ => rate_limits.per_day,
+        };
+        assert_eq!(decoded, value, "{field} must round-trip {value}");
+    }
+}
+
+#[test]
 fn fixture_room_joined_from_server() {
     let room_id = uuid::Uuid::new_v4();
     let player_id = uuid::Uuid::new_v4();

--- a/tests/real_server_e2e.rs
+++ b/tests/real_server_e2e.rs
@@ -42,7 +42,7 @@ use signal_fish_client::SignalFishPollingClient;
 use signal_fish_client::TokenBindingFailure;
 use signal_fish_client::{
     ErrorCode, JoinRoomParams, SignalFishClient, SignalFishConfig, SignalFishError,
-    SignalFishEvent, WebSocketTransport,
+    SignalFishEvent, SpectatorStateChangeReason, WebSocketTransport,
 };
 #[cfg(all(feature = "tls", feature = "token-binding"))]
 use signal_fish_client::{TokenBindingMode, TokenBindingStatus, WebSocketConnectOptions};
@@ -365,6 +365,26 @@ impl Drop for ServerGuard {
     fn drop(&mut self) {
         let _ = self.child.kill();
         let _ = self.child.wait();
+    }
+}
+
+impl ServerGuard {
+    /// Deliver SIGTERM so the server starts its graceful shutdown drain:
+    /// v3 clients receive a `GoingAway` advisory and, after the configured
+    /// grace, the authoritative WebSocket close with semantic code 4000.
+    #[cfg(unix)]
+    fn terminate_gracefully(&self) {
+        let pid = self.child.id().to_string();
+        let status = Command::new("kill")
+            .args(["-TERM", &pid])
+            .status()
+            .expect("spawn kill to deliver SIGTERM to the server");
+        assert!(status.success(), "kill -TERM {pid} must succeed");
+    }
+
+    #[cfg(not(unix))]
+    fn terminate_gracefully(&self) {
+        panic!("the graceful SIGTERM drain cell requires a Unix host");
     }
 }
 
@@ -1739,5 +1759,238 @@ async fn e2e_sender_ping_survives_own_game_data_flood() {
         worst_rtt < Duration::from_secs(2),
         "sender-side Pong RTT should stay low during its own flood; got {worst_rtt:?}"
     );
+    a.shutdown().await;
+}
+
+fn unix_epoch_ms_now() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("wall clock must be after the Unix epoch")
+        .as_millis()
+        .try_into()
+        .expect("epoch milliseconds must fit u64")
+}
+
+/// The GoingAway → close-4000 pair (issue #190): a connected v3 client must
+/// observe the graceful-shutdown advisory with an honest deadline and retry
+/// hint, and then the authoritative coded close attributed to the server.
+/// The drain must be triggerable with a bounded grace, so this cell is
+/// spawn-mode only.
+#[tokio::test]
+#[ignore = "requires pinned Signal Fish Server 0.7; set SIGNAL_FISH_SERVER_BIN"]
+async fn e2e_server_070_going_away_close_4000() {
+    const GRACE_SECS: u64 = 2;
+    // The deadline must be honored within a scheduling-slack budget on top of
+    // the configured grace, not stretched by another full grace window.
+    const DEADLINE_SLACK_MS: u64 = 5_000;
+    let grace = GRACE_SECS.to_string();
+    let Some((guard, url)) =
+        spawn_server(&[("SIGNAL_FISH__SERVER__DRAIN_GRACE_SECS", &grace)]).await
+    else {
+        eprintln!("skipping: SIGNAL_FISH_SERVER_BIN not set");
+        return;
+    };
+
+    let (_client, mut events) =
+        connect_authenticated(&url, SignalFishConfig::new(app_id()).enable_v3()).await;
+
+    let signal_epoch_ms = unix_epoch_ms_now();
+    guard.terminate_gracefully();
+
+    // The advisory is best-effort but reaches an idle connection: a missing
+    // GoingAway before the close must fail this cell loudly.
+    let advisory = wait_for_event(&mut events, "GoingAway", Duration::from_secs(10), |e| {
+        matches!(e, SignalFishEvent::GoingAway { .. })
+    })
+    .await;
+    let SignalFishEvent::GoingAway {
+        deadline_ms,
+        retry_after_secs,
+    } = advisory
+    else {
+        unreachable!()
+    };
+    assert!(
+        deadline_ms >= signal_epoch_ms
+            && deadline_ms <= signal_epoch_ms + GRACE_SECS * 1_000 + DEADLINE_SLACK_MS,
+        "GoingAway deadline {deadline_ms} must be a near-future epoch-ms deadline \
+         issued at SIGTERM time ({signal_epoch_ms} + {GRACE_SECS}s grace)"
+    );
+    assert_eq!(
+        retry_after_secs,
+        Some(GRACE_SECS),
+        "server 0.7 derives the retry hint from the configured grace"
+    );
+
+    // The close frame is authoritative: the terminal event must carry the
+    // semantic drain code, attributed to the server (never a send failure).
+    let disconnected = wait_for_event(&mut events, "Disconnected", Duration::from_secs(10), |e| {
+        matches!(e, SignalFishEvent::Disconnected { .. })
+    })
+    .await;
+    let SignalFishEvent::Disconnected {
+        reason,
+        last_server_error,
+    } = disconnected
+    else {
+        unreachable!()
+    };
+    let reason = reason.expect("a coded server close must surface close metadata");
+    assert!(
+        reason.starts_with("closed by server:"),
+        "a drain close is peer-initiated; got {reason:?}"
+    );
+    assert!(
+        reason.contains("code=Some(4000)"),
+        "the drain must close with semantic code 4000; got {reason:?}"
+    );
+    assert!(
+        last_server_error.is_none(),
+        "a drain close carries no error farewell; got {last_server_error:?}"
+    );
+    println!("E5 DATA: GoingAway deadline_ms={deadline_ms} retry_after_secs={retry_after_secs:?}; close reason={reason:?}");
+}
+
+/// Spectator lifecycle live smoke (issue #190): join → observe → exit against
+/// the pinned Server 0.7, exercising the live baseline snapshot, the room
+/// broadcasts, and the voluntary-exit acknowledgment that round 20/22 covered
+/// only through vendored-spec fixtures.
+#[tokio::test]
+#[ignore = "requires Signal Fish Server 0.7; set SIGNAL_FISH_SERVER_BIN or SIGNAL_FISH_E2E_URL"]
+async fn e2e_server_070_spectator_live_smoke() {
+    let (_guard, url): (Option<ServerGuard>, String) = match external_url() {
+        Some(url) => (None, url),
+        None => match spawn_server(&[]).await {
+            Some((guard, url)) => (Some(guard), url),
+            None => {
+                eprintln!("skipping: neither SIGNAL_FISH_E2E_URL nor SIGNAL_FISH_SERVER_BIN set");
+                return;
+            }
+        },
+    };
+
+    // A player creates the room the spectator will watch.
+    let (mut a, mut a_events) = connect_authenticated(&url, SignalFishConfig::new(app_id())).await;
+    a.join_room(JoinRoomParams::new("e2e-spectator-smoke", "host"))
+        .expect("A join_room");
+    let joined = wait_for_event(&mut a_events, "A RoomJoined", Duration::from_secs(5), |e| {
+        matches!(e, SignalFishEvent::RoomJoined { .. })
+    })
+    .await;
+    let SignalFishEvent::RoomJoined {
+        room_id,
+        room_code,
+        player_id,
+        ..
+    } = joined
+    else {
+        unreachable!()
+    };
+
+    // The spectator joins by room code and observes the live player roster.
+    let (mut s, mut s_events) = connect_authenticated(&url, SignalFishConfig::new(app_id())).await;
+    s.join_as_spectator(
+        "e2e-spectator-smoke".to_string(),
+        room_code.clone(),
+        "watcher".to_string(),
+    )
+    .expect("S join_as_spectator");
+    let spectated = wait_for_event(
+        &mut s_events,
+        "S SpectatorJoined",
+        Duration::from_secs(5),
+        |e| matches!(e, SignalFishEvent::SpectatorJoined { .. }),
+    )
+    .await;
+    let SignalFishEvent::SpectatorJoined {
+        room_id: spectated_room_id,
+        room_code: spectated_room_code,
+        spectator_id,
+        current_players,
+        ..
+    } = spectated
+    else {
+        unreachable!()
+    };
+    assert_eq!(spectated_room_id, room_id, "the join must target A's room");
+    assert_eq!(
+        spectated_room_code, room_code,
+        "the join must echo the requested room code"
+    );
+    assert_ne!(spectator_id, player_id);
+    assert!(
+        current_players
+            .iter()
+            .any(|p| p.id == player_id && p.name == "host"),
+        "the spectator baseline must include the live player roster; got {current_players:?}"
+    );
+
+    // The room observes the spectator join.
+    let observed = wait_for_event(
+        &mut a_events,
+        "A NewSpectatorJoined",
+        Duration::from_secs(5),
+        |e| matches!(e, SignalFishEvent::NewSpectatorJoined { .. }),
+    )
+    .await;
+    let SignalFishEvent::NewSpectatorJoined { spectator, .. } = observed else {
+        unreachable!()
+    };
+    assert_eq!(spectator.id, spectator_id);
+
+    // Voluntary exit: the acknowledgment must name the room and drain the
+    // spectator roster; the room must observe the departure.
+    s.leave_spectator().expect("S leave_spectator");
+    let left = wait_for_event(
+        &mut s_events,
+        "S SpectatorLeft",
+        Duration::from_secs(5),
+        |e| matches!(e, SignalFishEvent::SpectatorLeft { .. }),
+    )
+    .await;
+    let SignalFishEvent::SpectatorLeft {
+        room_id: left_room_id,
+        room_code: left_room_code,
+        reason,
+        current_spectators,
+    } = left
+    else {
+        unreachable!()
+    };
+    assert_eq!(
+        left_room_id,
+        Some(room_id),
+        "server 0.7 names the room on a voluntary SpectatorLeft"
+    );
+    assert_eq!(left_room_code, Some(room_code.clone()));
+    assert_eq!(reason, Some(SpectatorStateChangeReason::VoluntaryLeave));
+    assert!(
+        !current_spectators
+            .iter()
+            .any(|spectator| spectator.id == spectator_id),
+        "the departing spectator must not be counted in the remaining roster"
+    );
+
+    let departed = wait_for_event(
+        &mut a_events,
+        "A SpectatorDisconnected",
+        Duration::from_secs(5),
+        |e| matches!(e, SignalFishEvent::SpectatorDisconnected { .. }),
+    )
+    .await;
+    let SignalFishEvent::SpectatorDisconnected {
+        spectator_id: departed_id,
+        reason: departed_reason,
+        ..
+    } = departed
+    else {
+        unreachable!()
+    };
+    assert_eq!(departed_id, spectator_id);
+    assert_eq!(
+        departed_reason,
+        Some(SpectatorStateChangeReason::VoluntaryLeave)
+    );
+    s.shutdown().await;
     a.shutdown().await;
 }


### PR DESCRIPTION
## Why

Issue #190: round 22 found two server behaviors exercised only through vendored-spec fixtures — the `GoingAway` → close-4000 shutdown pair and the spectator lifecycle. If the server ever drifts on either, nothing live would catch it. This PR pins both against the real pinned Server 0.7.0 in the fail-closed compatibility matrix, and folds in the round-23 paranoid-audit findings (issue #126).

## What

- **Two live E2E cells** (pinned matrix, both fail loudly if removed):
  - `e2e_server_070_going_away_close_4000` — SIGTERM drain with a short configured grace; asserts the `GoingAway` advisory carries an honest deadline and retry hint, then the disconnect reports `closed by server: code=Some(4000)`.
  - `e2e_server_070_spectator_live_smoke` — player joins, spectator joins by room code and observes the live roster, room sees both broadcasts, exit acknowledges `VoluntaryLeave` with room identity.
- **Round-23 fixes:**
  - `RateLimitInfo` limits widened `u32` → `u64` (**breaking**). The protocol authority types them as unbounded integers; a value above `u32::MAX` in the required `Authenticated` frame previously failed authentication silently.
  - A v2 `RoomJoined` exposing v3-only `reconnection_token` / `ice_servers` is now a lifecycle violation — mirrors the existing `Reconnected` guard.
  - Documented that `set_ready()` **toggles** readiness (per the authority): a repeated call un-readies the player. Both drivers, trait, guides, and the lobby example.
- **New pins:** six driver-parity matrix cells (lobby/game-starting pre-room and post-leave, v2-dialect token/ICE) and a spectator-receipt test.

Rejected after hostile review: lenient decoding of unknown `error_code` tokens — the strict fail-loud behavior is deliberate, pinned design.

## Verification

- fmt / clippy `-D warnings` / full test suite green locally; all 28 perf-lab cells reproduce their ledgers.
- Both new cells verified against the real pinned Server 0.7.0 (red-checked: mutated assertions fail on the real wire data); the full 14-test E2E suite passes against the pinned 0.7.0 and 0.4.0 artifacts.
- CHANGELOG updated under `[Unreleased]` (one Breaking, two Fixed).

Closes #190.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking public type change on `RateLimitInfo` and stricter v2 `RoomJoined` validation affect authentication decoding and room join handling on misbehaving servers.
> 
> **Overview**
> Pins **two live Server 0.7 E2E cells** in CI (`GoingAway` → close **4000** after SIGTERM drain, and **spectator join/observe/voluntary leave** smoke) so fixture-only coverage cannot drift unnoticed.
> 
> **Breaking:** `RateLimitInfo` limit fields move from **`u32` to `u64`** so oversized `Authenticated` rate limits decode instead of failing authentication silently.
> 
> **Protocol hardening:** On negotiated **v2**, a `RoomJoined` that carries **`reconnection_token` or non-empty `ice_servers`** is now a **lifecycle violation** (aligned with the existing `Reconnected` guard).
> 
> **Documentation:** `set_ready()` / wire **`PlayerReady`** are documented as **toggle** readiness — call **once per room membership**.
> 
> Adds driver-parity matrix cases (lobby/game-starting timing, v2 token/ICE misuse) plus protocol decode tests for unbounded rate-limit integers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e407dac16abb849316b0b441f532418f061ebec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->