### PR TITLE
Round 34 audit: pin refusal contracts, align release inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,8 +67,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   UTF-8, so a corrupt text packet surfaces a terminal receive error that
   ends the stream at the driver.
 - Corrected docs: `set_ready()` toggles readiness (call it once per room
-  stay), `DecodeFailed.message_type` is `None` for frames over 512 bytes,
-  `with_max_players` saturates at `u8::MAX`, `MeshController` requires
+  stay),   `DecodeFailed.message_type` is `None` for frames over 512 bytes,
+  `with_max_players` takes a `u8` (values above 255 cannot be expressed),
+  `MeshController` requires
   `tokio-runtime`, the WASM guide warns pthreads is single-thread-only and
   outbound pacing is not surfaced, at Godot's inbound bounds web drops new
   frames while native backpressures, the polling client's `close()`
@@ -83,6 +84,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   quotes the actual user-side error for the wrong-target Emscripten
   transport, and the Godot adapter README's Quick Start lists the `godot`
   dependency its snippet imports and pins both crates to `0.11`.
+- The guide's `SignalFishError` reference table now lists the
+  `PayloadTooDeep { max_depth }` variant, matching the errors guide; the
+  table predated the variant.
+- The Godot adapter README's dependency pins now advance automatically
+  during release preparation instead of keeping the previously released
+  version after the next release cut.
 
 ## [0.11.0] - 2026-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   UTF-8, so a corrupt text packet surfaces a terminal receive error that
   ends the stream at the driver.
 - Corrected docs: `set_ready()` toggles readiness (call it once per room
-  stay),   `DecodeFailed.message_type` is `None` for frames over 512 bytes,
+  stay), `DecodeFailed.message_type` is `None` for frames over 512 bytes,
   `with_max_players` takes a `u8` (values above 255 cannot be expressed),
   `MeshController` requires
   `tokio-runtime`, the WASM guide warns pthreads is single-thread-only and
@@ -83,7 +83,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and uses the pinned `nightly-2026-03-01` toolchain consistently and
   quotes the actual user-side error for the wrong-target Emscripten
   transport, and the Godot adapter README's Quick Start lists the `godot`
-  dependency its snippet imports and pins both crates to `0.11`.
+  dependency its snippet imports and pins both crates to the previously
+  released version.
 - The guide's `SignalFishError` reference table now lists the
   `PayloadTooDeep { max_depth }` variant, matching the errors guide; the
   table predated the variant.

--- a/crates/signal-fish-client-godot/README.md
+++ b/crates/signal-fish-client-godot/README.md
@@ -23,8 +23,8 @@ directly:
 ```toml
 [dependencies]
 godot = { version = ">=0.4.5, <0.6" }
-signal-fish-client = { version = "0.11", default-features = false, features = ["polling-client"] }
-signal-fish-client-godot = { version = "0.11" }
+signal-fish-client = { version = "0.11.0", default-features = false, features = ["polling-client"] }
+signal-fish-client-godot = { version = "0.11.0" }
 ```
 
 ## Quick start

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -482,6 +482,7 @@ directly from client methods as `Result<(), SignalFishError>`.
 | `SessionPlanUnavailable` | A WebRTC signal was attempted but no authoritative session plan currently authorizes it (before a plan, targeting self, unknown, or departed players, or the negotiated session transport is not WebRTC). |
 | `StaleSessionGeneration { .. }` | A WebRTC signal was produced under an already-replaced session-plan generation; the newer plan remains authoritative. |
 | `BinaryFormatNotNegotiated` | Binary game data was requested while the connection uses JSON. |
+| `PayloadTooDeep { max_depth }` | A caller-supplied JSON payload was refused because its container nesting exceeds the outbound depth bound (128 nested containers, matching `serde_json`'s recursion limit). Applies to JSON game data, raw WebRTC signals, and `ConnectionInfo::Custom`; refused at the call site, before queuing, so flattening the payload is required. |
 | `TokenBinding(TokenBindingFailure)` | Native token-binding negotiation or proof generation failed (see `TokenBindingFailure` for the specific reason). |
 | `Timeout` | An operation exceeded its time limit. |
 | `InvalidConfig { field, problem }` | A configuration value was rejected because it is unusable (zero size limit, unparsable URL, `wss://` without the `tls` feature); correcting the value is required, retrying is not enough. |

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -36,6 +36,7 @@ PARTIAL_LOCKFILES = (
 )
 VERSION_FILES = (
     "README.md",
+    "crates/signal-fish-client-godot/README.md",
     "docs/client.md",
     "docs/getting-started.md",
     "docs/index.md",

--- a/src/client.rs
+++ b/src/client.rs
@@ -2347,6 +2347,14 @@ async fn transport_loop(
                 break;
             }
         }
+        // Arm selection among simultaneously-ready arms is deliberately
+        // nondeterministic. When a transport send failure and an
+        // already-fired shutdown signal become ready in the same
+        // iteration, either terminal teardown may win, so the farewell
+        // reason names whichever cause was observed first. Both causes are
+        // real terminal edges, every pinned invariant (one bounded
+        // farewell, cause precedence, event order) holds under either
+        // winner, and no priority is documented between them.
         tokio::select! {
             command = cmd_rx.recv(), if pending_send.is_none() => {
                 let Some(command) = command else {

--- a/tests/polling_parity_tests.rs
+++ b/tests/polling_parity_tests.rs
@@ -302,6 +302,13 @@ impl NeverSendMock {
             waker.wake();
         }
     }
+
+    fn push_frame(&self, frame: TransportFrame) {
+        self.incoming.lock().unwrap().push_back(frame);
+        if let Some(waker) = self.waker.lock().unwrap().take() {
+            waker.wake();
+        }
+    }
 }
 
 impl Transport for NeverSendMock {
@@ -456,9 +463,7 @@ impl FrameMock {
             incoming: Arc::new(Mutex::new(VecDeque::from([
                 TransportFrame::Text(AUTH.into()),
                 TransportFrame::Text(PI_V3.into()),
-                TransportFrame::Text(
-                    r#"{"type":"RoomJoined","data":{"room_id":"00000000-0000-0000-0000-000000000008","room_code":"ROOM","player_id":"00000000-0000-0000-0000-000000000009","game_name":"game","max_players":4,"supports_authority":true,"current_players":[{"id":"00000000-0000-0000-0000-000000000009","name":"local","is_authority":true,"is_ready":true,"connected_at":"2026-01-01T00:00:00Z","epoch":1,"seq":0},{"id":"00000000-0000-0000-0000-000000000007","name":"peer","is_authority":false,"is_ready":true,"connected_at":"2026-01-01T00:00:00Z","epoch":1,"seq":0},{"id":"00000000-0000-0000-0000-000000000006","name":"off-plan","is_authority":false,"is_ready":true,"connected_at":"2026-01-01T00:00:00Z","epoch":1,"seq":0}],"is_authority":true,"lobby_state":"finalized","ready_players":[],"relay_type":"websocket","current_spectators":[]}}"#.into(),
-                ),
+                TransportFrame::Text(V3_FINALIZED_ROOM.into()),
                 TransportFrame::Text(
                     r#"{"type":"SessionPlan","data":{"generation":"00000000-0000-0000-0000-00000000000c","topology":"mesh","transport":"webrtc","peers":[{"player_id":"00000000-0000-0000-0000-000000000007","player_name":"peer","is_authority":false,"initiate":true}],"fallback":"relay"}}"#.into(),
                 ),
@@ -958,6 +963,7 @@ const PEER_UUID: &str = "00000000-0000-0000-0000-000000000007";
 const AUTH: &str = r#"{"type":"Authenticated","data":{"app_name":"test","rate_limits":{"per_minute":60,"per_hour":1000,"per_day":10000}}}"#;
 const PI_V3: &str = r#"{"type":"ProtocolInfo","data":{"capabilities":[],"game_data_formats":["json","message_pack"],"protocol_version":3,"min_protocol_version":2,"max_protocol_version":3,"transports":["websocket"]}}"#;
 const PI_V3_ROOM_OPERATION_IDS: &str = r#"{"type":"ProtocolInfo","data":{"capabilities":["room_operation_ids"],"game_data_formats":["json","message_pack"],"protocol_version":3,"min_protocol_version":2,"max_protocol_version":3,"transports":["websocket"]}}"#;
+const V3_FINALIZED_ROOM: &str = r#"{"type":"RoomJoined","data":{"room_id":"00000000-0000-0000-0000-000000000008","room_code":"ROOM","player_id":"00000000-0000-0000-0000-000000000009","game_name":"game","max_players":4,"supports_authority":true,"current_players":[{"id":"00000000-0000-0000-0000-000000000009","name":"local","is_authority":true,"is_ready":true,"connected_at":"2026-01-01T00:00:00Z","epoch":1,"seq":0},{"id":"00000000-0000-0000-0000-000000000007","name":"peer","is_authority":false,"is_ready":true,"connected_at":"2026-01-01T00:00:00Z","epoch":1,"seq":0},{"id":"00000000-0000-0000-0000-000000000006","name":"off-plan","is_authority":false,"is_ready":true,"connected_at":"2026-01-01T00:00:00Z","epoch":1,"seq":0}],"is_authority":true,"lobby_state":"finalized","ready_players":[],"relay_type":"websocket","current_spectators":[]}}"#;
 // A v2 negotiation omits the version fields, so it deserializes to
 // `protocol_version: None` — a terminal relay floor.
 const PI_V2: &str = r#"{"type":"ProtocolInfo","data":{"capabilities":[],"game_data_formats":["json","message_pack"]}}"#;
@@ -4743,6 +4749,21 @@ async fn admitted_leave_fences_following_player_commands_in_both_drivers() {
         async_client.send_game_data(serde_json::json!({"after": "leave"})),
         Err(SignalFishError::RoomOperationPending)
     ));
+    // The fence gates room-joining commands before `AlreadyInRoom` (the
+    // local player is still rostered while the leave awaits its terminal
+    // response), and `ping` remains available during a pending fence —
+    // the documented gate order in docs/errors.md.
+    assert!(matches!(
+        async_client.join_room(JoinRoomParams::new("game", "again")),
+        Err(SignalFishError::RoomOperationPending)
+    ));
+    assert!(matches!(
+        async_client.join_as_spectator("game".into(), "ROOM".into(), "again".into()),
+        Err(SignalFishError::RoomOperationPending)
+    ));
+    async_client
+        .ping()
+        .expect("ping remains available during a pending fence");
 
     let polling_mock = FrameMock::v3();
     let polling_sent = Arc::clone(&polling_mock.sent);
@@ -4767,17 +4788,29 @@ async fn admitted_leave_fences_following_player_commands_in_both_drivers() {
         polling_client.send_game_data(serde_json::json!({"after": "leave"})),
         Err(SignalFishError::RoomOperationPending)
     ));
+    assert!(matches!(
+        polling_client.join_room(JoinRoomParams::new("game", "again")),
+        Err(SignalFishError::RoomOperationPending)
+    ));
+    assert!(matches!(
+        polling_client.join_as_spectator("game".into(), "ROOM".into(), "again".into()),
+        Err(SignalFishError::RoomOperationPending)
+    ));
+    polling_client
+        .ping()
+        .expect("ping remains available during a pending fence");
 
     let _ = polling_client.poll();
     tokio::time::timeout(std::time::Duration::from_secs(1), async {
-        while async_sent.lock().unwrap().is_empty() {
+        while async_sent.lock().unwrap().len() < 2 {
             tokio::task::yield_now().await;
         }
     })
     .await
-    .expect("async LeaveRoom frame");
-    assert_eq!(async_sent.lock().unwrap().len(), 1);
-    assert_eq!(polling_sent.lock().unwrap().len(), 1);
+    .expect("async LeaveRoom and Ping frames");
+    let _ = polling_client.poll();
+    assert_eq!(async_sent.lock().unwrap().len(), 2);
+    assert_eq!(polling_sent.lock().unwrap().len(), 2);
     assert!(matches!(
         &async_sent.lock().unwrap()[0],
         TransportFrame::Text(frame) if frame.contains("LeaveRoom")
@@ -4786,7 +4819,291 @@ async fn admitted_leave_fences_following_player_commands_in_both_drivers() {
         &polling_sent.lock().unwrap()[0],
         TransportFrame::Text(frame) if frame.contains("LeaveRoom")
     ));
+    assert!(matches!(
+        &async_sent.lock().unwrap()[1],
+        TransportFrame::Text(frame) if frame.contains("\"Ping\"")
+    ));
+    assert!(matches!(
+        &polling_sent.lock().unwrap()[1],
+        TransportFrame::Text(frame) if frame.contains("\"Ping\"")
+    ));
     async_client.shutdown().await;
+}
+
+#[tokio::test]
+async fn authority_gated_commands_refuse_at_driver_level_in_both_drivers() {
+    // The shared core refuses `start_game` and `request_authority(false)`
+    // while a peer holds authority; this pins the same typed refusal through
+    // both public drivers, whose membership matrices only classify these
+    // commands as AdmittedOrLaterGuard.
+    let authority_change = ServerMessage::AuthorityChanged {
+        authority_player: Some(uuid::Uuid::from_u128(7)),
+        you_are_authority: false,
+    };
+    {
+        let async_mock = FrameMock::v3();
+        async_mock
+            .incoming
+            .lock()
+            .unwrap()
+            .push_back(text_server_frame(authority_change.clone()));
+        let async_sent = Arc::clone(&async_mock.sent);
+        let (mut async_client, mut async_events) =
+            SignalFishClient::start(async_mock, SignalFishConfig::new("app").enable_v3());
+        common::wait_for_authentication(&async_client).await;
+        admit_initial_room_operation(&mut async_client, Some(InitialRoomOperation::JoinPlayer));
+        loop {
+            match async_events.recv().await {
+                Some(SignalFishEvent::AuthorityChanged { .. }) => break,
+                Some(_) => {}
+                None => panic!("async authority trace closed before AuthorityChanged"),
+            }
+        }
+        async_sent.lock().unwrap().clear();
+        assert!(matches!(
+            async_client.start_game(),
+            Err(SignalFishError::AuthorityRequired)
+        ));
+        assert!(matches!(
+            async_client.request_authority(false),
+            Err(SignalFishError::AuthorityRequired)
+        ));
+        assert!(
+            async_sent.lock().unwrap().is_empty(),
+            "authority refusals must not queue anything"
+        );
+        async_client.shutdown().await;
+
+        let polling_mock = FrameMock::v3();
+        polling_mock
+            .incoming
+            .lock()
+            .unwrap()
+            .push_back(text_server_frame(authority_change));
+        let polling_sent = Arc::clone(&polling_mock.sent);
+        let mut polling_client =
+            SignalFishPollingClient::new(polling_mock, SignalFishConfig::new("app").enable_v3());
+        for _ in 0..16 {
+            if polling_client.is_authenticated() {
+                break;
+            }
+            let _ = polling_client.poll();
+        }
+        assert!(
+            polling_client.is_authenticated(),
+            "polling fixture must authenticate before admission"
+        );
+        admit_initial_room_operation(&mut polling_client, Some(InitialRoomOperation::JoinPlayer));
+        let mut authority_seen = false;
+        for _ in 0..16 {
+            let events = polling_client.poll();
+            authority_seen |= events
+                .iter()
+                .any(|event| matches!(event, SignalFishEvent::AuthorityChanged { .. }));
+            if authority_seen {
+                break;
+            }
+        }
+        assert!(authority_seen, "polling trace must reach AuthorityChanged");
+        polling_sent.lock().unwrap().clear();
+        assert!(matches!(
+            polling_client.start_game(),
+            Err(SignalFishError::AuthorityRequired)
+        ));
+        assert!(matches!(
+            polling_client.request_authority(false),
+            Err(SignalFishError::AuthorityRequired)
+        ));
+        assert!(
+            polling_sent.lock().unwrap().is_empty(),
+            "authority refusals must not queue anything"
+        );
+    }
+}
+
+fn v2_relay_floor_mock() -> SharedMock {
+    let room = match finalized_v2_room_frame() {
+        TransportFrame::Text(room) => room,
+        TransportFrame::Binary(_) => unreachable!("room baseline must be text"),
+    };
+    let messages = vec![AUTH.to_string(), PI_V2.to_string(), room];
+    SharedMock::from_msgs_gated(
+        messages
+            .into_iter()
+            .map(|message| Some(Ok(message)))
+            .collect(),
+        false,
+    )
+}
+
+#[tokio::test]
+async fn v3_only_operations_refuse_on_the_v2_relay_floor_in_both_drivers() {
+    // Gate-7 arm membership: every v3-only outbound operation refuses with
+    // the terminal "relay-only" mode once a v2 ProtocolInfo has been
+    // observed, while reliable JSON game data stays admitted. Deleting a
+    // match arm from the shared ensure_v3 gate must fail this table.
+    for case in [
+        CommonCommandCase::LatestData,
+        CommonCommandCase::VolatileData,
+        CommonCommandCase::BinaryData,
+        CommonCommandCase::TransportStatus,
+    ] {
+        let async_mock = v2_relay_floor_mock();
+        let async_sent = Arc::clone(&async_mock.sent);
+        let (mut async_client, mut async_events) =
+            SignalFishClient::start(async_mock, SignalFishConfig::new("app"));
+        common::wait_for_authentication(&async_client).await;
+        admit_initial_room_operation(&mut async_client, Some(InitialRoomOperation::JoinPlayer));
+        loop {
+            match async_events.recv().await {
+                Some(SignalFishEvent::RoomJoined { .. }) | None => break,
+                _ => {}
+            }
+        }
+        async_sent.lock().unwrap().clear();
+        assert!(
+            matches!(
+                case.invoke(&mut async_client),
+                Err(SignalFishError::ProtocolUnsupported { mode: "relay-only" })
+            ),
+            "async {case:?} must refuse on the v2 relay floor"
+        );
+        assert!(
+            async_sent.lock().unwrap().is_empty(),
+            "async {case:?} refusal must not queue anything"
+        );
+        async_client.shutdown().await;
+
+        let polling_mock = v2_relay_floor_mock();
+        let polling_sent = Arc::clone(&polling_mock.sent);
+        let mut polling_client =
+            SignalFishPollingClient::new(polling_mock, SignalFishConfig::new("app"));
+        for _ in 0..16 {
+            if polling_client.is_authenticated() {
+                break;
+            }
+            let _ = polling_client.poll();
+        }
+        assert!(
+            polling_client.is_authenticated(),
+            "polling fixture must authenticate before admission"
+        );
+        admit_initial_room_operation(&mut polling_client, Some(InitialRoomOperation::JoinPlayer));
+        let _ = polling_client.poll();
+        polling_sent.lock().unwrap().clear();
+        assert!(
+            matches!(
+                case.invoke(&mut polling_client),
+                Err(SignalFishError::ProtocolUnsupported { mode: "relay-only" })
+            ),
+            "polling {case:?} must refuse on the v2 relay floor"
+        );
+        let _ = polling_client.poll();
+        assert!(
+            polling_sent.lock().unwrap().is_empty(),
+            "polling {case:?} refusal must not queue anything"
+        );
+    }
+
+    // Control: the relay floor keeps reliable JSON game data admitted.
+    let async_mock = v2_relay_floor_mock();
+    let async_sent = Arc::clone(&async_mock.sent);
+    let (mut async_client, mut async_events) =
+        SignalFishClient::start(async_mock.clone(), SignalFishConfig::new("app"));
+    common::wait_for_authentication(&async_client).await;
+    admit_initial_room_operation(&mut async_client, Some(InitialRoomOperation::JoinPlayer));
+    loop {
+        match async_events.recv().await {
+            Some(SignalFishEvent::RoomJoined { .. }) | None => break,
+            _ => {}
+        }
+    }
+    async_sent.lock().unwrap().clear();
+    async_client
+        .send_game_data(serde_json::json!({"relay": "floor"}))
+        .expect("reliable JSON stays admitted on the v2 relay floor");
+    wait_for_sent_len(&async_mock, 1).await;
+    assert!(
+        async_sent.lock().unwrap()[0].contains("GameData"),
+        "reliable JSON must reach the wire on the v2 relay floor"
+    );
+    async_client.shutdown().await;
+
+    let polling_mock = v2_relay_floor_mock();
+    let polling_sent = Arc::clone(&polling_mock.sent);
+    let mut polling_client =
+        SignalFishPollingClient::new(polling_mock, SignalFishConfig::new("app"));
+    for _ in 0..16 {
+        if polling_client.is_authenticated() {
+            break;
+        }
+        let _ = polling_client.poll();
+    }
+    assert!(
+        polling_client.is_authenticated(),
+        "polling fixture must authenticate before admission"
+    );
+    admit_initial_room_operation(&mut polling_client, Some(InitialRoomOperation::JoinPlayer));
+    let _ = polling_client.poll();
+    polling_sent.lock().unwrap().clear();
+    polling_client
+        .send_game_data(serde_json::json!({"relay": "floor"}))
+        .expect("reliable JSON stays admitted on the v2 relay floor");
+    let _ = polling_client.poll();
+    assert_eq!(polling_sent.lock().unwrap().len(), 1);
+}
+
+fn nested_chain(depth: u32) -> serde_json::Value {
+    let mut value = serde_json::json!(depth);
+    for _ in 0..depth {
+        value = serde_json::Value::Array(vec![value]);
+    }
+    value
+}
+
+#[tokio::test]
+async fn reliable_send_validation_precedes_waiting_for_queue_space() {
+    // docs/client.md pins the payload-depth check as a synchronous refusal:
+    // the caller's thread must not wait for queue capacity before local
+    // validation. The stalled transport keeps both command slots occupied,
+    // so an implementation that validated after waiting would park forever
+    // and fail this test by timeout.
+    let mock = NeverSendMock::new();
+    // Capacity 1: the dequeued Authenticate parks in the transport's send
+    // path forever, and the admitted join then fills the only channel slot.
+    let config = SignalFishConfig::new("app")
+        .enable_v3()
+        .with_command_channel_capacity(1)
+        .with_shutdown_timeout(std::time::Duration::from_millis(50));
+    let (mut client, mut events) = SignalFishClient::start(mock.clone(), config);
+    common::wait_for_authentication(&client).await;
+    // Admit the join before the room frame exists, so the scripted
+    // RoomJoined matches an armed fence instead of being suppressed as an
+    // unsolicited lifecycle violation.
+    client
+        .join_room(JoinRoomParams::new("game", "local"))
+        .expect("the free queue slot fits the join");
+    mock.push_frame(TransportFrame::Text(PI_V3.into()));
+    mock.push_frame(TransportFrame::Text(V3_FINALIZED_ROOM.into()));
+    loop {
+        match events.recv().await {
+            Some(SignalFishEvent::RoomJoined { .. }) => break,
+            Some(_) => {}
+            None => panic!("stalled-room trace closed before RoomJoined"),
+        }
+    }
+    assert_eq!(client.send_capacity(), 0, "both slots stay parked");
+    let result = tokio::time::timeout(
+        std::time::Duration::from_secs(1),
+        client.send_game_data_reliable(nested_chain(129)),
+    )
+    .await
+    .expect("reliable validation must not wait for queue space");
+    assert!(matches!(
+        result,
+        Err(SignalFishError::PayloadTooDeep { max_depth: 128 })
+    ));
+    client.shutdown().await;
 }
 
 #[tokio::test]

--- a/tests/polling_parity_tests.rs
+++ b/tests/polling_parity_tests.rs
@@ -5179,19 +5179,7 @@ async fn parity_ensure_v3_relay_only_mode_after_v2_negotiation() {
     // state before any `ProtocolInfo` arrives (see the parity test above).
     let peer: PlayerId = PEER_UUID.parse().unwrap();
 
-    let room = match finalized_v2_room_frame() {
-        TransportFrame::Text(room) => room,
-        TransportFrame::Binary(_) => unreachable!("room baseline must be text"),
-    };
-    let messages = [AUTH.to_string(), PI_V2.to_string(), room];
-    let async_mock = SharedMock::from_msgs_gated(
-        messages
-            .iter()
-            .cloned()
-            .map(|message| Some(Ok(message)))
-            .collect(),
-        false,
-    );
+    let async_mock = v2_relay_floor_mock();
     let (mut client, mut events) =
         SignalFishClient::start(async_mock, SignalFishConfig::new("app"));
     common::wait_for_authentication(&client).await;
@@ -5205,13 +5193,7 @@ async fn parity_ensure_v3_relay_only_mode_after_v2_negotiation() {
     }
     let async_err = client.send_offer(peer, "sdp").unwrap_err();
 
-    let poll_mock = SharedMock::from_msgs_gated(
-        messages
-            .into_iter()
-            .map(|message| Some(Ok(message)))
-            .collect(),
-        false,
-    );
+    let poll_mock = v2_relay_floor_mock();
     let mut poll_client = SignalFishPollingClient::new(poll_mock, SignalFishConfig::new("app"));
     for _ in 0..16 {
         if poll_client.is_authenticated() {


### PR DESCRIPTION
## Why

Three parallel adversarial audits (round 34 of the recurring correctness sweep, #126) found no production defects — but found that several documented behaviors could silently regress without failing any test, and that the next release would re-ship a stale-pin defect we already fixed once.

## What

- **Pin documented refusal contracts** (red/green-verified by mutation): every v3-only operation refuses on a v2 relay floor; a pending room fence gates joins before `AlreadyInRoom` while `ping` stays available; `start_game`/`request_authority(false)` refuse with `AuthorityRequired` when a peer holds authority; reliable sends validate locally before waiting for queue space.
- **Align release inventory and docs with the real 0.12 state**: the Godot adapter README's dependency pins now advance automatically on release preparation, the guide's error table lists `PayloadTooDeep` (matching the errors guide), and a false changelog sub-claim about `with_max_players` is corrected.
- **Document** the benign simultaneous shutdown/send-failure race that picks the farewell reason string.

Verified: fmt, clippy (`-D warnings`), and the full workspace test suite green locally; all 66 release-tooling self-tests pass; hostile review + convergence verifier closed all findings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly tests, documentation, and release inventory; no intentional behavior changes in the client core beyond an explanatory comment.
> 
> **Overview**
> Round 34 audit follow-up: **documented client refusal behavior is now regression-tested** across async and polling drivers, without changing production logic except a clarifying comment on async teardown.
> 
> **Test pins** add parity coverage for v3-only commands on a v2 relay floor (`ProtocolUnsupported { mode: "relay-only" }`), room-operation fencing (`RoomOperationPending` before re-join while `ping` still sends), authority gates (`AuthorityRequired` for `start_game` / `request_authority(false)` with no wire traffic), and synchronous `PayloadTooDeep` on reliable sends when the command queue is full (`NeverSendMock` + `push_frame`). Shared fixtures (`V3_FINALIZED_ROOM`, `v2_relay_floor_mock`) reduce duplication.
> 
> **Release and docs** add `crates/signal-fish-client-godot/README.md` to `VERSION_FILES` so prepare-release bumps Godot Quick Start pins with the workspace; `docs/concepts.md` and the changelog note `PayloadTooDeep` and correct `with_max_players` / Godot pin wording. **`src/client.rs`** documents that `tokio::select!` may pick either terminal cause when send failure and shutdown become ready together.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8853e3dc5a619aedf0ff9667f3ebefa568ea167e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->