### PR TITLE
Round 35 audit: unify-proof token binding, auto-trait pins, CI hygiene

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:
@@ -123,7 +123,7 @@ jobs:
       - name: Cache Cargo artifacts
         uses: Swatinem/rust-cache@v2.9.2
       - name: Run Clippy
-        run: cargo clippy ${{ matrix.scope }} --all-targets ${{ matrix.flags }} -- -D warnings
+        run: cargo clippy ${{ matrix.scope }} --all-targets ${{ matrix.flags }} --locked -- -D warnings
 
   # ──────────────────────────────────────────────────────────────
   # Tests — run across feature combinations
@@ -178,7 +178,7 @@ jobs:
       - name: Cache Cargo artifacts
         uses: Swatinem/rust-cache@v2.9.2
       - name: Run tests
-        run: cargo test ${{ matrix.scope }} ${{ matrix.flags }}
+        run: cargo test ${{ matrix.scope }} ${{ matrix.flags }} --locked
 
   # ──────────────────────────────────────────────────────────────
   # Pinned server compatibility E2E — generation-less 0.4, Server 0.7 mesh,

--- a/.github/workflows/godot-web.yml
+++ b/.github/workflows/godot-web.yml
@@ -36,7 +36,10 @@ jobs:
   build-export:
     name: Build and export official template
     runs-on: ubuntu-24.04
-    timeout-minutes: 35
+    # Full GDExtension web build + template export + fixtures: ~30 minutes
+    # on slow hosted runners; post-steps need honest headroom (PR #209 hit
+    # the old 35-minute ceiling with every step already green).
+    timeout-minutes: 50
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1

--- a/.github/workflows/godot-web.yml
+++ b/.github/workflows/godot-web.yml
@@ -22,6 +22,9 @@ env:
   # -Zbuild-std link flags (e.g. -lwebsocket.js) are emsdk-version-sensitive.
   # Upgrade only after a green probe of the web matrix (issue #201).
   EMSDK_VERSION: "3.1.74"
+  # Intentionally newer than docs-validation's 1.61.1: this lane adopted
+  # 1.62.1 on its own measured evaluation (issue #202); docs-validation keeps
+  # its tested per-lane pin until it runs the same evaluation.
   PLAYWRIGHT_VERSION: "1.62.1"
   RUST_NIGHTLY: "nightly-2026-03-01"
   NETEM_SEED: "6101"

--- a/.github/workflows/protocol-sync.yml
+++ b/.github/workflows/protocol-sync.yml
@@ -22,8 +22,9 @@ on:
       - tests/wire-samples/PROVENANCE.toml
       - tests/wire-samples/*.jsonl
   schedule:
-    # Mondays at 05:00 UTC — staggered from the other scheduled workflows.
-    - cron: "0 5 * * 1"
+    # Mondays at 05:30 UTC — 30 minutes after unused-deps (05:00) so the two
+    # Monday schedules never start simultaneously.
+    - cron: "30 5 * * 1"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,9 @@ jobs:
   release:
     name: Release publication
     runs-on: ubuntu-24.04
-    timeout-minutes: 45
+    # Widest single job: fmt + clippy + full tests + per-package semver checks
+    # + package/SBOM/attest + publish + registry retries; leave rerun headroom.
+    timeout-minutes: 60
     environment: crates-io
     steps:
       - name: Require the default branch

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -72,7 +72,9 @@ jobs:
   emscripten:
     name: Build (wasm32-unknown-emscripten)
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # Three -Zbuild-std full-std builds plus the harness build: a cold cache
+    # flirts with 30 minutes on hosted runners.
+    timeout-minutes: 40
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1

--- a/.llm/context.md
+++ b/.llm/context.md
@@ -148,8 +148,9 @@ connects locally — pre-I/O on unsatisfiable paths, post-handshake when no X.50
 client signer is selected — with `TokenBindingFailure::MissingClientFingerprint`. A selected connection consumes and validates the first challenge
 before either client sees a ready transport, derives HKDF-SHA-256 from the exact
 RFC 6455 key plus server nonce, zeroizes retained key material, and protects all
-outbound JSON/binary frames with one sequence. Sequence commits only at backend
-ownership transfer. Browser, Emscripten, and Godot APIs cannot expose the
+outbound JSON/binary frames with one sequence; canonical bytes stay stable even
+when consumers unify serde_json's `arbitrary_precision` feature. Sequence
+commits only at backend ownership transfer. Browser, Emscripten, and Godot APIs cannot expose the
 handshake key; `from_stream` is likewise post-handshake and cannot opt in.
 Required Server 0.7 profiles require WSS. Custom rustls token-binding offers
 wrap the resolver and disable resumption only on a clone, including Optional

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   diagnostics now count each deferred send once instead of once per poll.
 - The object-safe client trait's diagnostic accessors (`send_capacity`,
   `max_send_capacity`, `stats`, `snapshot`) are now `#[must_use]`.
+- Documented that the async client handle and its event receiver are
+  `Send + Sync`, pinned by compile-time assertions on both drivers.
 - Documented custom-transport panic semantics: a panicking `Transport`
   method kills the async loop (event channel closes without `Disconnected`,
   parked reliable sends resolve `NotConnected`) and propagates into the
@@ -37,6 +39,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Token-binding connections are now robust against serde_json's
+  `arbitrary_precision` feature being enabled by a consumer crate:
+  previously that unification delivered numbers as private marker maps
+  that bypassed the strict number gate and could corrupt outbound
+  payloads. Single-member objects carrying serde_json's private marker
+  key with a string value are now classified as numbers in all builds;
+  floats, exponents, and out-of-range integers keep their existing
+  refusals (only the literal `-0` differs: unified serde_json reports it
+  as the integer `0`, whose canonical form matches the server's RFC 8785
+  output).
 - Deeply nested caller JSON (game data, raw signals, custom connection
   info) is now refused at the call site with `PayloadTooDeep` instead of
   risking a stack-overflow process abort during serialization; the bound

--- a/docs/client.md
+++ b/docs/client.md
@@ -174,7 +174,9 @@ fn start(
 ```
 
 The return tuple is marked `#[must_use]` — you **must** consume the event
-receiver to observe server events.
+receiver to observe server events. Both the handle and the event receiver are
+`Send + Sync`: move the receiver into a `tokio::spawn` drain loop and share the
+handle via `Arc<Mutex<_>>` across tasks.
 
 On start, the client automatically sends an `Authenticate` message using the
 provided config. A background Tokio task is spawned to multiplex send/receive

--- a/src/client.rs
+++ b/src/client.rs
@@ -858,6 +858,9 @@ impl SignalFishClient {
     ///
     /// A tuple of `(client_handle, event_receiver)`. The event receiver yields
     /// [`SignalFishEvent`]s until the transport closes or the client shuts down.
+    /// Both the handle and the receiver are `Send + Sync`: move the receiver
+    /// into a `tokio::spawn` drain loop and share the handle via
+    /// `Arc<Mutex<_>>` across tasks.
     #[must_use = "the event receiver must be used to receive events"]
     pub fn start(
         transport: impl Transport + Send + 'static,
@@ -2707,6 +2710,20 @@ mod tests {
     use std::pin::Pin;
     use std::sync::{Barrier, Mutex as StdMutex};
     use std::task::{Context, Poll, Waker};
+
+    // The docs promise the handle and the event receiver are `Send + Sync` so
+    // the drain loop can run on a spawned task while the handle is shared via
+    // `Arc<Mutex<_>>`. Both embed the shared `ClientCore`, so pin the auto
+    // traits with compile-time assertions to catch accidental interior
+    // non-Send state before it breaks every documented usage.
+    const _: fn() = || {
+        fn assert_send<T: Send>() {}
+        fn assert_sync<T: Sync>() {}
+        assert_send::<SignalFishClient>();
+        assert_sync::<SignalFishClient>();
+        assert_send::<tokio::sync::mpsc::Receiver<SignalFishEvent>>();
+        assert_sync::<tokio::sync::mpsc::Receiver<SignalFishEvent>>();
+    };
 
     #[test]
     fn snapshot_debug_redacts_reconnection_token() {

--- a/src/polling_client.rs
+++ b/src/polling_client.rs
@@ -1621,6 +1621,17 @@ mod tests {
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Arc;
 
+    // The polling client's threading contract follows its transport: it is
+    // `Send`/`Sync` exactly when `T` is. It embeds the shared `ClientCore`,
+    // so pin the auto traits with a `Send` mock to catch accidental interior
+    // non-Send state in the core before it narrows this contract.
+    const _: fn() = || {
+        fn assert_send<T: Send>() {}
+        fn assert_sync<T: Sync>() {}
+        assert_send::<SignalFishPollingClient<MockTransport>>();
+        assert_sync::<SignalFishPollingClient<MockTransport>>();
+    };
+
     // ── Mock transport ──────────────────────────────────────────────
 
     struct MockTransport {

--- a/src/token_binding.rs
+++ b/src/token_binding.rs
@@ -517,8 +517,70 @@ impl<'de> serde::de::Visitor<'de> for UniqueJsonVisitor {
             }
             values.insert(key, value);
         }
+        // A consumer crate can silently enable serde_json's `arbitrary_precision`
+        // feature through Cargo feature unification; that feature delivers every
+        // number that fails its u64/i64 parse to `deserialize_any` visitors as a
+        // single-member marker map instead of calling the scalar visitors.
+        // Classify the marker unconditionally (the key is a serde_json-internal
+        // name no protocol payload legitimately carries) so a consumer's feature
+        // flags cannot flip accept/reject verdicts or the canonical bytes. The
+        // one deliberate divergence: serde_json classifies the literal `-0` as
+        // the integer `0` before any marker exists, so unified builds accept
+        // `-0` as `0` — as the bare literal or via a hand-crafted marker raw
+        // text — where default builds reject it as a negative-zero float;
+        // canonical `0` is exactly the server's RFC 8785 form for `-0`.
+        if values.len() == 1 {
+            if let Some(serde_json::Value::String(raw)) =
+                values.get(ARBITRARY_PRECISION_NUMBER_MARKER)
+            {
+                return classify_marker_number(raw)
+                    .map(UniqueJsonValue)
+                    .map_err(serde::de::Error::custom);
+            }
+        }
         Ok(UniqueJsonValue(serde_json::Value::Object(values)))
     }
+}
+
+#[cfg(feature = "token-binding")]
+const ARBITRARY_PRECISION_NUMBER_MARKER: &str = "$serde_json::private::Number";
+
+/// Classifies a serde_json `arbitrary_precision` marker payload exactly like
+/// the scalar visitors classify a directly parsed number: integers within the
+/// interoperable safe range are kept, and everything else (floats, exponents,
+/// out-of-range integers) is forbidden input. The literal `-0` never reaches
+/// this helper from serde_json itself — neither as the bare literal nor inside
+/// a genuine marker raw text: serde_json classifies it as the integer `0`
+/// before any marker exists, so unified builds accept it as `0` where default
+/// builds reject it as a negative-zero float (canonical `0` is exactly the
+/// server's RFC 8785 form for `-0`). A hand-crafted marker `"-0"` follows the
+/// same split verdicts.
+#[cfg(feature = "token-binding")]
+fn classify_marker_number(raw: &str) -> Result<serde_json::Value, String> {
+    // serde_json marker raw texts are exact number tokens with no surrounding
+    // whitespace; reject anything else instead of relying on `from_str`
+    // leniency.
+    if raw.trim() != raw {
+        return Err("malformed JSON number".to_string());
+    }
+    let parsed: serde_json::Value =
+        serde_json::from_str(raw).map_err(|_| "malformed JSON number".to_string())?;
+    if let Some(value) = parsed.as_u64() {
+        if value > MAX_SAFE_INTEGER {
+            return Err("JSON integer exceeds the interoperable safe range".to_string());
+        }
+        return Ok(serde_json::Value::Number(value.into()));
+    }
+    if let Some(value) = parsed.as_i64() {
+        if value.unsigned_abs() > MAX_SAFE_INTEGER {
+            return Err("JSON integer exceeds the interoperable safe range".to_string());
+        }
+        return Ok(serde_json::Value::Number(value.into()));
+    }
+    if parsed.as_f64().is_some() {
+        return Err("floating-point JSON numbers are unsupported".to_string());
+    }
+    Err("malformed JSON number".to_string())
 }
 
 #[cfg(all(test, feature = "token-binding"))]
@@ -682,6 +744,75 @@ mod tests {
                     TokenBindingFailure::UnsupportedJson
                 ))
             ));
+        }
+    }
+
+    /// A marker-shaped single-member string object is classified as a number
+    /// in every build (see `visit_map`): a safe-integer raw text must produce
+    /// the exact same signed envelope as the bare literal, and a non-string
+    /// marker value must keep the plain-object fall-through byte-stable.
+    /// (serde_json itself only ever produces marker raw texts for forbidden
+    /// classes — floats, exponents, out-of-range integers — so the `"5"`
+    /// case pins the deliberate default-build reclassification, the same
+    /// verdict a unified build would reach for that input.)
+    #[test]
+    fn canonical_json_treats_arbitrary_precision_marker_maps_like_numbers() {
+        // Two sessions from the same challenge share the derived key and
+        // start at the same sequence, so differing envelopes would prove the
+        // marker path changed the canonical bytes.
+        let marker = r#"{"type":"Ping","n":{"$serde_json::private::Number":"5"}}"#;
+        let plain = r#"{"type":"Ping","n":5}"#;
+        let signed_marker = TokenBindingSession::from_challenge(HANDSHAKE_KEY, challenge(), None)
+            .expect("test challenge must derive a session")
+            .prepare(&TransportFrame::Text(marker.to_string()))
+            .expect("marker-encoded safe integer must prepare");
+        let signed_plain = TokenBindingSession::from_challenge(HANDSHAKE_KEY, challenge(), None)
+            .expect("test challenge must derive a session")
+            .prepare(&TransportFrame::Text(plain.to_string()))
+            .expect("plain safe integer must prepare");
+        assert_eq!(signed_marker, signed_plain);
+
+        // A marker key with a non-string value is an ordinary object: sign it
+        // and prove the envelope differs from the number-reclassified form.
+        let object = r#"{"type":"Ping","w":{"$serde_json::private::Number":5}}"#;
+        let signed_object = TokenBindingSession::from_challenge(HANDSHAKE_KEY, challenge(), None)
+            .expect("test challenge must derive a session")
+            .prepare(&TransportFrame::Text(object.to_string()))
+            .expect("non-string marker value must stay an ordinary object");
+        let reclassified = TokenBindingSession::from_challenge(HANDSHAKE_KEY, challenge(), None)
+            .expect("test challenge must derive a session")
+            .prepare(&TransportFrame::Text(
+                r#"{"type":"Ping","w":5}"#.to_string(),
+            ))
+            .expect("plain nested number must prepare");
+        assert_ne!(
+            signed_object, reclassified,
+            "a non-string marker value must not be reclassified as its number"
+        );
+    }
+
+    #[test]
+    fn canonical_json_rejects_marker_encoded_forbidden_numbers() {
+        let session = TokenBindingSession::from_challenge(HANDSHAKE_KEY, challenge(), None)
+            .expect("test challenge must derive a session");
+        for raw in [
+            r#"{"type":"Ping","n":{"$serde_json::private::Number":"1.0"}}"#,
+            r#"{"type":"Ping","n":{"$serde_json::private::Number":"1e0"}}"#,
+            r#"{"type":"Ping","n":{"$serde_json::private::Number":"-0.0"}}"#,
+            r#"{"type":"Ping","n":{"$serde_json::private::Number":"9007199254740992"}}"#,
+            r#"{"type":"Ping","n":{"$serde_json::private::Number":"-9007199254740992"}}"#,
+            r#"{"type":"Ping","n":{"$serde_json::private::Number":"bogus"}}"#,
+            r#"{"type":"Ping","n":{"$serde_json::private::Number":""}}"#,
+        ] {
+            assert!(
+                matches!(
+                    session.prepare(&TransportFrame::Text(raw.to_string())),
+                    Err(SignalFishError::TokenBinding(
+                        TokenBindingFailure::UnsupportedJson
+                    ))
+                ),
+                "marker payload must be classified like the scalar visitors: {raw}"
+            );
         }
     }
 

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -2383,9 +2383,9 @@ mod ci_workflow_policy {
                 );
             }
             let expected_run = if job_name == "clippy" {
-                "cargo clippy ${{ matrix.scope }} --all-targets ${{ matrix.flags }} -- -D warnings"
+                "cargo clippy ${{ matrix.scope }} --all-targets ${{ matrix.flags }} --locked -- -D warnings"
             } else {
-                "cargo test ${{ matrix.scope }} ${{ matrix.flags }}"
+                "cargo test ${{ matrix.scope }} ${{ matrix.flags }} --locked"
             };
             assert!(
                 job.contains(expected_run),


### PR DESCRIPTION
## Why

Paranoid-audit round 35 (issue #126) audited three never-before-covered surfaces. One real defect surfaced: a game studio that enables serde_json's `arbitrary_precision` feature anywhere in their dependency graph would silently lose the token-binding security gate — floats got accepted, outbound payloads were corrupted into serde_json's private marker-map objects, and challenge parsing failed outright. None of our CI runs with that unification, so nothing could catch it.

## What changed

- **Token binding is now unification-proof.** serde_json's `arbitrary_precision` feature delivers numbers as private marker maps; the strict number gate now classifies those maps as numbers in every build, so accept/reject verdicts and signed bytes no longer depend on consumer feature flags. Red/green pinned and verified against a real unified build; the one deliberate divergence (the literal `-0`) is disclosed in the changelog.
- **`Send`/`Sync` contracts are now compile-pinned** for the async client handle, its event receiver, and the polling client — all share `ClientCore`, so one accidental non-Send field would have broken every documented `tokio::spawn` drain loop. The contract is now also stated in the docs.
- **CI execution hygiene:** clippy/test matrix lanes run `--locked` (matching the release lanes), the CI concurrency group can no longer let a manual dispatch cancel a `main` push run, the Emscripten and publish jobs got timeout headroom, and two scheduling/pin comments were corrected.

Everything else the audit probed (serde_json `preserve_order`/`float_roundtrip`, `tracing` unification, `uuid` features, upstream protocol authority drift, all 17 workflows' timeouts/concurrency/caching) verified clean with mechanism-level proofs.

## Verification

- `cargo fmt` + `cargo clippy --workspace --all-targets --all-features -- -D warnings` + `cargo test --workspace --all-features`: all clean
- Sparse `polling-client`-only and `tokio-runtime`-only cells: clean
- All repository guard scripts and ci_config pins: green
- Three hostile adversarial review rounds converged to zero blocking findings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes touch token-binding canonicalization (security-sensitive) and CI only elsewhere; the fix is defensive but alters accept/reject behavior for marker-shaped JSON.
> 
> **Overview**
> **Token-binding canonical JSON** no longer depends on whether a consumer enables serde_json's `arbitrary_precision` feature. During object deserialization, single-member maps using serde_json's private number marker are reclassified through the same rules as scalar numbers, so forbidden floats/out-of-range integers stay rejected and signed outbound bytes match bare literals. Changelog and internal context note the deliberate `-0` vs `0` edge when features unify.
> 
> **Threading contract** is documented (`Send + Sync` on the async handle and event receiver) and enforced with compile-time assertions on `SignalFishClient`, its `mpsc::Receiver`, and `SignalFishPollingClient` with a `Send` mock transport.
> 
> **CI workflows** add `--locked` to matrix clippy/test lanes, widen concurrency groups with `github.event_name` (so dispatch does not cancel `main` pushes), bump timeouts on Godot web export, publish, and wasm Emscripten jobs, and stagger protocol-sync's Monday cron by 30 minutes. Config guard tests expect the new cargo invocations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4251b92973809c5ecc59637c83a544f46a41a306. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->