### PR TITLE
Emscripten harness: full on-target coverage; fix spurious debug waker warning

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -116,11 +116,13 @@ jobs:
           --features transport-websocket-emscripten
           -- -D warnings
 
-      # On-target runtime coverage for the Emscripten transport (issue #194):
-      # the harness binary is linked against the transport and executed under
-      # Node.js against a loopback RFC 6455 server, pinning the send-after-
-      # close classification, ledger-bound fusion, close-metadata capture,
-      # and close→delete cleanup contracts that static lanes cannot execute.
+      # On-target runtime coverage for the Emscripten transport (issues #194
+      # and #212): the harness binary is linked against the transport and
+      # executed under Node.js against a loopback RFC 6455 server, pinning
+      # the send-after-close classification, ledger-bound fusion and
+      # drain-credit release, close-metadata capture, the rejected-handshake
+      # failure path, extended-length frames, abort, and close→delete cleanup
+      # contracts that static lanes cannot execute.
       - name: Run on-target Emscripten transport harness
         env:
           RUSTFLAGS: >-
@@ -130,7 +132,7 @@ jobs:
             -C link-arg=-sENVIRONMENT=node
             -C link-arg=-sEXIT_RUNTIME=0
             -C link-arg=-sWASM_ASYNC_COMPILATION=0
-            -C link-arg=-sEXPORTED_FUNCTIONS=_main,_sfh_begin,_sfh_step,_sfh_fail_reason,_malloc,_free
+            -C link-arg=-sEXPORTED_FUNCTIONS=_main,_sfh_begin,_sfh_step,_sfh_finish,_sfh_fail_reason,_malloc,_free
             -C link-arg=-sEXPORTED_RUNTIME_METHODS=ccall,UTF8ToString
             -C llvm-args=-enable-emscripten-cxx-exceptions=0
         run: |

--- a/.llm/skills/ffi-safety/SKILL.md
+++ b/.llm/skills/ffi-safety/SKILL.md
@@ -268,8 +268,6 @@ can hide indefinitely.
 
 1. **Always verify argument types for std API calls in cfg-guarded blocks.** The compiler
    won't catch errors in code that's never compiled for CI targets.
-2. **`Waker::will_wake` takes `&Waker`.** The compiler auto-refs owned `Waker`
-   values, so `.will_wake(noop)` is idiomatic. Do **not** write `.will_wake(&noop)`
    — nightly clippy flags the explicit `&` as `needless_borrow`. The emscripten CI
    job now runs clippy on the actual target, catching type errors directly.
 3. **Consider adding static analysis checks** (in `check-ffi-safety.sh`) for known
@@ -333,4 +331,4 @@ Use this checklist when adding or reviewing any FFI binding:
 | Deletion failure still frees callback state | Callback use-after-free | Preserve state and allow retry; safety-leak on final failure |
 | `unsafe impl Send` added for Emscripten | Main-thread callback state crosses the async spawn boundary | Keep the transport `!Send` and use the polling client |
 | Missing per-function SAFETY comment on callback | Inconsistent safety documentation, harder to audit | Add `// SAFETY:` referencing the block comment before every `extern "C" fn` |
-| `.will_wake(&waker)` with explicit `&` | Nightly clippy `needless_borrow` warning | Omit the `&` — write `.will_wake(waker)`; the compiler auto-refs. Caught by emscripten CI clippy job |
+| Runtime waker-misuse check via `Waker::will_wake` | False positives for every out-of-crate noop-waker caller (best-effort vtable identity duplicates per crate) | No reliable runtime probe exists; document the contract instead (see "Debug Assertions for FFI Transport Misuse") |

--- a/.llm/skills/ffi-safety/SKILL.md
+++ b/.llm/skills/ffi-safety/SKILL.md
@@ -267,10 +267,9 @@ can hide indefinitely.
 ### Rules
 
 1. **Always verify argument types for std API calls in cfg-guarded blocks.** The compiler
-   won't catch errors in code that's never compiled for CI targets.
-   — nightly clippy flags the explicit `&` as `needless_borrow`. The emscripten CI
-   job now runs clippy on the actual target, catching type errors directly.
-3. **Consider adding static analysis checks** (in `check-ffi-safety.sh`) for known
+   won't catch errors in code that's never compiled for CI targets; the emscripten
+   CI job now runs clippy on the actual target, catching type errors directly.
+2. **Consider adding static analysis checks** (in `check-ffi-safety.sh`) for known
    patterns that are prone to this class of bug.
 
 ## Target-Restricted Features

--- a/.llm/skills/ffi-safety/SKILL.md
+++ b/.llm/skills/ffi-safety/SKILL.md
@@ -246,10 +246,17 @@ runtime, the result is a silent hang that is extremely difficult to diagnose --
 especially in Godot/Emscripten debugging scenarios where standard debugger support
 is limited.
 
-Add `cfg(debug_assertions)` guards that detect misuse at runtime. For example,
-check whether the waker provided to `poll()` is a noop waker; if not, panic with
-a clear message directing the developer to use `SignalFishPollingClient` instead.
-See the `transport-abstraction` skill for the `NoopWakerPending` pattern.
+**Do not attempt runtime waker-misuse detection.** `Waker::will_wake` is
+documented best-effort: it compares `RawWaker` data plus vtable pointer
+identity, and the noop waker's `#[inline] const` internals duplicate that
+identity per crate. A check like
+`cx.waker().will_wake(Waker::noop())` returned `false` for genuine noop wakers
+in a verified two-crate probe (and in the on-target harness), so the check
+that once shipped in `EmscriptenWebSocketTransport::poll_recv` false-positived
+for every out-of-crate caller in debug builds and was removed. Enforce the
+noop-waker contract through documentation and the driver design
+(`SignalFishPollingClient` constructs its own noop-waker contexts; see the
+`transport-abstraction` skill) instead of a runtime probe.
 
 ## Std API Calls in `cfg`-Guarded Code
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Debug builds of downstream crates no longer log a spurious
+  "must be driven by SignalFishPollingClient" error on the Emscripten
+  transport's first receive poll: the debug-only waker-misuse check relied on
+  best-effort waker identity that does not hold across crate boundaries and
+  was removed (the polling-only contract remains documented).
 - Token-binding connections are now robust against serde_json's
   `arbitrary_precision` feature being enabled by a consumer crate:
   previously that unification delivered numbers as private marker maps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   proofs are forgeable by an on-path observer.
 
 - **Breaking:** `RateLimitInfo`'s `per_minute`, `per_hour`, and `per_day`
-  are now `u64` instead of `u32`; a server reporting a limit above
-  `u32::MAX` no longer fails authentication. Update literals/casts that
-  assumed `u32`.
+  are now `u64` instead of `u32` (update literals/casts that assumed
+  `u32`); a server reporting a limit above `u32::MAX` no longer fails
+  authentication.
 - The Godot adapter's `watermark_hits` and `backend_capacity_hits`
   diagnostics now count each deferred send once instead of once per poll.
 - The object-safe client trait's diagnostic accessors (`send_capacity`,
@@ -69,9 +69,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `arbitrary_precision` feature being enabled by a consumer crate:
   previously that unification delivered numbers as private marker maps
   that bypassed the strict number gate and could corrupt outbound
-  payloads. Single-member objects carrying serde_json's private marker
-  key with a string value are now classified as numbers in all builds;
-  floats, exponents, and out-of-range integers keep their existing
+  payloads, so single-member objects carrying serde_json's private marker
+  key with a string value are now classified as numbers in all builds,
+  while floats, exponents, and out-of-range integers keep their existing
   refusals (only the literal `-0` differs: unified serde_json reports it
   as the integer `0`, whose canonical form matches the server's RFC 8785
   output).
@@ -98,10 +98,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The Godot adapter classifies a caller-wrapped peer that already closed or
   is natively closing after an open connection (wire or engine-synthesized
   close code) as a post-open close with metadata instead of a "closed
-  before opening" failure; never-opened (`-1`), abnormal (`1006`/`1015`),
-  and pre-open web closes keep the failure classification. The initiator of
-  a pre-wrap close is unknowable and reported as peer-initiated. Crate docs
-  now also record that Godot's native backend does not validate text-frame
+  before opening" failure (never-opened (`-1`), abnormal (`1006`/`1015`),
+  and pre-open web closes keep the failure classification; the unknowable
+  initiator of a pre-wrap close is reported as peer-initiated), and crate
+  docs now record that Godot's native backend does not validate text-frame
   UTF-8, so a corrupt text packet surfaces a terminal receive error that
   ends the stream at the driver.
 - Corrected docs: `set_ready()` toggles readiness (call it once per room

--- a/crates/signal-fish-client-godot/src/lib.rs
+++ b/crates/signal-fish-client-godot/src/lib.rs
@@ -377,8 +377,10 @@ fn is_abnormal_close_code(raw_code: i32) -> bool {
 /// [`Transport::abort`] — a force-close (`close_ex().code(-1)`) that runs
 /// exactly once — covers every other teardown: dropping the client without a
 /// completed `close()`, a `close` deadline expiry, or a failed close. A
-/// `close()` on a client that never connected performs no transport I/O and
-/// leaves the peer untouched for its owner. Any teardown that reaches the peer
+/// `close()` on a client whose core already observed terminal failure
+/// performs no transport I/O and leaves the peer untouched for its owner; on
+/// a client still connecting it drives the peer's close path like any other
+/// teardown. Any teardown that reaches the peer
 /// closes it before the `Gd<WebSocketPeer>` is released, on both native and
 /// web. Dropping a bare transport without `abort`/`close` leaves reclamation
 /// to Godot's engine destructor semantics for an open peer, which differ by

--- a/docs/wasm.md
+++ b/docs/wasm.md
@@ -843,8 +843,10 @@ indefinitely when the callback queue is empty.
 **Explanation:** When no messages are buffered,
 `EmscriptenWebSocketTransport::poll_recv()` returns `Poll::Pending` without
 registering the supplied waker. Emscripten callbacks push to a
-`std::sync::mpsc` channel that has no waker integration. Debug builds log this
-misuse once when they observe a non-noop waker.
+`std::sync::mpsc` channel that has no waker integration. This misuse cannot be
+detected at runtime (`Waker::will_wake` is best-effort and its vtable identity
+check does not hold across crate boundaries), so the contract is
+documentation-enforced.
 
 **Solution:** Use `SignalFishPollingClient::poll()`, which calls the transport
 with a noop waker and correctly handles `Pending` by breaking out of the receive

--- a/src/transports/emscripten_websocket.rs
+++ b/src/transports/emscripten_websocket.rs
@@ -63,12 +63,9 @@
 //!   this transport does not register a waker, using it with
 //!   [`SignalFishClient::start()`](crate::SignalFishClient::start) or
 //!   any real executor will cause `poll_recv()` to remain pending indefinitely.
-//!
-//! - **Debug-build misuse detection.** In `cfg(debug_assertions)` builds,
-//!   `poll_recv()` emits a `tracing::error!` once if it detects a non-noop waker,
-//!   which indicates the transport is being driven by a real async runtime
-//!   instead of `SignalFishPollingClient`. This makes misuse visible
-//!   during development rather than manifesting as a silent hang.
+//!   Waker misuse cannot be detected at runtime — [`Waker::will_wake`] is
+//!   documented best-effort and compares vtable identities that duplicate
+//!   across crate boundaries — so this contract is documentation-enforced.
 //!
 //! # Example
 //!
@@ -418,8 +415,6 @@ pub struct EmscriptenWebSocketTransport {
     /// leave it unchanged so cleanup still attempts close before deletion.
     cleanup: CleanupState,
     close_info: Option<TransportCloseInfo>,
-    #[cfg(debug_assertions)]
-    reported_non_noop_waker: bool,
     /// Explicit `!Send` marker. The raw `callback_state` pointer already prevents
     /// auto-`Send`, but this field documents the intent and prevents it from being
     /// accidentally removed if the implementation ever changes.
@@ -607,8 +602,6 @@ impl EmscriptenWebSocketTransport {
             opened: false,
             cleanup,
             close_info: None,
-            #[cfg(debug_assertions)]
-            reported_non_noop_waker: false,
             _not_send: std::marker::PhantomData,
         })
     }
@@ -954,20 +947,8 @@ impl Transport for EmscriptenWebSocketTransport {
 
     fn poll_recv(
         &mut self,
-        cx: &mut std::task::Context<'_>,
+        _cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Option<Result<TransportFrame, SignalFishError>>> {
-        // Keep release builds warning-free when the debug-only diagnostic below
-        // is compiled out.
-        let _ = cx;
-        #[cfg(debug_assertions)]
-        if !self.reported_non_noop_waker && !cx.waker().will_wake(std::task::Waker::noop()) {
-            self.reported_non_noop_waker = true;
-            tracing::error!(
-                "EmscriptenWebSocketTransport must be driven by \
-                 SignalFishPollingClient with a noop waker; a wake-driven \
-                 executor can remain pending indefinitely"
-            );
-        }
         if self.closed {
             return std::task::Poll::Ready(None);
         }

--- a/src/transports/emscripten_websocket.rs
+++ b/src/transports/emscripten_websocket.rs
@@ -63,7 +63,8 @@
 //!   this transport does not register a waker, using it with
 //!   [`SignalFishClient::start()`](crate::SignalFishClient::start) or
 //!   any real executor will cause `poll_recv()` to remain pending indefinitely.
-//!   Waker misuse cannot be detected at runtime — [`Waker::will_wake`] is
+//!   Waker misuse cannot be detected at runtime —
+//!   [`Waker::will_wake`](std::task::Waker::will_wake) is
 //!   documented best-effort and compares vtable identities that duplicate
 //!   across crate boundaries — so this contract is documentation-enforced.
 //!

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -8208,23 +8208,29 @@ mod ffi_safety_documentation {
         );
     }
 
-    /// The Emscripten callback channel has no wake integration. Debug builds
-    /// must diagnose accidental wake-driven polling instead of hanging silently.
+    /// The Emscripten callback channel has no wake integration. Runtime
+    /// waker-misuse detection was removed: `Waker::will_wake` is documented
+    /// best-effort and compares per-crate duplicated vtable identities, so
+    /// the check false-positived for every out-of-crate noop-waker caller in
+    /// debug builds (issue #212's on-target harness latch caught it). The
+    /// misuse contract is documentation-enforced instead; guard against the
+    /// fragile check returning.
     #[test]
-    fn emscripten_pending_recv_diagnoses_non_noop_waker() {
+    fn emscripten_pending_recv_contract_is_documentation_enforced() {
         let contents = read_project_file("src/transports/emscripten_websocket.rs");
 
         assert!(
-            contents.contains("will_wake(std::task::Waker::noop())"),
-            "Emscripten poll_recv must distinguish the polling client's noop waker"
+            !contents.contains("will_wake(std::task::Waker::noop())"),
+            "the will_wake misuse check false-positives across crate boundaries \
+             (best-effort vtable identity) and must not return"
         );
         assert!(
-            contents.contains("reported_non_noop_waker"),
-            "Emscripten poll_recv must report wake-driven misuse only once"
+            !contents.contains("reported_non_noop_waker"),
+            "the per-transport waker-diagnostic latch must not return with its check"
         );
         assert!(
-            contents.contains("SignalFishPollingClient with a noop waker"),
-            "Emscripten poll_recv must emit an actionable misuse diagnostic"
+            contents.contains("remain pending indefinitely"),
+            "Emscripten poll_recv must still document the wake-driven misuse contract"
         );
         assert!(
             contents.contains("_not_send: std::marker::PhantomData<*const ()>"),

--- a/tests/emscripten-harness/Cargo.lock
+++ b/tests/emscripten-harness/Cargo.lock
@@ -227,6 +227,7 @@ name = "signal-fish-emscripten-harness"
 version = "0.0.0"
 dependencies = [
  "signal-fish-client",
+ "tracing",
 ]
 
 [[package]]

--- a/tests/emscripten-harness/Cargo.toml
+++ b/tests/emscripten-harness/Cargo.toml
@@ -9,5 +9,8 @@ description = "On-target wasm32-unknown-emscripten runtime harness for Emscripte
 signal-fish-client = { path = "../..", default-features = false, features = [
     "transport-websocket-emscripten",
 ] }
+# Minimal subscriber dependency: the harness latches error-level events so a
+# silent Drop-path cleanup failure fails a scenario (issue #212 M4).
+tracing = "0.1"
 
 [workspace]

--- a/tests/emscripten-harness/driver/run-harness.cjs
+++ b/tests/emscripten-harness/driver/run-harness.cjs
@@ -25,6 +25,14 @@
  *     opens (the transport bound admits two, fuses on the third).
  *   3 abrupt-error: destroy the TCP socket right after the client opens so
  *     the browser reports onerror + onclose(1006, unclean).
+ *   4 ledger-drain: send two 50-byte frames on open; when the client proves
+ *     it drained wave 1 ("next"), send two more, so a drain-credit leak
+ *     fuses wave 2 at the callback (issue #212 M2).
+ *   5 pre-open-failure: reject the handshake with HTTP 403 so the transport
+ *     must surface the terminal error before is_ready() (issue #212 M3).
+ *   6 abort-extended: send a 126-byte text frame and a 300-byte binary
+ *     frame (2-byte extended length), echo everything else verbatim so the
+ *     client's 70 KiB probe exercises the 8-byte encoding both directions.
  */
 
 const crypto = require("node:crypto");
@@ -33,7 +41,7 @@ const path = require("node:path");
 
 const WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
 const HARNESS_URL_PATH = "/harness";
-const SCENARIO_COUNT = 4;
+const SCENARIO_COUNT = 7;
 const DEADLINE_MS = 30_000;
 
 function fail(message) {
@@ -187,6 +195,9 @@ class LoopbackServer {
     // observe the CONNECTING window (pre-open send retention) get
     // deterministic scheduling steps instead of racing one event-loop turn.
     this.handshakeDelayMs = 0;
+    // When true, the handshake is rejected with an HTTP 403 response instead
+    // of upgraded (pre-open-failure scenario, issue #212 M3).
+    this.rejectHandshake = false;
     this.sockets = new Set();
     this.server = net.createServer((socket) => this.onConnection(socket));
   }
@@ -232,6 +243,19 @@ class LoopbackServer {
         responding = true;
         const request = handshake.subarray(0, end).toString("latin1");
         const key = /^sec-websocket-key:\s*(.+)\r?$/im.exec(request);
+        if (this.rejectHandshake) {
+          // Flush the rejection, then close so the browser polyfill reports
+          // the failed handshake as an abnormal closure.
+          responding = true;
+          debug("server: rejecting handshake with HTTP 403");
+          socket.end(
+            "HTTP/1.1 403 Forbidden\r\n" +
+              "Connection: close\r\n" +
+              "Content-Length: 0\r\n" +
+              "\r\n",
+          );
+          return;
+        }
         if (!/^get \/harness\s+http\/1\.[01]\r?$/i.test(request.split("\r\n")[0]) || key === null) {
           socket.destroy();
           return;
@@ -371,7 +395,11 @@ class HarnessWebSocket {
         const head = handshake.subarray(0, end).toString("latin1");
         const status = head.split("\r\n")[0];
         if (!/^http\/1\.1 101/i.test(status)) {
-          this.failConnection(1002, "handshake rejected");
+          // Browser-faithful per WHATWG: a rejected handshake is an abnormal
+          // closure because no close frame was ever received, so onclose
+          // reports 1006/unclean — a wire-level status like 403 is never
+          // surfaced through the close event.
+          this.failConnection(1006, "handshake rejected");
           return;
         }
         // RFC 6455 4.1: the client must verify the server's accept key.
@@ -524,6 +552,42 @@ const SCRIPTS = {
       peer.destroy();
     }, 30);
   },
+  4: (peer) => {
+    // Ledger drain-credit (issue #212 M2): wave 1 fills the 160-byte bound
+    // (two 50-byte frames, 64-unit minimum charge each). Wave 2 only leaves
+    // after the client proves it drained wave 1 ("next"), so a regression
+    // that leaks drain credit fuses wave 2 at the callback.
+    const sendWave = () => {
+      peer.sendText("b".repeat(50));
+      peer.sendText("b".repeat(50));
+    };
+    sendWave();
+    peer.onmessage = ({ isText, data }) => {
+      if (isText && data.toString("utf8") === "next") sendWave();
+    };
+  },
+  5: () => {
+    // The handshake is rejected before any script can attach; nothing to do.
+  },
+  6: (peer) => {
+    // Extended-length frames (issue #212): a 126-byte text frame and a
+    // 300-byte binary frame force the 2-byte extended length server→client;
+    // everything the client sends is echoed verbatim so its 70 KiB binary
+    // probe exercises the 8-byte encoding in both directions. The binary
+    // frame carries a byte-index ramp so corruption/reordering is detectable
+    // (the client expects offset-truncated values, identical to `i as u8`).
+    peer.sendText("x".repeat(126));
+    const ramp = Buffer.alloc(300);
+    for (let i = 0; i < ramp.length; ++i) ramp[i] = i & 0xff;
+    peer.sendBinary(ramp);
+    peer.onmessage = ({ isText, data }) => {
+      if (isText) {
+        peer.sendText(data.toString("utf8"));
+      } else {
+        peer.sendBinary(data);
+      }
+    };
+  },
 };
 
 // ── Harness module driving ──────────────────────────────────────────────────
@@ -551,6 +615,8 @@ async function main() {
     // handshake is delayed to guarantee several CONNECTING steps; every
     // other scenario opens immediately.
     server.handshakeDelayMs = mode === 0 ? 10 : 0;
+    // Scenario 5 rejects the handshake itself (issue #212 M3).
+    server.rejectHandshake = mode === 5;
     const begin = globalThis.Module.ccall(
       "sfh_begin",
       "number",

--- a/tests/emscripten-harness/driver/run-harness.cjs
+++ b/tests/emscripten-harness/driver/run-harness.cjs
@@ -611,10 +611,10 @@ async function main() {
 
   const runScenario = (mode) => new Promise((resolve) => {
     server.script = SCRIPTS[mode];
-    // Scenario 0 pins the pre-open Pending retention contract, so its
-    // handshake is delayed to guarantee several CONNECTING steps; every
-    // other scenario opens immediately.
-    server.handshakeDelayMs = mode === 0 ? 10 : 0;
+    // Scenarios 0 and 5 pin pre-open send retention, so their handshakes are
+    // delayed to guarantee several CONNECTING steps; every other scenario
+    // opens immediately.
+    server.handshakeDelayMs = mode === 0 || mode === 5 ? 10 : 0;
     // Scenario 5 rejects the handshake itself (issue #212 M3).
     server.rejectHandshake = mode === 5;
     const begin = globalThis.Module.ccall(
@@ -671,6 +671,13 @@ async function main() {
   try {
     for (let mode = 0; mode < SCENARIO_COUNT; ++mode) {
       await runScenario(mode);
+    }
+    // The last transport is never dropped by an sfh_begin (no scenario
+    // follows), so tear it down explicitly: a cleanup failure during that
+    // Drop must fail the harness instead of vanishing at process exit.
+    const finish = globalThis.Module.ccall("sfh_finish", "number");
+    if (finish !== 1) {
+      fail("sfh_finish: the final transport's Drop logged a cleanup failure");
     }
   } finally {
     await server.close();

--- a/tests/emscripten-harness/driver/run-harness.cjs
+++ b/tests/emscripten-harness/driver/run-harness.cjs
@@ -244,16 +244,18 @@ class LoopbackServer {
         const request = handshake.subarray(0, end).toString("latin1");
         const key = /^sec-websocket-key:\s*(.+)\r?$/im.exec(request);
         if (this.rejectHandshake) {
-          // Flush the rejection, then close so the browser polyfill reports
-          // the failed handshake as an abnormal closure.
-          responding = true;
-          debug("server: rejecting handshake with HTTP 403");
-          socket.end(
-            "HTTP/1.1 403 Forbidden\r\n" +
-              "Connection: close\r\n" +
-              "Content-Length: 0\r\n" +
-              "\r\n",
-          );
+          // Flush the rejection after the configured handshake delay (same
+          // determinism knob as the 101 path), then close so the browser
+          // polyfill reports the failed handshake as an abnormal closure.
+          debug(`server: rejecting handshake with HTTP 403 in ${this.handshakeDelayMs}ms`);
+          setTimeout(() => {
+            socket.end(
+              "HTTP/1.1 403 Forbidden\r\n" +
+                "Connection: close\r\n" +
+                "Content-Length: 0\r\n" +
+                "\r\n",
+            );
+          }, this.handshakeDelayMs);
           return;
         }
         if (!/^get \/harness\s+http\/1\.[01]\r?$/i.test(request.split("\r\n")[0]) || key === null) {

--- a/tests/emscripten-harness/src/main.rs
+++ b/tests/emscripten-harness/src/main.rs
@@ -14,6 +14,14 @@
 //! | 1    | send-after-close | sends on a socket the browser already closed fail terminally with the frame retained (round-24 fix), then peer close metadata |
 //! | 2    | ledger-bound     | inbound-byte bound admits two 50-byte frames, fuses on the third, drops flood frames afterwards |
 //! | 3    | abrupt-error     | `onerror` surfaces a terminal receive error and the queued `onclose` (1006, unclean) still reaches `close_info()` |
+//! | 4    | ledger-drain     | draining admitted frames releases ledger credit: a second admission wave against the same bound succeeds (issue #212 M2) |
+//! | 5    | pre-open-failure | a rejected handshake surfaces the terminal error before `is_ready()`, consumes the close tail, refuses post-terminal sends with the frame retained (issue #212 M3) |
+//! | 6    | abort-extended   | extended-length (126/127) frames round-trip byte-exact, `abort()` is idempotent, and post-abort sends/receives close cleanly (issue #212) |
+//!
+//! Every scenario runs under an error-latching tracing subscriber: a
+//! `tracing::error!` between scenario boundaries — the Drop path's
+//! cleanup-failure signal — fails the next scheduling step instead of
+//! passing silently (issue #212 M4).
 //!
 //! Invalid-UTF-8 text fusion is deliberately absent: Emscripten's WebSocket
 //! shim only delivers text frames as JavaScript strings (which are always
@@ -28,21 +36,91 @@ use signal_fish_client::{
 };
 use std::ffi::{c_char, CString};
 use std::ptr;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, OnceLock};
 use std::task::{Context, Poll, Waker};
 
 const RESULT_RUNNING: i32 = 0;
 const RESULT_PASS: i32 = 1;
 const RESULT_FAIL: i32 = 2;
 
-/// Ledger bound for the `ledger-bound` scenario: two 50-byte frames charge
-/// 64 units each (the 64-byte minimum charge); the third 64-unit charge
-/// would exceed 160 and fuse.
+/// Ledger bound for the `ledger-bound` and `ledger-drain` scenarios: two
+/// 50-byte frames charge 64 units each (the 64-byte minimum charge); the
+/// third 64-unit charge would exceed 160 and fuse.
 const LEDGER_BOUND_BYTES: usize = 160;
 const LEDGER_FLOOD_FRAME_LEN: usize = 50;
+
+/// Text-frame length that forces the 2-byte extended-length encoding
+/// (payload lengths from 126 through 65535).
+const EXTENDED_TEXT_LEN: usize = 126;
+/// Binary-frame length well inside the 2-byte extended-length encoding.
+const EXTENDED_BINARY_LEN: usize = 300;
+/// Binary probe length that forces the 8-byte extended-length encoding
+/// (payload lengths above 65535).
+const LARGE_PROBE_LEN: usize = 70_000;
 
 /// Upper bound on scheduling steps for one scenario so a wedged callback
 /// bridge fails the harness instead of hanging CI.
 const MAX_STEPS: u32 = 4096;
+
+// ── Error-latch subscriber (issue #212 M4) ──────────────────────────────────
+
+/// Latches the first `tracing::error!` event.
+///
+/// The transport's `Drop` path logs an error-level event when cleanup fails
+/// and its callback state is intentionally leaked. `store_harness` drops the
+/// previous scenario's transport inside the next `sfh_begin`, so without this
+/// latch a delete failure between scenarios would pass silently.
+struct ErrorLatch {
+    latched: AtomicBool,
+    detail: std::sync::Mutex<Option<String>>,
+}
+
+impl tracing::Subscriber for ErrorLatch {
+    fn enabled(&self, _metadata: &tracing::Metadata<'_>) -> bool {
+        true
+    }
+
+    fn new_span(&self, _attributes: &tracing::span::Attributes<'_>) -> tracing::Id {
+        // No spans are recorded by the transport; any id would do, and zero
+        // is the one value `Id::from_u64` rejects.
+        tracing::Id::from_u64(1)
+    }
+
+    fn record(&self, _span: &tracing::Id, _values: &tracing::span::Record<'_>) {}
+
+    fn record_follows_from(&self, _span: &tracing::Id, _follows: &tracing::Id) {}
+
+    fn event(&self, event: &tracing::Event<'_>) {
+        if event.metadata().level() == &tracing::Level::ERROR {
+            self.latched.store(true, Ordering::Relaxed);
+            if let Ok(mut detail) = self.detail.lock() {
+                *detail = Some(event.metadata().name().to_owned());
+            }
+        }
+    }
+
+    fn enter(&self, _span: &tracing::Id) {}
+
+    fn exit(&self, _span: &tracing::Id) {}
+}
+
+static ERROR_LATCH: OnceLock<Arc<ErrorLatch>> = OnceLock::new();
+
+fn error_latch() -> &'static Arc<ErrorLatch> {
+    ERROR_LATCH.get_or_init(|| ErrorLatch {
+        latched: AtomicBool::new(false),
+        detail: std::sync::Mutex::new(None),
+    }.into())
+}
+
+fn reset_error_latch() {
+    error_latch().latched.store(false, Ordering::Relaxed);
+}
+
+fn error_latched() -> bool {
+    error_latch().latched.load(Ordering::Relaxed)
+}
 
 fn ctx() -> Context<'static> {
     Context::from_waker(Waker::noop())
@@ -78,6 +156,18 @@ impl Harness {
         if self.steps > MAX_STEPS {
             return self.fail(format!("scenario did not finish within {MAX_STEPS} steps"));
         }
+        if error_latched() {
+            let detail = error_latch()
+                .detail
+                .lock()
+                .ok()
+                .and_then(|detail| detail.clone())
+                .unwrap_or_default();
+            return self.fail(format!(
+                "a tracing error-level event was observed ({detail}); the Drop \
+                 path's cleanup-failure signal must never fire between scenarios"
+            ));
+        }
         let Some(transport) = self.transport.as_mut() else {
             return self.fail("step called before sfh_begin".into());
         };
@@ -87,6 +177,9 @@ impl Harness {
             Scenario::SendAfterClose(scenario) => scenario.step(transport),
             Scenario::LedgerBound(scenario) => scenario.step(transport),
             Scenario::AbruptError(scenario) => scenario.step(transport),
+            Scenario::LedgerDrain(scenario) => scenario.step(transport),
+            Scenario::PreOpenFailure(scenario) => scenario.step(transport),
+            Scenario::AbortExtended(scenario) => scenario.step(transport),
         };
         match outcome {
             StepOutcome::Running => RESULT_RUNNING,
@@ -561,11 +654,421 @@ impl AbruptErrorScenario {
     }
 }
 
+// ── Scenario 4: ledger drain-credit ─────────────────────────────────────────
+//
+// Mode 2 proves admission/fusion on one admission wave. It cannot detect a
+// regression where draining frames never returns their ledger credit,
+// because the single wave fuses before any drain matters. This scenario
+// admits wave 1 against the same 160-byte bound, drains it, then proves a
+// second wave is admitted: if `poll_recv` stopped releasing credit, wave 2's
+// first frame would fuse at the callback and surface a terminal error.
+
+struct LedgerDrainScenario {
+    phase: LedgerDrainPhase,
+    drained_frames: usize,
+    /// Frame slot for the wave-2 request send.
+    slot: Option<TransportFrame>,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum LedgerDrainPhase {
+    /// Drain wave 1 (two 50-byte frames; the open event is consumed inside
+    /// the same first drain) — drains release ledger credit.
+    Draining,
+    /// All four frames drained; close cleanly.
+    Closing,
+}
+
+impl LedgerDrainScenario {
+    fn step(&mut self, transport: &mut EmscriptenWebSocketTransport) -> StepOutcome {
+        match self.phase {
+            LedgerDrainPhase::Draining => match poll_once(transport) {
+                Recv::Pending => {
+                    // Once wave 1 is fully drained, request wave 2. Pending
+                    // polls retain the caller-owned frame until accepted.
+                    if self.drained_frames == 2 {
+                        if self.slot.is_none() {
+                            self.slot = Some(TransportFrame::Text("next".into()));
+                        }
+                        match transport.poll_send(&mut ctx(), &mut self.slot) {
+                            Poll::Ready(Ok(())) => self.slot = None,
+                            Poll::Ready(Err(error)) => {
+                                return StepOutcome::Fail(format!("wave-2 request failed: {error}"))
+                            }
+                            Poll::Pending => {}
+                        }
+                    }
+                    StepOutcome::Running
+                }
+                Recv::Frame(TransportFrame::Text(text)) => {
+                    if text.len() != LEDGER_FLOOD_FRAME_LEN {
+                        return StepOutcome::Fail(format!(
+                            "wave frame {} had {} bytes, expected {LEDGER_FLOOD_FRAME_LEN}",
+                            self.drained_frames + 1,
+                            text.len()
+                        ));
+                    }
+                    self.drained_frames += 1;
+                    if self.drained_frames == 4 {
+                        self.phase = LedgerDrainPhase::Closing;
+                    }
+                    StepOutcome::Running
+                }
+                Recv::Frame(frame) => {
+                    StepOutcome::Fail(format!("unexpected wave frame kind: {frame:?}"))
+                }
+                Recv::TerminalError(error) => {
+                    if self.drained_frames >= 2 {
+                        return StepOutcome::Fail(format!(
+                            "wave 2 fused after {} drained frames; draining did not \
+                             release ledger credit (issue #212 M2 regression): {error}",
+                            self.drained_frames
+                        ));
+                    }
+                    StepOutcome::Fail(format!("error during wave 1: {error}"))
+                }
+                Recv::Ended => {
+                    StepOutcome::Fail("peer closed before both waves drained".into())
+                }
+            },
+            LedgerDrainPhase::Closing => {
+                if self.drained_frames != 4 {
+                    return StepOutcome::Fail(format!(
+                        "closing with {} drained frames; expected 4 (two full waves)",
+                        self.drained_frames
+                    ));
+                }
+                match transport.poll_close(&mut ctx()) {
+                    Poll::Ready(Ok(())) => StepOutcome::Pass,
+                    Poll::Ready(Err(error)) => {
+                        StepOutcome::Fail(format!("post-drain poll_close failed: {error}"))
+                    }
+                    Poll::Pending => StepOutcome::Running,
+                }
+            }
+        }
+    }
+}
+
+// ── Scenario 5: pre-open failure ────────────────────────────────────────────
+//
+// No other scenario starts from a failing handshake, so the transport's
+// error-before-open path never executed on-target: a terminal receive error
+// while `is_ready()` was never true, the close-tail consume behind it, and
+// the post-terminal send refusal. Host unit tests cannot reach this
+// target-gated module.
+
+struct PreOpenFailureScenario {
+    phase: PreOpenFailurePhase,
+    /// Probe frame installed during CONNECTING; must survive both the
+    /// pre-open `Pending` window and the post-terminal refusal.
+    slot: Option<TransportFrame>,
+    /// How many `poll_send` calls observed the pre-open `Pending` retention;
+    /// the scenario refuses to pass if the window was never observed.
+    pre_open_pending_polls: u32,
+}
+
+enum PreOpenFailurePhase {
+    /// CONNECTING against a server that rejects the handshake.
+    Connecting,
+    /// Terminal error drained while never open; verify close metadata.
+    VerifyCloseMetadata,
+    /// Post-terminal sends refuse with the frame retained.
+    ExpectSendRefusal,
+    /// The receive stream ends after the terminal error.
+    ExpectEnded,
+}
+
+impl PreOpenFailureScenario {
+    fn step(&mut self, transport: &mut EmscriptenWebSocketTransport) -> StepOutcome {
+        match self.phase {
+            PreOpenFailurePhase::Connecting => match poll_once(transport) {
+                Recv::Pending => {
+                    if transport.is_ready() {
+                        return StepOutcome::Fail(
+                            "the handshake opened before the server rejected it".into(),
+                        );
+                    }
+                    if self.slot.is_none() {
+                        self.slot = Some(TransportFrame::Text("retained-into-failure".into()));
+                    }
+                    match transport.poll_send(&mut ctx(), &mut self.slot) {
+                        Poll::Pending => {
+                            if self.slot.is_none() {
+                                return StepOutcome::Fail(
+                                    "pre-open Pending poll_send consumed the caller frame".into(),
+                                );
+                            }
+                            self.pre_open_pending_polls += 1;
+                            StepOutcome::Running
+                        }
+                        Poll::Ready(Ok(())) => StepOutcome::Fail(
+                            "pre-open poll_send accepted a frame during a rejected handshake".into(),
+                        ),
+                        Poll::Ready(Err(error)) => {
+                            StepOutcome::Fail(format!("pre-open poll_send failed: {error}"))
+                        }
+                    }
+                }
+                Recv::TerminalError(error) => {
+                    if transport.is_ready() {
+                        return StepOutcome::Fail(
+                            "is_ready() was observed before the terminal error".into(),
+                        );
+                    }
+                    if !matches!(error, SignalFishError::TransportReceive(_)) {
+                        return StepOutcome::Fail(format!(
+                            "expected TransportReceive for the rejected handshake, got: {error}"
+                        ));
+                    }
+                    if self.pre_open_pending_polls == 0 {
+                        return StepOutcome::Fail(
+                            "the CONNECTING window was never observed; the pre-open \
+                             retention pin did not run"
+                                .into(),
+                        );
+                    }
+                    self.phase = PreOpenFailurePhase::VerifyCloseMetadata;
+                    StepOutcome::Running
+                }
+                Recv::Frame(frame) => {
+                    StepOutcome::Fail(format!("unexpected frame before rejection: {frame:?}"))
+                }
+                Recv::Ended => {
+                    StepOutcome::Fail("transport ended without the pre-open terminal error".into())
+                }
+            },
+            PreOpenFailurePhase::VerifyCloseMetadata => {
+                // The browser polyfill reports an abnormal closure (1006,
+                // unclean) for a rejected handshake: no close frame was ever
+                // received. The close-tail consume must have captured it.
+                let Some(info) = transport.close_info() else {
+                    return StepOutcome::Fail(
+                        "close_info missing after the pre-open terminal error".into(),
+                    );
+                };
+                if info.code != Some(1006) || info.clean != Some(false) || !info.initiated_by_peer
+                {
+                    return StepOutcome::Fail(format!(
+                        "rejected-handshake close metadata mismatch: {info:?}"
+                    ));
+                }
+                self.phase = PreOpenFailurePhase::ExpectSendRefusal;
+                StepOutcome::Running
+            }
+            PreOpenFailurePhase::ExpectSendRefusal => {
+                let Some(slot) = self.slot.as_ref() else {
+                    return StepOutcome::Fail("probe frame vanished before the refusal".into());
+                };
+                let _ = slot;
+                match transport.poll_send(&mut ctx(), &mut self.slot) {
+                    Poll::Ready(Err(SignalFishError::TransportClosed)) => {
+                        if self.slot.is_none() {
+                            return StepOutcome::Fail(
+                                "post-terminal refusal destroyed the caller-owned frame".into(),
+                            );
+                        }
+                        self.phase = PreOpenFailurePhase::ExpectEnded;
+                        StepOutcome::Running
+                    }
+                    Poll::Ready(Err(error)) => {
+                        StepOutcome::Fail(format!(
+                            "expected TransportClosed after the terminal error, got: {error}"
+                        ))
+                    }
+                    Poll::Ready(Ok(())) => StepOutcome::Fail(
+                        "poll_send accepted a frame on a terminally closed transport".into(),
+                    ),
+                    Poll::Pending => StepOutcome::Fail(
+                        "poll_send deferred on a terminally closed transport".into(),
+                    ),
+                }
+            }
+            PreOpenFailurePhase::ExpectEnded => match poll_once(transport) {
+                Recv::Ended => StepOutcome::Pass,
+                Recv::Pending => StepOutcome::Fail(
+                    "the receive stream must end after the terminal error".into(),
+                ),
+                Recv::Frame(frame) => {
+                    StepOutcome::Fail(format!("unexpected frame after the terminal error: {frame:?}"))
+                }
+                Recv::TerminalError(error) => StepOutcome::Fail(format!(
+                    "unexpected second terminal error: {error}"
+                )),
+            },
+        }
+    }
+}
+
+// ── Scenario 6: abort + extended-length frames ──────────────────────────────
+//
+// Server→client frames of 126/127-class lengths never executed on-target,
+// and neither did `Transport::abort()`. The codec's extended-length encodings
+// are probe-verified standalone; this scenario pins the whole on-target path:
+// exact byte content through the shim for both extended encodings, in both
+// directions, then abort idempotence and its post-abort refusals.
+
+struct AbortExtendedScenario {
+    phase: AbortExtendedPhase,
+    /// Frame slot for `poll_send`; retained across `Pending` and refusals.
+    slot: Option<TransportFrame>,
+    /// The exact 70 KiB probe payload; the echo must match byte-for-byte.
+    probe: Vec<u8>,
+    server_text_seen: bool,
+    server_binary_seen: bool,
+}
+
+enum AbortExtendedPhase {
+    /// Drain the server's 126-byte text and 300-byte binary frames.
+    ExpectServerFrames,
+    /// Send the 70 KiB binary probe and verify the exact echo.
+    RoundTripLarge,
+    /// `abort()` twice, then pin post-abort refusals and clean close.
+    AbortAndVerify,
+}
+
+fn extended_probe(len: usize, seed: u8) -> Vec<u8> {
+    (0..len).map(|offset| seed.wrapping_add(offset as u8)).collect()
+}
+
+impl AbortExtendedScenario {
+    fn step(&mut self, transport: &mut EmscriptenWebSocketTransport) -> StepOutcome {
+        match self.phase {
+            AbortExtendedPhase::ExpectServerFrames => match poll_once(transport) {
+                Recv::Pending => StepOutcome::Running,
+                Recv::Frame(TransportFrame::Text(text)) => {
+                    if self.server_text_seen {
+                        return StepOutcome::Fail("duplicate server text frame".into());
+                    }
+                    let expected = "x".repeat(EXTENDED_TEXT_LEN);
+                    if text != expected {
+                        return StepOutcome::Fail(format!(
+                            "126-byte text frame mismatched (got {} bytes)",
+                            text.len()
+                        ));
+                    }
+                    self.server_text_seen = true;
+                    StepOutcome::Running
+                }
+                Recv::Frame(TransportFrame::Binary(bytes)) => {
+                    if !self.server_text_seen || self.server_binary_seen {
+                        return StepOutcome::Fail("server frames arrived out of order".into());
+                    }
+                    if bytes != extended_probe(EXTENDED_BINARY_LEN, 0) {
+                        return StepOutcome::Fail(format!(
+                            "300-byte binary frame mismatched (got {} bytes)",
+                            bytes.len()
+                        ));
+                    }
+                    self.server_binary_seen = true;
+                    self.phase = AbortExtendedPhase::RoundTripLarge;
+                    StepOutcome::Running
+                }
+                Recv::TerminalError(error) => {
+                    StepOutcome::Fail(format!("error during server frames: {error}"))
+                }
+                Recv::Ended => StepOutcome::Fail("peer closed during server frames".into()),
+            },
+            AbortExtendedPhase::RoundTripLarge => {
+                if self.slot.is_none() {
+                    self.slot = Some(TransportFrame::Binary(extended_probe(LARGE_PROBE_LEN, 7)));
+                }
+                if self.slot.is_some() {
+                    match transport.poll_send(&mut ctx(), &mut self.slot) {
+                        Poll::Ready(Ok(())) => {}
+                        Poll::Ready(Err(error)) => {
+                            return StepOutcome::Fail(format!("probe send failed: {error}"))
+                        }
+                        Poll::Pending => {}
+                    }
+                }
+                match poll_once(transport) {
+                    Recv::Pending => StepOutcome::Running,
+                    Recv::Frame(TransportFrame::Binary(bytes)) => {
+                        if bytes != self.probe {
+                            return StepOutcome::Fail(format!(
+                                "70 KiB echo mismatched (got {} bytes, expected {})",
+                                bytes.len(),
+                                self.probe.len()
+                            ));
+                        }
+                        self.phase = AbortExtendedPhase::AbortAndVerify;
+                        StepOutcome::Running
+                    }
+                    Recv::Frame(frame) => {
+                        StepOutcome::Fail(format!("unexpected frame during probe echo: {frame:?}"))
+                    }
+                    Recv::TerminalError(error) => {
+                        StepOutcome::Fail(format!("error during probe echo: {error}"))
+                    }
+                    Recv::Ended => StepOutcome::Fail("peer closed during probe echo".into()),
+                }
+            }
+            AbortExtendedPhase::AbortAndVerify => {
+                // Required, prompt, nonblocking, idempotent: the second call
+                // must be a no-op rather than a panic or repeated cleanup.
+                transport.abort();
+                transport.abort();
+                if self.slot.is_none() {
+                    self.slot = Some(TransportFrame::Text("post-abort".into()));
+                }
+                match transport.poll_send(&mut ctx(), &mut self.slot) {
+                    Poll::Ready(Err(SignalFishError::TransportClosed)) => {
+                        if self.slot.is_none() {
+                            return StepOutcome::Fail(
+                                "post-abort refusal destroyed the caller-owned frame".into(),
+                            );
+                        }
+                    }
+                    Poll::Ready(Err(error)) => {
+                        return StepOutcome::Fail(format!(
+                            "expected TransportClosed after abort, got: {error}"
+                        ))
+                    }
+                    Poll::Ready(Ok(())) => {
+                        return StepOutcome::Fail("poll_send accepted a frame after abort".into())
+                    }
+                    Poll::Pending => {
+                        return StepOutcome::Fail("poll_send deferred after abort".into())
+                    }
+                }
+                match poll_once(transport) {
+                    Recv::Ended => {}
+                    Recv::Pending => {
+                        return StepOutcome::Fail("the receive stream must end after abort".into())
+                    }
+                    Recv::Frame(frame) => {
+                        return StepOutcome::Fail(format!(
+                            "unexpected frame after abort: {frame:?}"
+                        ))
+                    }
+                    Recv::TerminalError(error) => {
+                        return StepOutcome::Fail(format!("unexpected error after abort: {error}"))
+                    }
+                }
+                // Abort completed the cleanup; a later poll_close stays safe.
+                match transport.poll_close(&mut ctx()) {
+                    Poll::Ready(Ok(())) => StepOutcome::Pass,
+                    Poll::Ready(Err(error)) => {
+                        StepOutcome::Fail(format!("poll_close after abort failed: {error}"))
+                    }
+                    Poll::Pending => {
+                        StepOutcome::Fail("poll_close deferred after a completed abort".into())
+                    }
+                }
+            }
+        }
+    }
+}
+
 enum Scenario {
     Roundtrip(RoundtripScenario),
     SendAfterClose(SendAfterCloseScenario),
     LedgerBound(LedgerBoundScenario),
     AbruptError(AbruptErrorScenario),
+    LedgerDrain(LedgerDrainScenario),
+    PreOpenFailure(PreOpenFailureScenario),
+    AbortExtended(AbortExtendedScenario),
 }
 
 // ── Exported entry points ───────────────────────────────────────────────────
@@ -574,8 +1077,17 @@ enum Scenario {
 ///
 /// Returns [`RESULT_FAIL`] (with the reason readable through
 /// `sfh_fail_reason`) when setup fails, otherwise [`RESULT_RUNNING`].
+// The `url` pointer is only dereferenced through `CStr::from_ptr`, whose
+// validity the caller contract guarantees (a NUL-terminated string allocated
+// by the driver's `ccall`, valid for this call); clippy cannot see that
+// cross-language guarantee.
 #[no_mangle]
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub extern "C" fn sfh_begin(url: *const c_char, mode: i32) -> i32 {
+    // Fresh attribution: an error latched by dropping the previous scenario's
+    // transport must fail the next scheduling step, not the previous scenario.
+    reset_error_latch();
+
     // SAFETY: the driver passes a NUL-terminated string allocated by the
     // Emscripten runtime (via `ccall`), valid for this call.
     let url = unsafe { std::ffi::CStr::from_ptr(url) };
@@ -584,11 +1096,13 @@ pub extern "C" fn sfh_begin(url: *const c_char, mode: i32) -> i32 {
         Err(error) => return begin_fail(format!("url was not valid UTF-8: {error}")),
     };
 
-    let options = if mode == 2 {
-        EmscriptenWebSocketConnectOptions::new()
-            .with_max_inbound_queue_bytes(Some(LEDGER_BOUND_BYTES))
-    } else {
-        EmscriptenWebSocketConnectOptions::new()
+    let options = match mode {
+        // The bounded scenarios share the 160-byte bound: two 64-unit charges
+        // fit, a third would fuse (mode 2) or require released drain credit
+        // (mode 4).
+        2 | 4 => EmscriptenWebSocketConnectOptions::new()
+            .with_max_inbound_queue_bytes(Some(LEDGER_BOUND_BYTES)),
+        _ => EmscriptenWebSocketConnectOptions::new(),
     };
 
     let transport = match EmscriptenWebSocketTransport::connect_with_options(&url, options) {
@@ -608,6 +1122,23 @@ pub extern "C" fn sfh_begin(url: *const c_char, mode: i32) -> i32 {
         }),
         3 => Scenario::AbruptError(AbruptErrorScenario {
             phase: AbruptPhase::Connecting,
+        }),
+        4 => Scenario::LedgerDrain(LedgerDrainScenario {
+            phase: LedgerDrainPhase::Draining,
+            drained_frames: 0,
+            slot: None,
+        }),
+        5 => Scenario::PreOpenFailure(PreOpenFailureScenario {
+            phase: PreOpenFailurePhase::Connecting,
+            slot: None,
+            pre_open_pending_polls: 0,
+        }),
+        6 => Scenario::AbortExtended(AbortExtendedScenario {
+            phase: AbortExtendedPhase::ExpectServerFrames,
+            slot: None,
+            probe: extended_probe(LARGE_PROBE_LEN, 7),
+            server_text_seen: false,
+            server_binary_seen: false,
         }),
         other => return begin_fail(format!("unknown scenario mode {other}")),
     };
@@ -671,4 +1202,13 @@ pub extern "C" fn sfh_fail_reason() -> *const c_char {
         .map_or(NO_FAILURE.as_ptr().cast(), |reason| reason.as_ptr())
 }
 
-fn main() {}
+fn main() {
+    // Install the error latch before any scenario can run: `main` executes
+    // during module initialization, before the driver's first `sfh_begin`.
+    if tracing::subscriber::set_global_default(Arc::clone(error_latch())).is_err() {
+        // A second install would mean a prior subscriber exists; the latch
+        // contract only holds under our own subscriber, so fail loudly.
+        eprintln!("harness FAIL: could not install the error-latch subscriber");
+        std::process::exit(1);
+    }
+}

--- a/tests/emscripten-harness/src/main.rs
+++ b/tests/emscripten-harness/src/main.rs
@@ -21,7 +21,8 @@
 //! Every scenario runs under an error-latching tracing subscriber: a
 //! `tracing::error!` between scenario boundaries — the Drop path's
 //! cleanup-failure signal — fails the next scheduling step instead of
-//! passing silently (issue #212 M4).
+//! passing silently (issue #212 M4); `sfh_finish` drops the final transport
+//! under the same latch so the last cleanup is observed too.
 //!
 //! Invalid-UTF-8 text fusion is deliberately absent: Emscripten's WebSocket
 //! shim only delivers text frames as JavaScript strings (which are always
@@ -668,6 +669,10 @@ struct LedgerDrainScenario {
     drained_frames: usize,
     /// Frame slot for the wave-2 request send.
     slot: Option<TransportFrame>,
+    /// The wave-2 request is sent exactly once; the server answers every
+    /// request with a fresh two-frame wave, so a re-send would stack waves
+    /// past the ledger bound and spuriously report an M2 regression.
+    sent_next: bool,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -684,14 +689,18 @@ impl LedgerDrainScenario {
         match self.phase {
             LedgerDrainPhase::Draining => match poll_once(transport) {
                 Recv::Pending => {
-                    // Once wave 1 is fully drained, request wave 2. Pending
-                    // polls retain the caller-owned frame until accepted.
-                    if self.drained_frames == 2 {
+                    // Once wave 1 is fully drained, request wave 2 exactly
+                    // once. Pending polls retain the caller-owned frame
+                    // until accepted.
+                    if self.drained_frames == 2 && !self.sent_next {
                         if self.slot.is_none() {
                             self.slot = Some(TransportFrame::Text("next".into()));
                         }
                         match transport.poll_send(&mut ctx(), &mut self.slot) {
-                            Poll::Ready(Ok(())) => self.slot = None,
+                            Poll::Ready(Ok(())) => {
+                                self.slot = None;
+                                self.sent_next = true;
+                            }
                             Poll::Ready(Err(error)) => {
                                 return StepOutcome::Fail(format!("wave-2 request failed: {error}"))
                             }
@@ -916,6 +925,9 @@ struct AbortExtendedScenario {
     probe: Vec<u8>,
     server_text_seen: bool,
     server_binary_seen: bool,
+    /// The 70 KiB probe is installed and sent exactly once; a re-send would
+    /// put a second echo in flight whose bytes nothing compares.
+    probe_sent: bool,
 }
 
 enum AbortExtendedPhase {
@@ -970,12 +982,12 @@ impl AbortExtendedScenario {
                 Recv::Ended => StepOutcome::Fail("peer closed during server frames".into()),
             },
             AbortExtendedPhase::RoundTripLarge => {
-                if self.slot.is_none() {
-                    self.slot = Some(TransportFrame::Binary(extended_probe(LARGE_PROBE_LEN, 7)));
-                }
-                if self.slot.is_some() {
+                if !self.probe_sent {
+                    if self.slot.is_none() {
+                        self.slot = Some(TransportFrame::Binary(extended_probe(LARGE_PROBE_LEN, 7)));
+                    }
                     match transport.poll_send(&mut ctx(), &mut self.slot) {
-                        Poll::Ready(Ok(())) => {}
+                        Poll::Ready(Ok(())) => self.probe_sent = true,
                         Poll::Ready(Err(error)) => {
                             return StepOutcome::Fail(format!("probe send failed: {error}"))
                         }
@@ -1127,6 +1139,7 @@ pub extern "C" fn sfh_begin(url: *const c_char, mode: i32) -> i32 {
             phase: LedgerDrainPhase::Draining,
             drained_frames: 0,
             slot: None,
+            sent_next: false,
         }),
         5 => Scenario::PreOpenFailure(PreOpenFailureScenario {
             phase: PreOpenFailurePhase::Connecting,
@@ -1139,6 +1152,7 @@ pub extern "C" fn sfh_begin(url: *const c_char, mode: i32) -> i32 {
             probe: extended_probe(LARGE_PROBE_LEN, 7),
             server_text_seen: false,
             server_binary_seen: false,
+            probe_sent: false,
         }),
         other => return begin_fail(format!("unknown scenario mode {other}")),
     };
@@ -1200,6 +1214,27 @@ pub extern "C" fn sfh_fail_reason() -> *const c_char {
         .as_ref()
         .and_then(|harness| harness.fail_reason.as_ref())
         .map_or(NO_FAILURE.as_ptr().cast(), |reason| reason.as_ptr())
+}
+
+/// Tear the harness down: drop the last transport explicitly so its `Drop`
+/// cleanup runs while the error latch can still observe it (the driver stops
+/// stepping once the final scenario passes, so `store_harness` would never
+/// reclaim it).
+///
+/// Returns [`RESULT_FAIL`] when a `tracing::error!` fired during that drop —
+/// the transport's intentional-leak signal — otherwise [`RESULT_PASS`].
+#[no_mangle]
+pub extern "C" fn sfh_finish() -> i32 {
+    reset_error_latch();
+    // SAFETY: see the `HARNESS` static comment; the driver calls this exactly
+    // once, after every scenario completed.
+    let harness = unsafe { std::ptr::replace(ptr::addr_of_mut!(HARNESS), None) };
+    drop(harness);
+    if error_latched() {
+        RESULT_FAIL
+    } else {
+        RESULT_PASS
+    }
 }
 
 fn main() {

--- a/tests/polling_parity_tests.rs
+++ b/tests/polling_parity_tests.rs
@@ -1173,10 +1173,19 @@ impl Transport for SendFailureFarewellTransport {
     }
 }
 
+/// Clock-agnostic: bounded `yield_now` spins first, then parks on a 1 ms
+/// sleep — under paused (`start_paused`) virtual time a pure spin would
+/// starve auto-advance and the 1 s guard could never fire.
 async fn wait_until(condition: impl Fn() -> bool) {
     tokio::time::timeout(std::time::Duration::from_secs(1), async {
+        let mut spins = 0usize;
         while !condition() {
-            tokio::task::yield_now().await;
+            if spins < 64 {
+                spins += 1;
+                tokio::task::yield_now().await;
+            } else {
+                tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+            }
         }
     })
     .await
@@ -1515,13 +1524,22 @@ fn reconnected_with_missed(missed: Vec<ServerMessage>) -> String {
     serde_json::to_string(&ServerMessage::Reconnected(Box::new(payload))).unwrap()
 }
 
+/// Clock-agnostic: bounded `yield_now` spins first, then parks on a 1 ms
+/// sleep — under paused (`start_paused`) virtual time a pure spin would
+/// starve auto-advance and the 1 s guard could never fire.
 async fn wait_for_sent_len(mock: &SharedMock, expected_len: usize) {
     tokio::time::timeout(std::time::Duration::from_secs(1), async {
+        let mut spins = 0usize;
         loop {
             if mock.sent.lock().unwrap().len() >= expected_len {
                 break;
             }
-            tokio::task::yield_now().await;
+            if spins < 64 {
+                spins += 1;
+                tokio::task::yield_now().await;
+            } else {
+                tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+            }
         }
     })
     .await


### PR DESCRIPTION
Closes #212.

## Why

Round 37's audit of the Emscripten on-target harness found it sound but under-covered: a drain-credit leak, a failing handshake, a broken final cleanup, extended-length frames, and `abort()` could all regress without any on-target test noticing (issue #212).

## What

**Harness coverage (tests/emscripten-harness, 4 → 7 scenarios)**

- **Ledger drain-credit**: drains a full admission wave, then proves a second wave is admitted against the same bound — a credit leak now fails the run instead of hiding behind a single wave.
- **Rejected handshake**: the loopback can reject with HTTP 403; pins the terminal error before the transport is ready, the captured unclean close metadata, and the post-terminal send refusal (frame kept).
- **Abort + extended-length frames**: 126-byte and 70 KiB frames round-trip byte-exact through both wire encodings; `abort()` is pinned idempotent with clean post-abort behavior.
- **Error latch**: a minimal tracing subscriber fails any scenario whose cleanup (`Drop`) logs an error — previously silent between scenarios. `sfh_finish` drops the last transport under the same latch.

**Production fix the latch caught immediately**

Debug builds logged a spurious "must be driven by SignalFishPollingClient" error on the Emscripten transport's first receive poll — for every out-of-crate caller, even correct ones. The check compared best-effort waker identity that does not hold across crate boundaries (verified with a two-crate probe). Removed; the polling-only contract stays documented, and the ffi-safety skill now explains why runtime waker probes are unreliable. Changelogged.

**Also**: the loopback's browser-faithful WebSocket polyfill now reports rejected handshakes as 1006 (abnormal closure), matching browsers.

## Verification

- Mandatory workflow: fmt, clippy (`-D warnings`), 1102 tests passed / 0 failed.
- Harness 7/7 PASS on-target locally (emsdk 3.1.74, exact CI pin); every new pin has a red-state proof (targeted neutering fails exactly that scenario) and all probes were reverted.
- Hostile review + convergence verifier loop: two reviewer-found harness defects (unlatched wave requests stacking under jitter; a handshake-rejection race against the retention guard) fixed and re-verified.
- Round 38 of the recurring audit (#126) rode along: paused-clock test-hang fix in the polling-parity helpers, Godot `close()` doc accuracy, changelog one-sentence rule.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes debug diagnostics and expands CI/runtime coverage for Emscripten transport teardown and polling contracts; the waker change only affects debug builds but alters observable logging for integrators.
> 
> **Overview**
> **Emscripten on-target harness** grows from four to seven Node-driven scenarios and CI now exports `sfh_finish` so the last transport’s `Drop` is exercised under the same checks. New pins cover **ledger drain-credit** (second admission wave after draining), **rejected handshake** (HTTP 403 → terminal error before ready, 1006 close metadata, post-terminal send refusal), **extended-length frames** plus **idempotent `abort()`**, and an **error latch** that fails the run if cleanup logs `tracing::error!` between scenarios.
> 
> **Production fix:** debug builds no longer run the `EmscriptenWebSocketTransport::poll_recv` check that compared `Waker::will_wake` against `Waker::noop()` — it false-positived for legitimate out-of-crate noop wakers, so the polling-only contract is **documentation-enforced** instead (ffi-safety skill, wasm docs, inverted `ci_config_tests` guard).
> 
> Smaller follow-ups: loopback polyfill treats failed handshakes as abnormal **1006**; Godot adapter `close()` docs clarify terminal-failure vs still-connecting; polling-parity `wait_until` helpers sleep under paused virtual time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc485b9a83ac885f2e94f85235ec5fe83a677e82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->