### PR TITLE
Round 39 audit: release lock stamping, consumer DX, docs site

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,7 +266,7 @@ jobs:
           server_bin="$(find .signal-fish-server -type f -name signal-fish-server -print -quit)"
           chmod +x "${server_bin}"
           listed_tests="$(
-            cargo test --all-features --test real_server_e2e \
+            cargo test --locked --all-features --test real_server_e2e \
               "${SERVER_TEST}" \
               -- --ignored --exact --list
           )"
@@ -279,7 +279,7 @@ jobs:
             exit 1
           fi
           SIGNAL_FISH_SERVER_BIN="${PWD}/${server_bin}" \
-            cargo test --all-features --test real_server_e2e \
+            cargo test --locked --all-features --test real_server_e2e \
               "${SERVER_TEST}" \
               -- --ignored --exact --test-threads=1
 
@@ -370,7 +370,7 @@ jobs:
       - name: Cache Cargo artifacts
         uses: Swatinem/rust-cache@v2.9.2
       - name: Build documentation
-        run: cargo doc --workspace --all-features --no-deps
+        run: cargo doc --workspace --all-features --no-deps --locked
       - name: Install nightly toolchain
         run: rustup toolchain install nightly --profile minimal
       - name: Verify docs.rs compatibility

--- a/.github/workflows/deep-safety.yml
+++ b/.github/workflows/deep-safety.yml
@@ -162,6 +162,9 @@ jobs:
         with:
           workspaces: fuzz
 
+      # Load-bearing gate ordering: `cargo fuzz run` cannot take --locked,
+      # so this verify must stay ahead of it — on a fixed checkout nothing
+      # can re-resolve fuzz/Cargo.lock between the two steps.
       - name: Verify fuzz lockfile is current
         run: bash scripts/cargo-retry.sh metadata --manifest-path fuzz/Cargo.toml --locked > /dev/null
 

--- a/.github/workflows/examples-validation.yml
+++ b/.github/workflows/examples-validation.yml
@@ -49,7 +49,7 @@ jobs:
         uses: Swatinem/rust-cache@v2.9.2
 
       - name: Run doc tests
-        run: cargo test --doc --all-features
+        run: cargo test --doc --all-features --locked
 
   # ──────────────────────────────────────────────────────────────
   # Examples — validate example programs build
@@ -71,7 +71,7 @@ jobs:
         uses: Swatinem/rust-cache@v2.9.2
 
       - name: Build and test examples
-        run: cargo test --examples --all-features
+        run: cargo test --examples --all-features --locked
 
       - name: Run offline custom_transport example
         run: timeout 120 cargo run --locked --example custom_transport
@@ -80,7 +80,7 @@ jobs:
         run: timeout 120 cargo run --locked --example mesh_session --features mesh
 
       - name: Clippy mesh example without default features
-        run: cargo clippy --example mesh_session --no-default-features --features mesh,tokio-runtime -- -D warnings
+        run: cargo clippy --example mesh_session --no-default-features --features mesh,tokio-runtime --locked -- -D warnings
 
   # ──────────────────────────────────────────────────────────────
   # Snippet check — validate Rust code blocks in markdown

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -102,8 +102,8 @@ jobs:
           VERSION: ${{ steps.release-metadata.outputs.version }}
         run: |
           cargo fmt --all -- --check
-          cargo clippy --workspace --all-targets --all-features -- -D warnings
-          cargo test --workspace --all-features
+          cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
+          cargo test --workspace --all-features --locked
           previous=$(python3 scripts/release.py previous-version "$VERSION")
           while IFS= read -r package; do
             baseline=$(python3 scripts/release.py registry-checksum "$package" "$previous")

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -65,9 +65,9 @@ jobs:
       - name: Cache Cargo artifacts
         uses: Swatinem/rust-cache@v2.9.2
       - name: Build for WASM target
-        run: cargo build --target wasm32-unknown-unknown --no-default-features
+        run: cargo build --target wasm32-unknown-unknown --no-default-features --locked
       - name: Clippy check for WASM target
-        run: cargo clippy --target wasm32-unknown-unknown --no-default-features -- -D warnings
+        run: cargo clippy --target wasm32-unknown-unknown --no-default-features --locked -- -D warnings
 
   emscripten:
     name: Build (wasm32-unknown-emscripten)
@@ -102,18 +102,21 @@ jobs:
           cargo +nightly build -Zbuild-std
           --target wasm32-unknown-emscripten
           --no-default-features
+          --locked
       - name: Build (emscripten transport)
         run: >-
           cargo +nightly build -Zbuild-std
           --target wasm32-unknown-emscripten
           --no-default-features
           --features transport-websocket-emscripten
+          --locked
       - name: Clippy (emscripten transport)
         run: >-
           cargo +nightly clippy -Zbuild-std
           --target wasm32-unknown-emscripten
           --no-default-features
           --features transport-websocket-emscripten
+          --locked
           -- -D warnings
 
       # On-target runtime coverage for the Emscripten transport (issues #194

--- a/.llm/skills/transport-abstraction/SKILL.md
+++ b/.llm/skills/transport-abstraction/SKILL.md
@@ -191,10 +191,10 @@ changes while the async driver is blocked, wake a waker registered by
 `poll_send` or `poll_recv`, because `is_ready()` cannot register one itself.
 
 `begin_poll_cycle()` marks a driver scheduling cycle, not necessarily a
-rendered frame. The polling client calls it once per public `poll()` invocation;
-the async client calls it once per outer transport-loop iteration. Backends may
-sample buffering or capacity once at this boundary, but must not infer a fixed
-wall-clock cadence from it.
+rendered frame. The polling client calls it once per public `poll()` invocation
+plus once for that driver's `close()`; the async client calls it once per outer
+transport-loop iteration. Backends may sample buffering or capacity once at
+this boundary, but must not infer a fixed wall-clock cadence from it.
 
 ## Minimal Channel Transport
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `WebSocketTransport::connect_with_options` now logs a warning when a
   token-binding offer proceeds over a plain `ws://` URL, where the resulting
   proofs are forgeable by an on-path observer.
+- The custom-transport guide documents the mandatory `ProtocolInfo`
+  negotiation step that scripted test peers must send between
+  `Authenticated` and any further server traffic, and the docs site's
+  model-facing `llms.txt` now lists every guide page.
 
 - **Breaking:** `RateLimitInfo`'s `per_minute`, `per_hour`, and `per_day`
   are now `u64` instead of `u32` (update literals/casts that assumed
@@ -60,6 +64,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Prepare Release now also stamps the tracked
+  `tests/emscripten-harness/Cargo.lock`; its stale recorded version failed
+  the WASM workflow's Emscripten lane on every release branch.
 - Debug builds of downstream crates no longer log a spurious
   "must be driven by SignalFishPollingClient" error on the Emscripten
   transport's first receive poll: the debug-only waker-misuse check relied on

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ choice.
 - [Client commands and configuration](https://Ambiguous-Interactive.github.io/signal-fish-client-rust/client/)
 - [Events](https://Ambiguous-Interactive.github.io/signal-fish-client-rust/events/)
   and [errors](https://Ambiguous-Interactive.github.io/signal-fish-client-rust/errors/)
-- [Godot and WebAssembly](https://Ambiguous-Interactive.github.io/signal-fish-client-rust/wasm/)
+- [WebAssembly (WASM)](https://Ambiguous-Interactive.github.io/signal-fish-client-rust/wasm/)
 - [Protocol v2, v3, and mesh](https://Ambiguous-Interactive.github.io/signal-fish-client-rust/protocol-versioning/)
 - [Custom transports](https://Ambiguous-Interactive.github.io/signal-fish-client-rust/transport/)
 - [API reference](https://docs.rs/signal-fish-client)

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -132,7 +132,11 @@ that a v2 connection never sees.
    `protocol_version` (plus min/max) back in `ProtocolInfo`.
 3. The client records it; `supports_mesh()` reports negotiated local capability
    only when WebRTC and a Host or Mesh topology were advertised. It does not say
-   which plan the server selected.
+   which plan the server selected. Until a valid `ProtocolInfo` completes
+   negotiation, the client rejects every server frame except authentication,
+   negotiation, pong, and error control frames as lifecycle violations —
+   scripted test peers must send `ProtocolInfo` after `Authenticated` and
+   before any further traffic.
 
 v3-only sends (`send_signal`, `report_transport_status`, …) **fail fast** with
 [`SignalFishError::ProtocolUnsupported`](errors.md) until v3 is negotiated —

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -106,4 +106,7 @@ canonical guide for that subsystem:
   fixture with the [Godot and WebAssembly guide](wasm.md)
 
 The focused guides own platform setup and protocol contracts so those details
-have one maintained source of truth.
+have one maintained source of truth. When a lobby or mesh session behaves
+nondeterministically under your own game loop, the
+[deterministic testing guide](testing.md) shows how to reproduce it with
+paused clocks and caller-driven cadence on both drivers.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -103,7 +103,7 @@ canonical guide for that subsystem:
 - [`load_lab.rs`](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/blob/main/examples/load_lab.rs)
   with the [delivery and backpressure guide](delivery.md)
 - the complete [`tests/godot-web-smoke`](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/tree/main/tests/godot-web-smoke)
-  fixture with the [Godot and WebAssembly guide](wasm.md)
+  fixture with the [WebAssembly (WASM) guide](wasm.md)
 
 The focused guides own platform setup and protocol contracts so those details
 have one maintained source of truth. When a lobby or mesh session behaves

--- a/docs/protocol-versioning.md
+++ b/docs/protocol-versioning.md
@@ -242,3 +242,4 @@ the explicit-start audit:
 - [Protocol Types](protocol.md) — the v3 wire types in detail.
 - [Events](events.md#mesh-events-protocol-v3) — the v3 events.
 - [Errors](errors.md) — `ProtocolUnsupported` and the v3 error codes.
+- [Migrating 0.8 to 0.9](migration-0.9.md) — the 0.9 delivery and signaling changes.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -177,7 +177,7 @@ Details that matter for deterministic polling tests:
 - **The Godot adapter samples per `begin_poll_cycle`.** One `poll()` call is
   one scheduling cycle; tests inject cadence by calling `poll()` in a fixed
   loop rather than sleeping between calls. See
-  [WebAssembly & Godot](wasm.md).
+  [WebAssembly (WASM)](wasm.md).
 
 ## Why there is no injectable Clock API
 

--- a/docs/transport.md
+++ b/docs/transport.md
@@ -137,8 +137,9 @@ the frame. This lets both clients admit FIFO commands during an asynchronous
 handshake without transferring them prematurely.
 
 `begin_poll_cycle` lets adaptive transports sample once per driver scheduling
-cycle: once per `SignalFishPollingClient::poll` call in the polling driver and
-once per outer transport-loop iteration in the async driver.
+cycle: once per `SignalFishPollingClient::poll` call in the polling driver
+(plus once for that driver's `close()`), and once per outer transport-loop
+iteration in the async driver.
 `diagnostics` distinguishes backend-owned buffering/admission from the client
 queue. `abort` is required and is invoked when graceful close errors, either
 client's close deadline expires, or an owner is dropped before close completes.
@@ -342,7 +343,6 @@ pub struct LoopbackTransport {
     rx: mpsc::UnboundedReceiver<TransportFrame>,
     closed: bool,
 }
-
 impl Transport for LoopbackTransport {
     fn poll_send(
         &mut self,
@@ -392,6 +392,14 @@ impl Transport for LoopbackTransport {
 The channel send completes synchronously, so it can take the frame and return
 `Ready` in the same call. A socket that remains pending after acceptance needs
 an internal outbound slot or equivalent state machine.
+
+When your test peer scripts a Signal Fish server, it must complete protocol
+negotiation before room-scoped traffic: after `Authenticated`, send a
+`ProtocolInfo` frame carrying a valid `game_data_formats` list
+(`["json"]` or `["json", "message_pack"]`) before any room reply such as
+`RoomJoined`. A room-scoped frame that arrives before a valid `ProtocolInfo`
+is rejected as a lifecycle violation and surfaces as
+[`ProtocolViolation`](events.md), not as a join failure.
 
 Use it with the async client only when the transport is `Send + 'static`:
 

--- a/docs/transport.md
+++ b/docs/transport.md
@@ -343,6 +343,7 @@ pub struct LoopbackTransport {
     rx: mpsc::UnboundedReceiver<TransportFrame>,
     closed: bool,
 }
+
 impl Transport for LoopbackTransport {
     fn poll_send(
         &mut self,

--- a/llms.txt
+++ b/llms.txt
@@ -17,12 +17,25 @@ repository git dependency when evaluating APIs and fixes listed under
 ## Documentation
 
 - [Getting started](https://Ambiguous-Interactive.github.io/signal-fish-client-rust/getting-started/): Installation, features, and first client
-- [Client APIs](https://Ambiguous-Interactive.github.io/signal-fish-client-rust/client/): Async and polling clients, work budgets, shutdown, and diagnostics
-- [Transport contract](https://Ambiguous-Interactive.github.io/signal-fish-client-rust/transport/): Ownership, backpressure, framing, and close semantics
-- [Godot and WebAssembly](https://Ambiguous-Interactive.github.io/signal-fish-client-rust/wasm/): Supported targets and current Godot 4.5 setup
+- [Basic lobby walkthrough](https://Ambiguous-Interactive.github.io/signal-fish-client-rust/examples/): A complete lobby client with readiness, game start, and shutdown
+- [Client commands and state](https://Ambiguous-Interactive.github.io/signal-fish-client-rust/client/): Async and polling clients, commands, work budgets, shutdown, and diagnostics
+- [Events](https://Ambiguous-Interactive.github.io/signal-fish-client-rust/events/): The event stream and every variant a game loop must handle
+- [Errors](https://Ambiguous-Interactive.github.io/signal-fish-client-rust/errors/): Error types, codes, and recovery guidance
+- [Deterministic testing](https://Ambiguous-Interactive.github.io/signal-fish-client-rust/testing/): Paused-clock and caller-cadence recipes for both drivers
+- [WebAssembly (WASM)](https://Ambiguous-Interactive.github.io/signal-fish-client-rust/wasm/): Supported targets and current Godot 4.5 setup
 - [Godot + Fortress](https://Ambiguous-Interactive.github.io/signal-fish-client-rust/fortress/): Bounded rollback relay and game-loop ordering
-- [Delivery and backpressure](https://Ambiguous-Interactive.github.io/signal-fish-client-rust/delivery/): Delivery stages, capacity, metrics, and load testing
+- [Core concepts](https://Ambiguous-Interactive.github.io/signal-fish-client-rust/concepts/): Connections, rooms, authority, and the protocol in brief
 - [Protocol versioning](https://Ambiguous-Interactive.github.io/signal-fish-client-rust/protocol-versioning/): v2/v3 negotiation and compatibility
+- [Delivery and backpressure](https://Ambiguous-Interactive.github.io/signal-fish-client-rust/delivery/): Delivery stages, capacity, metrics, and load testing
+- [Mesh guide](https://Ambiguous-Interactive.github.io/signal-fish-client-rust/mesh-guide/): WebRTC mesh signaling (protocol v3)
+- [Transport contract](https://Ambiguous-Interactive.github.io/signal-fish-client-rust/transport/): Ownership, backpressure, framing, and close semantics
+- [Protocol types](https://Ambiguous-Interactive.github.io/signal-fish-client-rust/protocol/): The typed wire messages and payloads
+- [WebSocket token binding](https://Ambiguous-Interactive.github.io/signal-fish-client-rust/token-binding/): Negotiation and outbound proofs on native WSS
+- [Migrating 0.7 to 0.8](https://Ambiguous-Interactive.github.io/signal-fish-client-rust/migration-0.8/): Explicit game start and 0.8 changes
+- [Migrating 0.8 to 0.9](https://Ambiguous-Interactive.github.io/signal-fish-client-rust/migration-0.9/): 0.9 delivery and signaling changes
+- [Migrating 0.10 to 0.11](https://Ambiguous-Interactive.github.io/signal-fish-client-rust/migration-0.11/): Error-surface and capability changes in 0.11
+- [Release operations](https://Ambiguous-Interactive.github.io/signal-fish-client-rust/releasing/): Prepare Release and Release workflows
+- [Brand and font attribution](https://Ambiguous-Interactive.github.io/signal-fish-client-rust/attributions/): Asset provenance and licenses
 - [API reference](https://docs.rs/signal-fish-client): Rust API documentation
 
 ## Project

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -127,6 +127,10 @@ extra_css:
 extra_javascript:
   - javascripts/accessibility.js
 
+# Snippet sources are inputs only; never render docs/includes/ as pages.
+exclude_docs: |
+  includes/*
+
 validation:
   nav:
     omitted_files: info
@@ -140,11 +144,11 @@ nav:
       - Installation & Quick Start: getting-started.md
       - Basic Lobby Walkthrough: examples.md
   - Use the SDK:
-      - Client Commands & State: client.md
+      - Client API Reference: client.md
       - Events: events.md
       - Errors: errors.md
       - Deterministic Testing: testing.md
-      - WebAssembly & Godot: wasm.md
+      - WebAssembly (WASM): wasm.md
       - Godot + Fortress: fortress.md
   - Multiplayer Choices:
       - Core Concepts: concepts.md

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -30,9 +30,13 @@ LOCKSTEP_LOCKFILES = (
 # a duplicate entry still fails closed. fuzz/Cargo.lock records only the
 # path-depended core (the fuzz graph never reaches the Godot adapter), and
 # its stale recorded version would fail the Deep Safety lane's
-# `cargo metadata --locked` freshness verify after a bump.
+# `cargo metadata --locked` freshness verify after a bump. The Emscripten
+# harness lock has the same shape (core only, `--locked` build lane), and a
+# stale recorded version fails the required WASM workflow's Emscripten job
+# on every release branch.
 PARTIAL_LOCKFILES = (
     "fuzz/Cargo.lock",
+    "tests/emscripten-harness/Cargo.lock",
 )
 VERSION_FILES = (
     "README.md",

--- a/scripts/test_release.py
+++ b/scripts/test_release.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import re
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
@@ -1115,6 +1116,46 @@ class WorkflowPolicyTests(unittest.TestCase):
                     version,
                     path.read_text(encoding="utf-8"),
                     f"{relative} does not mention workspace version {version}",
+                )
+
+    def test_tracked_lockfile_inventory_matches_release_lists(self) -> None:
+        # Guards the lock-stamping inventory against fixture drift: a tracked
+        # standalone Cargo.lock absent from both release lists never gets its
+        # recorded member versions stamped, so the first release branch after
+        # adding the fixture fails its own `--locked` lanes (the
+        # tests/emscripten-harness omission produced exactly that on the
+        # WASM workflow's Emscripten job).
+        root = Path(__file__).resolve().parents[1]
+        listed = set(release.LOCKSTEP_LOCKFILES) | set(release.PARTIAL_LOCKFILES)
+        self.assertEqual(
+            len(listed),
+            len(release.LOCKSTEP_LOCKFILES) + len(release.PARTIAL_LOCKFILES),
+            "a lockfile appears in both LOCKSTEP_LOCKFILES and PARTIAL_LOCKFILES",
+        )
+        tracked = subprocess.run(
+            ["git", "ls-files", "Cargo.lock", "**/Cargo.lock"],
+            cwd=root,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.splitlines()
+        self.assertTrue(tracked, "git ls-files found no tracked Cargo.lock")
+        for relative in sorted(tracked):
+            with self.subTest(lockfile=relative):
+                self.assertIn(
+                    relative,
+                    listed,
+                    f"tracked {relative} is absent from LOCKSTEP_LOCKFILES "
+                    "and PARTIAL_LOCKFILES; release stamping would leave it "
+                    "stale and fail its --locked lanes",
+                )
+        for relative in sorted(listed):
+            with self.subTest(listed=relative):
+                self.assertIn(
+                    relative,
+                    tracked,
+                    f"{relative} is listed for release stamping but is not "
+                    "tracked in git",
                 )
 
     def test_compatibility_top_level_identity_matches_this_checkout(self) -> None:


### PR DESCRIPTION
## Why

Round 39 of the recurring correctness audit (issue #126) targeted three never-audited surfaces. One real release blocker surfaced: the Emscripten harness's tracked lockfile had no release stamping writer, so the first release branch after #214 would deterministically fail its own required `--locked` CI lane. The out-of-tree consumer probe and docs-site audit then found only documentation-level gaps.

## What

**Release tooling (the one real defect)**
- `tests/emscripten-harness/Cargo.lock` joined `PARTIAL_LOCKFILES` in `scripts/release.py`; a new checkout-level test pins every tracked lockfile to exactly one stamping list (red/green verified against the omission).
- Same-class sweep: every remaining unpinned cargo invocation across the WASM, CI, Examples, and publish lanes now runs `--locked`; the fuzz lane's load-bearing gate ordering is documented.

**Consumer experience (empirical out-of-tree probe)**
- A fresh downstream crate implementing `Transport` from the public docs alone compiled and passed 14 scripted scenarios with zero wedges — the seam works as documented. The one gap found: nothing said a scripted peer must send `ProtocolInfo` after `Authenticated`. Now documented in the custom-transport and concepts guides, with `begin_poll_cycle`'s polling `close()` cycle added to the guide and skill.

**Docs site**
- `llms.txt` lists all 21 guide pages (was 7), every route verified against a strict build; the empty abbreviations include no longer renders as an orphan page; `migration-0.9.md` and `testing.md` gained their first inbound links; page titles are consistent across nav, landing cards, README, and llms.txt.

## Verification

- Mandatory workflow: fmt/clippy clean, 1102 tests passed, 0 failed.
- 235 ci-config tests, 67 release-tooling tests (new inventory guard red/green), all 17 pre-commit checks, `check-workflows` 9/9 phases.
- Strict MkDocs build clean; all 20 same-site llms.txt routes resolve; docs checks 17/17.

Closes one round of #126 (report to follow on the issue).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are CI flags, release stamping, documentation, and a regression test; no runtime client or protocol behavior changes.
> 
> **Overview**
> **Release blocker:** Prepare Release now stamps `tests/emscripten-harness/Cargo.lock` via `PARTIAL_LOCKFILES`, and a new `test_release` guard requires every git-tracked `Cargo.lock` to appear in the lockstep or partial stamping lists so future fixtures cannot miss release bumps.
> 
> **CI hardening:** Remaining unpinned `cargo` steps in CI, examples-validation, publish verification, and WASM (including Emscripten `--locked` builds) now pass `--locked`; the fuzz workflow documents why lock verification must run before `cargo fuzz run`.
> 
> **Consumer/docs:** Guides and the transport skill clarify that scripted test peers must send `ProtocolInfo` after `Authenticated`, and that the polling driver calls `begin_poll_cycle` on `close()` as well as each `poll()`. The docs site expands `llms.txt` to all guide pages, aligns WASM naming in nav/README, excludes `docs/includes/` from MkDocs output, and adds cross-links (e.g. `migration-0.9`, deterministic testing).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f286a7a9c8fb7657213e5022099cf72be01d1d6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->