### PR TITLE
Round 30: fixture/tool freshness, oracle hardening, docs fixes

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@v2.87.1
         with:
-          tool: cargo-llvm-cov@0.8.4
+          tool: cargo-llvm-cov@0.9.0
 
       - name: Cache Cargo artifacts
         uses: Swatinem/rust-cache@v2.9.2

--- a/.github/workflows/deep-safety.yml
+++ b/.github/workflows/deep-safety.yml
@@ -222,7 +222,7 @@ jobs:
       - name: Install cargo-mutants
         uses: taiki-e/install-action@v2.87.1
         with:
-          tool: cargo-mutants@26.2.0
+          tool: cargo-mutants@27.1.0
 
       - name: Run mutation tests
         run: >-

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -20,10 +20,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     # Least privilege: only `deploy` consumes the workflow-level pages/id-token
-    # grants. The build job installs third-party docs dependencies, so it must
-    # not hold an OIDC-minting handle.
+    # write grants. The build job installs third-party docs dependencies, so it
+    # must not hold an OIDC-minting handle; `pages: read` covers the
+    # configure-pages metadata GET (actions/configure-pages#188).
     permissions:
       contents: read
+      pages: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -19,6 +19,11 @@ jobs:
     name: Build Documentation
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # Least privilege: only `deploy` consumes the workflow-level pages/id-token
+    # grants. The build job installs third-party docs dependencies, so it must
+    # not hold an OIDC-minting handle.
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1

--- a/.github/workflows/godot-web.yml
+++ b/.github/workflows/godot-web.yml
@@ -17,8 +17,12 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
   GODOT_VERSION: "4.5"
+  # Pinned to the emsdk matching Godot 4.5's web export toolchain: the
+  # official export templates and the tier-3 wasm32-unknown-emscripten
+  # -Zbuild-std link flags (e.g. -lwebsocket.js) are emsdk-version-sensitive.
+  # Upgrade only after a green probe of the web matrix (issue #201).
   EMSDK_VERSION: "3.1.74"
-  PLAYWRIGHT_VERSION: "1.61.1"
+  PLAYWRIGHT_VERSION: "1.62.1"
   RUST_NIGHTLY: "nightly-2026-03-01"
   NETEM_SEED: "6101"
   IPROUTE2_VERSION: "6.6.0"
@@ -475,7 +479,11 @@ jobs:
               --scenario clean --server-url "${server_url}" 2>&1 | tee fortress-browser.log
             node scripts/run-godot-web-smoke.mjs \
               tests/godot-web-smoke/project/build "${server_pid}" 2>&1 | tee browser.log
-            wait "${server_pid}"
+            # The runner already SIGTERMed the server; its exit status is not
+            # an oracle (the runner's own close-attribution checks are). Stay
+            # symmetric with the impaired branch so a non-zero SIGTERM exit
+            # cannot false-red the job after every oracle passed.
+            wait "${server_pid}" || true
             server_pid=""
             node scripts/run-godot-web-smoke.mjs \
               tests/godot-web-smoke/project/build-negative \

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -81,6 +81,9 @@ jobs:
       - name: Install Emscripten SDK
         uses: emscripten-core/setup-emsdk@v16
         with:
+          # Matched to the Godot 4.5 web export toolchain; the tier-3
+          # wasm32-unknown-emscripten -Zbuild-std link flags are
+          # emsdk-version-sensitive. Upgrade only after a green probe (issue #201).
           version: 3.1.74
       - name: Cache Cargo artifacts
         uses: Swatinem/rust-cache@v2.9.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The self-contained mesh example's scripted server spoke an obsolete
   protocol flow and hung; it now completes end-to-end and the examples
   surface protocol violations instead of silently discarding them.
+- Corrected recommended usage in the docs: the `wasm.md` guide now installs
+  and uses the pinned `nightly-2026-03-01` toolchain consistently and
+  quotes the actual user-side error for the wrong-target Emscripten
+  transport, and the Godot adapter README's Quick Start lists the `godot`
+  dependency its snippet imports and pins both crates to `0.11`.
 
 ## [0.11.0] - 2026-08-28
 

--- a/crates/signal-fish-client-godot/README.md
+++ b/crates/signal-fish-client-godot/README.md
@@ -16,13 +16,15 @@ for setup and migration instructions.
 | godot-rust (`godot` crate) | `>=0.4.5, <0.6` — pick one exact version so your `Gd<WebSocketPeer>` shares the adapter's type identity |
 | Godot Engine | 4.5, native or official web export |
 
-Add both crates as direct dependencies — the Quick Start imports
-`signal_fish_client` types directly:
+Add the adapter, the core crate, and a matching `godot` binding as direct
+dependencies — the Quick Start imports `signal_fish_client` and `godot` types
+directly:
 
 ```toml
 [dependencies]
-signal-fish-client = { version = "0.10", default-features = false, features = ["polling-client"] }
-signal-fish-client-godot = { version = "0.10" }
+godot = { version = ">=0.4.5, <0.6" }
+signal-fish-client = { version = "0.11", default-features = false, features = ["polling-client"] }
+signal-fish-client-godot = { version = "0.11" }
 ```
 
 ## Quick start

--- a/docs/fortress.md
+++ b/docs/fortress.md
@@ -7,7 +7,7 @@ by the repository's two-process Godot browser test.
 Add the rollback library beside the SDK in the Godot GDExtension crate:
 
 ```toml
-fortress-rollback = "=0.10.0"
+fortress-rollback = "=0.13.0"
 godot = { version = "0.5.5", features = ["api-custom", "experimental-wasm", "experimental-wasm-nothreads", "lazy-function-tables"] }
 serde = { version = "1.0", features = ["derive"] }
 signal-fish-client = { git = "https://github.com/Ambiguous-Interactive/signal-fish-client-rust", default-features = false, features = ["polling-client"] }

--- a/docs/wasm.md
+++ b/docs/wasm.md
@@ -109,9 +109,9 @@ export templates that explicitly link Emscripten's WebSocket library.
 
 | Requirement | Version | Notes |
 |-------------|---------|-------|
-| Rust nightly | 2026-03-01 | Pinned tier 3 toolchain used by CI |
+| Rust nightly | 2026-03-01 | Pinned tier 3 toolchain; the Godot web export CI lane pins the same date |
 | `rust-src` component | (matches nightly) | Required by `-Zbuild-std` to build `std` from source |
-| Emscripten SDK | 3.1.74 | Provides the sysroot and system libraries |
+| Emscripten SDK | 3.1.74 | Provides the sysroot and system libraries. Pinned to the emsdk matching Godot 4.5's web export toolchain; newer emsdk releases are unverified |
 
 ### Feature flags
 
@@ -662,9 +662,11 @@ Step-by-step instructions for setting up the Emscripten build environment.
 
 ### 1. Install Rust nightly and `rust-src`
 
+The Godot web export path pins a dated nightly so local builds match CI
+exactly; every command on this page uses the same toolchain.
+
 ```sh
-rustup toolchain install nightly
-rustup component add rust-src --toolchain nightly
+rustup toolchain install nightly-2026-03-01 --component rust-src
 ```
 
 ### 2. Install the Emscripten SDK
@@ -685,12 +687,12 @@ source ./emsdk_env.sh
 
 ```sh
 # Core types only (no transport)
-cargo +nightly build -Zbuild-std \
+cargo +nightly-2026-03-01 build -Zbuild-std \
     --target wasm32-unknown-emscripten \
     --no-default-features
 
 # With Emscripten WebSocket transport
-cargo +nightly build -Zbuild-std \
+cargo +nightly-2026-03-01 build -Zbuild-std \
     --target wasm32-unknown-emscripten \
     --no-default-features \
     --features transport-websocket-emscripten
@@ -775,15 +777,17 @@ source `emsdk_env.sh` before building. See
 **Error:**
 
 ```text
-error[E0432]: unresolved import `crate::transports::emscripten_websocket`
+error[E0432]: unresolved import `signal_fish_client::EmscriptenWebSocketTransport`
 ```
 
 **Solution:** You are building for `wasm32-unknown-unknown` with the
-`transport-websocket-emscripten` feature enabled. This feature is only available
-on `wasm32-unknown-emscripten`. Switch to the correct target:
+`transport-websocket-emscripten` feature enabled. The type is only available
+on `wasm32-unknown-emscripten`; the SDK compiles cleanly without it on the
+wrong target, so the failure surfaces at your own import site. Switch to the
+correct target:
 
 ```sh
-cargo +nightly build -Zbuild-std \
+cargo +nightly-2026-03-01 build -Zbuild-std \
     --target wasm32-unknown-emscripten \
     --no-default-features \
     --features transport-websocket-emscripten
@@ -802,7 +806,7 @@ error: the `-Zbuild-std` flag requires the `rust-src` component
 **Solution:**
 
 ```sh
-rustup component add rust-src --toolchain nightly
+rustup component add rust-src --toolchain nightly-2026-03-01
 ```
 
 ---

--- a/scripts/run-godot-web-smoke.mjs
+++ b/scripts/run-godot-web-smoke.mjs
@@ -95,14 +95,19 @@ try {
   throw error;
 }
 const consoleLines = [];
+const consoleErrors = [];
 const pageErrors = [];
 let metricsBefore = "";
 let metricsAfter = "";
 let loadSummary;
 page.on("console", (message) => {
   const line = message.text();
+  const type = message.type();
   consoleLines.push(line);
-  process.stdout.write(`[browser:${message.type()}] ${line}\n`);
+  if (type === "error") {
+    consoleErrors.push({ type, text: line });
+  }
+  process.stdout.write(`[browser:${type}] ${line}\n`);
 });
 page.on("pageerror", (error) => {
   pageErrors.push(error.message);
@@ -309,9 +314,9 @@ try {
     const failures = consoleLines.filter(
       (line) => line.includes("-error") || line.includes("unexpected-disconnect"),
     );
-    if (pageErrors.length > 0 || failures.length > 0) {
+    if (pageErrors.length > 0 || consoleErrors.length > 0 || failures.length > 0) {
       throw new Error(
-        `browser reported failures: ${JSON.stringify({ pageErrors, failures })}`,
+        `browser reported failures: ${JSON.stringify({ pageErrors, consoleErrors, failures })}`,
       );
     }
   }

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -258,7 +258,7 @@ mod godot_issue_61_policy {
             .as_str()
             .expect("Fortress dependency uses a simple exact version");
 
-        assert_eq!(fortress, "=0.10.0");
+        assert_eq!(fortress, "=0.13.0");
         assert!(fortress_fixture.contains("const PREDICTION_WINDOW_FRAMES: usize = 20;"));
         assert!(fortress_fixture.contains("with_max_prediction_window(PREDICTION_WINDOW_FRAMES)"));
         assert!(fortress_runner.contains("scenario === \"soak\" ? 3_600 : 600"));

--- a/tests/godot-web-smoke/Cargo.lock
+++ b/tests/godot-web-smoke/Cargo.lock
@@ -18,23 +18,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
-name = "bincode"
-version = "2.0.1"
+name = "bincode-next"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
+checksum = "dbe9e7e6d14aeb39557f226bff158a30e367fac279d0e69b8b42fb41999f9a86"
 dependencies = [
- "bincode_derive",
  "serde",
- "unty",
-]
-
-[[package]]
-name = "bincode_derive"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
-dependencies = [
- "virtue",
+ "unty-next",
 ]
 
 [[package]]
@@ -73,11 +63,11 @@ checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "fortress-rollback"
-version = "0.10.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65410c9563f7a4dff7221c8e250bd632317a932a2ff52943e7d74be5b25d9470"
+checksum = "f42aff6e1b7c9b1e9a4bebb0eb22e0742768426c3787dbfbd75161e005a8a25c"
 dependencies = [
- "bincode",
+ "bincode-next",
  "loom",
  "parking_lot",
  "serde",
@@ -728,10 +718,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "unty"
-version = "0.0.4"
+name = "unty-next"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+checksum = "16062d030850f35054e37746427b9febb74a2f24c9c6dd6fa2d0c13c5f53221e"
 
 [[package]]
 name = "uuid"
@@ -760,12 +750,6 @@ dependencies = [
  "proc-macro2",
  "quote",
 ]
-
-[[package]]
-name = "virtue"
-version = "0.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "wasm-bindgen"

--- a/tests/godot-web-smoke/Cargo.toml
+++ b/tests/godot-web-smoke/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 raw-emscripten-proof = ["signal-fish-client/transport-websocket-emscripten"]
 
 [dependencies]
-fortress-rollback = "=0.10.0"
+fortress-rollback = "=0.13.0"
 godot = { version = "=0.5.5", features = ["api-custom", "experimental-wasm", "experimental-wasm-nothreads", "lazy-function-tables"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/tests/godot-web-smoke/README.md
+++ b/tests/godot-web-smoke/README.md
@@ -37,7 +37,7 @@ commands do not try to link a GDExtension test binary outside Godot.
 ## Fortress rollback scenario
 
 The same fixture also contains a deterministic two-player
-`fortress-rollback` 0.10.0 game. CI launches two independent Chromium
+`fortress-rollback` 0.13.0 game. CI launches two independent Chromium
 processes, each hosting its own Godot runtime and Signal Fish client, against
 one real Signal Fish server process. The primary clean, impaired, and soak jobs
 pin 0.7.0, while a clean compatibility job pins 0.4.0. Player A creates a room and player B


### PR DESCRIPTION
## Why

Three evidence-first follow-ups from round 29 were waiting on measured evaluations, and the recurring correctness audit (#126) was due for round 30. This PR closes all of them in one pass, plus the real defects the audits found.

## What

**Dependency and tool freshness (evidence first)**

- The gameplay fixture now rolls on fortress-rollback 0.13.0 (#200). The 0.12 serialization-backend swap kept the fixture's codec API source-compatible: all 9 fixture tests pass on the exact CI lane, and the hosted clean/impaired/soak matrix re-proves the wire oracles.
- Adopted cargo-mutants 27.1.0 after a measured local run with the exact CI arguments (54 mutants: 46 caught, 8 unviable, 0 missed), cargo-llvm-cov 0.9.0 after a full-suite gate diff against 0.8.4 (94.96% → 94.97% lines; the 93% gate passes on both), and Playwright 1.62.1 for the Godot Web lane (#202).
- The emsdk 3.1.74 pin now documents why it exists (#201): it matches Godot 4.5's web export toolchain, and the tier-3 build flags are emsdk-sensitive.

**Round 30 audit fixes (#126)**

- E2E oracle scripts: verified all thresholds, coercions, and exit plumbing clean. The smoke runner now also fails on error-severity browser console output (parity with the fortress runner), and the clean job's server wait can no longer false-red after every oracle passed.
- Integration journeys: the adapter README told users to install crate 0.10 (the old release) and omitted the `godot` dependency its own Quick Start snippet imports — both fixed. The wasm guide now installs the pinned `nightly-2026-03-01` toolchain its commands actually use, and the wrong-target troubleshooting entry quotes the error a user really sees.
- Workflow least privilege: the docs-deploy build job no longer holds `pages: write`/`id-token: write` it never uses while installing third-party docs dependencies.
- Two audit candidates were refuted with hosted evidence and left alone: the Repository Policy workflow's token can read rulesets (the August 17 failure was genuine drift detection), and the action-ref linter already rejects non-numeric tags.

## Verification

- `cargo fmt`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo test --workspace --all-features`: all green.
- Fixture: `cargo check`/`cargo test --locked` on the exact CI lane (godot-rust 0.5.5 + Godot 4.5 binary); unified-godot-lock policy suite green.
- All 18 pre-commit checks green; hosted CI validates the web matrix, coverage gate, mutation lane, and docs lanes on this PR.

Closes #200, closes #201, closes #202. Contributes round 30 to #126.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are CI pins, test oracles, workflow permissions tightening, and docs; no production SDK or protocol logic changes.
> 
> **Overview**
> Bumps **CI tooling and the Godot web fixture**: `fortress-rollback` **0.13.0** in the smoke workspace (lockfile, tests, and docs), **cargo-mutants 27.1.0**, **cargo-llvm-cov 0.9.0**, and **Playwright 1.62.1**. Workflow comments document why **emsdk 3.1.74** stays pinned to Godot 4.5’s web export toolchain.
> 
> **E2E reliability and security**: the Godot web smoke runner now **fails on browser `console` errors** (aligned with the fortress runner), and the clean scenario uses **`wait` on the server PID with `|| true`** so a SIGTERM exit cannot fail the job after oracles pass. **docs-deploy**’s build job gets **job-level `contents`/`pages: read`** so it no longer inherits workflow **Pages OIDC write** while installing third-party deps.
> 
> **Documentation corrections**: `wasm.md` consistently uses **`nightly-2026-03-01`** and updates wrong-target troubleshooting; the Godot adapter README Quick Start lists **`godot`** and pins **0.11** crates. **CHANGELOG** records these doc fixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28242ae26e614d828299f492e5855c84ad9e5fd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->