### PR TITLE
Round 36 audit: true dependency floors, teardown pins, mock fidelity

### DIFF
--- a/.llm/skills/testing-async/SKILL.md
+++ b/.llm/skills/testing-async/SKILL.md
@@ -68,7 +68,9 @@ impl Transport for MockTransport {
     ) -> Poll<Result<(), SignalFishError>> {
         if let Some(frame) = frame.take() {
             let TransportFrame::Text(message) = frame else {
-                panic!("test expected an outbound text frame");
+                return Poll::Ready(Err(SignalFishError::TransportSend(
+                    "test mock does not accept outbound binary frames".into(),
+                )));
             };
             self.sent.lock().unwrap().push(message);
         }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `max_send_capacity`, `stats`, `snapshot`) are now `#[must_use]`.
 - Documented that the async client handle and its event receiver are
   `Send + Sync`, pinned by compile-time assertions on both drivers.
+- Raised the declared dependency floors to verified values (`rustls`
+  0.23.16, `serde_json` 1.0.68, `tracing` 0.1.35, dev-only `tokio` 1.50)
+  so a downstream resolver without this repository's lockfile cannot
+  assemble a broken build.
+- Documented teardown semantics: plain-dropping the mesh controller never
+  disconnects driver peers (aborting the signaling transport is its whole
+  teardown), the Godot transport's exact abort/graceful-close split, and
+  the async handle-drop race where an immediate graceful close can win
+  over the abort fallback.
 - Documented custom-transport panic semantics: a panicking `Transport`
   method kills the async loop (event channel closes without `Disconnected`,
   parked reliable sends resolve `NotConnected`) and propagates into the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,9 @@ tokio = { version = "1.21", features = ["sync", "macros"] }
 
 # Serialization
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+# 1.0.68 is the true minimum: older releases parsed a bare `-0` as integer
+# `0`, silently disabling the token-binding forbidden-input (float) gate.
+serde_json = "1.0.68"
 serde_bytes = "0.11"
 rmp = "0.8"
 rmp-serde = "1.3"
@@ -78,7 +80,11 @@ uuid = { version = "1", features = ["v4", "serde"] }
 thiserror = "2.0"
 
 # Logging
-tracing = "0.1"
+# 0.1.35 is the oldest release line verified to build under a fresh
+# minimal-versions resolution; older tracing releases fail to compile on
+# modern toolchains through their own dependency graph (tracing-core or
+# tracing-attributes/syn, depending on the release).
+tracing = "0.1.35"
 
 # Optional Signal Fish token-binding-v2 primitives.
 base64 = { version = "0.23", optional = true }
@@ -94,15 +100,19 @@ futures-util = { version = "0.3", optional = true, features = ["sink"] }
 # `ring::default_provider().install_default()` in `connect_with_options` so the
 # wss:// path always has a provider — even when the dependency graph also pulls
 # rustls' aws_lc_rs provider, whose auto-detection otherwise panics on ambiguity.
-rustls = { version = "0.23", default-features = false, features = ["ring"], optional = true }
+# 0.23.16 is the true minimum: `ResolvesClientCert::only_raw_public_keys`
+# first shipped there.
+rustls = { version = "0.23.16", default-features = false, features = ["ring"], optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 uuid = { version = "1", features = ["v4", "serde", "js"] }
 
 [dev-dependencies]
-tokio = { version = "1.21", features = ["full", "test-util"] }
+# 1.50 is the true minimum for the suites: `TcpStream::set_zero_linger`
+# (1.50) backs the test transports.
+tokio = { version = "1.50", features = ["full", "test-util"] }
 futures-util = "0.3"
-serde_json = "1.0"
+serde_json = "1.0.68"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 toml = "1.0"
 # Used by the wire-sample provenance policy test to verify checksums.

--- a/crates/signal-fish-client-godot/Cargo.toml
+++ b/crates/signal-fish-client-godot/Cargo.toml
@@ -18,7 +18,9 @@ include = ["/src/**", "/Cargo.toml", "/README.md", "/LICENSE"]
 [dependencies]
 godot = { version = ">=0.4.5, <0.6", features = ["experimental-wasm", "experimental-wasm-nothreads", "lazy-function-tables"] }
 signal-fish-client = { workspace = true, default-features = false, features = ["polling-client"] }
-tracing = "0.1"
+# 0.1.35 matches the core crate's verified minimum (older tracing releases
+# fail to compile on modern toolchains through their own dependency graph).
+tracing = "0.1.35"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/signal-fish-client-godot/src/lib.rs
+++ b/crates/signal-fish-client-godot/src/lib.rs
@@ -371,6 +371,20 @@ fn is_abnormal_close_code(raw_code: i32) -> bool {
 /// Godot object is intentionally not required to be `Send`; call the polling
 /// client's `poll()` method from the same Godot thread on every frame.
 ///
+/// Drop/close semantics: a successful
+/// [`SignalFishPollingClient::close`](signal_fish_client::SignalFishPollingClient::close)
+/// tears down through the transport's graceful close handshake. The transport's
+/// [`Transport::abort`] — a force-close (`close_ex().code(-1)`) that runs
+/// exactly once — covers every other teardown: dropping the client without a
+/// completed `close()`, a `close` deadline expiry, or a failed close. A
+/// `close()` on a client that never connected performs no transport I/O and
+/// leaves the peer untouched for its owner. Any teardown that reaches the peer
+/// closes it before the `Gd<WebSocketPeer>` is released, on both native and
+/// web. Dropping a bare transport without `abort`/`close` leaves reclamation
+/// to Godot's engine destructor semantics for an open peer, which differ by
+/// platform; drive it through the polling client (or call `close()`/`abort()`
+/// explicitly) for deterministic teardown.
+///
 /// A connection that closes before opening surfaces as
 /// [`SignalFishError::TransportReceive`] even when observed first through
 /// [`Transport::poll_send`]: the handshake result is a receive-path event, so

--- a/src/client.rs
+++ b/src/client.rs
@@ -17,7 +17,8 @@
 //!   [`ClientStats::messages_undecodable`]) rather than dropped. An event can
 //!   only be missed when the loop stops delivering entirely: the receiver was
 //!   dropped, the client handle was dropped without calling
-//!   [`shutdown`](SignalFishClient::shutdown) (which aborts immediately),
+//!   [`shutdown`](SignalFishClient::shutdown) (which stops the loop
+//!   immediately and tears down its transport exactly once),
 //!   delivery was preempted — `shutdown`, or a terminal disconnect facing a
 //!   consumer that never drains, abandon at most the one event delivery they
 //!   interrupt (remaining batch events get one nonblocking attempt), close
@@ -924,8 +925,12 @@ impl SignalFishClient {
     /// finish; if the timeout expires (e.g. a transport whose `poll_close`
     /// remains pending), the transport is aborted and the loop normally
     /// returns. A later watchdog cancels the task if it still does not stop.
-    /// Task cancellation and handle drop also invoke the transport's required
-    /// abort fallback. The same budget bounds a terminal disconnect when
+    /// Task cancellation and handle drop also finish the loop without a
+    /// graceful deadline: the transport's required abort fallback runs, or —
+    /// in the rare race where the loop observes the dropped handle's closed
+    /// command channel before cancellation lands — an immediate graceful
+    /// close wins. Cleanup runs exactly once either way and is never
+    /// repeated. The same budget bounds a terminal disconnect when
     /// `shutdown` is never called: a consumer that wedges permanently cannot
     /// keep the loop (and every waiting reliable sender) alive past it.
     /// After shutdown completes, the event

--- a/src/terminal_drain.rs
+++ b/src/terminal_drain.rs
@@ -160,7 +160,7 @@ mod tests {
 
     /// Minimal transport: a scripted receive queue plus close metadata.
     struct StubDrainTransport {
-        frames: std::vec::Vec<Option<Result<TransportFrame, SignalFishError>>>,
+        frames: std::collections::VecDeque<Option<Result<TransportFrame, SignalFishError>>>,
         close: Option<TransportCloseInfo>,
     }
 
@@ -186,7 +186,7 @@ mod tests {
             &mut self,
             _cx: &mut Context<'_>,
         ) -> Poll<Option<Result<TransportFrame, SignalFishError>>> {
-            Poll::Ready(self.frames.pop().flatten())
+            Poll::Ready(self.frames.pop_front().flatten())
         }
 
         fn poll_close(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), SignalFishError>> {
@@ -214,19 +214,26 @@ mod tests {
         ]);
         let mut drain = ReadyFrameDrain::new(None, ReadyFrameDrainBudget::new(3, 1_000));
         let mut cx = noop_context();
-        let mut drained = 0;
+        let mut drained = Vec::new();
         for expected_reached in [false, false, true] {
-            let budget_reached = match drain.poll_next(&mut transport, &mut cx, false) {
-                ReadyFrameDrainPoll::Frame { budget_reached, .. } => budget_reached,
+            let (frame, budget_reached) = match drain.poll_next(&mut transport, &mut cx, false) {
+                ReadyFrameDrainPoll::Frame {
+                    frame,
+                    budget_reached,
+                } => (frame, budget_reached),
                 ReadyFrameDrainPoll::Pending => panic!("transport unexpectedly pending"),
                 ReadyFrameDrainPoll::Closed => panic!("transport unexpectedly closed"),
                 ReadyFrameDrainPoll::ReceiveFailed(_) => panic!("unexpected receive failure"),
                 ReadyFrameDrainPoll::DeadlineReached => panic!("unexpected deadline"),
             };
             assert_eq!(budget_reached, expected_reached);
-            drained += 1;
+            let TransportFrame::Text(payload) = frame else {
+                panic!("expected a text frame")
+            };
+            drained.push(payload);
         }
-        assert_eq!(drained, 3);
+        // The scripted queue is consumed first-in-first-out.
+        assert_eq!(drained, ["1", "2", "3"]);
     }
 
     #[test]

--- a/src/webrtc.rs
+++ b/src/webrtc.rs
@@ -270,6 +270,15 @@ mod controller {
     /// `MeshController<D>` is [`Send`] when `D` is, so the `recv()` loop can run
     /// on a spawned task. A `!Send` driver (e.g. a browser `RTCPeerConnection`
     /// wrapper) must instead be driven on the current task.
+    ///
+    /// Dropping the controller without [`shutdown`](Self::shutdown) finishes
+    /// the underlying signaling client through the client handle's teardown
+    /// path: the transport's abort fallback runs exactly once, except in the
+    /// rare race where an immediate graceful close wins first (see
+    /// [`SignalFishClient::shutdown`]). Driver peers are never disconnected by
+    /// plain drop; graceful peer teardown — disconnecting each known peer once
+    /// — belongs to [`shutdown`](Self::shutdown) and to `recv` observing the
+    /// end of the signaling stream.
     pub struct MeshController<D: WebRtcDriver> {
         client: SignalFishClient,
         events: mpsc::Receiver<SignalFishEvent>,
@@ -932,7 +941,7 @@ mod tests {
     use crate::client::SignalFishConfig;
     use crate::protocol::{ClientMessage, Topology, TransportKind};
     use std::collections::VecDeque;
-    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
 
     // The docs promise `MeshController<D>` is `Send` when `D` is, so the `recv()`
@@ -994,6 +1003,41 @@ mod tests {
         Send(PlayerId, Vec<u8>),
         Disconnect(PlayerId),
         Poll,
+    }
+
+    /// Counts `abort` invocations so teardown pins can distinguish the
+    /// required abort fallback from a graceful `poll_close`.
+    struct AbortCountingTransport {
+        inner: MockTransport,
+        aborts: Arc<AtomicUsize>,
+    }
+
+    impl Transport for AbortCountingTransport {
+        fn abort(&mut self) {
+            self.aborts.fetch_add(1, Ordering::Relaxed);
+            self.inner.abort();
+        }
+        fn poll_send(
+            &mut self,
+            cx: &mut std::task::Context<'_>,
+            frame: &mut Option<crate::transport::TransportFrame>,
+        ) -> std::task::Poll<Result<(), crate::error::SignalFishError>> {
+            self.inner.poll_send(cx, frame)
+        }
+        fn poll_recv(
+            &mut self,
+            cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<
+            Option<Result<crate::transport::TransportFrame, crate::error::SignalFishError>>,
+        > {
+            self.inner.poll_recv(cx)
+        }
+        fn poll_close(
+            &mut self,
+            cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<Result<(), crate::error::SignalFishError>> {
+            self.inner.poll_close(cx)
+        }
     }
 
     #[derive(Default)]
@@ -1289,7 +1333,11 @@ mod tests {
         ) -> std::task::Poll<Result<(), crate::error::SignalFishError>> {
             if let Some(frame) = frame.take() {
                 let crate::transport::TransportFrame::Text(message) = frame else {
-                    panic!("test mock expected an outbound text frame");
+                    return std::task::Poll::Ready(Err(
+                        crate::error::SignalFishError::TransportSend(
+                            "test mock does not accept outbound binary frames".into(),
+                        ),
+                    ));
                 };
                 self.sent.lock().unwrap().push(message);
             }
@@ -1825,7 +1873,11 @@ mod tests {
             permit.forget();
             if let Some(frame) = frame.take() {
                 let crate::transport::TransportFrame::Text(message) = frame else {
-                    panic!("test mock expected an outbound text frame");
+                    return std::task::Poll::Ready(Err(
+                        crate::error::SignalFishError::TransportSend(
+                            "test mock does not accept outbound binary frames".into(),
+                        ),
+                    ));
                 };
                 self.sent.lock().unwrap().push(message);
             }
@@ -2585,6 +2637,68 @@ mod tests {
         );
 
         mesh.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn plain_drop_aborts_signaling_but_never_disconnects_driver_peers() {
+        // Plain `Drop` (no `shutdown()`) runs the signaling transport's abort
+        // fallback exactly once and never calls driver `Disconnect` — graceful
+        // peer teardown belongs to `shutdown()` and end-of-stream handling.
+        // This pins the documented plain-drop contract end to end.
+        let peer = uuid(4);
+        let driver = SharedDriver::default();
+        let aborts = Arc::new(AtomicUsize::new(0));
+        let (inner, sent) = MockTransport::new_in_room(vec![
+            Some(Ok(authed())),
+            Some(Ok(protocol_info_v3())),
+            Some(Ok(room_baseline(peer))),
+            Some(Ok(session_plan(peer, true))),
+        ]);
+        let transport = AbortCountingTransport {
+            inner,
+            aborts: Arc::clone(&aborts),
+        };
+        let mut mesh =
+            MeshController::start(transport, SignalFishConfig::new("app"), driver.clone());
+        wait_for_authenticated(&mut mesh).await;
+        mesh.join_room(crate::client::JoinRoomParams::new("test", "local"))
+            .expect("scripted room response must follow an admitted join");
+        let connected = pump_until(&mut mesh, &driver, |calls| {
+            calls.contains(&DriverCall::Connect(peer, true))
+        })
+        .await;
+        assert!(connected, "the planned peer connect must be driven");
+
+        drop(mesh);
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            while aborts.load(Ordering::Relaxed) < 1 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("plain drop must run the transport abort fallback");
+        // Settle, then pin all three faces of the contract: exactly one abort,
+        // no driver `Disconnect` ever issued by the plain-drop path, and no
+        // graceful LeaveRoom on the wire.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        assert_eq!(
+            aborts.load(Ordering::Relaxed),
+            1,
+            "abort fallback must run exactly once on plain drop"
+        );
+        assert_eq!(
+            count_calls(&driver, |call| matches!(call, DriverCall::Disconnect(_))),
+            0,
+            "plain drop must never disconnect driver peers"
+        );
+        assert!(
+            !sent
+                .lock()
+                .unwrap()
+                .iter()
+                .any(|message| message.contains("LeaveRoom")),
+            "plain drop must not send a graceful LeaveRoom"
+        );
     }
 
     #[tokio::test]

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -31,6 +31,15 @@ use signal_fish_client::{ClientMessage, SignalFishError, Transport};
 ///
 /// Scripted server responses are consumed in order by `recv()`.
 /// All messages sent by the client are recorded in `sent`.
+///
+/// Deliberate polling-faithful limitations (pin, do not "fix" here):
+/// `poll_recv` `Pending` registers no waker, so scripted frames only flow
+/// when the driver loop is re-polling anyway (command sends, timers) —
+/// there is no autonomous readiness-driven progress and no mid-session
+/// server-push injection API — and outbound binary frames are refused with
+/// a terminal `TransportSend` error (text-only backend face). Use a
+/// wake-faithful mock (e.g. the in-crate `MockTransport` in `src/client.rs`'s
+/// test module) for server-push or readiness-wake coverage.
 pub struct MockTransport {
     /// Scripted server responses (consumed in order by `recv`).
     incoming: VecDeque<Option<Result<TransportFrame, SignalFishError>>>,
@@ -109,7 +118,12 @@ impl Transport for MockTransport {
     ) -> std::task::Poll<Result<(), SignalFishError>> {
         if let Some(frame) = frame.take() {
             let TransportFrame::Text(message) = frame else {
-                panic!("test mock expected an outbound text frame");
+                // Post-acceptance failure face (contract-legal): refuse the
+                // binary frame terminally instead of a physically impossible
+                // silent acceptance.
+                return std::task::Poll::Ready(Err(SignalFishError::TransportSend(
+                    "test mock does not accept outbound binary frames".into(),
+                )));
             };
             self.sent.lock().unwrap().push(message);
         }

--- a/tests/negotiation_robustness_tests.rs
+++ b/tests/negotiation_robustness_tests.rs
@@ -513,7 +513,9 @@ impl Transport for SendErrorTransport {
         }
         if let Some(frame) = frame.take() {
             let TransportFrame::Text(message) = frame else {
-                panic!("test mock expected an outbound text frame");
+                return std::task::Poll::Ready(Err(SignalFishError::TransportSend(
+                    "test mock does not accept outbound binary frames".into(),
+                )));
             };
             if serde_json::from_str::<ClientMessage>(&message)
                 .is_ok_and(|message| matches!(message, ClientMessage::JoinRoom { .. }))

--- a/tests/polling_parity_tests.rs
+++ b/tests/polling_parity_tests.rs
@@ -1298,7 +1298,9 @@ impl Transport for SharedMock {
     ) -> std::task::Poll<Result<(), SignalFishError>> {
         if let Some(frame) = frame.take() {
             let TransportFrame::Text(message) = frame else {
-                panic!("parity mock expected an outbound text frame");
+                return std::task::Poll::Ready(Err(SignalFishError::TransportSend(
+                    "parity mock does not accept outbound binary frames".into(),
+                )));
             };
             self.sent.lock().unwrap().push(message);
         }

--- a/tools/perf-lab/Cargo.toml
+++ b/tools/perf-lab/Cargo.toml
@@ -25,7 +25,7 @@ perf = [
 [dependencies]
 rmp-serde = { version = "1.3", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
-serde_json = { version = "1.0", optional = true }
+serde_json = { version = "1.0.68", optional = true }
 sha2 = { version = "0.11", optional = true }
 signal-fish-client = { path = "../..", default-features = false, optional = true }
 stats_alloc = { version = "=0.1.10", optional = true }


### PR DESCRIPTION
## Why

Paranoid-audit round 36 found that the published crates' declared dependency floors were lower than the code actually requires. A downstream resolver (which ignores this repository's lockfile) could assemble a broken build from the declared minimums — and below `serde_json` 1.0.68, a bare `-0` parses as the integer `0`, silently defeating the token-binding float gate. The rest of the round (drop-path teardown, test-mock fidelity) proved behaviorally correct; its outputs are accurate documentation plus pins so the contracts stay that way.

## What

- **True dependency floors** — `rustls` 0.23.16 (`only_raw_public_keys`), `serde_json` 1.0.68 (the `-0` behavioral floor), `tracing` 0.1.35 (oldest line verified under a fresh minimal-versions resolution), dev-only `tokio` 1.50. Verified end to end: the workspace builds and the full test suite passes under `cargo +nightly -Zminimal-versions`.
- **Drop-contract pins** — plain-dropping the `MeshController` aborts the signaling transport exactly once and never disconnects driver peers (new pin, mutation-verified against a disconnect-on-drop regression); the Godot transport's abort/graceful-close split and the async handle-drop race are now documented accurately.
- **Mock fidelity** — five text-only test mocks refuse outbound binary frames with a contract-legal terminal error instead of a physically impossible panic; `StubDrainTransport` delivers its scripted queue FIFO per its documented contract (order now pinned).

## Verification

- `cargo fmt && cargo clippy --workspace --all-targets --all-features -- -D warnings && cargo test --workspace --all-features`: clean.
- Fresh minimal-versions resolution: `check --all-targets` and the full suite green.
- Two hostile reviewers + a convergence verifier closed every finding (including a false first-draft doc paragraph and an over-claimed floor, both corrected with mechanism probes).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly manifest floors, docs, and test harness behavior; runtime API is unchanged aside from stricter minimum dependency versions for downstream resolvers.
> 
> **Overview**
> Raises **declared minimum versions** in manifests (`rustls` 0.23.16, `serde_json` 1.0.68, `tracing` 0.1.35, dev `tokio` 1.50) with comments tying each to a real API or behavior floor—especially `serde_json` 1.0.68 for correct `-0` handling in token-binding gates—so consumers resolving without this repo’s lockfile cannot pick broken graphs.
> 
> **Documents teardown** for mesh plain-drop (signaling abort once, no WebRTC `Disconnect`/`LeaveRoom`), Godot `WebSocketPeer` graceful vs `abort`, and async handle-drop where graceful close can beat abort; **CHANGELOG** mirrors that.
> 
> **Test mocks** that only accept text frames now return **`TransportSend`** on outbound binary instead of panicking; integration `MockTransport` docs call out that limitation. **`StubDrainTransport`** uses FIFO `VecDeque` with an order assertion. A new **`plain_drop_aborts_signaling_but_never_disconnects_driver_peers`** test pins mesh drop behavior via **`AbortCountingTransport`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00f43c88d6658e8d5ff357ed1cfbc5a0e2473753. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->