### PR TITLE
Round 32 audit: run Repository Policy on every PR, sweep workflow credentials

### DIFF
--- a/.github/required-checks.json
+++ b/.github/required-checks.json
@@ -6,6 +6,7 @@
     { "workflow": "Examples Validation", "file": "examples-validation.yml", "job": "Examples Validation Required" },
     { "workflow": "Godot Web", "file": "godot-web.yml", "job": "Godot Web Required" },
     { "workflow": "No Panics", "file": "no-panics.yml", "job": "No Panics Required" },
+    { "workflow": "Repository Policy", "file": "repository-policy.yml", "job": "Repository Policy Required" },
     { "workflow": "Security", "file": "security-supply-chain.yml", "job": "Security Required" },
     { "workflow": "Semver Checks", "file": "semver-checks.yml", "job": "Semver Required" },
     { "workflow": "Unused Deps", "file": "unused-deps.yml", "job": "Unused Deps Required" },
@@ -13,8 +14,10 @@
     { "workflow": "Workflow Lint", "file": "workflow-lint.yml", "job": "Workflow Lint Required" }
   ],
   "repository_rules": {
+    "target": "branch",
     "enforcement": "active",
     "include": ["~DEFAULT_BRANCH"],
+    "exclude": [],
     "required_approving_review_count": 1,
     "dismiss_stale_reviews_on_push": true,
     "required_review_thread_resolution": true,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -59,6 +61,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
       - name: Run typos spell checker
         uses: crate-ci/typos@v1.50.0
         with:
@@ -110,6 +114,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -165,6 +171,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Cache Cargo artifacts
@@ -237,6 +245,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Cache Cargo artifacts
@@ -284,6 +294,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
       - name: Install MSRV Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -329,6 +341,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
       - name: Install adapter Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -349,6 +363,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Cache Cargo artifacts
@@ -371,6 +387,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
       - name: Run cargo-deny
         uses: EmbarkStudios/cargo-deny-action@v2.1.1
 
@@ -385,6 +403,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
       - name: Install pinned measurement toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -424,6 +444,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -36,6 +36,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/deep-safety.yml
+++ b/.github/workflows/deep-safety.yml
@@ -65,6 +65,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install Rust nightly with Miri
         uses: dtolnay/rust-toolchain@nightly
@@ -99,6 +101,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install Rust nightly with rust-src
         uses: dtolnay/rust-toolchain@nightly
@@ -142,6 +146,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install Rust nightly
         uses: dtolnay/rust-toolchain@nightly
@@ -209,6 +215,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@v7.0.0

--- a/.github/workflows/docs-validation.yml
+++ b/.github/workflows/docs-validation.yml
@@ -38,6 +38,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Run markdownlint
         uses: DavidAnson/markdownlint-cli2-action@v24.2.0
@@ -55,6 +57,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Run lychee link checker
         uses: lycheeverse/lychee-action@v2.9.0

--- a/.github/workflows/examples-validation.yml
+++ b/.github/workflows/examples-validation.yml
@@ -39,6 +39,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -59,6 +61,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -88,6 +92,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/godot-web.yml
+++ b/.github/workflows/godot-web.yml
@@ -37,6 +37,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install Rust nightly with rust-src
         uses: dtolnay/rust-toolchain@nightly
@@ -326,6 +328,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Download exported browser fixture
         uses: actions/download-artifact@v8.0.1

--- a/.github/workflows/no-panics.yml
+++ b/.github/workflows/no-panics.yml
@@ -36,6 +36,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/protocol-sync.yml
+++ b/.github/workflows/protocol-sync.yml
@@ -48,6 +48,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Compare vendored samples to upstream and fail on drift
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,6 +42,7 @@ jobs:
           ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 0
           fetch-tags: true
+          persist-credentials: true
 
       - name: Verify default-branch HEAD and required checks
         env:

--- a/.github/workflows/repository-policy.yml
+++ b/.github/workflows/repository-policy.yml
@@ -12,8 +12,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: repository-policy
-  cancel-in-progress: false
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   audit:

--- a/.github/workflows/repository-policy.yml
+++ b/.github/workflows/repository-policy.yml
@@ -1,8 +1,11 @@
 name: Repository Policy
 
 on:
+  push:
+    branches: [main]
+  pull_request:
   schedule:
-    - cron: "17 7 * * 1"
+    - cron: "17 7 * * *"
   workflow_dispatch:
 
 permissions:
@@ -20,6 +23,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Test policy audit
         run: python3 -m unittest scripts/test_audit_repository_rules.py scripts/test_required_checks.py
@@ -28,3 +33,20 @@ jobs:
         run: python3 scripts/audit-repository-rules.py
         env:
           GH_TOKEN: ${{ github.token }}
+
+  required:
+    name: Repository Policy Required
+    if: ${{ always() }}
+    needs: [audit]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Require every repository policy job
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          failures=$(jq -r 'to_entries[] | select(.value.result != "success") | "\(.key)=\(.value.result)"' <<< "$NEEDS_JSON")
+          if [ -n "$failures" ]; then
+            printf '::error::Required jobs did not succeed:\n%s\n' "$failures"
+            exit 1
+          fi

--- a/.github/workflows/security-supply-chain.yml
+++ b/.github/workflows/security-supply-chain.yml
@@ -48,6 +48,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -81,6 +83,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Run cargo-deny
         uses: EmbarkStudios/cargo-deny-action@v2.1.1
@@ -98,6 +102,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -59,6 +59,7 @@ jobs:
         uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/unused-deps.yml
+++ b/.github/workflows/unused-deps.yml
@@ -50,6 +50,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -81,6 +83,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@nightly

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -55,6 +55,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -74,6 +76,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
       - name: Install Rust nightly with rust-src
         uses: dtolnay/rust-toolchain@nightly
         with:

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -3,7 +3,7 @@
 # Runs on every push to main and on all pull requests so its stable aggregate
 # gate reports on every protected-branch candidate.
 # Jobs: actionlint — workflow syntax, yamllint — YAML style, shellcheck — shell scripts,
-#        devcontainer-compat — cross-platform devcontainer validation
+#        python-tooling — repository Python guards, devcontainer-compat — cross-platform validation
 #
 # Cancel in-progress runs on the same branch to save resources.
 
@@ -33,6 +33,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@v7.0.0
@@ -57,6 +59,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install yamllint
         run: pip install 'yamllint>=1.35,<2'
@@ -74,6 +78,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Run shellcheck
         run: shellcheck scripts/*.sh .devcontainer/scripts/*.sh
@@ -83,6 +89,51 @@ jobs:
 
       - name: Run test quality checker unit tests
         run: bash scripts/test_check_test_quality.sh
+
+      - name: Run target-gated doc-link checker unit tests
+        run: bash scripts/test_check_target_gated_doc_links.sh
+
+      - name: Run shell portability checker unit tests
+        run: bash scripts/test_shell_portability.sh
+
+  # ──────────────────────────────────────────────────────────────
+  # python-tooling — run every repository Python guard and self-test
+  # ──────────────────────────────────────────────────────────────
+  python-tooling:
+    name: Python tooling
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v7.0.0
+        with:
+          python-version: '3.11'
+
+      - name: Install pytest
+        run: python3 -m pip install 'pytest==9.1.1'
+
+      - name: Validate Agent Skills and generated index
+        run: |
+          python3 scripts/pre-commit-llm.py
+          git diff --exit-code HEAD --
+
+      - name: Test Agent Skills validation
+        run: python3 -m pytest -q scripts/test_pre_commit_llm.py
+
+      - name: Test repository Python tooling
+        run: >-
+          python3 -m unittest
+          scripts/test_release.py
+          scripts/test_required_checks.py
+          scripts/test_audit_repository_rules.py
+
+      - name: Test admonition validation
+        run: python3 scripts/test_check_admonitions.py
 
   # ──────────────────────────────────────────────────────────────
   # devcontainer-compat — validate cross-platform devcontainer behavior
@@ -94,6 +145,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Validate devcontainer cross-platform compatibility
         run: bash scripts/check-devcontainer-compat.sh
@@ -107,7 +160,7 @@ jobs:
   required:
     name: Workflow Lint Required
     if: ${{ always() }}
-    needs: [actionlint, yamllint, shellcheck, devcontainer-compat]
+    needs: [actionlint, yamllint, shellcheck, python-tooling, devcontainer-compat]
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:

--- a/.llm/context.md
+++ b/.llm/context.md
@@ -36,8 +36,8 @@ Repository-only material stays in the linked source repository; see `skills/rele
 
 Every blocking workflow runs on PR and default-branch SHAs and ends in a
 uniquely named aggregate `Required` job. The names and desired rules live in
-`.github/required-checks.json`; the scheduled Repository Policy workflow audits
-GitHub for visible drift with its authenticated built-in `GITHUB_TOKEN`.
+`.github/required-checks.json`; the required, daily Repository Policy workflow
+audits GitHub for visible drift with its authenticated built-in `GITHUB_TOKEN`.
 GitHub hides ruleset bypass actors from workflow tokens, so maintainers verify an empty bypass list in the ruleset UI. Prepare Release uses only `GITHUB_TOKEN` and dispatches required workflows explicitly on its generated branch because token-created pull-request events are suppressed; path filters must not suppress a configured gate. No checked-in `GITHUB_TOKEN` workflow may auto-merge Dependabot PRs: such merges rely on drifting rules and can suppress push CI on the resulting SHA, so the fail-closed policy rejects Dependabot-specific workflows, automated-merge primitives, and write permissions outside the release/docs allowlist. Ruleset #14801090 live-enforces reviewed merges and all required checks.
 
 ## GitHub Tool Order

--- a/.llm/skills/ci-configuration/SKILL.md
+++ b/.llm/skills/ci-configuration/SKILL.md
@@ -37,7 +37,7 @@ verify the exact default-branch SHA rather than only the pre-merge PR head.
 
 `.github/required-checks.json` is the canonical list of gate names and desired
 default-branch rules. Keep gate names unique and stable. Update the config, the
-workflow gate, and `required_check_policy` tests together. The scheduled
+workflow gate, and `required_check_policy` tests together. The required, daily
 Repository Policy workflow detects live GitHub ruleset drift; do not add bypass
 actors to make a failing gate mergeable. Live ruleset reads use the workflow's
 authenticated built-in `GITHUB_TOKEN`. GitHub hides bypass actors from workflow
@@ -312,7 +312,7 @@ When test code skips files by module name (e.g., excluding `emscripten_websocket
 Major-version tags like `@v2` are mutable (supply-chain risk). Prefer patch-level pinning (e.g., `@v2.8.2`). Exceptions (keep in sync with `scripts/check-workflows.sh` Phase 7 `MAJOR_ONLY_EXCEPTIONS` array):
 
 - `dtolnay/rust-toolchain` — uses channels (`@stable`, `@nightly`, `@beta`)
-- `mymindstorm/setup-emsdk` — only publishes major-version tags
+- `emscripten-core/setup-emsdk` — uses project-supported major-version tags
 - `taiki-e/install-action` — releases near-daily; patch pins go stale fast
 
 Phase 7 emits non-blocking warnings for major-only pins. Verified by `ci_config_tests.rs::workflow_security::check_workflows_script_detects_major_only_version_tags`.

--- a/scripts/audit-repository-rules.py
+++ b/scripts/audit-repository-rules.py
@@ -107,8 +107,10 @@ def audit(policy: dict[str, Any], rulesets: list[dict[str, Any]]) -> list[str]:
     if not isinstance(expected, dict):
         raise ValueError("policy has no repository_rules object")
     supported_keys = {
+        "target",
         "enforcement",
         "include",
+        "exclude",
         "required_approving_review_count",
         "dismiss_stale_reviews_on_push",
         "required_review_thread_resolution",
@@ -122,6 +124,14 @@ def audit(policy: dict[str, Any], rulesets: list[dict[str, Any]]) -> list[str]:
     expected_refs = set(expected.get("include", []))
     if not expected_refs:
         raise ValueError("repository_rules.include must not be empty")
+    expected_excludes = expected.get("exclude")
+    if not isinstance(expected_excludes, list) or any(
+        not isinstance(pattern, str) for pattern in expected_excludes
+    ):
+        raise ValueError("repository_rules.exclude must be a list of ref patterns")
+    expected_target = expected.get("target")
+    if expected_target not in ("branch", "tag"):
+        raise ValueError("repository_rules.target must be branch or tag")
     configured_checks = policy.get("required_checks")
     if not isinstance(configured_checks, list) or not configured_checks:
         raise ValueError("policy must define a non-empty required_checks list")
@@ -138,18 +148,20 @@ def audit(policy: dict[str, Any], rulesets: list[dict[str, Any]]) -> list[str]:
     def ruleset_applies(ruleset: dict[str, Any]) -> bool:
         ref_name = ruleset.get("conditions") or {}
         ref_name = ref_name.get("ref_name") or {}
-        excluded = ref_name.get("exclude") or []
-        # A ref excluded from the same ruleset that includes it is protected
-        # by nothing: GitHub conditions apply exclusions after inclusions.
-        # The ~ALL alias and wildcard exclude patterns are not modeled here,
-        # so they also fail closed instead of letting an inert ruleset pass
-        # the audit.
-        if expected_refs.intersection(excluded) or "~ALL" in excluded or any(
-            isinstance(pattern, str) and set(pattern) & set("*?[")
-            for pattern in excluded
+        included = ref_name.get("include")
+        excluded = ref_name.get("exclude")
+        if (
+            ruleset.get("target") != expected_target
+            or not isinstance(included, list)
+            or any(not isinstance(pattern, str) for pattern in included)
+            or not isinstance(excluded, list)
+            or any(not isinstance(pattern, str) for pattern in excluded)
         ):
             return False
-        return expected_refs.issubset(ref_name.get("include") or [])
+        # Exclusions override inclusions. Require the exact checked-in set so
+        # an explicit default-branch ref, alias, or glob cannot silently make
+        # an otherwise matching ruleset inert.
+        return expected_refs.issubset(included) and excluded == expected_excludes
 
     applicable = [
         ruleset

--- a/scripts/test_audit_repository_rules.py
+++ b/scripts/test_audit_repository_rules.py
@@ -20,8 +20,10 @@ class RepositoryRuleTests(unittest.TestCase):
     policy = {
         "required_checks": [{"workflow": "CI", "job": "CI Required"}],
         "repository_rules": {
+            "target": "branch",
             "enforcement": "active",
             "include": ["~DEFAULT_BRANCH"],
+            "exclude": [],
             "required_approving_review_count": 1,
             "dismiss_stale_reviews_on_push": True,
             "required_review_thread_resolution": True,
@@ -32,6 +34,7 @@ class RepositoryRuleTests(unittest.TestCase):
     @staticmethod
     def ruleset() -> dict[str, object]:
         return {
+            "target": "branch",
             "enforcement": "active",
             "conditions": {"ref_name": {"include": ["~DEFAULT_BRANCH"], "exclude": []}},
             "rules": [
@@ -67,10 +70,29 @@ class RepositoryRuleTests(unittest.TestCase):
             ["no active ruleset targets ~DEFAULT_BRANCH"],
         )
 
-    def test_excluding_an_unrelated_ref_keeps_the_ruleset_applicable(self) -> None:
+    def test_rejects_every_exclusion_not_in_the_checked_in_policy(self) -> None:
         ruleset = self.ruleset()
         ruleset["conditions"]["ref_name"]["exclude"] = ["refs/heads/dev"]
-        self.assertEqual(audit.audit(self.policy, [ruleset]), [])
+        self.assertEqual(
+            audit.audit(self.policy, [ruleset]),
+            ["no active ruleset targets ~DEFAULT_BRANCH"],
+        )
+
+    def test_rejects_explicit_default_branch_exclusion(self) -> None:
+        ruleset = self.ruleset()
+        ruleset["conditions"]["ref_name"]["exclude"] = ["refs/heads/main"]
+        self.assertEqual(
+            audit.audit(self.policy, [ruleset]),
+            ["no active ruleset targets ~DEFAULT_BRANCH"],
+        )
+
+    def test_rejects_tag_ruleset_for_default_branch_policy(self) -> None:
+        ruleset = self.ruleset()
+        ruleset["target"] = "tag"
+        self.assertEqual(
+            audit.audit(self.policy, [ruleset]),
+            ["no active ruleset targets ~DEFAULT_BRANCH"],
+        )
 
     def test_wildcard_exclude_patterns_fail_closed(self) -> None:
         # A pattern like refs/heads/ma* can exclude the default branch while

--- a/scripts/test_pre_commit_llm.py
+++ b/scripts/test_pre_commit_llm.py
@@ -584,11 +584,14 @@ class TestMainFunctionValidation:
         fake_root.mkdir()
         llm_dir = fake_root / ".llm"
         llm_dir.mkdir()
+        skills_dir = llm_dir / "skills"
+        skills_dir.mkdir()
+        (llm_dir / "context.md").write_text("# Context\n", encoding="utf-8")
 
         monkeypatch.setattr(_mod, "REPO_ROOT", fake_root)
         monkeypatch.setattr(_mod, "LLM_DIR", llm_dir)
-        monkeypatch.setattr(_mod, "SKILLS_DIR", llm_dir / "skills")
-        monkeypatch.setattr(_mod, "INDEX_FILE", llm_dir / "skills" / "index.md")
+        monkeypatch.setattr(_mod, "SKILLS_DIR", skills_dir)
+        monkeypatch.setattr(_mod, "INDEX_FILE", skills_dir / "index.md")
         monkeypatch.setattr(_mod, "find_md_files", lambda _directory: [])
         monkeypatch.setattr(_mod, "validate_mkdocs_nav", lambda: [])
         monkeypatch.setattr(_mod, "validate_yaml_step_indentation", lambda _md: [])
@@ -665,7 +668,6 @@ class TestMainFunctionValidation:
         monkeypatch.setattr(_mod, "sync_crate_version_references", lambda _v: ([], []))
 
         skills_dir = tmp_path / "repo" / ".llm" / "skills"
-        skills_dir.mkdir()
         _write_modern_skill(
             skills_dir,
             "example",

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -128,6 +128,29 @@ mod required_check_policy {
 
     use super::*;
 
+    fn workflow_job_block(workflow: &str, job: &str) -> String {
+        let marker = format!("  {job}:");
+        let mut found = false;
+        let mut block = String::new();
+        for line in workflow.lines() {
+            if line == marker {
+                found = true;
+                block.push_str(line);
+                block.push('\n');
+                continue;
+            }
+            if found && line.starts_with("  ") && !line.starts_with("    ") && line.ends_with(':') {
+                break;
+            }
+            if found {
+                block.push_str(line);
+                block.push('\n');
+            }
+        }
+        assert!(found, "workflow must define job {job}");
+        block
+    }
+
     #[test]
     fn every_blocking_pr_workflow_has_a_stable_aggregate_gate() {
         let policy: serde_json::Value =
@@ -136,7 +159,7 @@ mod required_check_policy {
         let checks = policy["required_checks"]
             .as_array()
             .expect("required_checks must be an array");
-        assert_eq!(checks.len(), 11);
+        assert_eq!(checks.len(), 12);
 
         let mut jobs = BTreeSet::new();
         for check in checks {
@@ -288,7 +311,183 @@ mod required_check_policy {
         assert!(policy["repository_rules"]
             .get("forbid_bypass_actors")
             .is_none());
+        assert_eq!(policy["repository_rules"]["target"], "branch");
+        assert_eq!(policy["repository_rules"]["exclude"], serde_json::json!([]));
         assert!(audit.contains(r#""Authorization": f"Bearer {token}""#));
+        assert!(workflow.contains("  pull_request:\n"));
+        assert!(workflow.contains("  push:\n    branches: [main]\n"));
+        assert!(workflow.contains("    - cron: \"17 7 * * *\""));
+        assert!(workflow.contains("name: Repository Policy Required"));
+    }
+
+    #[test]
+    fn required_python_tooling_runs_every_repository_python_suite() {
+        let workflow = read_project_file(".github/workflows/workflow-lint.yml");
+        let job = workflow_job_block(&workflow, "python-tooling");
+        for required in [
+            "uses: actions/setup-python@v7.0.0",
+            "python-version: '3.11'",
+            "python3 -m pip install 'pytest==9.1.1'",
+            "python3 scripts/pre-commit-llm.py",
+            "git diff --exit-code HEAD --",
+        ] {
+            assert!(job.contains(required), "python-tooling must run {required}");
+        }
+
+        let scripts = project_root().join("scripts");
+        let python_suites: BTreeSet<String> = std::fs::read_dir(&scripts)
+            .expect("read scripts directory")
+            .map(|entry| entry.expect("read scripts entry").file_name())
+            .map(|name| name.to_string_lossy().into_owned())
+            .filter(|name| name.starts_with("test_") && name.ends_with(".py"))
+            .collect();
+        assert!(
+            !python_suites.is_empty(),
+            "expected Python self-test suites"
+        );
+        for suite in python_suites {
+            let path = format!("scripts/{suite}");
+            assert!(
+                job.contains(&path),
+                "required python-tooling job must run {path}"
+            );
+        }
+    }
+
+    #[test]
+    fn every_repository_checker_self_test_runs_in_a_workflow() {
+        let workflow_corpus = REQUIRED_WORKFLOW_PATHS
+            .iter()
+            .map(|path| read_project_file(path))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let scripts = project_root().join("scripts");
+        let suites: BTreeSet<String> = std::fs::read_dir(&scripts)
+            .expect("read scripts directory")
+            .map(|entry| entry.expect("read scripts entry").file_name())
+            .map(|name| name.to_string_lossy().into_owned())
+            .filter(|name| {
+                name.starts_with("test_") && (name.ends_with(".py") || name.ends_with(".sh"))
+            })
+            .collect();
+        assert!(!suites.is_empty(), "expected repository checker self-tests");
+        for suite in suites {
+            let path = format!("scripts/{suite}");
+            assert!(
+                workflow_corpus.contains(&path),
+                "repository checker self-test {path} is absent from every workflow"
+            );
+        }
+    }
+
+    #[test]
+    fn checkout_credentials_are_retained_only_for_push_jobs() {
+        let credential_writers = BTreeSet::from([
+            (".github/workflows/prepare-release.yml", "prepare"),
+            (".github/workflows/publish.yml", "release"),
+        ]);
+        let mut seen_writers = BTreeSet::new();
+
+        let workflows = project_root().join(".github/workflows");
+        let mut paths: Vec<PathBuf> = std::fs::read_dir(&workflows)
+            .expect("read workflows directory")
+            .map(|entry| entry.expect("read workflow entry").path())
+            .filter(|path| {
+                matches!(
+                    path.extension().and_then(|extension| extension.to_str()),
+                    Some("yml" | "yaml")
+                )
+            })
+            .collect();
+        paths.sort();
+
+        for path in paths {
+            let relative = path
+                .strip_prefix(project_root())
+                .expect("workflow path is below project root")
+                .to_string_lossy()
+                .replace('\\', "/");
+            let workflow = std::fs::read_to_string(&path)
+                .unwrap_or_else(|error| panic!("read {relative}: {error}"));
+            let lines: Vec<&str> = workflow.lines().collect();
+            let mut job = "";
+
+            for (index, line) in lines.iter().enumerate() {
+                let indentation = line.len() - line.trim_start().len();
+                let trimmed = line.trim();
+                if indentation == 2 && !trimmed.starts_with('#') && trimmed.ends_with(':') {
+                    job = trimmed.trim_end_matches(':');
+                    continue;
+                }
+                let uses = if indentation == 6 {
+                    trimmed.strip_prefix("- uses:")
+                } else if indentation == 8 {
+                    trimmed.strip_prefix("uses:")
+                } else {
+                    None
+                };
+                let Some(action) = uses.map(str::trim) else {
+                    continue;
+                };
+                let action = action.trim_matches(['\'', '"']);
+                if !action.starts_with("actions/checkout@") {
+                    continue;
+                }
+                assert!(!job.is_empty(), "{relative}: checkout is outside a job");
+
+                let mut values = Vec::new();
+                for following in &lines[index + 1..] {
+                    let following_indent = following.len() - following.trim_start().len();
+                    let following_trimmed = following.trim();
+                    if following_indent <= 6 && following_trimmed.starts_with('-') {
+                        break;
+                    }
+                    if following_indent == 2
+                        && !following_trimmed.starts_with('#')
+                        && following_trimmed.ends_with(':')
+                    {
+                        break;
+                    }
+                    if let Some(value) = following_trimmed.strip_prefix("persist-credentials:") {
+                        values.push(value.trim().trim_matches(['\'', '"']));
+                    }
+                }
+                assert_eq!(
+                    values.len(),
+                    1,
+                    "{relative}::{job}: checkout must set persist-credentials exactly once"
+                );
+                let retains_credentials = match values[0] {
+                    "true" => true,
+                    "false" => false,
+                    value => panic!(
+                        "{relative}::{job}: persist-credentials must be a literal boolean, got {value}"
+                    ),
+                };
+                let identity = (relative.as_str(), job);
+                let expected = credential_writers.contains(&identity);
+                assert_eq!(
+                    retains_credentials, expected,
+                    "{relative}::{job}: checkout credential policy mismatch"
+                );
+                if expected {
+                    assert!(
+                        workflow_job_block(&workflow, job).contains("git push"),
+                        "{relative}::{job}: credential exception no longer performs a push"
+                    );
+                    assert!(
+                        seen_writers.insert((relative.clone(), job.to_string())),
+                        "{relative}::{job}: credential-bearing checkout must be unique"
+                    );
+                }
+            }
+        }
+
+        let expected_writers: BTreeSet<(String, String)> = credential_writers
+            .iter()
+            .map(|(path, job)| ((*path).to_string(), (*job).to_string()))
+            .collect();
+        assert_eq!(seen_writers, expected_writers);
     }
 }
 
@@ -6849,10 +7048,6 @@ mod docs_brand_policy {
             .nth(1)
             .and_then(|jobs| jobs.split("  required:").next())
             .expect("Docs Validation must retain its rendering job");
-        assert!(
-            rendering_job.contains("persist-credentials: false"),
-            "the docs rendering checkout must not persist repository credentials"
-        );
         let render_position = rendering_job
             .find("bash scripts/check-docs-rendering.sh")
             .expect("Docs Validation must build docs before browser testing");

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -321,6 +321,59 @@ mod required_check_policy {
     }
 
     #[test]
+    fn required_multi_trigger_workflows_do_not_share_one_concurrency_group() {
+        // A fully static concurrency group is shared by every trigger: with
+        // GitHub's one-pending-run-per-group behavior, a newer queued run of
+        // another event type cancels an older still-pending run, leaving the
+        // required aggregate check unreported on that PR or branch head.
+        let policy: serde_json::Value =
+            serde_json::from_str(&read_project_file(".github/required-checks.json"))
+                .expect("required-checks policy must be valid JSON");
+        let required_files: BTreeSet<String> = policy["required_checks"]
+            .as_array()
+            .expect("required_checks must be an array")
+            .iter()
+            .map(|check| {
+                let file = check["file"]
+                    .as_str()
+                    .expect("every required check names a workflow file");
+                format!(".github/workflows/{file}")
+            })
+            .collect();
+
+        for file in required_files {
+            let workflow = read_project_file(&file);
+            let on_block = workflow
+                .split("\non:")
+                .nth(1)
+                .map(|rest| rest.split("\njobs:").next().unwrap_or(rest))
+                .unwrap_or_default();
+            let event_count = on_block
+                .lines()
+                .filter(|line| {
+                    let indent = line.len() - line.trim_start().len();
+                    let trimmed = line.trim();
+                    indent == 2 && !trimmed.starts_with('#') && trimmed.ends_with(':')
+                })
+                .count();
+            let group = workflow
+                .lines()
+                .filter_map(|line| line.trim().strip_prefix("group:"))
+                .map(str::trim)
+                .next()
+                .expect("every required workflow defines a concurrency group");
+            let interpolated = group.contains("${{");
+            assert!(
+                interpolated || event_count <= 1,
+                "{file} declares {event_count} event types but shares the static \
+                 concurrency group \"{group}\"; interpolate github.ref / \
+                 github.event_name so one trigger's queued run cannot cancel \
+                 another trigger's pending required check"
+            );
+        }
+    }
+
+    #[test]
     fn required_python_tooling_runs_every_repository_python_suite() {
         let workflow = read_project_file(".github/workflows/workflow-lint.yml");
         let job = workflow_job_block(&workflow, "python-tooling");


### PR DESCRIPTION
## Why

The live branch ruleset already requires a 12th check, `Repository Policy Required`, but the Repository Policy workflow only ran on a weekly schedule. No pull request could ever produce that check, so every future merge would hang forever. This PR delivers the missing half of that contract and hardens the CI governance around it.

## What changed

- **Repository Policy runs on every PR and main push** (daily audit kept), behind a new `Repository Policy Required` aggregate gate. `.github/required-checks.json` now lists all 12 checks and mirrors the live ruleset exactly (`target: branch`, `exclude: []`).
- **Fail-closed ruleset-drift audit**: the audit now rejects mismatched ruleset targets, any exclusion that could silently exempt the default branch (wildcards, `~ALL`, extra refs), and malformed conditions — instead of passing an inert ruleset.
- **Credential-free checkouts**: all 43 `actions/checkout` sites set `persist-credentials` explicitly — `false` everywhere except the two release jobs that `git push`, which now set `true` on purpose instead of relying on the unsafe default.
- **All Python self-tests run in required CI**: a new `python-tooling` job in Workflow Lint runs every `scripts/test_*.py` suite and fails if the generated Agent Skills index goes stale. Two shell self-test suites joined the shellcheck job.
- New `ci_config_tests` pins freeze the check count, the credential policy, and full self-test coverage; internal CI changes only, so no changelog entry per policy.

## Verification

- `cargo fmt` / `clippy -D warnings` / `cargo test --workspace --all-features` all green locally.
- All 19 pre-commit checks pass; actionlint 1.7.7 and yamllint 1.38.0 clean on every workflow.
- The checked-in policy audited green against the live ruleset #14801090 (fetched via API).
- Hosted evidence: the Repository Policy run on `main` `47d78eb` already reads the rulesets API successfully with the same `contents: read` token used on PRs.

Part of the recurring audit on #126.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes branch-protection CI behavior and repository rules auditing (could block merges if live GitHub rules drift), but does not alter application runtime code.
> 
> **Overview**
> Fixes a **merge deadlock**: branch protection already required **Repository Policy Required**, but that workflow only ran on a schedule, so PRs could never satisfy the 12th gate. **Repository Policy** now runs on **pull requests**, **pushes to `main`**, and a **daily** cron, with a **`Repository Policy Required`** aggregate job; `.github/required-checks.json` registers that check and documents **`target: branch`** and **`exclude: []`** for the live ruleset.
> 
> The **ruleset drift audit** is stricter: it matches **branch** rulesets only and requires **exact** include/exclude ref patterns (extra exclusions, tag rulesets, or wildcard excludes no longer pass as “good enough”).
> 
> **Supply-chain hygiene**: almost every `actions/checkout` step now sets **`persist-credentials: false`**; only the release jobs that **`git push`** keep **`persist-credentials: true`** (explicit instead of the default).
> 
> **Workflow Lint** gains a required **`python-tooling`** job that runs all `scripts/test_*.py` suites, validates/regenerates the Agent Skills index, and the shellcheck job picks up two more shell self-tests. **`tests/ci_config_tests.rs`** locks in the 12-check list, checkout credential policy, concurrency groups for multi-trigger required workflows, and that every checker self-test runs in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52c9400156cb5eb5ecdb9df98f5b0169aca77f5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->