### PR TITLE
Round 29 audit: fix the mesh demo hang, track the fuzz lock, refresh stale dependency pins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
       - name: Run typos spell checker
-        uses: crate-ci/typos@v1.49.0
+        uses: crate-ci/typos@v1.50.0
         with:
           config: .typos.toml
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -43,7 +43,7 @@ jobs:
           components: llvm-tools-preview
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@v2.86.5
+        uses: taiki-e/install-action@v2.87.1
         with:
           tool: cargo-llvm-cov@0.8.4
 

--- a/.github/workflows/deep-safety.yml
+++ b/.github/workflows/deep-safety.yml
@@ -147,17 +147,17 @@ jobs:
         uses: dtolnay/rust-toolchain@nightly
 
       - name: Install cargo-fuzz
-        uses: taiki-e/install-action@v2.86.5
+        uses: taiki-e/install-action@v2.87.1
         with:
-          tool: cargo-fuzz@0.13.1
+          tool: cargo-fuzz@0.13.2
 
       - name: Cache Cargo artifacts
         uses: Swatinem/rust-cache@v2.9.2
         with:
           workspaces: fuzz
 
-      - name: Generate lockfile
-        run: bash scripts/cargo-retry.sh generate-lockfile --manifest-path fuzz/Cargo.toml
+      - name: Verify fuzz lockfile is current
+        run: bash scripts/cargo-retry.sh metadata --manifest-path fuzz/Cargo.toml --locked > /dev/null
 
       - name: Run every protocol fuzz target
         run: |
@@ -220,7 +220,7 @@ jobs:
         run: bash scripts/cargo-retry.sh generate-lockfile
 
       - name: Install cargo-mutants
-        uses: taiki-e/install-action@v2.86.5
+        uses: taiki-e/install-action@v2.87.1
         with:
           tool: cargo-mutants@26.2.0
 

--- a/.github/workflows/examples-validation.yml
+++ b/.github/workflows/examples-validation.yml
@@ -2,7 +2,9 @@
 #
 # Runs on every PR and push to main. Verifies that:
 #   - rustdoc examples compile and pass (cargo test --doc)
-#   - example programs build (cargo test --examples)
+#   - example programs build and their unit tests pass (cargo test --examples)
+#   - the offline examples actually run to completion (custom_transport,
+#     mesh_session) so protocol-flow rot fails CI instead of hanging users
 #   - Rust code blocks in markdown files compile (extract-rust-snippets.sh)
 #
 # Cancel in-progress runs on the same branch to save resources.
@@ -66,6 +68,15 @@ jobs:
 
       - name: Build and test examples
         run: cargo test --examples --all-features
+
+      - name: Run offline custom_transport example
+        run: timeout 120 cargo run --locked --example custom_transport
+
+      - name: Run offline mesh_session example
+        run: timeout 120 cargo run --locked --example mesh_session --features mesh
+
+      - name: Clippy mesh example without default features
+        run: cargo clippy --example mesh_session --no-default-features --features mesh,tokio-runtime -- -D warnings
 
   # ──────────────────────────────────────────────────────────────
   # Snippet check — validate Rust code blocks in markdown

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -72,9 +72,9 @@ jobs:
         uses: Swatinem/rust-cache@v2.9.2
 
       - name: Install release tools
-        uses: taiki-e/install-action@v2.86.5
+        uses: taiki-e/install-action@v2.87.1
         with:
-          tool: cargo-cyclonedx@0.5.7,cargo-semver-checks@0.50.0
+          tool: cargo-cyclonedx@0.5.9,cargo-semver-checks@0.50.0
 
       - name: Derive and validate release metadata
         id: release-metadata

--- a/.github/workflows/security-supply-chain.yml
+++ b/.github/workflows/security-supply-chain.yml
@@ -59,9 +59,9 @@ jobs:
         run: bash scripts/cargo-retry.sh generate-lockfile
 
       - name: Install cargo-audit
-        uses: taiki-e/install-action@v2.86.5
+        uses: taiki-e/install-action@v2.87.1
         with:
-          tool: cargo-audit@0.22.1
+          tool: cargo-audit@0.22.2
 
       - name: Run cargo audit
         run: cargo audit
@@ -109,9 +109,9 @@ jobs:
         run: bash scripts/cargo-retry.sh generate-lockfile
 
       - name: Install cargo-cyclonedx
-        uses: taiki-e/install-action@v2.86.5
+        uses: taiki-e/install-action@v2.87.1
         with:
-          tool: cargo-cyclonedx@0.5.7
+          tool: cargo-cyclonedx@0.5.9
 
       - name: Generate CycloneDX SBOM
         run: cargo cyclonedx --format json

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -67,7 +67,7 @@ jobs:
         uses: Swatinem/rust-cache@v2.9.2
 
       - name: Install cargo-semver-checks
-        uses: taiki-e/install-action@v2.86.5
+        uses: taiki-e/install-action@v2.87.1
         with:
           tool: cargo-semver-checks@0.50.0
 

--- a/.github/workflows/unused-deps.yml
+++ b/.github/workflows/unused-deps.yml
@@ -58,9 +58,9 @@ jobs:
         uses: Swatinem/rust-cache@v2.9.2
 
       - name: Install cargo-machete
-        uses: taiki-e/install-action@v2.86.5
+        uses: taiki-e/install-action@v2.87.1
         with:
-          tool: cargo-machete@0.9.1
+          tool: cargo-machete@0.9.2
 
       - name: Run cargo machete
         run: cargo machete
@@ -92,9 +92,9 @@ jobs:
         run: bash scripts/cargo-retry.sh generate-lockfile
 
       - name: Install cargo-udeps
-        uses: taiki-e/install-action@v2.86.5
+        uses: taiki-e/install-action@v2.87.1
         with:
-          tool: cargo-udeps@0.1.60
+          tool: cargo-udeps@0.1.61
 
       - name: Run cargo udeps
         run: cargo +nightly udeps --all-targets --all-features

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -79,7 +79,7 @@ jobs:
         with:
           components: rust-src, clippy
       - name: Install Emscripten SDK
-        uses: mymindstorm/setup-emsdk@v16
+        uses: emscripten-core/setup-emsdk@v16
         with:
           version: 3.1.74
       - name: Cache Cargo artifacts

--- a/.gitignore
+++ b/.gitignore
@@ -19,12 +19,15 @@
 
 # Dependency locks: the root lock is tracked so published .crate archives
 # embed one stable resolution and Release recovery reruns rebuild
-# byte-identical artifacts; nested workspace locks stay local.
+# byte-identical artifacts; nested workspace locks stay local. Fixture and
+# fuzz locks are tracked so their lanes verify resolution instead of
+# silently re-resolving on every run.
 Cargo.lock
 !/Cargo.lock
 !tests/godot-compat-min/Cargo.lock
 !tests/godot-web-smoke/Cargo.lock
 !tests/emscripten-harness/Cargo.lock
+!fuzz/Cargo.lock
 
 # Editor swap files
 *.swp

--- a/.llm/context.md
+++ b/.llm/context.md
@@ -55,7 +55,7 @@ secret-handling rules verified in session 070).
 ## CI/CD Action Reference Policy
 
 Use `owner/action@vN.N.N` (preferred) or `@vN`, not commit hashes. Exceptions:
-`dtolnay/rust-toolchain@stable|nightly|beta` and `mymindstorm/setup-emsdk@vN`.
+`dtolnay/rust-toolchain@stable|nightly|beta` and `emscripten-core/setup-emsdk@vN`.
 
 ## Changelog Policy
 
@@ -346,7 +346,7 @@ The core manifest must never depend on `godot` or expose godot-rust types.
 an inherited workspace dependency, `default-features = false`, and
 `polling-client`, and declares
 `godot = ">=0.4.5, <0.6"` with no-thread WASM and lazy-function-table support.
-Its minimum 0.4.5 and latest 0.5.4 standalone fixtures must each lock exactly
+Its minimum 0.4.5 and latest 0.5.5 standalone fixtures must each lock exactly
 one `godot` and one version of every `godot-*` family crate.
 Core tests additionally use full-featured `tokio` and `tracing-subscriber` (the adapter suite has no dev-dependencies).
 

--- a/.llm/skills/godot-websocket/SKILL.md
+++ b/.llm/skills/godot-websocket/SKILL.md
@@ -18,7 +18,7 @@ their direct Godot dependency; the adapter retains no-thread WASM and lazy
 function-table support.
 
 ```toml
-godot = { version = "0.5.4", features = ["api-custom", "experimental-wasm", "experimental-wasm-nothreads", "lazy-function-tables"] }
+godot = { version = "0.5.5", features = ["api-custom", "experimental-wasm", "experimental-wasm-nothreads", "lazy-function-tables"] }
 signal-fish-client = { git = "https://github.com/Ambiguous-Interactive/signal-fish-client-rust", default-features = false, features = ["polling-client"] }
 signal-fish-client-godot = { git = "https://github.com/Ambiguous-Interactive/signal-fish-client-rust" }
 ```
@@ -150,7 +150,7 @@ Primary sources: [Godot WebSocketPeer API](https://docs.godotengine.org/en/stabl
 
 The `tests/godot-compat-min` fixture pins godot-rust 0.4.5 and passes a
 directly-created `Gd<WebSocketPeer>` through `from_peer`. The
-`tests/godot-web-smoke` fixture pins 0.5.4 and is the standalone production
+`tests/godot-web-smoke` fixture pins 0.5.5 and is the standalone production
 GDExtension workspace. Both lockfiles must contain exactly one `godot` version
 and one version of every `godot-*` family crate. Compile both natively and for
 `wasm32-unknown-emscripten`; run browser scenarios only on the latest fixture.

--- a/.llm/skills/public-api-design/SKILL.md
+++ b/.llm/skills/public-api-design/SKILL.md
@@ -214,6 +214,13 @@ This crate is pre-1.0 (0.1.0). Under semver:
 | Add required method to `Transport` trait | Yes |
 | Change `#[serde(rename)]` or tag values | Yes (wire protocol) |
 
+Known `cargo semver-checks` blind spots (verified against 0.50.0, round 29):
+required-trait-method additions whose signatures use crate-defined type
+aliases (e.g. methods returning `error::Result<T>`) are missed by the
+sealing analysis, and plain-struct field type changes have no lint at all.
+For those classes the `**Breaking:**` changelog marker is the only working
+gate — and it drives Prepare Release's bump policy, so it is mandatory.
+
 ## Documenting Public API
 
 Every public item should have a doc comment:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,8 +62,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `with_max_players` saturates at `u8::MAX`, `MeshController` requires
   `tokio-runtime`, the WASM guide warns pthreads is single-thread-only and
   outbound pacing is not surfaced, at Godot's inbound bounds web drops new
-  frames while native backpressures, and the token-binding guide
+  frames while native backpressures, the polling client's `close()`
+  documents that already-buffered inbound frames are drained and discarded
+  without being decoded or delivered, and the token-binding guide
   classifies challenge-window transport errors.
+- The self-contained mesh example's scripted server spoke an obsolete
+  protocol flow and hung; it now completes end-to-end and the examples
+  surface protocol violations instead of silently discarding them.
 
 ## [0.11.0] - 2026-08-28
 

--- a/docs/fortress.md
+++ b/docs/fortress.md
@@ -8,7 +8,7 @@ Add the rollback library beside the SDK in the Godot GDExtension crate:
 
 ```toml
 fortress-rollback = "=0.10.0"
-godot = { version = "0.5.4", features = ["api-custom", "experimental-wasm", "experimental-wasm-nothreads", "lazy-function-tables"] }
+godot = { version = "0.5.5", features = ["api-custom", "experimental-wasm", "experimental-wasm-nothreads", "lazy-function-tables"] }
 serde = { version = "1.0", features = ["derive"] }
 signal-fish-client = { git = "https://github.com/Ambiguous-Interactive/signal-fish-client-rust", default-features = false, features = ["polling-client"] }
 signal-fish-client-godot = { git = "https://github.com/Ambiguous-Interactive/signal-fish-client-rust" }

--- a/docs/migration-0.9.md
+++ b/docs/migration-0.9.md
@@ -11,13 +11,13 @@ Godot binding version selected by your GDExtension:
 
 ```diff
 -signal-fish-client = { version = "0.8", default-features = false, features = ["transport-godot"] }
-+godot = { version = "0.5.4", features = ["api-custom", "experimental-wasm", "experimental-wasm-nothreads", "lazy-function-tables"] }
++godot = { version = "0.5.5", features = ["api-custom", "experimental-wasm", "experimental-wasm-nothreads", "lazy-function-tables"] }
 +signal-fish-client = { version = "0.9", default-features = false, features = ["polling-client"] }
 +signal-fish-client-godot = "0.9"
 ```
 
 The adapter supports godot-rust 0.4.5 through every compatible 0.5.x release.
-The browser/Fortress fixture pins 0.5.4, while a standalone minimum fixture
+The browser/Fortress fixture pins 0.5.5, while a standalone minimum fixture
 pins 0.4.5 and passes a directly constructed `Gd<WebSocketPeer>` through
 `GodotWebSocketTransport::from_peer`.
 
@@ -34,7 +34,7 @@ crate. If a 0.4.5 project retains a 0.5 binding selected only for the adapter,
 align the lockfile explicitly and commit it:
 
 ```sh
-cargo update -p godot@0.5.4 --precise 0.4.5
+cargo update -p godot@0.5.5 --precise 0.4.5
 ```
 
 Do not pass `Gd` values between duplicate binding versions; those are distinct

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -125,7 +125,11 @@ default-branch move stops the run. Never delete or move release state to make a
 rerun pass. The root `Cargo.lock` is tracked: release preparation updates it
 in lockstep with the manifests, and the release workflows package and publish
 with `--locked`, so a rerun resolves the same dependency versions as the
-interrupted attempt and rebuilds byte-identical `.crate` archives. If only a
+interrupted attempt and rebuilds byte-identical `.crate` archives. The nested
+fixture locks and `fuzz/Cargo.lock` are stamped in lockstep too (partial locks
+— such as the fuzz lock, whose graph reaches only the core — are stamped for
+the members they actually contain), keeping their `--locked` verification
+lanes green across a version bump. If only a
 dependent remains unpublished, the rerun uses
 `--no-verify` after full workspace verification and exact dependency checksum
 matching so crates.io sparse-index propagation cannot strand recovery.

--- a/docs/wasm.md
+++ b/docs/wasm.md
@@ -119,7 +119,7 @@ For Godot 4.5 native and official web exports, enable the supported transport:
 
 ```toml
 [dependencies]
-godot = { version = "0.5.4", features = ["api-custom", "experimental-wasm", "experimental-wasm-nothreads", "lazy-function-tables"] }
+godot = { version = "0.5.5", features = ["api-custom", "experimental-wasm", "experimental-wasm-nothreads", "lazy-function-tables"] }
 signal-fish-client = { git = "https://github.com/Ambiguous-Interactive/signal-fish-client-rust", default-features = false, features = ["polling-client"] }
 signal-fish-client-godot = { git = "https://github.com/Ambiguous-Interactive/signal-fish-client-rust" }
 ```
@@ -555,7 +555,7 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-godot = { version = "0.5.4", features = ["api-custom", "experimental-wasm", "experimental-wasm-nothreads", "lazy-function-tables"] }
+godot = { version = "0.5.5", features = ["api-custom", "experimental-wasm", "experimental-wasm-nothreads", "lazy-function-tables"] }
 signal-fish-client = { git = "https://github.com/Ambiguous-Interactive/signal-fish-client-rust", default-features = false, features = ["polling-client"] }
 signal-fish-client-godot = { git = "https://github.com/Ambiguous-Interactive/signal-fish-client-rust" }
 serde_json = "1.0"  # Required for send_game_data(serde_json::Value)

--- a/examples/basic_lobby.rs
+++ b/examples/basic_lobby.rs
@@ -199,6 +199,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         tracing::error!("Server error [{error_code:?}]: {message}");
                     }
 
+                    // ── Hostile-server diagnostics ───────────────────
+                    // The default violation policy is Quarantine: the client
+                    // suppresses the offending server's delivery but stays
+                    // up. Surface both loudly — they never belong in a
+                    // debug-level catch-all.
+                    SignalFishEvent::ProtocolViolation { kind, diagnostic } => {
+                        tracing::error!("Protocol violation ({kind:?}): {diagnostic}");
+                    }
+
+                    SignalFishEvent::DecodeFailed { .. } => {
+                        tracing::warn!("Received a frame that failed to decode");
+                    }
+
                     // ── Disconnect ───────────────────────────────────
                     SignalFishEvent::Disconnected { reason, .. } => {
                         tracing::warn!("Disconnected: {}", reason.as_deref().unwrap_or("unknown"));

--- a/examples/load_lab.rs
+++ b/examples/load_lab.rs
@@ -165,6 +165,14 @@ async fn connect(
             Ok(Some(SignalFishEvent::AuthenticationError { error, .. })) => {
                 return Err(format!("{name}: authentication failed: {error}").into());
             }
+            // A measurement harness must not confuse hostile-server
+            // diagnostics with silence.
+            Ok(Some(SignalFishEvent::DecodeFailed { .. })) => {
+                eprintln!("{name}: received an undecodable server frame");
+            }
+            Ok(Some(SignalFishEvent::ProtocolViolation { diagnostic, .. })) => {
+                eprintln!("{name}: protocol violation: {diagnostic}");
+            }
             Ok(Some(_)) => {}
             _ => return Err(format!("{name}: no Authenticated within 5s").into()),
         }
@@ -191,6 +199,12 @@ async fn join(
             Ok(Some(SignalFishEvent::RoomJoined { room_code, .. })) => return Ok(room_code),
             Ok(Some(SignalFishEvent::RoomJoinFailed { reason, .. })) => {
                 return Err(format!("{name}: join failed: {reason}").into());
+            }
+            Ok(Some(SignalFishEvent::DecodeFailed { .. })) => {
+                eprintln!("{name}: received an undecodable server frame");
+            }
+            Ok(Some(SignalFishEvent::ProtocolViolation { diagnostic, .. })) => {
+                eprintln!("{name}: protocol violation: {diagnostic}");
             }
             Ok(Some(_)) => {}
             _ => return Err(format!("{name}: no RoomJoined within 5s").into()),
@@ -226,6 +240,12 @@ async fn drain_role(
                 disconnected = true;
                 break;
             }
+            Ok(Some(SignalFishEvent::DecodeFailed { .. })) => {
+                eprintln!("drain: received an undecodable server frame");
+            }
+            Ok(Some(SignalFishEvent::ProtocolViolation { diagnostic, .. })) => {
+                eprintln!("drain: protocol violation: {diagnostic}");
+            }
             Ok(Some(_)) => {}
             Ok(None) => {
                 disconnected = true;
@@ -235,6 +255,13 @@ async fn drain_role(
         }
     }
     (latencies, received, disconnected)
+}
+
+/// Discard a client's own event stream after each send. The measurement
+/// loops only need send results and explicitly-awaited events; informational
+/// room traffic is intentionally dropped here rather than counted.
+fn discard_events(events: &mut tokio::sync::mpsc::Receiver<SignalFishEvent>) {
+    while events.try_recv().is_ok() {}
 }
 
 // ── Modes ───────────────────────────────────────────────────────────
@@ -260,6 +287,7 @@ async fn mode_ping(opts: &Options) -> Result<(), Box<dyn Error>> {
     let (n, p50, p95, p99, max) = summarize(rtts);
     println!("mode,samples,p50_ms,p95_ms,p99_ms,max_ms");
     println!("ping,{n},{p50:.2},{p95:.2},{p99:.2},{max:.2}");
+    client.shutdown().await;
     Ok(())
 }
 
@@ -306,17 +334,17 @@ async fn mode_throughput(opts: &Options) -> Result<(), Box<dyn Error>> {
                 Err(_) => refused += 1,
             }
             // Keep the sender's own event stream drained.
-            while sender_events.try_recv().is_ok() {}
+            discard_events(&mut sender_events);
         }
         let accepted_per_s = accepted as f64 / opts.secs as f64;
 
         let mut all_latencies = Vec::new();
         let mut delivered_total = 0u64;
-        for (rx_client, handle) in receiver_handles {
+        for (mut rx_client, handle) in receiver_handles {
             let (latencies, received, _) = handle.await?;
             delivered_total += received;
             all_latencies.extend(latencies);
-            drop(rx_client);
+            rx_client.shutdown().await;
         }
         let delivered_per_s =
             delivered_total as f64 / opts.secs as f64 / std::cmp::max(opts.recipients, 1) as f64;
@@ -325,7 +353,7 @@ async fn mode_throughput(opts: &Options) -> Result<(), Box<dyn Error>> {
             "throughput,{rate},{},{accepted_per_s:.1},{refused},{delivered_per_s:.1},{p50:.2},{p95:.2},{p99:.2},{max:.2}",
             opts.payload
         );
-        drop(sender);
+        sender.shutdown().await;
         tokio::time::sleep(Duration::from_millis(250)).await;
     }
     Ok(())
@@ -380,7 +408,7 @@ async fn mode_slow_consumer(opts: &Options) -> Result<(), Box<dyn Error>> {
             .send_game_data_reliable(payload_with_timestamp(opts.payload))
             .await?;
         sent += 1;
-        while sender_events.try_recv().is_ok() {}
+        discard_events(&mut sender_events);
     }
     let achieved = sent as f64 / opts.secs as f64;
 
@@ -388,13 +416,13 @@ async fn mode_slow_consumer(opts: &Options) -> Result<(), Box<dyn Error>> {
         "mode,role,offered_per_s,achieved_per_s,received,p50_ms,p95_ms,p99_ms,max_ms,disconnected"
     );
     println!("slow-consumer,sender,{},{achieved:.1},,,,,,", opts.rate);
-    for (i, (c, handle)) in healthy.into_iter().enumerate() {
+    for (i, (mut c, handle)) in healthy.into_iter().enumerate() {
         let (latencies, received, disconnected) = handle.await?;
         let (_, p50, p95, p99, max) = summarize(latencies);
         println!(
             "slow-consumer,healthy{i},,,{received},{p50:.2},{p95:.2},{p99:.2},{max:.2},{disconnected}"
         );
-        drop(c);
+        c.shutdown().await;
     }
     let (latencies, received, disconnected) = slow_handle.await?;
     let (_, p50, p95, p99, max) = summarize(latencies);
@@ -402,7 +430,8 @@ async fn mode_slow_consumer(opts: &Options) -> Result<(), Box<dyn Error>> {
         "slow-consumer,slow(drain {}ms),,,{received},{p50:.2},{p95:.2},{p99:.2},{max:.2},{disconnected}",
         opts.drain_ms
     );
-    drop(slow_client);
+    slow_client.shutdown().await;
+    sender.shutdown().await;
     Ok(())
 }
 
@@ -438,8 +467,9 @@ async fn mode_control_starvation(opts: &Options) -> Result<(), Box<dyn Error>> {
                 break;
             }
             sent += 1;
-            while flooder_events.try_recv().is_ok() {}
+            discard_events(&mut flooder_events);
         }
+        flooder.shutdown().await;
         sent
     });
 
@@ -494,6 +524,8 @@ async fn mode_control_starvation(opts: &Options) -> Result<(), Box<dyn Error>> {
     println!(
         "control-starvation,{flooded},{received},{gd_p50:.2},{gd_p99:.2},{n_pong},{pong_p50:.2},{pong_p95:.2},{pong_p99:.2},{pong_max:.2}"
     );
+    // The flooder handle is owned by the flood task and is torn down there.
+    victim.shutdown().await;
     Ok(())
 }
 

--- a/examples/mesh_session.rs
+++ b/examples/mesh_session.rs
@@ -7,8 +7,11 @@
 //! reporting transport status, and surfacing a clean [`MeshEvent`] stream.
 //!
 //! This example is fully self-contained: a scripted in-process "server" plays
-//! the v3 handshake, and a tiny in-memory driver completes it, so the whole
-//! stack runs end-to-end with no network.
+//! the canonical v3 flow (authenticate → negotiate v3 → join → ready →
+//! finalize → authoritative session plan → relayed signal), and a tiny
+//! in-memory driver completes the handshake, so the whole stack runs
+//! end-to-end with no network. A pinned test runs this demo under a timeout,
+//! so a protocol-flow regression here fails CI instead of hanging silently.
 //!
 //! In a real game, replace [`DemoDriver`] with a wrapper around a real WebRTC
 //! backend (str0m, webrtc-rs, or the browser's `RTCPeerConnection` via web-sys)
@@ -22,11 +25,15 @@
 
 use std::collections::VecDeque;
 
+use signal_fish_client::protocol::{
+    GameDataEncoding, IceServer, LobbyState, MessageTransport, PlayerInfo, ProtocolInfoPayload,
+    RoomJoinedPayload, SessionPeer, SessionPlanPayload, Topology, TransportKind,
+};
 use signal_fish_client::transport::TransportFrame;
 use signal_fish_client::webrtc::{DriverEvent, MeshController, MeshEvent, WebRtcDriver};
-use signal_fish_client::{IceServer, PlayerId, SessionGeneration};
 use signal_fish_client::{
-    JoinRoomParams, PeerSignal, SignalFishConfig, SignalFishError, SignalFishEvent, Transport,
+    ClientMessage, JoinRoomParams, PeerSignal, PlayerId, ServerMessage, SessionGeneration,
+    SignalFishConfig, SignalFishError, SignalFishEvent, Transport,
 };
 
 // ─────────────────────────────────────────────────────────────────────
@@ -108,11 +115,79 @@ impl WebRtcDriver for DemoDriver {
 // Step 2: A scripted loopback transport that plays the v3 server side.
 // ─────────────────────────────────────────────────────────────────────
 
+/// The player id the scripted server assigns to the local player ("Alice").
+const ALICE: uuid::Uuid = uuid::Uuid::from_u128(0xA);
+/// The scripted peer ("Bob") that shares the room and the session plan.
+const BOB: uuid::Uuid = uuid::Uuid::from_u128(0xB);
+/// The authoritative session-plan generation the scripted server publishes.
+const GENERATION: uuid::Uuid = uuid::Uuid::from_u128(0x7);
+
 struct ScriptedServer {
     incoming: VecDeque<String>,
-    peer: PlayerId,
-    started: bool,
+    plan_sent: bool,
     aborted: bool,
+}
+
+impl ScriptedServer {
+    fn queue(&mut self, message: ServerMessage) {
+        let frame = serde_json::to_string(&message).unwrap_or_default();
+        self.incoming.push_back(frame);
+    }
+
+    /// Canonical, room-ordered join baseline: the server picks the local
+    /// player id, the roster already contains the future plan peer, and the
+    /// protocol-v3 roster stamps each player with a paired `epoch`/`seq`.
+    fn room_joined(&mut self) {
+        let player = |id: uuid::Uuid, name: &str, is_authority: bool| PlayerInfo {
+            id,
+            name: name.into(),
+            is_authority,
+            is_ready: true,
+            connected_at: "2026-01-01T00:00:00Z".into(),
+            connection_info: None,
+            epoch: Some(1),
+            seq: Some(0),
+        };
+        self.queue(ServerMessage::RoomJoined(Box::new(RoomJoinedPayload {
+            room_id: uuid::Uuid::from_u128(0x100),
+            room_code: "DEMO1".into(),
+            player_id: ALICE,
+            game_name: "demo-game".into(),
+            max_players: 4,
+            supports_authority: true,
+            current_players: vec![player(ALICE, "Alice", true), player(BOB, "Bob", false)],
+            is_authority: true,
+            lobby_state: LobbyState::Lobby,
+            ready_players: vec![],
+            relay_type: "websocket".into(),
+            current_spectators: vec![],
+            ice_servers: vec![],
+            reconnection_token: None,
+        })));
+    }
+
+    fn session_plan(&mut self) {
+        self.queue(ServerMessage::SessionPlan(Box::new(SessionPlanPayload {
+            generation: Some(GENERATION),
+            topology: Topology::Mesh,
+            transport: TransportKind::WebRtc,
+            host: None,
+            direct_endpoint: None,
+            peers: vec![SessionPeer {
+                player_id: BOB,
+                player_name: "Bob".into(),
+                is_authority: false,
+                initiate: true,
+            }],
+            ice_servers: vec![IceServer {
+                urls: vec!["stun:stun.l.google.com:19302".into()],
+                username: None,
+                credential: None,
+            }],
+            fallback: TransportKind::Relay,
+        })));
+        self.plan_sent = true;
+    }
 }
 
 impl Transport for ScriptedServer {
@@ -132,13 +207,35 @@ impl Transport for ScriptedServer {
                 "scripted server does not accept binary frames".into(),
             )));
         };
-        // The server reacts to the client's StartGame by finalizing the session.
-        if message.contains("\"StartGame\"") && !self.started {
-            self.started = true;
-            self.incoming.push_back(session_plan_json(self.peer));
-            // ...then the peer's answer arrives, completing the handshake.
-            self.incoming
-                .push_back(signal_json(self.peer, r#"{"Answer":"<remote-sdp>"}"#));
+        // React to the client's commands the way a real server would: answer
+        // the join, finalize on the game-start request, and relay the peer's
+        // answer back over the signaling path.
+        match serde_json::from_str::<ClientMessage>(&message) {
+            Ok(ClientMessage::JoinRoom { .. }) => {
+                self.room_joined();
+                self.queue(ServerMessage::LobbyStateChanged {
+                    lobby_state: LobbyState::Lobby,
+                    ready_players: vec![ALICE, BOB],
+                    all_ready: true,
+                });
+            }
+            Ok(ClientMessage::StartGame) => {
+                self.queue(ServerMessage::LobbyStateChanged {
+                    lobby_state: LobbyState::Finalized,
+                    ready_players: vec![ALICE, BOB],
+                    all_ready: true,
+                });
+                self.session_plan();
+            }
+            Ok(ClientMessage::Signal { to, .. }) if self.plan_sent && to == BOB => {
+                // The server relays Alice's offer to Bob, who answers.
+                self.queue(ServerMessage::Signal {
+                    from: BOB,
+                    generation: Some(GENERATION),
+                    signal: serde_json::json!({ "Answer": "<remote-sdp>" }),
+                });
+            }
+            _ => {}
         }
         std::task::Poll::Ready(Ok(()))
     }
@@ -172,32 +269,46 @@ impl Transport for ScriptedServer {
     }
 }
 
-fn session_plan_json(peer: PlayerId) -> String {
-    format!(
-        r#"{{"type":"SessionPlan","data":{{"topology":"mesh","transport":"webrtc","peers":[{{"player_id":"{peer}","player_name":"Bob","is_authority":false,"initiate":true}}],"ice_servers":[{{"urls":["stun:stun.l.google.com:19302"]}}],"fallback":"relay"}}}}"#
-    )
-}
-
-fn signal_json(from: PlayerId, signal: &str) -> String {
-    format!(r#"{{"type":"Signal","data":{{"from":"{from}","signal":{signal}}}}}"#)
+fn protocol_info() -> ServerMessage {
+    ServerMessage::ProtocolInfo(ProtocolInfoPayload {
+        platform: None,
+        sdk_version: None,
+        minimum_version: None,
+        recommended_version: None,
+        capabilities: vec![],
+        notes: None,
+        game_data_formats: vec![GameDataEncoding::Json, GameDataEncoding::MessagePack],
+        player_name_rules: None,
+        protocol_version: Some(3),
+        min_protocol_version: Some(2),
+        max_protocol_version: Some(3),
+        transports: Some(vec![MessageTransport::Websocket]),
+        max_outbound_message_size: Some(8_388_608),
+    })
 }
 
 // ─────────────────────────────────────────────────────────────────────
 // Step 3: Drive the mesh — a handful of lines.
 // ─────────────────────────────────────────────────────────────────────
 
-#[tokio::main]
-async fn main() -> Result<(), SignalFishError> {
-    let peer = uuid::Uuid::from_u128(0xB);
+async fn run_demo() -> Result<(), SignalFishError> {
     let transport = ScriptedServer {
-        // The server authenticates, advertises v3, then waits for StartGame.
+        // The server authenticates, then advertises the canonical protocol-v3
+        // negotiation while it waits for the client's room commands.
         incoming: VecDeque::from(vec![
-            r#"{"type":"Authenticated","data":{"app_name":"demo","rate_limits":{"per_minute":60,"per_hour":1000,"per_day":10000}}}"#.to_string(),
-            r#"{"type":"ProtocolInfo","data":{"capabilities":[],"game_data_formats":[],"protocol_version":3,"min_protocol_version":2,"max_protocol_version":3}}"#.to_string(),
-            r#"{"type":"LobbyStateChanged","data":{"lobby_state":"lobby","ready_players":[],"all_ready":true}}"#.to_string(),
+            serde_json::to_string(&ServerMessage::Authenticated {
+                app_name: "demo".into(),
+                organization: None,
+                rate_limits: signal_fish_client::RateLimitInfo {
+                    per_minute: 60,
+                    per_hour: 1_000,
+                    per_day: 10_000,
+                },
+            })
+            .unwrap_or_default(),
+            serde_json::to_string(&protocol_info()).unwrap_or_default(),
         ]),
-        peer,
-        started: false,
+        plan_sent: false,
         aborted: false,
     };
 
@@ -209,6 +320,11 @@ async fn main() -> Result<(), SignalFishError> {
         DemoDriver::default(),
     );
 
+    // Ready-state updates repeat — request the game start only once.
+    let mut start_requested = false;
+    // The demo completes only when the peer handshake lands.
+    let mut completed = false;
+
     while let Some(event) = mesh.recv().await {
         match event {
             MeshEvent::Signaling(sig) => match *sig {
@@ -218,18 +334,38 @@ async fn main() -> Result<(), SignalFishError> {
                 }
                 SignalFishEvent::LobbyStateChanged {
                     all_ready: true, ..
-                } => {
+                } if !start_requested => {
                     println!("everyone ready → starting game");
+                    start_requested = true;
                     mesh.start_game()?;
                 }
                 SignalFishEvent::SessionPlan { peers, .. } => {
                     println!("session plan: {} peer(s) to connect", peers.len());
                 }
-                _ => {}
+                // Terminal diagnostics must never vanish silently — the
+                // scripted flow is broken if any of these arrive.
+                SignalFishEvent::ProtocolViolation { kind, diagnostic } => {
+                    eprintln!("protocol violation ({kind:?}): {diagnostic}");
+                    break;
+                }
+                SignalFishEvent::DecodeFailed { .. } => {
+                    eprintln!("received an undecodable server frame");
+                    break;
+                }
+                SignalFishEvent::RoomJoinFailed { reason, .. } => {
+                    eprintln!("join failed: {reason}");
+                    break;
+                }
+                SignalFishEvent::Disconnected { .. } => {
+                    eprintln!("signaling ended before the peer connected");
+                    break;
+                }
+                other => println!("  event: {:?}", other),
             },
             MeshEvent::PeerConnected(peer) => {
                 println!("✅ peer {peer} connected over WebRTC — sending a packet");
                 mesh.send_to(peer, b"hello peer");
+                completed = true;
                 break; // demo complete
             }
             MeshEvent::PeerDisconnected(peer) => println!("peer {peer} disconnected"),
@@ -240,6 +376,36 @@ async fn main() -> Result<(), SignalFishError> {
     }
 
     mesh.shutdown().await;
+    if !completed {
+        eprintln!("demo ended without a connected peer");
+        return Err(SignalFishError::TransportClosed);
+    }
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> Result<(), SignalFishError> {
+    run_demo().await?;
     println!("done");
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::run_demo;
+
+    /// Rot detector: the demo must complete the whole scripted v3 handshake
+    /// (plan accepted, peer connected) well inside this budget instead of
+    /// hanging on a protocol-flow regression.
+    #[tokio::test]
+    async fn end_to_end_completes() {
+        let finished = tokio::time::timeout(std::time::Duration::from_secs(15), run_demo())
+            .await
+            .map(|demo| demo.is_ok())
+            .unwrap_or(false);
+        assert!(
+            finished,
+            "mesh_session demo must complete end-to-end without hanging"
+        );
+    }
 }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -3,13 +3,10 @@
 version = 4
 
 [[package]]
-name = "aho-corasick"
-version = "1.1.5"
+name = "arbitrary"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
-dependencies = [
- "memchr",
-]
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
 name = "autocfg"
@@ -18,30 +15,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
-name = "bincode"
-version = "2.0.1"
+name = "base64"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
-dependencies = [
- "bincode_derive",
- "serde",
- "unty",
-]
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
-name = "bincode_derive"
-version = "2.0.1"
+name = "block-buffer"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
- "virtue",
+ "hybrid-array",
 ]
-
-[[package]]
-name = "bitflags"
-version = "2.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "bumpalo"
@@ -50,12 +36,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
+name = "bytes"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
 name = "cc"
 version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -66,31 +60,101 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core",
+]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
+ "ctutils",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
-name = "fortress-rollback"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65410c9563f7a4dff7221c8e250bd632317a932a2ff52943e7d74be5b25d9470"
-dependencies = [
- "bincode",
- "loom",
- "parking_lot",
- "serde",
- "smallvec",
- "tracing",
- "web-time",
-]
-
-[[package]]
 name = "futures-core"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
@@ -105,30 +169,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-core",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
  "pin-project-lite",
  "slab",
-]
-
-[[package]]
-name = "gdextension-api"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3489a9e7463353467db3cfe3eb12de31c9b6200e4f928bde4959bf5db5b31d2f"
-
-[[package]]
-name = "generator"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3b854b0e584ead1a33f18b2fcad7cf7be18b3875c78816b753639aa501513ae"
-dependencies = [
- "cc",
- "cfg-if",
- "libc",
- "log",
- "rustversion",
- "windows-link",
- "windows-result",
 ]
 
 [[package]]
@@ -140,101 +185,67 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
+ "rand_core",
 ]
 
 [[package]]
-name = "glam"
-version = "0.32.1"
+name = "hkdf"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f70749695b063ecbf6b62949ccccde2e733ec3ecbbd71d467dca4e5c6c97cca0"
-
-[[package]]
-name = "godot"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e21dfe3a0c8c253cb293a4f915f2359fdb4cf45a4d0557cb1841ea99aae4edfb"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
 dependencies = [
- "godot-core",
- "godot-macros",
+ "hmac",
 ]
 
 [[package]]
-name = "godot-bindings"
-version = "0.5.5"
+name = "hmac"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ce6fed360f27cc44ee188246880bb842cdb96bf13aec1d0ec31cccfa50b1cf6"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "gdextension-api",
- "regex",
- "which",
+ "digest",
 ]
 
 [[package]]
-name = "godot-cell"
-version = "0.5.5"
+name = "http"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc4695597110f27de8f0adbdf3afd01692e3596cc89de2aaa2a42d31b93bfc4"
-
-[[package]]
-name = "godot-codegen"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08409103fba47d9cb5b64dcb0b679b06ba3153d9c96d5e918bb97f065d553c60"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
- "godot-bindings",
- "heck",
- "nanoserde",
- "proc-macro2",
- "quote",
+ "bytes",
+ "itoa",
 ]
 
 [[package]]
-name = "godot-core"
-version = "0.5.5"
+name = "httparse"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ab630dbc7ce797f09eda29025ebadab1b700778c988ad19c47bddc51874a90"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
- "glam",
- "godot-bindings",
- "godot-cell",
- "godot-codegen",
- "godot-ffi",
+ "typenum",
 ]
-
-[[package]]
-name = "godot-ffi"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18c296047c042d74828b2cb2e71bbadd22dd4ff98346c696b6c0a4a5decbf57f"
-dependencies = [
- "godot-bindings",
- "godot-codegen",
- "libc",
-]
-
-[[package]]
-name = "godot-macros"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9ffca7ec0dfad5885a96b3819b3dafc1014c36d2931464f96d9ab0bee87b52e"
-dependencies = [
- "godot-bindings",
- "proc-macro2",
- "quote",
- "venial",
-]
-
-[[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -248,24 +259,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
 name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
-name = "lock_api"
-version = "0.4.14"
+name = "libfuzzer-sys"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+checksum = "a9fd2f41a1cba099f79a0b6b6c35656cf7c03351a7bae8ff0f28f25270f929d2"
 dependencies = [
- "scopeguard",
+ "arbitrary",
+ "cc",
 ]
 
 [[package]]
@@ -275,54 +281,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
-name = "loom"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
-dependencies = [
- "cfg-if",
- "generator",
- "scoped-tls",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "matchers"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
-dependencies = [
- "regex-automata",
-]
-
-[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
-name = "nanoserde"
-version = "0.2.1"
+name = "mio"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a36fb3a748a4c9736ed7aeb5f2dfc99665247f1ce306abbddb2bf0ba2ac530a4"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
- "nanoserde-derive",
-]
-
-[[package]]
-name = "nanoserde-derive"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a846cbc04412cf509efcd8f3694b114fc700a035fb5a37f21517f9fb019f1ebc"
-
-[[package]]
-name = "nu-ansi-term"
-version = "0.50.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
-dependencies = [
+ "libc",
+ "wasi",
  "windows-sys",
 ]
 
@@ -340,29 +311,6 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
-
-[[package]]
-name = "parking_lot"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-link",
-]
 
 [[package]]
 name = "pin-project-lite"
@@ -395,42 +343,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
-name = "redox_syscall"
-version = "0.5.18"
+name = "rand"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "bitflags",
+ "chacha20",
+ "getrandom",
+ "rand_core",
 ]
 
 [[package]]
-name = "regex"
-version = "1.13.1"
+name = "rand_core"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rmp"
@@ -456,18 +383,6 @@ name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
-
-[[package]]
-name = "scoped-tls"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
@@ -523,12 +438,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "sharded-slab"
-version = "0.1.7"
+name = "sha1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
- "lazy_static",
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -541,36 +469,31 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 name = "signal-fish-client"
 version = "0.11.0"
 dependencies = [
+ "base64",
+ "futures-util",
+ "hkdf",
+ "hmac",
  "rmp",
  "rmp-serde",
  "serde",
  "serde_bytes",
  "serde_json",
+ "sha2",
  "thiserror",
  "tokio",
+ "tokio-tungstenite",
  "tracing",
  "uuid",
+ "zeroize",
 ]
 
 [[package]]
-name = "signal-fish-client-godot"
-version = "0.11.0"
-dependencies = [
- "godot",
- "signal-fish-client",
- "tracing",
-]
-
-[[package]]
-name = "signal-fish-godot-smoke"
+name = "signal-fish-client-fuzz"
 version = "0.0.0"
 dependencies = [
- "fortress-rollback",
- "godot",
- "serde",
+ "libfuzzer-sys",
  "serde_json",
  "signal-fish-client",
- "signal-fish-client-godot",
 ]
 
 [[package]]
@@ -580,12 +503,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
-name = "smallvec"
-version = "1.15.2"
+name = "socket2"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
- "serde",
+ "libc",
+ "windows-sys",
 ]
 
 [[package]]
@@ -631,22 +555,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "thread_local"
-version = "1.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "tokio"
 version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
+ "bytes",
+ "libc",
+ "mio",
  "pin-project-lite",
+ "socket2",
  "tokio-macros",
+ "windows-sys",
 ]
 
 [[package]]
@@ -658,6 +578,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.4",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17a073bfed563fa236697a068031408a93cd9522e08abf9933ead3e73411bd71"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
 ]
 
 [[package]]
@@ -689,49 +621,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
- "valuable",
 ]
 
 [[package]]
-name = "tracing-log"
-version = "0.2.0"
+name = "tungstenite"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+checksum = "e48ac77174b19c110a50ab2128b24215ac9cb40e0e12e093fb602d175c569d22"
 dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
  "log",
- "once_cell",
- "tracing-core",
+ "rand",
+ "sha1",
+ "thiserror",
 ]
 
 [[package]]
-name = "tracing-subscriber"
-version = "0.3.23"
+name = "typenum"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
-dependencies = [
- "matchers",
- "nu-ansi-term",
- "once_cell",
- "regex-automata",
- "sharded-slab",
- "smallvec",
- "thread_local",
- "tracing",
- "tracing-core",
- "tracing-log",
-]
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "unty"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
 
 [[package]]
 name = "uuid"
@@ -746,26 +664,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "valuable"
-version = "0.1.1"
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "venial"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a42528baceab6c7784446df2a10f4185078c39bf73dc614f154353f1a6b1229"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "virtue"
-version = "0.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasm-bindgen"
@@ -813,38 +715,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "web-time"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "which"
-version = "8.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bae2f2b2b816647a1cab1acc91f5bd20812d53cb344382635ec2181940c8034f"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link",
-]
 
 [[package]]
 name = "windows-sys"
@@ -854,6 +728,12 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zmij"

--- a/scripts/check-workflows.sh
+++ b/scripts/check-workflows.sh
@@ -324,7 +324,7 @@ echo -e "${YELLOW}Phase 7: Checking for major-only version tags (informational).
 # Actions exempt from major-only tag warnings (easy to extend).
 MAJOR_ONLY_EXCEPTIONS=(
     "dtolnay/rust-toolchain"
-    "mymindstorm/setup-emsdk"
+    "emscripten-core/setup-emsdk"
     "taiki-e/install-action"
 )
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -25,6 +25,15 @@ LOCKSTEP_LOCKFILES = (
     "tests/godot-compat-min/Cargo.lock",
     "tests/godot-web-smoke/Cargo.lock",
 )
+# Locks that need not contain every publishable member: each member's
+# recorded version is stamped when present, absence of a member is fine, and
+# a duplicate entry still fails closed. fuzz/Cargo.lock records only the
+# path-depended core (the fuzz graph never reaches the Godot adapter), and
+# its stale recorded version would fail the Deep Safety lane's
+# `cargo metadata --locked` freshness verify after a bump.
+PARTIAL_LOCKFILES = (
+    "fuzz/Cargo.lock",
+)
 VERSION_FILES = (
     "README.md",
     "docs/client.md",
@@ -184,6 +193,27 @@ def replace_lockstep_package_versions(
         lock, count = pattern.subn(rf"\g<1>{new}\2", lock, count=1)
         if count != 1:
             raise ReleaseError(f"{path} has no unique locked {package} {old}")
+    path.write_text(lock, encoding="utf-8")
+
+
+def replace_present_lockstep_package_versions(
+    path: Path, package_names: list[str], old: str, new: str
+) -> None:
+    """Stamp every member present exactly once; absent members stay absent.
+
+    Counterpart to [`replace_lockstep_package_versions`] for partial locks
+    (see [`PARTIAL_LOCKFILES`]): prepare's validation loop has already
+    rejected duplicate entries for the whole tree before any write, so
+    `count=1` here caps a replacement that validation proved unique-or-absent.
+    """
+    lock = path.read_text(encoding="utf-8")
+    for package in package_names:
+        pattern = re.compile(
+            rf'(^\[\[package\]\]\nname = "{re.escape(package)}"\nversion = ")'
+            rf'{re.escape(old)}("$)',
+            re.MULTILINE,
+        )
+        lock, _count = pattern.subn(rf"\g<1>{new}\2", lock, count=1)
     path.write_text(lock, encoding="utf-8")
 
 
@@ -721,6 +751,12 @@ def prepare(
             marker = f'name = "{package}"\nversion = "{old}"'
             if lock.count(marker) != 1:
                 raise ReleaseError(f"{relative} has no unique locked {package} {old}")
+    for relative in PARTIAL_LOCKFILES:
+        lock = (root / relative).read_text(encoding="utf-8")
+        for package in package_names:
+            marker = f'name = "{package}"\nversion = "{old}"'
+            if lock.count(marker) > 1:
+                raise ReleaseError(f"{relative} has duplicate locked {package} {old}")
     compatibility_text = (root / "tests/compatibility.toml").read_text(encoding="utf-8")
     # Only the top-level table carries the release-stamped identity. Section
     # tables ([protocol_authority] and the vendored PROVENANCE.toml files) hold
@@ -770,6 +806,10 @@ def prepare(
     )
     for relative in LOCKSTEP_LOCKFILES:
         replace_lockstep_package_versions(root / relative, package_names, old, new)
+    for relative in PARTIAL_LOCKFILES:
+        replace_present_lockstep_package_versions(
+            root / relative, package_names, old, new
+        )
     for relative in VERSION_FILES:
         replace_required(root / relative, old, new)
     compatibility = root / "tests/compatibility.toml"

--- a/scripts/test_release.py
+++ b/scripts/test_release.py
@@ -239,6 +239,16 @@ class PreparationTests(unittest.TestCase):
                 'name = "signal-fish-client-godot"\nversion = "1.2.3"\n',
                 encoding="utf-8",
             )
+        # Partial locks record only the members their graph reaches (the
+        # fuzz graph never contains the Godot adapter).
+        for relative in release.PARTIAL_LOCKFILES:
+            path = self.root / relative
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(
+                'version = 4\n\n[[package]]\nname = "signal-fish-client"\n'
+                'version = "1.2.3"\n',
+                encoding="utf-8",
+            )
         (self.root / "CHANGELOG.md").write_text(
             "# Changelog\n\n## [Unreleased]\n\n### Added\n\n- Good thing.\n\n"
             "## [1.2.3] - 2020-01-01\n\n- Old.\n\n"
@@ -259,6 +269,12 @@ class PreparationTests(unittest.TestCase):
         for relative in release.LOCKSTEP_LOCKFILES:
             lock = (self.root / relative).read_text(encoding="utf-8")
             self.assertEqual(lock.count('version = "1.3.0"'), 2)
+        for relative in release.PARTIAL_LOCKFILES:
+            lock = (self.root / relative).read_text(encoding="utf-8")
+            # The fuzz graph contains only the core; the adapter must stay
+            # absent, and the core's recorded version must move in lockstep.
+            self.assertEqual(lock.count('version = "1.3.0"'), 1)
+            self.assertNotIn("signal-fish-client-godot", lock)
         changelog = (self.root / "CHANGELOG.md").read_text(encoding="utf-8")
         self.assertIn("## [Unreleased]\n\n## [1.3.0] - 2026-07-13", changelog)
         self.assertIn("compare/v1.2.3...v1.3.0", changelog)
@@ -628,6 +644,19 @@ class PreparationTests(unittest.TestCase):
         missing = self.root / release.VERSION_FILES[-1]
         missing.write_text("stale\n", encoding="utf-8")
         with self.assertRaisesRegex(release.ReleaseError, "required value"):
+            release.prepare(self.root, "patch", "2026-07-13", allow_dirty=True)
+        self.assertEqual(release.package_version(self.root), "1.2.3")
+
+    def test_duplicate_partial_lock_entry_fails_before_writes(self) -> None:
+        # A partial lock must never carry a member twice; that would make the
+        # lockstep stamp ambiguous and the --locked verify unreliable.
+        path = self.root / release.PARTIAL_LOCKFILES[0]
+        path.write_text(
+            path.read_text(encoding="utf-8")
+            + '\n[[package]]\nname = "signal-fish-client"\nversion = "1.2.3"\n',
+            encoding="utf-8",
+        )
+        with self.assertRaisesRegex(release.ReleaseError, "duplicate locked"):
             release.prepare(self.root, "patch", "2026-07-13", allow_dirty=True)
         self.assertEqual(release.package_version(self.root), "1.2.3")
 

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -3163,8 +3163,8 @@ mod workflow_security {
         );
 
         assert!(
-            contents.contains("mymindstorm/setup-emsdk"),
-            "scripts/check-workflows.sh must include mymindstorm/setup-emsdk \
+            contents.contains("emscripten-core/setup-emsdk"),
+            "scripts/check-workflows.sh must include emscripten-core/setup-emsdk \
              in the MAJOR_ONLY_EXCEPTIONS list as a known exception."
         );
 

--- a/tests/godot-web-smoke/Cargo.toml
+++ b/tests/godot-web-smoke/Cargo.toml
@@ -12,7 +12,7 @@ raw-emscripten-proof = ["signal-fish-client/transport-websocket-emscripten"]
 
 [dependencies]
 fortress-rollback = "=0.10.0"
-godot = { version = "=0.5.4", features = ["api-custom", "experimental-wasm", "experimental-wasm-nothreads", "lazy-function-tables"] }
+godot = { version = "=0.5.5", features = ["api-custom", "experimental-wasm", "experimental-wasm-nothreads", "lazy-function-tables"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 signal-fish-client = { path = "../..", default-features = false, features = ["polling-client"] }

--- a/tests/godot_adapter_policy_tests.rs
+++ b/tests/godot_adapter_policy_tests.rs
@@ -146,7 +146,7 @@ fn minimum_and_latest_fixtures_pin_the_contract_endpoints() {
     let core = parse_toml(root().join("Cargo.toml"));
     let expected_client = workspace_version(&core);
 
-    for (fixture, expected_godot) in [(MIN_FIXTURE, "0.4.5"), (LATEST_FIXTURE, "0.5.4")] {
+    for (fixture, expected_godot) in [(MIN_FIXTURE, "0.4.5"), (LATEST_FIXTURE, "0.5.5")] {
         let manifest = parse_toml(root().join(fixture).join("Cargo.toml"));
         let expected_requirement = format!("={expected_godot}");
         assert_eq!(


### PR DESCRIPTION
## Why

Paranoid-audit round 29 (issue #126) over three fresh surfaces — dependency freshness, release-window semver truthfulness, and example fidelity — plus the session's dependency-freshness goal. Three real defect clusters came out of it, each fixed at the class level.

## What

**The flagship mesh example hung forever.** `mesh_session`'s scripted server spoke an obsolete protocol flow (empty `game_data_formats`, a v3 triple without `transports`, lobby state before the room join, a session plan before finalization) and then swallowed the resulting `ProtocolViolation` events in a `_ => {}` arm — so the "runnable end-to-end demo" advertised by the mesh guide silently did nothing. It is rebuilt on the crate's public `ServerMessage`/`ClientMessage` types with the canonical v3 sequence (negotiate → join → ready → finalize → generated plan → relayed signal), breaks loudly on terminal events, uses the guide-mandated one-shot start latch, and is pinned by a timeout-bounded in-example test. Because nothing ever *executed* an example, Examples Validation now runs both offline examples under a timeout and clippy-checks the sparse mesh combo — this rot class now fails CI instead of hanging users. `load_lab` shuts its clients down gracefully (documented drop = abort-grade teardown) and the examples surface `ProtocolViolation`/`DecodeFailed` instead of discarding them.

**Two stale dependency facts.** The "latest" godot fixture was pinned to `=0.5.4` while 0.5.5 (same MSRV, identical feature set, already resolved by the workspace) is current — bumped with unified-lock regeneration, policy-test alignment, and every doc claim updated; proven locally with the exact CI lane (`GODOT4_BIN` + `clippy --all-targets --locked` + tests). And `fuzz/Cargo.lock` — the hostile-input lane — was stale, untracked, and silently regenerated by CI on every run, so nothing pinned what the fuzzers actually build; it is now tracked like the root and fixture locks, and Deep Safety verifies it with `--locked` (fail-closed) instead of masking drift.

**Release tooling keeps the new invariant green.** `fuzz/Cargo.lock` records the core's version, so the next bump would have bricked the scheduled lane; `release.py prepare` now stamps it in lockstep as a *partial* lock (its graph never reaches the Godot adapter), with fail-closed duplicate detection and unit tests.

Also: mechanical tool-pin refresh (cargo-audit 0.22.2, cargo-fuzz 0.13.2, machete, udeps, cyclonedx, typos, install-action), the canonical `emscripten-core/setup-emsdk` rename swept across all four pinning sites, the verified `cargo-semver-checks` blind spot documented in the public-API skill (repro posted upstream, obi1kenobi/cargo-semver-checks#1341 — the `**Breaking:**` changelog marker that drives release policy remains the working gate for that class), and the polling `close()` drain-and-discard doc correction changelogged.

## Verification

- Mandatory workflow clean; 1,085 tests green across 23 suites.
- Red/green: mesh demo `timeout` exit 124 → exit 0 with peer connected; fuzz `--locked` verify fails on the stale lock, passes on the tracked one; fixture policy test pins 0.5.5 with a unified lock.
- `release.py release-intent` unchanged: 0.12.0, major policy. Semver-checks vs `v0.11.0`: no new findings.
- Follow-ups filed evidence-first: #200 (fortress-rollback 0.13), #201 (emsdk probe), #202 (major tool bumps).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are mostly examples, CI, lockfile policy, and dependency pins; no production client protocol or auth logic changes in the core library path.
> 
> **Overview**
> **Fixes the self-contained `mesh_session` example**, which used an obsolete scripted v3 server flow and could hang forever while swallowing `ProtocolViolation` events. The scripted server is rebuilt on `ServerMessage`/`ClientMessage` with negotiate → join → ready → finalize → plan → relayed signal, fails loudly on terminal diagnostics, and is guarded by an in-example timeout test.
> 
> **Examples Validation now executes offline demos** (`custom_transport`, `mesh_session` under 120s) and clippy-checks the sparse mesh feature combo so protocol rot fails CI instead of users. Other examples (`basic_lobby`, `load_lab`) log `ProtocolViolation`/`DecodeFailed` and `load_lab` shuts clients down explicitly.
> 
> **Fuzz dependency resolution is pinned**: `fuzz/Cargo.lock` is tracked (like fixture locks), Deep Safety verifies it with `cargo metadata --locked` instead of regenerating each run, and `release.py prepare` stamps it as a partial lock so version bumps do not break that lane.
> 
> **Mechanical maintenance**: latest Godot web-smoke fixture bumps to **0.5.5** (lock + docs/skills), `mymindstorm/setup-emsdk` → `emscripten-core/setup-emsdk` across workflows/scripts, and assorted CI tool pin bumps (typos, install-action, cargo-audit/fuzz/machete/udeps/cyclonedx). Changelog/docs note the mesh fix and polling `close()` drain behavior; the public-API skill documents known `cargo-semver-checks` blind spots.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81a7c9dfa39a01dad33588e03877f6997256dc6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->