### PR TITLE
audit!: concise changelog entries and client-API parity fixes

### DIFF
--- a/.llm/skills/changelog-discipline/SKILL.md
+++ b/.llm/skills/changelog-discipline/SKILL.md
@@ -45,6 +45,21 @@ Before finalizing a user-visible change:
    `Removed`, `Fixed`, `Security`).
 4. Use concrete, consumer-facing wording (what changed and impact).
 
+## Entry Style (issue #197)
+
+Entries exist for consumers scanning release notes. Keep each one short,
+simple, and consumer-facing:
+
+- One sentence per entry; use a second sentence only when a breaking change
+  needs a migration hint.
+- Lead with what the consumer experiences. Omit internal mechanics (module
+  paths, fix history, server commit pins, test names) unless they change
+  how the consumer uses the crate.
+- Fold related fixes of the same class into one entry instead of listing
+  each instance.
+- Never edit released sections: the release cut syncs them into published
+  release notes. Fix wording only in `## [Unreleased]`.
+
 ## Section Classification Rules
 
 - New public API surface area belongs under `### Added`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,118 +7,63 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Breaking:** the exhaustive `SignalFishError` enum gains
+  `PayloadTooDeep { max_depth }`; add an arm to exhaustive matches.
+- **Breaking:** the `SignalFishClientApi` trait gains `transport_diagnostics`;
+  implementors must add the method (consumers of either driver are
+  unaffected).
+- Added root re-exports for `ProtocolInfoPayload`, `PlayerNameRulesPayload`,
+  and `MeshWaker` (the latter requires the `mesh` and `tokio-runtime`
+  features).
+
 ### Changed
 
 - **Breaking:** `RateLimitInfo`'s `per_minute`, `per_hour`, and `per_day`
-  fields are now `u64` instead of `u32`. The protocol authority types these
-  limits as unbounded integers, and a value above `u32::MAX` previously
-  failed to decode the entire required `Authenticated` frame, silently
-  preventing authentication. Update any code that assigned these fields
-  with a literal or cast that assumed `u32`.
-- **Breaking:** the exhaustive `SignalFishError` enum gains
-  `PayloadTooDeep { max_depth: usize }`, so exhaustive matches must add an
-  arm. Caller-supplied JSON payloads nested deeper than 128 containers are
-  now refused at the call site (see the Fixed entry below).
+  are now `u64` instead of `u32`; a server reporting a limit above
+  `u32::MAX` no longer fails authentication. Update literals/casts that
+  assumed `u32`.
 - The Godot adapter's `watermark_hits` and `backend_capacity_hits`
-  transport diagnostics now count each deferred send once, instead of once
-  per poll attempt that re-observed the same parked frame — so a frame held
-  across N polls no longer inflates the counters N-fold.
-- The `SignalFishClientApi` trait's diagnostic accessors (`send_capacity`,
-  `max_send_capacity`, `stats`, `snapshot`) are now `#[must_use]`, matching
-  the concrete drivers, so discarding them silently is a compile warning.
-- Documented the panic boundary between the SDK and custom transports: a
-  `Transport` method that panics (a contract violation — only `abort`
-  promises never to panic) now has explicit, pinned semantics. On the async
-  driver the loop task dies: the event channel closes without a
-  `Disconnected` event, queued and parked reliable sends resolve with
-  `NotConnected`, the transport's `abort` still runs, and the snapshot keeps
-  its last pre-death values until a later `shutdown()` reconciles them. On
-  the polling driver the panic propagates into the caller's thread, and
-  `close()` heals — through the close-deadline `abort` only if the violating
-  method keeps panicking.
-- Documented that a room creator joining with `supports_authority` already
-  holds authority (the server auto-assigns it), so an immediate
-  `request_authority(true)` is denied with `AuthorityConflict` — relinquish
-  first to hand authority to another player.
+  diagnostics now count each deferred send once instead of once per poll.
+- The object-safe client trait's diagnostic accessors (`send_capacity`,
+  `max_send_capacity`, `stats`, `snapshot`) are now `#[must_use]`.
+- Documented custom-transport panic semantics: a panicking `Transport`
+  method kills the async loop (event channel closes without `Disconnected`,
+  parked reliable sends resolve `NotConnected`) and propagates into the
+  caller on the polling driver, where `close()` heals.
+- Documented that a room creator already holds authority, so an immediate
+  `request_authority(true)` is refused with `AuthorityConflict`.
 
 ### Fixed
 
-- Deeply nested caller-supplied JSON payloads — game data, raw WebRTC
-  signals (`send_raw_signal`), and custom connection info — whose container
-  nesting exceeds 128 levels are now refused at the call site with the new
-  `SignalFishError::PayloadTooDeep` error. Such a payload was previously
-  serialized recursively on a driver thread, where a sufficiently deep
-  value aborts the whole process with a stack overflow — after the send
-  call had already reported success (the async driver serializes on a
-  tokio worker thread the application does not own). The bound matches
-  `serde_json`'s own deserialization recursion limit, so every payload the
-  client could receive is also sendable; flatten deeply nested payloads or
-  send binary game data.
-- `MeshSession` now ignores `NewPeer` directives while the selected
-  transport is not WebRTC — before any plan, and on relay plans. The
-  protocol authority scopes `NewPeer` to WebRTC peer directives, so a
-  nonconformant or racing server can no longer make the session view list
-  a peer that will never be connected; matching `PeerTransportStatus`, the
-  directive is applied normally once a WebRTC plan is selected.
-- A `ProtocolInfo` advertisement whose `max_outbound_message_size` falls
-  outside the vendored authority bounds (1..=67108864) is now a lifecycle
-  violation instead of being mirrored unbound into
-  `ClientSnapshot::server_max_outbound_message_size`, and a v2-shaped
-  advertisement carrying the v3-only size field is rejected like the other
-  v2/v3 dialect crossings.
-- The Emscripten WebSocket transport no longer acknowledges sends on a
-  connection the browser has already closed. The browser's `send()` on a
-  closing/closed WebSocket silently discards the data while the JS shim
-  reports success, so a full polling tick's queued commands could be lost
-  and counted as delivered; each send now checks the live
-  `WebSocket.readyState` and fails terminally instead, leaving the frame
-  to the driver's teardown.
-- The Emscripten WebSocket transport now fuses the connection with a
-  terminal receive error when a text frame's payload is not valid UTF-8.
-  Such frames were previously dropped silently, contradicting the
-  transport contract and diverging from the native and Godot transports,
-  which surface corruption instead of omitting frames.
-- The Emscripten WebSocket transport now preserves structured close
-  metadata when the browser queues `onclose` behind `onerror` (the common
-  failed-handshake shape): `close_info()` reports the close code, reason,
-  and cleanliness instead of staying empty.
-- WebSocket connect URLs whose scheme is not exactly lowercase `ws://` or
-  `wss://` (for example `http://`, `WS://`) are now rejected with
-  `InvalidConfig` before any network I/O. Previously the classification
-  depended on network reachability — an uppercase or foreign scheme with an
-  explicit port dialed first and could report either `InvalidConfig` (on a
-  reachable endpoint) or `Io` (on a closed one) — contradicting the
-  documented value-determined error contract.
-- The Godot adapter now selects Godot's web capacity boundary (refusal at
-  or above the outbound buffer size) for every wasm target family member,
-  not just `wasm32-unknown-emscripten`, so `wasm32-unknown-unknown` web
-  builds classify an exactly-buffer-sized frame correctly instead of
-  admitting it for the engine to refuse.
-- Corrected the Godot adapter's inbound-limit documentation: at Godot's
-  inbound bounds, the web backend silently drops newly arriving frames
-  while the native backend stops reading and backpressures (delivery
-  stalls until the application drains queued packets). Previously both
-  platforms were described as silently dropping.
-- The async driver's `transport_diagnostics()` sample now refreshes during
-  the post-send-failure terminal drain, as its per-receive-poll contract
-  documents, instead of freezing at the last pre-teardown value.
-- A protocol-v2 `RoomJoined` that exposes protocol-v3-only metadata
-  (a `reconnection_token` or non-empty `ice_servers`) is now rejected as a
-  lifecycle violation under the violation policy, matching the existing
-  `Reconnected` guard; previously the token surfaced in `snapshot()`.
-- Corrected published documentation for `set_ready()`: the wire
-  `PlayerReady` message **toggles** readiness, so a repeated call un-readies
-  the player. Both drivers' docs, the client/getting-started/protocol
-  guides, and the lobby example now say to call it exactly once per room
-  membership.
-- Corrected additional published documentation claims: `DecodeFailed`'s
-  `message_type: None` case covers frames too large for tag recovery
-  (>512 bytes); `with_max_players` documents its `u8` saturation; the mesh
-  guide and crate feature table state that `MeshController` requires the
-  `tokio-runtime` feature; the WASM guide warns that pthreads is
-  single-thread-only and that outbound pacing is not surfaced; and the
-  token-binding guide classifies transport errors raised inside the
-  challenge window.
+- Deeply nested caller JSON (game data, raw signals, custom connection
+  info) is now refused at the call site with `PayloadTooDeep` instead of
+  risking a stack-overflow process abort during serialization; the bound
+  is 128 nested containers.
+- `MeshSession` ignores `NewPeer` directives while the selected transport
+  is not WebRTC.
+- v2/v3 dialect crossings are now rejected as lifecycle violations:
+  out-of-bounds `ProtocolInfo.max_outbound_message_size`, v2 frames
+  carrying the v3-only size field, and v2 `RoomJoined` frames carrying
+  `reconnection_token` or `ice_servers`.
+- The Emscripten transport no longer acknowledges sends on a connection
+  the browser already closed (they fail terminally and keep the frame),
+  fuses on non-UTF-8 text frames instead of dropping them, and reports the
+  queued `onclose` metadata when it arrives behind `onerror`.
+- WebSocket URLs whose scheme is not lowercase `ws://` or `wss://` are
+  rejected with `InvalidConfig` before any network I/O.
+- The Godot adapter applies Godot's web capacity boundary on every wasm
+  target, not just Emscripten.
+- The async driver's `transport_diagnostics()` now refreshes during the
+  terminal drain instead of freezing at the pre-teardown value.
+- Corrected docs: `set_ready()` toggles readiness (call it once per room
+  stay), `DecodeFailed.message_type` is `None` for frames over 512 bytes,
+  `with_max_players` saturates at `u8::MAX`, `MeshController` requires
+  `tokio-runtime`, the WASM guide warns pthreads is single-thread-only and
+  outbound pacing is not surfaced, at Godot's inbound bounds web drops new
+  frames while native backpressures, and the token-binding guide
+  classifies challenge-window transport errors.
 
 ## [0.11.0] - 2026-08-28
 

--- a/docs/client.md
+++ b/docs/client.md
@@ -884,7 +884,7 @@ configured capacity.
 | `send_game_data(data: serde_json::Value)` | Send protocol-reliable JSON game data. |
 | `send_game_data_with_delivery(data, delivery)` | Select a protocol-v3 JSON delivery class. |
 | `send_binary_game_data(payload: Vec<u8>)` | Send a protocol-v3 binary game-data frame. |
-| `request_authority(become: bool)` | Request or release room authority. |
+| `request_authority(become_authority: bool)` | Request or release room authority. |
 | `provide_connection_info(info: ConnectionInfo)` | Provide P2P connection information. |
 | `reconnect(player_id, room_id, auth_token)` | Reconnect to a previous session. |
 | `ping()` | Send a heartbeat ping. |

--- a/src/client.rs
+++ b/src/client.rs
@@ -1831,6 +1831,10 @@ impl crate::client_api::SignalFishClientApi for SignalFishClient {
         SignalFishClient::snapshot(self)
     }
 
+    fn transport_diagnostics(&self) -> TransportDiagnostics {
+        SignalFishClient::transport_diagnostics(self)
+    }
+
     fn supports_mesh(&self) -> bool {
         SignalFishClient::supports_mesh(self)
     }
@@ -2753,6 +2757,9 @@ mod tests {
             Option<Pin<Box<dyn Future<Output = tokio::sync::OwnedSemaphorePermit> + Send>>>,
         /// Count of outbound frames the gate has taken ownership of.
         frames_taken: Arc<std::sync::atomic::AtomicUsize>,
+        /// When present, outbound binary frames are recorded verbatim instead
+        /// of being refused by the text-only default.
+        sent_binary: Option<Arc<StdMutex<Vec<Vec<u8>>>>>,
         /// Diagnostics reported by the mocked backend.
         diagnostics: crate::transport::TransportDiagnostics,
     }
@@ -2763,6 +2770,23 @@ mod tests {
         ) -> (Self, Arc<StdMutex<Vec<String>>>, Arc<AtomicBool>) {
             let (transport, sent, closed, _controls) = Self::new_shared(incoming);
             (transport, sent, closed)
+        }
+
+        /// A mock that additionally records outbound binary frames verbatim
+        /// instead of refusing them.
+        #[allow(clippy::type_complexity)]
+        fn new_binary_recording(
+            incoming: Vec<Option<std::result::Result<String, SignalFishError>>>,
+        ) -> (
+            Self,
+            Arc<StdMutex<Vec<String>>>,
+            Arc<StdMutex<Vec<Vec<u8>>>>,
+            Arc<AtomicBool>,
+        ) {
+            let (mut transport, sent, closed, _controls) = Self::new_shared(incoming);
+            let sent_binary = Arc::new(StdMutex::new(Vec::new()));
+            transport.sent_binary = Some(Arc::clone(&sent_binary));
+            (transport, sent, sent_binary, closed)
         }
 
         #[allow(clippy::type_complexity)]
@@ -2788,6 +2812,7 @@ mod tests {
                 held_frame: None,
                 permit_wait: None,
                 frames_taken: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+                sent_binary: None,
                 diagnostics: crate::transport::TransportDiagnostics::default(),
             };
             (
@@ -2847,9 +2872,15 @@ mod tests {
                         self.sent.lock().unwrap().push(message);
                         Poll::Ready(Ok(()))
                     }
-                    Some(TransportFrame::Binary(_)) => Poll::Ready(Err(
-                        SignalFishError::TransportSend("mock expected a text frame".into()),
-                    )),
+                    Some(TransportFrame::Binary(payload)) => match &self.sent_binary {
+                        Some(log) => {
+                            log.lock().unwrap().push(payload);
+                            Poll::Ready(Ok(()))
+                        }
+                        None => Poll::Ready(Err(SignalFishError::TransportSend(
+                            "mock expected a text frame".into(),
+                        ))),
+                    },
                     None => Poll::Ready(Ok(())),
                 };
             };
@@ -5541,6 +5572,30 @@ mod tests {
             client.send_binary_game_data(vec![1, 2, 3]),
             Err(SignalFishError::BinaryFormatNotNegotiated)
         ));
+        client.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn async_binary_send_forwards_exact_bytes_verbatim() {
+        let (transport, _sent, sent_binary, _closed) = MockTransport::new_binary_recording(vec![
+            Some(Ok(authenticated_json())),
+            Some(Ok(protocol_info_v3_json())),
+            Some(Ok(finalized_room_v3_json(uuid::Uuid::from_u128(7)))),
+        ]);
+        let mut config = SignalFishConfig::new("mb_test").enable_v3();
+        config.game_data_format = Some(GameDataEncoding::MessagePack);
+        let (mut client, mut events) = SignalFishClient::start(transport, config);
+        enter_scripted_player_room(&mut client, &mut events).await;
+
+        client
+            .send_binary_game_data(vec![1, 2, 3])
+            .expect("negotiated MessagePack accepts binary game data");
+        wait_until(|| !sent_binary.lock().unwrap().is_empty()).await;
+        assert_eq!(
+            sent_binary.lock().unwrap().as_slice(),
+            [vec![1, 2, 3]],
+            "the binary frame must reach the transport byte-for-byte"
+        );
         client.shutdown().await;
     }
 

--- a/src/client_api.rs
+++ b/src/client_api.rs
@@ -97,8 +97,7 @@ pub trait SignalFishClientApi {
     /// Most recent backend buffering/admission diagnostics sample.
     ///
     /// Reads the same per-I/O-step sample as the inherent driver methods; see
-    /// [`TransportDiagnostics`](crate::TransportDiagnostics) for field
-    /// semantics.
+    /// [`TransportDiagnostics`] for field semantics.
     #[must_use = "this diagnostic view is discarded if not used"]
     fn transport_diagnostics(&self) -> TransportDiagnostics;
 

--- a/src/client_api.rs
+++ b/src/client_api.rs
@@ -6,6 +6,7 @@ use crate::protocol::{
     ConnectionInfo, GameDataEncoding, PlayerId, RoomId, SessionGeneration, Topology, TransportKind,
 };
 use crate::signal::PeerSignal;
+use crate::transport::TransportDiagnostics;
 
 /// Object-safe synchronous command and state surface shared by both clients.
 ///
@@ -13,7 +14,8 @@ use crate::signal::PeerSignal;
 /// connection is driven by `SignalFishClient` or `SignalFishPollingClient`.
 /// Driver-specific
 /// operations such as async waiting sends, `shutdown`, `poll`, and `close` are
-/// intentionally excluded.
+/// intentionally excluded; `transport_diagnostics` is shared and therefore
+/// included.
 ///
 /// Signal methods here take a concrete [`PeerSignal`] rather than
 /// `impl Into<PeerSignal>` because object safety forbids generic parameters;
@@ -92,6 +94,13 @@ pub trait SignalFishClientApi {
     /// Coherent connection and room snapshot.
     #[must_use = "this diagnostic view is discarded if not used"]
     fn snapshot(&self) -> ClientSnapshot;
+    /// Most recent backend buffering/admission diagnostics sample.
+    ///
+    /// Reads the same per-I/O-step sample as the inherent driver methods; see
+    /// [`TransportDiagnostics`](crate::TransportDiagnostics) for field
+    /// semantics.
+    #[must_use = "this diagnostic view is discarded if not used"]
+    fn transport_diagnostics(&self) -> TransportDiagnostics;
 
     /// Server-confirmed local role in the current room.
     fn room_role(&self) -> Option<RoomRole> {

--- a/src/event.rs
+++ b/src/event.rs
@@ -37,13 +37,16 @@ use crate::protocol::{
 ///
 /// # Example
 ///
+/// The enum is exhaustive: every variant is handled explicitly, with no
+/// catch-all arm.
+///
 /// ```text
 /// // Assuming `events` is an async receiver of SignalFishEvent:
 /// match event {
-///     SignalFishEvent::RoomJoined { room_code, current_players, .. } => { /* … */ }
-///     SignalFishEvent::PlayerJoined { player } => { /* … */ }
-///     SignalFishEvent::Disconnected { reason, .. } => { /* … */ }
-///     _ => {}
+///     SignalFishEvent::RoomJoined { .. } => { /* … */ }
+///     SignalFishEvent::PlayerJoined { .. } => { /* … */ }
+///     SignalFishEvent::Disconnected { .. } => { /* … */ }
+///     // …one arm per remaining variant…
 /// }
 /// ```
 #[derive(Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,11 +183,11 @@ pub use protocol::{
     decode_v3_binary_game_data, ClientMessage, ConnectionInfo, DeliveryClass,
     DeliveryCountersByClass, DeliveryGap, DeliveryGapReason, DeliveryReportPayload, DirectEndpoint,
     GameDataEncoding, IceServer, LatestDeliveryCounters, LobbyState, MessageTransport,
-    PeerConnectionInfo, PlayerId, PlayerInfo, RateLimitInfo, RelayTransport,
-    ReliableDeliveryCounters, ReplayStatus, RoomId, RoomOperationId, RoomOperationRequest,
-    RoomOperationResult, SenderWatermark, ServerMessage, SessionGeneration, SessionPeer,
-    SessionPlanPayload, SpectatorInfo, SpectatorStateChangeReason, Topology, TransportKind,
-    V3BinaryGameDataFrame, VolatileDeliveryCounters, ROOM_OPERATION_IDS_CAPABILITY,
+    PeerConnectionInfo, PlayerId, PlayerInfo, PlayerNameRulesPayload, ProtocolInfoPayload,
+    RateLimitInfo, RelayTransport, ReliableDeliveryCounters, ReplayStatus, RoomId, RoomOperationId,
+    RoomOperationRequest, RoomOperationResult, SenderWatermark, ServerMessage, SessionGeneration,
+    SessionPeer, SessionPlanPayload, SpectatorInfo, SpectatorStateChangeReason, Topology,
+    TransportKind, V3BinaryGameDataFrame, VolatileDeliveryCounters, ROOM_OPERATION_IDS_CAPABILITY,
 };
 pub use signal::PeerSignal;
 #[cfg(feature = "transport-websocket")]
@@ -219,6 +219,9 @@ pub mod webrtc;
 
 #[cfg(feature = "mesh")]
 pub use webrtc::{DriverEvent, MeshEvent, WebRtcDriver};
+
+#[cfg(all(feature = "mesh", feature = "tokio-runtime"))]
+pub use webrtc::MeshWaker;
 
 #[cfg(all(feature = "mesh", feature = "tokio-runtime"))]
 pub use webrtc::MeshController;

--- a/src/polling_client.rs
+++ b/src/polling_client.rs
@@ -1587,6 +1587,10 @@ impl<T: Transport> crate::client_api::SignalFishClientApi for SignalFishPollingC
         SignalFishPollingClient::snapshot(self)
     }
 
+    fn transport_diagnostics(&self) -> TransportDiagnostics {
+        SignalFishPollingClient::transport_diagnostics(self)
+    }
+
     fn supports_mesh(&self) -> bool {
         SignalFishPollingClient::supports_mesh(self)
     }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -417,20 +417,30 @@ pub struct RateLimitInfo {
 /// Describes negotiated protocol capabilities for a specific SDK.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProtocolInfoPayload {
+    /// Platform label the server recognized from the client's advertised
+    /// platform, when echoed.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub platform: Option<String>,
+    /// Client SDK version echoed back by the server, when present.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sdk_version: Option<String>,
+    /// Lowest server SDK version the deployment supports, when advertised.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub minimum_version: Option<String>,
+    /// Server SDK version the deployment recommends, when advertised.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub recommended_version: Option<String>,
+    /// Optional capability tokens the deployment supports.
     #[serde(default)]
     pub capabilities: Vec<String>,
+    /// Free-form deployment notes, when advertised.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub notes: Option<String>,
+    /// Game-data encodings the deployment accepts, in the canonical
+    /// negotiation order (JSON first, MessagePack optional).
     #[serde(default)]
     pub game_data_formats: Vec<GameDataEncoding>,
+    /// Player-name character rules, when advertised.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub player_name_rules: Option<PlayerNameRulesPayload>,
     /// Protocol version negotiated for this connection (protocol v3+ only).
@@ -483,13 +493,20 @@ pub struct ProtocolInfoPayload {
 /// Describes the characters a deployment allows inside `player_name`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PlayerNameRulesPayload {
+    /// Maximum accepted `player_name` length.
     pub max_length: usize,
+    /// Minimum accepted `player_name` length.
     pub min_length: usize,
+    /// Whether Unicode alphanumeric characters are allowed.
     pub allow_unicode_alphanumeric: bool,
+    /// Whether spaces are allowed.
     pub allow_spaces: bool,
+    /// Whether leading and trailing whitespace is allowed.
     pub allow_leading_trailing_whitespace: bool,
+    /// Symbols accepted in addition to the base rules.
     #[serde(default)]
     pub allowed_symbols: Vec<char>,
+    /// Additional allowed characters as a free-form string, when advertised.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub additional_allowed_characters: Option<String>,
 }

--- a/tests/polling_parity_tests.rs
+++ b/tests/polling_parity_tests.rs
@@ -1465,6 +1465,8 @@ fn pi_v2_payload() -> ProtocolInfoPayload {
     p.protocol_version = None;
     p.min_protocol_version = None;
     p.max_protocol_version = None;
+    p.transports = None;
+    p.max_outbound_message_size = None;
     p
 }
 


### PR DESCRIPTION
## Why

Two work items, one coherent deliverable:

- **Issue #197** asked for shorter changelog entries: consumer-facing, one sentence, no fluff.
- **Issue #126** continues as recurring paranoid-audit rounds; round 28 audited three fresh surfaces.

## What ships

**Concise changelog (issue #197)**

- `[Unreleased]` entries condensed to one sentence each, related fixes folded into one entry. Released sections are untouched (they sync into published release notes). `**Breaking:**` markers preserved, so release intent parsing is unchanged (`release-intent` still reports breaking → 0.12.0, major policy).
- The changelog-discipline skill now pins the entry style so future entries stay short.

**Round-28 audit fixes**

- `transport_diagnostics()` joined the `SignalFishClientApi` trait. It is shared by both drivers with identical signatures, so its absence from the object-safe surface was an oversight. **Breaking for implementors only** (exactly the two in-repo drivers).
- Root re-exports for `MeshWaker`, `ProtocolInfoPayload`, and `PlayerNameRulesPayload` — all previously reachable only via deep module paths while sibling types were root-exported. `MeshWaker`'s re-export is gated on `mesh` + `tokio-runtime`, matching the type's own gate (a hostile review pass caught the naive version breaking `--features mesh` alone).
- Documented all 15 previously undocumented public fields on the two payload structs, corrected against the protocol authority (platform/`sdk_version` are echoes, `minimum_version` is a support bound, formats are canonical-order).
- Docs: fixed the polling-table parameter name (`become_authority`) and stopped the `SignalFishEvent` doc example from teaching a `_ => {}` catch-all, which contradicted the exhaustive-match design.
- Tests: async binary sends are now pinned byte-for-byte (only length markers existed), and the v2 `ProtocolInfo` test helper no longer carries v3-only fields — the last survivor of the mock-fidelity class fixed in rounds 22–23.

**Round-28 verdict:** the outbound v3 binary data plane and the complete Server 0.4 generation-less story came back clean (12 candidates mechanically refuted against the vendored authority); all landed fixes are the items above.

## Verification

- `cargo fmt && cargo clippy --workspace --all-targets --all-features -- -D warnings && cargo test --workspace --all-features`: clean (1,085 tests).
- Sparse combos `--no-default-features --features mesh` and `polling-client,mesh` compile (the gate that fixed them).
- `scripts/release.py release-intent` parses the condensed changelog unchanged.
- Adversarial review loop converged to zero findings.

Closes #197

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a required trait method (breaking for implementors) and expands the public re-export surface; runtime behavior changes are mostly documentation and changelog wording aside from the trait/API surface.
> 
> **Overview**
> **Changelog (issue #197):** `[Unreleased]` entries are shortened to one consumer-facing sentence each, with related fixes merged; breaking items are grouped under `### Added` while keeping `**Breaking:**` markers. The changelog-discipline skill now documents that style and warns not to edit released sections.
> 
> **API parity:** `transport_diagnostics()` is added to **`SignalFishClientApi`** (implemented on both drivers)—**breaking only for external trait implementors**. Root re-exports add `ProtocolInfoPayload`, `PlayerNameRulesPayload`, and `MeshWaker` (`mesh` + `tokio-runtime` only, matching the type’s feature gate).
> 
> **Docs & tests:** Fifteen public fields on the two payload structs get doc comments; `docs/client.md` uses `become_authority`; the `SignalFishEvent` example no longer suggests a `_ => {}` catch-all. Tests add byte-for-byte async binary send coverage via an extended mock transport, and the v2 `ProtocolInfo` helper drops v3-only fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7cddf344081f4f02ab5ebd294bcee0ac2abe0f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->