### PR TITLE
Round 37 audit: deterministic test clocks and advisory-doc truth

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -141,7 +141,9 @@ jobs:
             --no-default-features \
             --features signal-fish-client/transport-websocket-emscripten \
             --locked
-          node tests/emscripten-harness/driver/run-harness.cjs \
+          # A panic-free infinite spin inside one wasm ccall must fail this
+          # step in two minutes instead of hanging to the job-level timeout.
+          timeout 120 node tests/emscripten-harness/driver/run-harness.cjs \
             target/wasm32-unknown-emscripten/debug/signal-fish-emscripten-harness.js
 
   required:

--- a/.llm/skills/testing-async/SKILL.md
+++ b/.llm/skills/testing-async/SKILL.md
@@ -341,3 +341,62 @@ Not every `.unwrap()` needs to become `.expect()`. These cases are acceptable:
   obeys the server, signals are relayed, and `PeerConnected`/`PeerDisconnected`
   surface with correct transport-status reports. Cross-test controller config
   augmentation and selected topology/transport against both client drivers.
+
+## Paused Virtual Time (start_paused + advance)
+
+The async driver reads only `tokio::time`, so `#[tokio::test(start_paused = true)]`
+(current-thread runtime only) virtualizes every SDK deadline, including
+`shutdown_timeout`. Enabled by the dev-dependency's `test-util` feature
+(`tokio = { version = "1.50", features = ["full", "test-util"] }`). Semantics
+verified on tokio 1.53:
+
+- **Auto-advance**: with paused time, the runtime advances the clock to the
+  next timer deadline when (and only when) *every* task is parked. So
+  `tokio::time::sleep(Nms).await` in a test is a deterministic "wait until the
+  driver parks" — if the driver is wedged on a full channel, the clock stays
+  frozen and the sleep does not resolve early.
+- **Deadlines fire deterministically**: a regression that blocks until a
+  budget/timeout pushes virtual elapsed past the assertion bound and fails in
+  ~0 real ms. Measure budgets with `tokio::time::Instant` deltas, never
+  `std::time::Instant`.
+- **Advancer-task pattern**: for "fire the budget if the fast path doesn't
+  win", spawn `tokio::spawn(async move { sleep(budget).await; ... })` or call
+  `tokio::time::advance(...)` explicitly; auto-advance alone only helps when
+  the test task parks too.
+- **multi_thread exclusion**: paused time requires the current-thread flavor.
+  `multi_thread` tests (e.g., `src/webrtc.rs` waker latency, `src/client.rs`
+  concurrency) must stay real-time.
+- **Mock timer caution**: helpers that spin with `yield_now` never park, which
+  starves auto-advance — a `timeout(...)` guard around a pure spin loop hangs
+  forever under paused time instead of firing. Make such helpers clock-agnostic
+  with a bounded spin that falls back to a 1ms sleep (see
+  `tests/common/mod.rs::wait_for_authentication`); pure-yield loops are fine
+  when the awaited condition is guaranteed. Mesh `recv()` parks on a
+  `sleep(pump_interval)` select arm (default 20ms), which auto-advance fires
+  harmlessly; a deliberately huge `with_pump_interval` test proving
+  waker-beats-pump must stay real-time.
+- **Pre-0.7.0-style regressions stay detected**: re-introducing a blocking
+  emit that ignores the shutdown signal must fail the converted wedged-consumer
+  tests on virtual elapsed; re-introducing a fresh close budget must fail the
+  budget-sharing assertion at ~2x the configured timeout.
+
+Example (wedged close resolved by the virtual budget):
+
+```rust
+#[tokio::test(start_paused = true)]
+async fn shutdown_deadline_is_fully_virtual() {
+    // HangingCloseTransport: poll_close pends forever; abort() flips a flag.
+    let (transport, _close, abort_called, _dropped) =
+        HangingCloseTransport::with_incoming(vec![]);
+    let config = SignalFishConfig::new("mb_test")
+        .with_shutdown_timeout(std::time::Duration::from_millis(250));
+    let (client, _events) = SignalFishClient::start(transport, config);
+
+    let started = tokio::time::Instant::now();
+    client.shutdown().await;
+
+    // Auto-advance fired the budget while the close was parked.
+    assert_eq!(started.elapsed(), std::time::Duration::from_millis(250));
+    assert!(abort_called.load(Ordering::Acquire));
+}
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added root re-exports for `ProtocolInfoPayload`, `PlayerNameRulesPayload`,
   and `MeshWaker` (the latter requires the `mesh` and `tokio-runtime`
   features).
+- Added a deterministic-testing guide (`docs/testing.md`) covering paused-clock
+  and caller-cadence recipes for both drivers.
 
 ### Changed
+
+- `WebSocketTransport::connect_with_options` now logs a warning when a
+  token-binding offer proceeds over a plain `ws://` URL, where the resulting
+  proofs are forgeable by an on-path observer.
 
 - **Breaking:** `RateLimitInfo`'s `per_minute`, `per_hour`, and `per_day`
   are now `u64` instead of `u32`; a server reporting a limit above
@@ -45,6 +51,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   caller on the polling driver, where `close()` heals.
 - Documented that a room creator already holds authority, so an immediate
   `request_authority(true)` is refused with `AuthorityConflict`.
+- Documented `GoingAway`'s absolute epoch-ms deadline and seconds retry hint,
+  `RelayStats`' validated invariants (violations report as
+  `ProtocolViolation { Counters }`), the `u8` `max_players` ceiling (oversized
+  values fail the frame as `DecodeFailed`), `PlayerNameRulesPayload`'s
+  unvalidated pass-through, and corrected the wasm docs' `tokio-runtime` /
+  `transport-websocket` guidance.
 
 ### Fixed
 

--- a/docs/delivery.md
+++ b/docs/delivery.md
@@ -86,7 +86,12 @@ the server 0.4.0 reference accountability algorithm and validates snapshots,
 lifecycle epochs, exact gap coverage, reports, terminal watermarks, and
 reconnect baselines. A sequence hole is authorized only by the union of prior
 exact `DeliveryReport` ranges for that sender and epoch; aggregate
-`RelayStats` and counter deltas are diagnostics, not authorization.
+`RelayStats` and counter deltas are diagnostics, not authorization. A
+`RelayStats` frame that violates the authority's own invariants — a
+non-positive or changed-mid-connection `interval_ms`, or non-monotonic
+counters — is itself rejected: the frame is suppressed and reported as a
+`ProtocolViolation { Counters }` diagnostic (under `Observe`, the violating
+frame is still delivered).
 
 On a violation the SDK emits `SignalFishEvent::ProtocolViolation`. The default
 `ProtocolViolationPolicy::Quarantine` suppresses subsequent room game data

--- a/docs/events.md
+++ b/docs/events.md
@@ -191,7 +191,7 @@ Events related to joining, failing to join, or leaving a room.
 | `room_code` | `String` | Human-readable room code. |
 | `player_id` | `PlayerId` | The local player's identifier. |
 | `game_name` | `String` | Name of the game this room is for. |
-| `max_players` | `u8` | Maximum number of players allowed. |
+| `max_players` | `u8` | Maximum number of players allowed. `u8` ceilings the model at 255: a server advertising a larger capacity fails the frame as `DecodeFailed` rather than truncating the value. |
 | `supports_authority` | `bool` | Whether the room supports authority delegation. |
 | `current_players` | `Vec<PlayerInfo>` | Players already present in the room. |
 | `is_authority` | `bool` | Whether the local player is the authority. |
@@ -469,8 +469,8 @@ match event {
 | Variant | Fields | Description |
 |---|---|---|
 | `DeliveryReport(payload)` | `DeliveryReportPayload` | Cumulative per-class outcomes and exact omitted sequence ranges. Exact ranges are the only authorization for continuing-connection gaps. |
-| `RelayStats` | `interval_ms`, `sent_to_you`, `dropped_for_you`, `backpressure_events` | Optional cumulative connection diagnostics; never gap authorization. |
-| `GoingAway` | `deadline_ms`, `retry_after_secs` | Best-effort graceful-drain advisory. The subsequent structured transport close remains authoritative. |
+| `RelayStats` | `interval_ms`, `sent_to_you`, `dropped_for_you`, `backpressure_events` | Optional cumulative connection diagnostics; never gap authorization. Counters are cumulative since this connection registered with the relay (they survive reconnection); the SDK validates the authority's invariants (positive constant interval, monotonic counters) and reports a violating frame as `ProtocolViolation { Counters }`. A rising `backpressure_events` predicts a `4002 slow_consumer` eviction. |
+| `GoingAway` | `deadline_ms`, `retry_after_secs` | Best-effort graceful-drain advisory. `deadline_ms` is an absolute Unix epoch timestamp in milliseconds; `retry_after_secs` is an operator hint in seconds. The subsequent structured transport close remains authoritative. |
 
 Applications normally let the SDK consume these for accountability and also
 record the typed events for telemetry. `GoingAway` is a cue to preserve the

--- a/docs/mesh-guide.md
+++ b/docs/mesh-guide.md
@@ -149,7 +149,8 @@ timer.
 
 `MeshController` drives the **entire** v3 handshake against your driver on top of
 an async `SignalFishClient` — it is unavailable on `tokio-runtime`-less builds
-(such as wasm) and there is no polling-client variant: `SignalFishPollingClient`
+(the SDK ships no WASM profile that drives the async client) and there is no
+polling-client variant: `SignalFishPollingClient`
 users integrate their own driver with the manual
 `send_signal_for_generation` / `report_transport_status` choreography described
 below. On a WebRTC `SessionPlan`/`NewPeer` it calls

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -646,7 +646,7 @@ pub enum ServerMessage { /* ... */ }
 | `PeerTransportStatus` | **(v3)** A peer's data-path transport state changed (informational). |
 | `DeliveryReport` | **(v3)** Cumulative per-class outcomes plus exact omitted sequence ranges. |
 | `RelayStats` | **(v3)** Optional cumulative connection-level relay diagnostics. |
-| `GoingAway` | **(v3)** Best-effort server drain advisory preceding a structured close. |
+| `GoingAway` | **(v3)** Best-effort server drain advisory (absolute Unix-epoch-ms deadline, optional seconds retry hint) preceding a structured close. |
 
 !!! note
     You don't parse `ServerMessage` directly. The `SignalFishClient` run loop

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,193 @@
+# Deterministic Testing
+
+Integration tests for a multiplayer SDK fail in two ways that have nothing to
+do with your code: a deadline that was *probably* long enough on the CI
+runner, and a `sleep` that was *probably* long enough for the event you were
+awaiting. This page explains which clocks the SDK actually reads and how to
+remove wall-clock luck from your tests.
+
+## The time model: who reads which clock
+
+Every SDK deadline is derived from one of three clock sources, and each can
+be made deterministic:
+
+| Driver | Clock source | How to control it |
+|---|---|---|
+| [`SignalFishClient`](client.md#signalfishclient) (async) | [`tokio::time`](https://docs.rs/tokio/latest/tokio/time/) only — `shutdown_timeout` and every internal deadline are tokio timers | `#[tokio::test(start_paused = true)]` or `tokio::time::pause()` virtualizes **every** SDK deadline, with no SDK configuration |
+| [`SignalFishPollingClient`](client.md#signalfishpollingclient) | `std::time::Instant`, sampled only inside your `poll()` / `close()` calls | The cadence is already yours; deadlines inside `close()` are bounded by `SignalFishConfig::shutdown_timeout` — use a tiny (or `Duration::ZERO`) budget for determinism |
+| Godot adapter | Samples per `begin_poll_cycle` (one per polling-client `poll()` call) | Inject the cadence: call `poll()` from a fixed-point in your game loop rather than on a timer |
+
+The practical consequence for the async driver: the SDK never reads the wall
+clock directly, so a paused tokio clock freezes the entire driver. A
+`shutdown_timeout` of 5 seconds elapses in zero real milliseconds the moment
+you `tokio::time::advance(Duration::from_secs(5)).await`.
+
+!!! note "Enable tokio's test-util feature"
+    `start_paused` lives behind tokio's `test-util` feature, which is for
+    test builds only. Add it to your dev-dependencies:
+    `tokio = { version = "1", features = ["full", "test-util"] }`.
+
+## Recipe: mock transport + paused time
+
+Transport implementations are channel-driven objects, so they work unchanged
+under a paused clock. The example below proves the shutdown deadline end to
+end: the graceful close can never complete, so teardown can only come from
+the budget expiry aborting the transport. The test completes in microseconds
+of real time while asserting exact virtual-time behavior — and a regression
+that turns the abort into a hang fails the exact-elapsed assertion (via the
+shutdown watchdog) instead of passing vacuously.
+
+```rust
+use std::collections::VecDeque;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use signal_fish_client::{
+    SignalFishClient, SignalFishConfig, SignalFishError, Transport, TransportFrame,
+};
+
+/// A scripted transport whose graceful close never completes: teardown can
+/// only come from the shutdown budget expiring and aborting the transport.
+struct HangingCloseTransport {
+    incoming: VecDeque<Result<TransportFrame, SignalFishError>>,
+    aborted: Arc<AtomicBool>,
+}
+
+impl Transport for HangingCloseTransport {
+    fn poll_send(
+        &mut self,
+        _cx: &mut Context<'_>,
+        frame: &mut Option<TransportFrame>,
+    ) -> Poll<Result<(), SignalFishError>> {
+        frame.take(); // backend ownership transfers here
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_recv(
+        &mut self,
+        _cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<TransportFrame, SignalFishError>>> {
+        match self.incoming.pop_front() {
+            Some(result) => Poll::Ready(Some(result)),
+            None => Poll::Pending,
+        }
+    }
+
+    fn poll_close(
+        &mut self,
+        _cx: &mut Context<'_>,
+    ) -> Poll<Result<(), SignalFishError>> {
+        Poll::Pending // graceful close never completes
+    }
+
+    fn abort(&mut self) {
+        self.aborted.store(true, Ordering::Relaxed);
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn shutdown_deadline_is_fully_virtual() {
+    let aborted = Arc::new(AtomicBool::new(false));
+    let transport = HangingCloseTransport {
+        incoming: VecDeque::from(vec![]),
+        aborted: Arc::clone(&aborted),
+    };
+    let config = SignalFishConfig::new("mb_app_abc123")
+        .with_shutdown_timeout(std::time::Duration::from_millis(250));
+    let (mut client, _events) = SignalFishClient::start(transport, config);
+
+    let started = tokio::time::Instant::now();
+    client.shutdown().await;
+
+    // Tokio auto-advanced the paused clock to the budget deadline while the
+    // close was parked: virtual elapsed is exactly the 250ms budget, with
+    // zero real time spent sleeping.
+    let elapsed = started.elapsed();
+    assert_eq!(
+        elapsed,
+        std::time::Duration::from_millis(250),
+        "shutdown must resolve at the virtual budget deadline"
+    );
+    // The expiry (not a graceful close) ended the shutdown: the budget
+    // aborted the transport.
+    assert!(aborted.load(Ordering::Relaxed));
+}
+```
+
+Three rules keep this honest:
+
+- **Waiting is `advance`, never `sleep`.** Under paused time a plain
+  `tokio::time::sleep` resolves only via tokio's *auto-advance*, which fires
+  when every task on the runtime is parked. That makes `sleep(ms)` a
+  deterministic "wait until the driver parks" primitive — but if you need
+  time to move while your test task could still run, drive it explicitly
+  with `tokio::time::advance(d).await` (the advancer-task pattern:
+  `tokio::spawn` a task that sleeps and then lets the budget fire, so a fast
+  path wins the race and a slow path hits the deterministically-advanced
+  deadline).
+- **Mocks must not read the wall clock.** Script responses through channels
+  or `std::sync::atomic` flags, and have `poll_recv` return
+  `Poll::Pending` with no waker rather than sleeping. A mock that uses
+  `std::thread::sleep` or `std::time::Instant` deadlines drags real time
+  back into a paused test.
+- **Real I/O stays on the real clock.** The built-in
+  [`WebSocketTransport`](transport.md) performs actual TCP/TLS work; a
+  paused clock does not freeze the network, so a connect deadline could fire
+  while real I/O is still in flight. Keep end-to-end tests against a live
+  server on real time and use generous, direction-safe budgets (a sleep that
+  strictly exceeds the deadline it must outlive), or put a mock behind
+  `SignalFishClient::start` when you need virtual time.
+
+## Recipe: polling-client cadence control
+
+`SignalFishPollingClient` has no background task and no timer of its own:
+time only moves when you call `poll()`. That makes your test the clock.
+
+```rust,ignore
+use std::time::Duration;
+
+use signal_fish_client::{SignalFishConfig, SignalFishPollingClient};
+
+// A zero close budget makes teardown synchronous and exact: the close can
+// never linger on a std-time deadline.
+let mut client = SignalFishPollingClient::new(
+    transport,
+    SignalFishConfig::new("mb_app_abc123")
+        .with_shutdown_timeout(Duration::ZERO),
+);
+
+// One poll per game tick: the cadence is the test's, not the SDK's.
+let events = client.poll();
+for event in events {
+    // handle event
+}
+
+client.close();
+```
+
+Details that matter for deterministic polling tests:
+
+- **`close()` emits no events.** Completion is observed through
+  [`snapshot()`](client.md#signalfishpollingclient), which is coherent the
+  moment `close()` returns.
+- **The default close policy abandons client-owned queued work.** Flush is
+  an explicit opt-in (`PollingClosePolicy::Flush`); with a
+  `Duration::ZERO`-bounded budget the close is synchronous and exact.
+- **The Godot adapter samples per `begin_poll_cycle`.** One `poll()` call is
+  one scheduling cycle; tests inject cadence by calling `poll()` in a fixed
+  loop rather than sleeping between calls. See
+  [WebAssembly & Godot](wasm.md).
+
+## Why there is no injectable Clock API
+
+We evaluated a `ClockFn`-style abstraction (as used by rollback netcode
+frameworks such as fortress-rollback) and deliberately did not build one.
+The async driver reads **only** `tokio::time`, which tokio itself lets you
+pause and advance; the polling driver is caller-driven, so its clock is your
+game loop. Together those two properties already virtualize every production
+clock read, and a public clock trait would add API surface that downstream
+users do not need — anyone requiring virtual time gets it from tokio with
+zero SDK coupling. If you need `std`-clock injection on the polling driver
+(for example, to simulate queue-age aging without calling `poll()`), please
+[open an issue](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/issues).

--- a/docs/token-binding.md
+++ b/docs/token-binding.md
@@ -38,8 +38,8 @@ assert_eq!(transport.token_binding_status(), TokenBindingStatus::Active);
 | Mode | Behavior |
 |---|---|
 | `Disabled` | Default. Does not offer a subprotocol and preserves the old connection path exactly. |
-| `Optional` | Offers v2. If the server completes the upgrade without selecting a subprotocol, reconnects once without the offer and reports `NotNegotiated`. It never retries an HTTP rejection, malformed challenge, unexpected selection, network error, or TLS failure. |
-| `Required` | Fails with a typed `SignalFishError::TokenBinding` unless the server selects v2 and sends a valid first-message challenge before the configured deadline. HTTP upgrade rejections (404, 401, 500, ...) are not negotiation outcomes and surface as `Io` carrying the underlying status, exactly like `Disabled`; network failures inside the challenge window (an abrupt drop with no close handshake) keep the transport-error classification instead of being relabeled as negotiation outcomes. |
+| `Optional` | Offers v2. If the server completes the upgrade without selecting a subprotocol, reconnects once without the offer and reports `NotNegotiated`. It never retries an HTTP rejection, malformed challenge, unexpected selection, network error, or TLS failure. On plain `ws://` the offer itself logs a warning, because if the server selects v2 the proofs are forgeable by an on-path observer; use `wss://`. |
+| `Required` | Fails with a typed `SignalFishError::TokenBinding` unless the server selects v2 and sends a valid first-message challenge before the configured deadline. HTTP upgrade rejections (404, 401, 500, ...) are not negotiation outcomes and surface as `Io` carrying the underlying status, exactly like `Disabled`; network failures inside the challenge window (an abrupt drop with no close handshake) keep the transport-error classification instead of being relabeled as negotiation outcomes. On plain `ws://` the resulting proofs are forgeable by an on-path observer (the client logs a warning at connect time); use `wss://`. |
 
 Optional mode permits an explicit downgrade when the server accepts an
 unsigned upgrade. TLS authenticates the handshake and prevents an on-path

--- a/docs/wasm.md
+++ b/docs/wasm.md
@@ -729,7 +729,7 @@ for the full workflow. Key steps:
 | `transport-websocket-emscripten` | No | `EmscriptenWebSocketTransport`; enables `polling-client` | No | Yes |
 | `token-binding` | No | Native `WebSocketTransport` support for `signalfish.tokenbinding.v2` | No | No |
 | `tls` | No | `wss://` TLS for the built-in native WebSocket transport (rustls) | No | No |
-| `mesh` | No | Protocol v3 mesh tracker plus the `WebRtcDriver` seam; `MeshController` needs `tokio-runtime`, which wasm forbids, so on wasm only the tracker/seam (manual choreography via the polling client) is available; bundles no WebRTC stack | Yes | Yes |
+| `mesh` | No | Protocol v3 mesh tracker plus the `WebRtcDriver` seam; `MeshController` needs `tokio-runtime`, which has no supported WASM profile, so on wasm only the tracker/seam (manual choreography via the polling client) is available; bundles no WebRTC stack | Yes | Yes |
 | `polling-client` | No | `SignalFishPollingClient` — sync, polling-based client for any `Transport` | Yes | Yes |
 | `tokio-runtime` | Yes (via `transport-websocket`) | Enables `tokio/rt` and `tokio/time` for background task spawning | No | No |
 
@@ -743,9 +743,11 @@ for the full workflow. Key steps:
 | Custom link-enabled Emscripten host | `--no-default-features --features transport-websocket-emscripten` |
 
 !!! warning "Feature conflicts"
-    Do not enable `transport-websocket` or `tokio-runtime` when targeting any
-    WASM target. They depend on `tokio::net::TcpStream` and Tokio's
-    multi-threaded runtime, which do not compile to WebAssembly.
+    Do not enable `transport-websocket` when targeting any WASM target: its
+    TCP socket stack does not compile to WebAssembly. `tokio-runtime` alone
+    compiles today, but the SDK ships no WASM profile that drives the async
+    client, so it is unsupported and untested there — use the
+    `--no-default-features` profile and bring your own transport.
 
 !!! warning "Required token-binding deployments are native-only"
     Browser WebSocket APIs—including Emscripten and Godot's browser-backed

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -143,6 +143,7 @@ nav:
       - Client Commands & State: client.md
       - Events: events.md
       - Errors: errors.md
+      - Deterministic Testing: testing.md
       - WebAssembly & Godot: wasm.md
       - Godot + Fortress: fortress.md
   - Multiplayer Choices:

--- a/src/client.rs
+++ b/src/client.rs
@@ -4767,8 +4767,17 @@ mod tests {
 
     async fn wait_until(condition: impl Fn() -> bool) {
         tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            let mut spins = 0usize;
             while !condition() {
-                tokio::task::yield_now().await;
+                // Bounded spin, then park: a pure `yield_now` loop never
+                // parks, so under paused (`start_paused`) virtual time it
+                // would starve auto-advance and the guard could never fire.
+                if spins < 64 {
+                    spins += 1;
+                    tokio::task::yield_now().await;
+                } else {
+                    tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+                }
             }
         })
         .await
@@ -7192,7 +7201,7 @@ mod tests {
     /// A receive error wedges terminal delivery exactly like a clean close:
     /// with no `shutdown()` and an uncompletable `poll_close`, teardown must
     /// come from the budget-expiry abort, never hang the loop.
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn terminal_receive_error_aborts_only_after_the_shutdown_budget() {
         // Connected and Authenticated fill the capacity-2 channel, so the
         // terminal Disconnected delivery wedges with no `shutdown()` call.
@@ -7200,6 +7209,12 @@ mod tests {
         // impossible: teardown can only come from the budget expiry aborting
         // the transport. A regression that restores unbounded delivery keeps
         // this spin alive forever instead of passing vacuously.
+        //
+        // Paused virtual time: the spin's 5ms sleeps resolve via tokio
+        // auto-advance only while every task is parked, so the abort surfaces
+        // at virtual ~100ms (the budget) and the guard below is exact. A
+        // regression that wedges past the budget would push virtual elapsed
+        // to the 2s guard instead of hanging on the wall clock.
         let (transport, _close_called, abort_called, _dropped) =
             HangingCloseTransport::with_incoming(vec![
                 Some(Ok(authenticated_json())),
@@ -7212,7 +7227,7 @@ mod tests {
             .with_shutdown_timeout(std::time::Duration::from_millis(100));
         let (client, mut events) = SignalFishClient::start(transport, config);
 
-        let started = std::time::Instant::now();
+        let started = tokio::time::Instant::now();
         while !abort_called.load(Ordering::Acquire) {
             assert!(
                 started.elapsed() < std::time::Duration::from_secs(2),
@@ -7245,7 +7260,7 @@ mod tests {
     /// A policy-driven disconnect wedges on its violation batch exactly like
     /// a peer close: with no `shutdown()` and a full channel, teardown must
     /// come from the shared shutdown budget, never hang past it.
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn policy_disconnect_violation_batch_is_bounded_by_the_shutdown_budget() {
         // Connected, Authenticated, and ProtocolInfo fill the capacity-3
         // channel, so the violation batch that precedes the Disconnect-policy
@@ -7254,6 +7269,11 @@ mod tests {
         // budget expiry aborting the transport. A regression that restores
         // unbounded delivery keeps this spin alive forever instead of passing
         // vacuously.
+        //
+        // Paused virtual time: the spin's 5ms sleeps resolve via tokio
+        // auto-advance only while every task is parked, so the abort surfaces
+        // at virtual ~200ms (the budget) and the budget-sharing assertion
+        // below is exact on the virtual clock.
         let room_left_json = serde_json::to_string(&ServerMessage::RoomLeft).unwrap();
         let (transport, _close_called, abort_called, _dropped) =
             HangingCloseTransport::with_incoming(vec![
@@ -7267,7 +7287,7 @@ mod tests {
             .with_shutdown_timeout(std::time::Duration::from_millis(200));
         let (client, mut events) = SignalFishClient::start(transport, config);
 
-        let started = std::time::Instant::now();
+        let started = tokio::time::Instant::now();
         while !abort_called.load(Ordering::Acquire) {
             assert!(
                 started.elapsed() < std::time::Duration::from_secs(2),
@@ -7277,7 +7297,8 @@ mod tests {
         }
         // The batch and the close share one budget: a regression that lets
         // the close restart a fresh window after the batch consumed it
-        // observes roughly twice the configured timeout here.
+        // aborts at virtual ~400ms — twice the configured timeout — and
+        // fails this assertion deterministically.
         let elapsed = started.elapsed();
         assert!(
             elapsed < std::time::Duration::from_millis(300),
@@ -7370,7 +7391,7 @@ mod tests {
 
     /// When a batch delivery is preempted, the remaining batch events get one
     /// nonblocking attempt instead of being discarded sight unseen.
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn expired_budget_preempts_blocked_batch_delivers_without_corruption() {
         let (tx, mut rx) = mpsc::channel(4);
         let (_shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
@@ -7378,12 +7399,13 @@ mod tests {
 
         // A budget that expired before the call makes every blocked delivery
         // deterministic. The channel starts full, so both batch events are
-        // preempted instead of delivered or queued.
+        // preempted instead of delivered or queued. The expiry is produced by
+        // advancing the paused virtual clock past the sampled deadline.
         for _ in 0..4 {
             tx.try_send(SignalFishEvent::Pong).expect("filler fits");
         }
         let stale_deadline = tokio::time::Instant::now();
-        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        tokio::time::advance(std::time::Duration::from_millis(10)).await;
 
         let batch = vec![SignalFishEvent::Connected, SignalFishEvent::Connected];
         let delivered = emit_event_batch(&tx, &mut shutdown, Some(stale_deadline), batch).await;

--- a/src/event.rs
+++ b/src/event.rs
@@ -372,16 +372,37 @@ pub enum SignalFishEvent {
     },
 
     /// Cumulative relay-delivery diagnostics (protocol v3 only).
+    ///
+    /// Counters are cumulative since this connection registered with the
+    /// relay (they survive reconnection) and `interval_ms` must stay constant
+    /// for the whole connection. The SDK validates those invariants —
+    /// positive interval, fixed interval, monotonic counters — and suppresses
+    /// the violating frame and reports `ProtocolViolation { Counters }`
+    /// under the configured policy. A rising `backpressure_events` predicts
+    /// the server's `4002 slow_consumer` eviction.
     RelayStats {
+        /// Configured emission interval in milliseconds.
         interval_ms: u64,
+        /// Cumulative frames delivered to this connection.
         sent_to_you: u64,
+        /// Cumulative frames dropped instead of being delivered to this
+        /// connection.
         dropped_for_you: u64,
+        /// Cumulative intervals in which this connection's outbound queue
+        /// was observed full.
         backpressure_events: u64,
     },
 
     /// Graceful server-shutdown advisory (protocol v3 only).
+    ///
+    /// Best-effort: the structured transport close that follows remains the
+    /// authoritative disconnect signal. The advisory is passed through
+    /// verbatim; the SDK never acts on it.
     GoingAway {
+        /// Absolute Unix epoch timestamp, in milliseconds, at which the
+        /// server will force-close the connection.
         deadline_ms: u64,
+        /// Operator retry hint in seconds, if the deployment advertises one.
         retry_after_secs: Option<u64>,
     },
 

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -491,6 +491,10 @@ pub struct ProtocolInfoPayload {
 }
 
 /// Describes the characters a deployment allows inside `player_name`.
+///
+/// Free-form advisory: the server authors these values and the SDK passes
+/// them through without coherence validation — for example, a `max_length`
+/// below `min_length` is surfaced verbatim rather than rejected.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PlayerNameRulesPayload {
     /// Maximum accepted `player_name` length.
@@ -576,6 +580,9 @@ pub struct RoomJoinedPayload {
     pub room_code: String,
     pub player_id: PlayerId,
     pub game_name: String,
+    /// Server-advertised room capacity ceiling. `u8` bounds the SDK's model
+    /// at 255: a server advertising a larger capacity fails the whole frame
+    /// as `DecodeFailed` rather than truncating the value.
     pub max_players: u8,
     pub supports_authority: bool,
     pub current_players: Vec<PlayerInfo>,
@@ -612,6 +619,9 @@ pub struct ReconnectedPayload {
     pub room_code: String,
     pub player_id: PlayerId,
     pub game_name: String,
+    /// Server-advertised room capacity ceiling. `u8` bounds the SDK's model
+    /// at 255: a server advertising a larger capacity fails the whole frame
+    /// as `DecodeFailed` rather than truncating the value.
     pub max_players: u8,
     pub supports_authority: bool,
     pub current_players: Vec<PlayerInfo>,
@@ -1214,15 +1224,30 @@ pub enum ServerMessage {
         connected: bool,
     },
     /// Periodic cumulative relay-delivery diagnostics (protocol v3 only).
+    /// Counters are cumulative since this connection registered with the
+    /// relay (they survive reconnection) and `interval_ms` must stay constant
+    /// for the whole connection; the SDK validates those invariants before
+    /// surfacing the frame.
     RelayStats {
+        /// Configured emission interval in milliseconds.
         interval_ms: u64,
+        /// Cumulative frames delivered to this connection.
         sent_to_you: u64,
+        /// Cumulative frames dropped instead of being delivered to this
+        /// connection.
         dropped_for_you: u64,
+        /// Cumulative intervals in which this connection's outbound queue
+        /// was observed full.
         backpressure_events: u64,
     },
-    /// Graceful server-shutdown advisory (protocol v3 only).
+    /// Graceful server-shutdown advisory (protocol v3 only). `deadline_ms` is
+    /// an absolute Unix epoch timestamp in milliseconds; `retry_after_secs` is
+    /// an operator retry hint in seconds.
     GoingAway {
+        /// Absolute Unix epoch timestamp, in milliseconds, at which the
+        /// server will force-close the connection.
         deadline_ms: u64,
+        /// Operator retry hint in seconds, if the deployment advertises one.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         retry_after_secs: Option<u64>,
     },

--- a/src/transports/websocket.rs
+++ b/src/transports/websocket.rs
@@ -823,7 +823,9 @@ impl WebSocketTransport {
     /// socket tuning, inbound frame/message size limits, and token-binding
     /// negotiation policy. Socket options are applied before any TLS handshake,
     /// so they cover both `ws://` and `wss://`. A selected token-binding
-    /// challenge is consumed before this method returns.
+    /// challenge is consumed before this method returns. A token-binding
+    /// offer over a plain `ws://` URL logs a warning: the resulting proofs
+    /// are forgeable by an on-path observer there.
     ///
     /// # Errors
     ///
@@ -862,8 +864,21 @@ impl WebSocketTransport {
         #[cfg(feature = "tls")]
         install_tls_provider();
 
+        let secure = url.starts_with("wss://");
+        #[cfg(feature = "token-binding")]
+        if options.token_binding != TokenBindingMode::Disabled && !secure {
+            // tokio-tungstenite performs no TLS handshake on a plain URL, so
+            // an on-path observer reads the handshake key and nonce and can
+            // forge every proof. Never inline the URL here; `validate_request_url`
+            // makes `!secure` equivalent to a plain `ws://` scheme.
+            tracing::warn!(
+                "token-binding mode {:?} on a plain ws:// URL produces proofs \
+                 forgeable by an on-path observer; use wss://",
+                options.token_binding
+            );
+        }
         tracing::debug!(
-            secure = url.starts_with("wss://"),
+            secure,
             disable_nagle = options.disable_nagle,
             max_inbound_message_size = options.max_inbound_message_size,
             token_binding = ?options.token_binding,
@@ -2093,6 +2108,167 @@ mod tests {
             Some(Err(SignalFishError::TransportReceive(_)))
         ));
         finish_mock_server(server_task).await;
+    }
+
+    #[cfg(feature = "token-binding")]
+    #[test]
+    fn plain_ws_token_binding_offer_warns_that_proofs_are_forgeable() {
+        use tracing_subscriber::layer::SubscriberExt as _;
+
+        // The warn fires at connect time before I/O, so a thread-local
+        // subscriber capture around a separate single-thread runtime pins it
+        // without a global subscriber or a capture precedent elsewhere.
+        struct MessageVisitor(Option<String>);
+
+        impl tracing::field::Visit for MessageVisitor {
+            fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+                if field.name() == "message" {
+                    self.0 = Some(format!("{value:?}"));
+                }
+            }
+        }
+
+        struct WarnCapture(Arc<std::sync::Mutex<Vec<String>>>);
+
+        impl<S> tracing_subscriber::layer::Layer<S> for WarnCapture
+        where
+            S: tracing::Subscriber,
+        {
+            fn on_event(
+                &self,
+                event: &tracing::Event<'_>,
+                _context: tracing_subscriber::layer::Context<'_, S>,
+            ) {
+                if event.metadata().level() != &tracing::Level::WARN {
+                    return;
+                }
+                let mut visitor = MessageVisitor(None);
+                event.record(&mut visitor);
+                if let Some(message) = visitor.0 {
+                    self.0
+                        .lock()
+                        .expect("warn capture mutex must not be poisoned")
+                        .push(message);
+                }
+            }
+        }
+
+        let capture_messages = |capture: &Arc<std::sync::Mutex<Vec<String>>>| {
+            capture
+                .lock()
+                .expect("warn capture mutex must not be poisoned")
+                .clone()
+        };
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("test runtime must build");
+
+        let plain_capture = Arc::new(std::sync::Mutex::new(Vec::new()));
+        tracing::subscriber::with_default(
+            tracing_subscriber::registry().with(WarnCapture(plain_capture.clone())),
+            || {
+                runtime.block_on(async {
+                    use tokio_tungstenite::tungstenite::http::header::SEC_WEBSOCKET_PROTOCOL;
+
+                    let listener = TcpListener::bind("127.0.0.1:0")
+                        .await
+                        .expect("plain-ws offer listener must bind");
+                    let addr = listener
+                        .local_addr()
+                        .expect("plain-ws offer listener must have an address");
+                    let server_task = tokio::spawn(async move {
+                        let (tcp, _) = listener.accept().await.expect("server must accept");
+                        let mut ws = tokio_tungstenite::accept_hdr_async(
+                            tcp,
+                            |request: &tokio_tungstenite::tungstenite::handshake::server::Request,
+                             mut response: tokio_tungstenite::tungstenite::handshake::server::Response| {
+                                assert_eq!(
+                                    request
+                                        .headers()
+                                        .get(SEC_WEBSOCKET_PROTOCOL)
+                                        .and_then(|value| value.to_str().ok()),
+                                    Some(crate::token_binding::TOKEN_BINDING_SUBPROTOCOL)
+                                );
+                                response.headers_mut().insert(
+                                    SEC_WEBSOCKET_PROTOCOL,
+                                    tokio_tungstenite::tungstenite::http::HeaderValue::from_static(
+                                        crate::token_binding::TOKEN_BINDING_SUBPROTOCOL,
+                                    ),
+                                );
+                                Ok(response)
+                            },
+                        )
+                        .await
+                        .expect("plain-ws handshake must succeed");
+                        ws.send(Message::Text(challenge_json().into()))
+                            .await
+                            .expect("server must send challenge");
+                        let _signed_or_dropped = ws.next().await;
+                    });
+
+                    let transport = WebSocketTransport::connect_with_options(
+                        &format!("ws://{addr}"),
+                        required_token_binding_options(),
+                    )
+                    .await
+                    .expect("a plain-ws token-binding connect must still succeed");
+                    assert_eq!(
+                        transport.token_binding_status(),
+                        TokenBindingStatus::Active
+                    );
+                    drop(transport);
+                    finish_mock_server(server_task).await;
+                });
+            },
+        );
+        let messages = capture_messages(&plain_capture);
+        assert_eq!(
+            messages.len(),
+            1,
+            "exactly one plain-scheme warning must fire at connect time: {messages:?}"
+        );
+        assert!(
+            messages[0].contains("Required"),
+            "warning must name the mode: {}",
+            messages[0]
+        );
+        assert!(
+            messages[0].contains("ws://") && messages[0].contains("wss://"),
+            "warning must name the scheme and recommend wss://: {}",
+            messages[0]
+        );
+        assert!(
+            !messages[0].contains("127.0.0.1"),
+            "warning must never inline the caller's URL: {}",
+            messages[0]
+        );
+
+        // Meaningful only where a wss:// URL reaches the warn site (the
+        // missing-`tls` rejection precedes it and is pinned separately).
+        #[cfg(feature = "tls")]
+        {
+            let secure_capture = Arc::new(std::sync::Mutex::new(Vec::new()));
+            tracing::subscriber::with_default(
+                tracing_subscriber::registry().with(WarnCapture(secure_capture.clone())),
+                || {
+                    runtime.block_on(async {
+                        let error = WebSocketTransport::connect_with_options(
+                            "wss://127.0.0.1:1",
+                            required_token_binding_options(),
+                        )
+                        .await
+                        .expect_err("wss:// to a closed port must fail as a network error");
+                        assert!(matches!(error, SignalFishError::Io(_)), "got: {error}");
+                    });
+                },
+            );
+            assert!(
+                capture_messages(&secure_capture).is_empty(),
+                "a wss:// URL must not trigger the plain-scheme warning"
+            );
+        }
     }
 
     #[cfg(all(feature = "tls", feature = "token-binding"))]

--- a/src/webrtc.rs
+++ b/src/webrtc.rs
@@ -1721,15 +1721,29 @@ mod tests {
             .count()
     }
 
+    /// Clock-agnostic bounded spin: `yield_now` for the fast path (no timer),
+    /// then a parking 1 ms sleep so an enclosing `timeout` guard still fires —
+    /// under paused (`start_paused`) time a pure spin never parks and would
+    /// starve tokio's auto-advance forever.
+    async fn spin_until(mut done: impl FnMut() -> bool) {
+        let mut spins = 0usize;
+        while !done() {
+            if spins < 64 {
+                spins += 1;
+                tokio::task::yield_now().await;
+            } else {
+                tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+            }
+        }
+    }
+
     async fn wait_for_sent_count(
         sent: &Arc<Mutex<Vec<String>>>,
         needles: &[&str],
         expected: usize,
     ) {
         tokio::time::timeout(std::time::Duration::from_secs(1), async {
-            while sent_count(sent, needles) < expected {
-                tokio::task::yield_now().await;
-            }
+            spin_until(|| sent_count(sent, needles) >= expected).await;
         })
         .await
         .unwrap_or_else(|_| {
@@ -2057,7 +2071,13 @@ mod tests {
     /// signal relay: a driver signal refused by a full command queue must be
     /// buffered (not dropped), survive `recv()` cancellation, and go out
     /// exactly once when the congestion clears.
-    #[tokio::test]
+    ///
+    /// Runs on paused virtual time: all mocks are channel/semaphore-based,
+    /// so progress never needs the wall clock. Parked `recv()` pumps resolve
+    /// through tokio auto-advance (the 20ms default pump timer fires as a
+    /// no-op before each `timeout` bound), keeping the drain loops
+    /// deterministic instead of racing CI scheduling.
+    #[tokio::test(start_paused = true)]
     async fn congestion_buffers_driver_signal_and_relays_exactly_once() {
         let peer = uuid(9);
         // Two permits establish the real Authenticate + JoinRoom setup.
@@ -2082,9 +2102,7 @@ mod tests {
         let config = SignalFishConfig::new("app").with_command_channel_capacity(1);
         let mut mesh = MeshController::start(transport, config, driver.clone());
         tokio::time::timeout(std::time::Duration::from_secs(5), async {
-            while sent_count(&sent, &[r#""type":"Authenticate""#]) == 0 {
-                tokio::task::yield_now().await;
-            }
+            spin_until(|| sent_count(&sent, &[r#""type":"Authenticate""#]) > 0).await;
         })
         .await
         .expect("Authenticate never left the capacity-1 queue");
@@ -2108,9 +2126,7 @@ mod tests {
             .send_game_data(serde_json::json!({ "filler": 1 }))
             .unwrap();
         tokio::time::timeout(std::time::Duration::from_secs(5), async {
-            while entered.load(std::sync::atomic::Ordering::Acquire) < 3 {
-                tokio::task::yield_now().await;
-            }
+            spin_until(|| entered.load(std::sync::atomic::Ordering::Acquire) >= 3).await;
         })
         .await
         .expect("transport loop never parked in the gated send");
@@ -2153,7 +2169,12 @@ mod tests {
     /// retried after capacity returns. Otherwise the controller's local
     /// `connected_peers` transition suppresses every duplicate driver event
     /// while the server retains stale WebRTC liveness for the whole interval.
-    #[tokio::test]
+    ///
+    /// Paused virtual time for the same reasons as
+    /// [`congestion_buffers_driver_signal_and_relays_exactly_once`]: the
+    /// permit/counter/channel seams carry all progress, and parked pump
+    /// windows resolve deterministically via auto-advance.
+    #[tokio::test(start_paused = true)]
     async fn congestion_retries_transport_status_edges_exactly_once() {
         let peer = uuid(9);
         // Authenticate + JoinRoom consume the two setup permits. Using the
@@ -2173,9 +2194,7 @@ mod tests {
             .send_game_data(serde_json::json!({ "filler": 1 }))
             .expect("first filler should enter the transport");
         tokio::time::timeout(std::time::Duration::from_secs(5), async {
-            while entered.load(std::sync::atomic::Ordering::Acquire) < 3 {
-                tokio::task::yield_now().await;
-            }
+            spin_until(|| entered.load(std::sync::atomic::Ordering::Acquire) >= 3).await;
         })
         .await
         .expect("transport loop never parked in the first congested send");
@@ -2213,9 +2232,7 @@ mod tests {
             .send_game_data(serde_json::json!({ "filler": 3 }))
             .expect("third filler should enter the transport");
         tokio::time::timeout(std::time::Duration::from_secs(5), async {
-            while entered.load(std::sync::atomic::Ordering::Acquire) < 6 {
-                tokio::task::yield_now().await;
-            }
+            spin_until(|| entered.load(std::sync::atomic::Ordering::Acquire) >= 6).await;
         })
         .await
         .expect("transport loop never parked in the second congested send");
@@ -2269,9 +2286,7 @@ mod tests {
             .send_game_data(serde_json::json!({ "filler": 1 }))
             .expect("first filler should enter the transport");
         tokio::time::timeout(std::time::Duration::from_secs(5), async {
-            while entered.load(std::sync::atomic::Ordering::Acquire) < 3 {
-                tokio::task::yield_now().await;
-            }
+            spin_until(|| entered.load(std::sync::atomic::Ordering::Acquire) >= 3).await;
         })
         .await
         .expect("transport loop never parked in the first congested send");
@@ -2317,9 +2332,7 @@ mod tests {
             .send_game_data(serde_json::json!({ "filler": 3 }))
             .expect("third filler should enter the transport");
         tokio::time::timeout(std::time::Duration::from_secs(5), async {
-            while entered.load(std::sync::atomic::Ordering::Acquire) < 7 {
-                tokio::task::yield_now().await;
-            }
+            spin_until(|| entered.load(std::sync::atomic::Ordering::Acquire) >= 7).await;
         })
         .await
         .expect("transport loop never parked in the second congested send");
@@ -2378,9 +2391,7 @@ mod tests {
             .send_game_data(serde_json::json!({ "filler": 1 }))
             .expect("first filler should enter the transport");
         tokio::time::timeout(std::time::Duration::from_secs(5), async {
-            while entered.load(std::sync::atomic::Ordering::Acquire) < 3 {
-                tokio::task::yield_now().await;
-            }
+            spin_until(|| entered.load(std::sync::atomic::Ordering::Acquire) >= 3).await;
         })
         .await
         .expect("transport loop never parked in the congested send");
@@ -2413,7 +2424,12 @@ mod tests {
     /// A leave fence is also transient when the correlated operation later
     /// fails. The last-channel down edge must survive `RoomOperationPending`
     /// and be reported after the failure leaves this client in the room.
-    #[tokio::test]
+    ///
+    /// Paused virtual time for the same reasons as
+    /// [`congestion_buffers_driver_signal_and_relays_exactly_once`]: the
+    /// permit/counter/channel seams carry all progress, and parked pump
+    /// windows resolve deterministically via auto-advance.
+    #[tokio::test(start_paused = true)]
     async fn failed_leave_retries_transport_status_after_operation_fence_clears() {
         let peer = uuid(10);
         // Authenticate, JoinRoom, and the initial up status consume these
@@ -2437,9 +2453,7 @@ mod tests {
         mesh.leave_room()
             .expect("leave should arm the negotiated room-operation fence");
         tokio::time::timeout(std::time::Duration::from_secs(5), async {
-            while entered.load(std::sync::atomic::Ordering::Acquire) < 4 {
-                tokio::task::yield_now().await;
-            }
+            spin_until(|| entered.load(std::sync::atomic::Ordering::Acquire) >= 4).await;
         })
         .await
         .expect("LeaveRoom never parked in the gated transport");
@@ -2546,9 +2560,7 @@ mod tests {
         let config = SignalFishConfig::new("app").with_command_channel_capacity(1);
         let mut mesh = MeshController::start(transport, config, driver.clone());
         tokio::time::timeout(std::time::Duration::from_secs(5), async {
-            while sent_count(&sent, &[r#""type":"Authenticate""#]) == 0 {
-                tokio::task::yield_now().await;
-            }
+            spin_until(|| sent_count(&sent, &[r#""type":"Authenticate""#]) > 0).await;
         })
         .await
         .expect("Authenticate never left the capacity-1 queue");
@@ -2571,9 +2583,7 @@ mod tests {
             .send_game_data(serde_json::json!({ "filler": 1 }))
             .unwrap();
         tokio::time::timeout(std::time::Duration::from_secs(5), async {
-            while entered.load(std::sync::atomic::Ordering::Acquire) < 3 {
-                tokio::task::yield_now().await;
-            }
+            spin_until(|| entered.load(std::sync::atomic::Ordering::Acquire) >= 3).await;
         })
         .await
         .expect("transport loop never parked in the gated send");
@@ -2671,9 +2681,7 @@ mod tests {
 
         drop(mesh);
         tokio::time::timeout(std::time::Duration::from_secs(2), async {
-            while aborts.load(Ordering::Relaxed) < 1 {
-                tokio::task::yield_now().await;
-            }
+            spin_until(|| aborts.load(Ordering::Relaxed) >= 1).await;
         })
         .await
         .expect("plain drop must run the transport abort fallback");
@@ -3313,9 +3321,7 @@ mod tests {
         }
 
         tokio::time::timeout(std::time::Duration::from_secs(5), async {
-            while mesh.client().snapshot().session_generation != Some(second) {
-                tokio::task::yield_now().await;
-            }
+            spin_until(|| mesh.client().snapshot().session_generation == Some(second)).await;
         })
         .await
         .expect("core never observed replacement generation");

--- a/tests/client_tests.rs
+++ b/tests/client_tests.rs
@@ -2260,13 +2260,20 @@ async fn disconnected_last_server_error_is_none_without_prior_error() {
 // Wedged-consumer shutdown: graceful close instead of abort-only
 // ════════════════════════════════════════════════════════════════════
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn shutdown_completes_gracefully_with_wedged_consumer() {
     // A consumer that stops draining wedges the transport loop in the event
     // send. Pre-0.7.0 the shutdown oneshot was starved too, so shutdown()
     // could only abort the task, leaving the transport unclosed. Now the
     // event send races the shutdown signal: the loop unblocks, closes the
     // transport, and shutdown() completes without reaching the abort.
+    //
+    // Paused virtual time: the 50ms sleep resolves only once every task is
+    // parked (tokio auto-advance), i.e. once the loop is wedged on the full
+    // channel — so the wait is deterministic, and the elapsed budget below is
+    // measured on the virtual clock. A regression that restores the blocking
+    // emit would park shutdown() until the 5s shutdown_timeout fires, pushing
+    // virtual elapsed to >= 5s and failing the assertion deterministically.
     let (transport, _sent, closed) = MockTransport::new(vec![
         Some(Ok(authenticated_json())),
         Some(Ok(protocol_info_json(None))),
@@ -2278,10 +2285,10 @@ async fn shutdown_completes_gracefully_with_wedged_consumer() {
         .with_shutdown_timeout(std::time::Duration::from_secs(5));
     let (mut client, events) = SignalFishClient::start(transport, config);
 
-    // Never drain `events`; give the loop time to wedge on a full channel.
+    // Never drain `events`; park until the loop has wedged on a full channel.
     tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
-    let started = std::time::Instant::now();
+    let started = tokio::time::Instant::now();
     client.shutdown().await;
     let elapsed = started.elapsed();
 
@@ -2290,17 +2297,23 @@ async fn shutdown_completes_gracefully_with_wedged_consumer() {
         "transport must be closed gracefully even with a wedged consumer"
     );
     assert!(
-        elapsed < std::time::Duration::from_secs(4),
-        "shutdown must not need the timeout/abort path; took {elapsed:?}"
+        elapsed < std::time::Duration::from_secs(1),
+        "shutdown must not need the timeout/abort path; took {elapsed:?} of \
+         virtual time"
     );
     drop(events);
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn wedged_consumer_events_before_shutdown_are_not_lost_when_drained() {
     // Guards against over-eager abandonment: a consumer that resumes draining
     // BEFORE shutdown still receives every event, and shutdown then delivers
     // the terminal Disconnected.
+    //
+    // Paused virtual time: the pre-shutdown sleep below resolves via tokio
+    // auto-advance only once the loop is parked (wedged on the full channel),
+    // making the "resume draining" ordering deterministic instead of a
+    // wall-clock race.
     let (transport, _sent, closed) = MockTransport::new(vec![
         Some(Ok(authenticated_json())),
         Some(Ok(protocol_info_json(None))),
@@ -2309,7 +2322,7 @@ async fn wedged_consumer_events_before_shutdown_are_not_lost_when_drained() {
     let config = SignalFishConfig::new("mb_test_integration").with_event_channel_capacity(1);
     let (mut client, mut events) = SignalFishClient::start(transport, config);
 
-    // Let the loop wedge against the capacity-1 channel.
+    // Park until the loop has wedged against the capacity-1 channel.
     tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
     // Resume draining: everything must arrive in order.
@@ -2328,7 +2341,7 @@ async fn wedged_consumer_events_before_shutdown_are_not_lost_when_drained() {
     assert!(closed.load(std::sync::atomic::Ordering::Relaxed));
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn shutdown_races_wedged_terminal_disconnect() {
     // The *terminal* Disconnected — emitted on a transport error, a clean
     // server close, or a dropped handle — must race the shutdown signal too,
@@ -2336,8 +2349,13 @@ async fn shutdown_races_wedged_terminal_disconnect() {
     // one helper; this exercises it via a transport receive error that fires
     // while the event channel is full (cap 1, undrained Connected), so the
     // terminal delivery blocks. Pre-fix those paths used a blocking emit that
-    // ignored shutdown, pinning shutdown() to its full timeout/abort. A
-    // generous timeout makes the racing path (ms) unmistakable vs blocking (s).
+    // ignored shutdown, pinning shutdown() to its full timeout/abort.
+    //
+    // Paused virtual time: the sleep resolves via auto-advance exactly when
+    // the loop has parked (wedged terminal delivery), and the elapsed budget
+    // below is virtual. The racing path completes in ~0 virtual ms; a
+    // regression that blocks until the 10s shutdown_timeout/abort fires
+    // would advance virtual elapsed to >= 10s and fail the 3s budget.
     let (transport, _sent, closed) = MockTransport::new(vec![Some(Err(
         SignalFishError::TransportReceive("boom".into()),
     ))]);
@@ -2350,7 +2368,7 @@ async fn shutdown_races_wedged_terminal_disconnect() {
 
     tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
-    let started = std::time::Instant::now();
+    let started = tokio::time::Instant::now();
     client.shutdown().await;
     let elapsed = started.elapsed();
     assert!(
@@ -2596,8 +2614,16 @@ async fn generation_bound_typed_and_raw_signals_refuse_stale_plan() {
     ])
     .await;
     tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        let mut spins = 0usize;
         while client.snapshot().session_generation != Some(second) {
-            tokio::task::yield_now().await;
+            // Bounded spin, then park: a pure `yield_now` loop would starve
+            // auto-advance under paused virtual time.
+            if spins < 64 {
+                spins += 1;
+                tokio::task::yield_now().await;
+            } else {
+                tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+            }
         }
     })
     .await

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -497,13 +497,23 @@ pub fn finalized_reconnected_json() -> String {
 
 /// Wait until the mock transport records at least `expected_len` outgoing
 /// messages. This avoids fixed sleeps when testing queued async sends.
+///
+/// Clock-agnostic: bounded `yield_now` spins first (no timer), then parks on
+/// a 1 ms sleep — under paused (`start_paused`) virtual time a pure spin
+/// would starve auto-advance and the 1 s guard could never fire.
 pub async fn wait_for_sent_len(sent: &Arc<StdMutex<Vec<String>>>, expected_len: usize) {
     tokio::time::timeout(std::time::Duration::from_secs(1), async {
+        let mut spins = 0usize;
         loop {
             if sent.lock().unwrap().len() >= expected_len {
                 break;
             }
-            tokio::task::yield_now().await;
+            if spins < 64 {
+                spins += 1;
+                tokio::task::yield_now().await;
+            } else {
+                tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+            }
         }
     })
     .await
@@ -520,10 +530,24 @@ pub async fn wait_for_sent_len(sent: &Arc<StdMutex<Vec<String>>>, expected_len: 
 /// requirement to await `SignalFishEvent::Authenticated` before room
 /// operations. Room operations refuse earlier with
 /// [`SignalFishError::NotAuthenticated`].
+///
+/// Clock-agnostic by construction: the first spins use `yield_now` (no
+/// timer), so the common case completes without touching the clock in real
+/// time and under paused (`start_paused`) virtual time alike. If the flag is
+/// still unset after a bounded spin, the loop parks on a 1ms sleep — that
+/// keeps real-time behavior unchanged and, under paused time, lets tokio's
+/// auto-advance walk the virtual clock so the `timeout` guard still fires
+/// (a pure spin would never park and could starve auto-advance forever).
 pub async fn wait_for_authentication(client: &signal_fish_client::SignalFishClient) {
     tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        let mut spins = 0usize;
         while !client.is_authenticated() {
-            tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+            if spins < 64 {
+                spins += 1;
+                tokio::task::yield_now().await;
+            } else {
+                tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+            }
         }
     })
     .await

--- a/tests/emscripten-harness/driver/run-harness.cjs
+++ b/tests/emscripten-harness/driver/run-harness.cjs
@@ -102,8 +102,9 @@ function encodeClientFrame(opcode, payload) {
 /**
  * Incremental frame parser. Feed raw chunks; yields complete frames.
  * Supports the single-frame unfragmented messages this harness uses and
- * rejects anything else (fragmentation, RSV bits, unknown opcodes) the way
- * a conformant peer must.
+ * rejects anything else (fragmentation, RSV bits, unknown opcodes,
+ * control frames with a payload over 125 bytes, close frames with a
+ * 1-byte body) the way a conformant peer must.
  */
 class FrameParser {
   constructor(requireMasked = false) {
@@ -148,6 +149,16 @@ class FrameParser {
       if (opcode !== OP_TEXT && opcode !== OP_BINARY && opcode !== OP_CLOSE
           && opcode !== OP_PING && opcode !== OP_PONG) {
         fail(`harness received unknown opcode ${opcode}`);
+      }
+      // RFC 6455 5.5: control frames must have a payload of 125 bytes or
+      // less, and 5.5.1: a close body of exactly 1 byte is invalid. Both are
+      // mandatory-fail protocol errors (1002); the shim must never emit them.
+      const isControl = opcode >= OP_CLOSE && opcode <= OP_PONG;
+      if (isControl && length > 125) {
+        fail(`harness received a control frame (opcode ${opcode}) with a ${length}-byte payload; RFC 6455 5.5 requires failing the connection with 1002`);
+      }
+      if (opcode === OP_CLOSE && length === 1) {
+        fail("harness received a 1-byte close body; RFC 6455 5.5.1 requires failing the connection with 1002");
       }
       let payload = this.buffer.subarray(offset + maskKey, offset + maskKey + length);
       if (masked) {

--- a/tests/polling_parity_tests.rs
+++ b/tests/polling_parity_tests.rs
@@ -5223,8 +5223,12 @@ async fn parity_ensure_v3_relay_only_mode_after_v2_negotiation() {
 
 // ── PARITY 3: relay-only v3 negotiation does not claim mesh ──────────
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn parity_negotiated_version_after_v3() {
+    // Paused virtual time: the three scripted events arrive through the
+    // buffered channel, so the drain recvs complete without time passing;
+    // the 100ms drain windows are only a failure-path guard, where tokio
+    // auto-advance fires them deterministically instead of racing CI load.
     let async_mock = SharedMock::new(vec![AUTH, PI_V3]);
     let (client, mut events) = SignalFishClient::start(async_mock, SignalFishConfig::new("app"));
     for _ in 0..3 {
@@ -5242,8 +5246,12 @@ async fn parity_negotiated_version_after_v3() {
 
 // ── PARITY 4: reconnect replay restores v3 (downgrade-risk hunt) ──────
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn parity_reconnect_preserves_outer_v3_negotiation() {
+    // Paused virtual time: the four scripted events arrive through the
+    // buffered channel, so the drain recvs complete without time passing;
+    // the 100ms drain windows are only a failure-path guard, where tokio
+    // auto-advance fires them deterministically instead of racing CI load.
     let recon = reconnected_with_missed(vec![]);
 
     let async_mock = SharedMock::new(vec![AUTH, PI_V3, &recon]);
@@ -5705,8 +5713,14 @@ async fn parity_reconnected_baseline_is_planless_until_fresh_session_plan() {
 
 // ── PARITY 7: disconnect resets negotiated version in both ─────────────
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn parity_disconnect_resets_negotiated_version() {
+    // Paused virtual time: Connected/Authenticated/ProtocolInfo arrive
+    // through the buffered channel immediately and the terminal
+    // Disconnected is already queued behind them (the receive error is
+    // scripted), so the drain recvs complete without time passing. The
+    // 150ms windows are only a failure-path guard, where tokio auto-advance
+    // fires them deterministically instead of racing CI load.
     let poll_mock = SharedMock::new(vec![AUTH, PI_V3]);
     let mut poll_client =
         SignalFishPollingClient::new(poll_mock, SignalFishConfig::new("app").enable_mesh());
@@ -5739,8 +5753,12 @@ async fn parity_disconnect_resets_negotiated_version() {
 
 // ── PARITY 9: DecodeFailed surfacing is identical ─────────────────────
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn parity_decode_failed_async_vs_polling() {
+    // Paused virtual time: the events arrive through the buffered channel,
+    // so the drain recvs complete without time passing; the 150ms windows
+    // are only a failure-path guard, where tokio auto-advance fires them
+    // deterministically instead of racing CI load.
     const BAD_FRAME: &str =
         r#"{"type":"Error","data":{"message":"x","error_code":"FUTURE_CODE_XYZ"}}"#;
 
@@ -5796,8 +5814,13 @@ async fn parity_decode_failed_async_vs_polling() {
 
 // ── PARITY 10: Disconnected carries last_server_error identically ─────
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn parity_disconnected_carries_last_server_error() {
+    // Paused virtual time: the farewell and the terminal Disconnected are
+    // queued on the buffered channel, so the drain recvs complete without
+    // time passing; the 150ms windows are only a failure-path guard, where
+    // tokio auto-advance fires them deterministically instead of racing CI
+    // load.
     const FAREWELL: &str = r#"{"type":"Error","data":{"message":"Disconnected as a slow consumer","error_code":"SLOW_CONSUMER"}}"#;
 
     // Async: farewell then clean close.


### PR DESCRIPTION
Closes #210 (deterministic clocks). Round 37 of the recurring #126 audit.

## Why

Two things needed fixing at once: tests that can flake under CI load (the repo already recorded one such wall-clock flake), and audit findings where our docs described things the code does not do.

## What changed

**Deterministic test clocks (#210).** We studied fortress-rollback and found every production deadline here is already controllable without a new abstraction: the async driver reads only tokio time (so tokio's paused clock virtualizes it), and the polling client is caller-ticked. So instead of adding a public Clock API, we put that machinery to work: 14 load-sensitive tests now run on paused virtual time with exact budget assertions instead of 25–150 ms real-clock windows, and every "wait for X" spin now parks so its timeout guard still fires (a regression now panics in ~0.1 s instead of hanging). Each conversion was proven to still catch the bug it guards against. New `docs/testing.md` shows downstream users how to do the same.

**Round-37 audit fixes.**
- `connect_with_options` now warns when a token-binding offer proceeds over plain `ws://`, where the proofs are forgeable by an on-path observer — previously `Required` silently reported `Active`.
- The Emscripten harness loopback server now enforces RFC 6455's mandatory-fail rules (>125-byte control frames, 1-byte close bodies), and its CI run is bounded at 120 s.
- Docs now tell the truth about server advisories: `GoingAway`'s deadline is absolute epoch ms, `RelayStats` invariants are SDK-enforced (violations report as `ProtocolViolation { Counters }`), `max_players` > 255 fails the frame rather than truncating, and `PlayerNameRules` is an unvalidated pass-through.
- Corrected the stale "tokio-runtime does not compile to wasm" claim to the real limitation: it compiles, but no supported wasm profile drives the async client.

## Evidence

- Mandatory workflow: 1102 tests pass, clippy/fmt clean.
- Red/green proofs for every test conversion, the new warning, and the harness parser rules (valid traffic passes; both violations exit 1; full harness 4/4 on the real wasm binary).
- Two hostile review passes plus a convergence verifier: zero blocking findings.

Follow-up filed: #212 (expand on-target harness scenarios).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are mostly tests, docs, and connect-time logging; runtime behavior shifts are limited to the new ws:// warning and stricter harness parsing in CI.
> 
> **Overview**
> This PR makes **async integration tests deterministic** by running load-sensitive cases on **paused tokio time** (`start_paused`) with **virtual budget assertions**, and updates **spin/wait helpers** so they park (bounded yield then 1ms sleep) instead of starving auto-advance under a frozen clock.
> 
> It adds **`docs/testing.md`** (and nav/changelog/skill notes) explaining paused-clock vs polling cadence for downstream users, without introducing a public Clock API.
> 
> **Round-37 audit alignment:** `WebSocketTransport::connect_with_options` now **warns** when token-binding is offered on plain **`ws://`** (forgeable proofs); docs clarify **`GoingAway`**, **`RelayStats`** invariant handling (`ProtocolViolation { Counters }`), **`max_players`** `u8`/`DecodeFailed`, **`PlayerNameRules`** pass-through, and wasm **`tokio-runtime`** guidance. The Emscripten harness **rejects invalid RFC 6455 control/close frames** and CI wraps the harness in a **120s timeout**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84bbe84eef1b28913ef0986f5a820bd691545a68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->