### PR TITLE
chore!: prepare release 0.12.0

### DIFF
--- a/.llm/context.md
+++ b/.llm/context.md
@@ -4,7 +4,7 @@
 
 - **Company:** Ambiguous Interactive
 - **Crates:** `signal-fish-client` (core) and `signal-fish-client-godot` (adapter)
-- **Version:** 0.11.0 lockstep across both crates
+- **Version:** 0.12.0 lockstep across both crates
 - **Edition:** 2021
 - **MSRV:** Rust 1.87.0 for core; Rust 1.94.0 for the Godot adapter
 - **License:** MIT

--- a/.llm/skills/crate-publishing/SKILL.md
+++ b/.llm/skills/crate-publishing/SKILL.md
@@ -38,10 +38,10 @@ The workspace owns the lockstep version and exact internal requirement:
 
 ```toml
 [workspace.package]
-version = "0.11.0"
+version = "0.12.0"
 
 [workspace.dependencies]
-signal-fish-client = { version = "=0.11.0", path = ".", default-features = false }
+signal-fish-client = { version = "=0.12.0", path = ".", default-features = false }
 ```
 
 The adapter inherits that version and dependency, uses Rust 1.94.0, and has its

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-09-01
+
+<!-- semver-checks: major -->
+
 ### Added
 
 - **Breaking:** the exhaustive `SignalFishError` enum gains
@@ -1340,7 +1344,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - After: `SignalFishError::ServerError { message, error_code }` where `error_code` is `Option<ErrorCode>`
   - Recommended handling: `match error_code { Some(code) => ..., None => ... }`
 
-[Unreleased]: https://github.com/Ambiguous-Interactive/signal-fish-client-rust/compare/v0.11.0...HEAD
+[Unreleased]: https://github.com/Ambiguous-Interactive/signal-fish-client-rust/compare/v0.12.0...HEAD
+[0.12.0]: https://github.com/Ambiguous-Interactive/signal-fish-client-rust/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/Ambiguous-Interactive/signal-fish-client-rust/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/Ambiguous-Interactive/signal-fish-client-rust/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/Ambiguous-Interactive/signal-fish-client-rust/compare/v0.8.0...v0.9.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -906,7 +906,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-fish-client"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "base64",
  "futures-util",
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "signal-fish-client-godot"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "godot",
  "signal-fish-client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,10 +179,10 @@ members = ["crates/signal-fish-client-godot", "tools/perf-lab"]
 resolver = "2"
 
 [workspace.package]
-version = "0.11.0"
+version = "0.12.0"
 
 [workspace.dependencies]
-signal-fish-client = { version = "=0.11.0", path = ".", default-features = false }
+signal-fish-client = { version = "=0.12.0", path = ".", default-features = false }
 
 # Release builds validate under the same arithmetic semantics as every debug
 # test, fuzz, and Miri run: integer overflow aborts loudly instead of wrapping

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Add the client and Tokio:
 
 ```toml
 [dependencies]
-signal-fish-client = "0.11.0"
+signal-fish-client = "0.12.0"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ```
 
@@ -77,9 +77,9 @@ cargo run --example basic_lobby
 Set `SIGNAL_FISH_URL` to use a server other than
 `ws://localhost:3536/v2/ws`.
 
-The published `0.11.0` crate is the stable release. This branch also documents
-unreleased changes ahead of the next release. Use the [0.11.0 API
-docs](https://docs.rs/signal-fish-client/0.11.0/) for the published surface, or
+The published `0.12.0` crate is the stable release. This branch also documents
+unreleased changes ahead of the next release. Use the [0.12.0 API
+docs](https://docs.rs/signal-fish-client/0.12.0/) for the published surface, or
 see the
 [changelog](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/blob/main/CHANGELOG.md)
 before depending on `main`.

--- a/crates/signal-fish-client-godot/README.md
+++ b/crates/signal-fish-client-godot/README.md
@@ -23,8 +23,8 @@ directly:
 ```toml
 [dependencies]
 godot = { version = ">=0.4.5, <0.6" }
-signal-fish-client = { version = "0.11.0", default-features = false, features = ["polling-client"] }
-signal-fish-client-godot = { version = "0.11.0" }
+signal-fish-client = { version = "0.12.0", default-features = false, features = ["polling-client"] }
+signal-fish-client-godot = { version = "0.12.0" }
 ```
 
 ## Quick start

--- a/docs/client.md
+++ b/docs/client.md
@@ -9,11 +9,11 @@ For WebAssembly environments without an async runtime,
 game-loop-driven alternative.
 
 !!! note "Published crate versus this guide"
-    The stable crates.io release is **0.11.0**. This guide tracks the current
+    The stable crates.io release is **0.12.0**. This guide tracks the current
     `main` branch, which may include additions that have not reached a release
     yet; the [changelog](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/blob/main/CHANGELOG.md)
     lists what is new. Use the
-    [0.11.0 API docs](https://docs.rs/signal-fish-client/0.11.0/) for the
+    [0.12.0 API docs](https://docs.rs/signal-fish-client/0.12.0/) for the
     published surface, or a `git` dependency on `main` for the unreleased APIs.
 
 ---
@@ -81,7 +81,7 @@ use signal_fish_client::{GameDataEncoding, SignalFishConfig};
 
 let config = SignalFishConfig {
     app_id: "mb_app_abc123".into(),
-    sdk_version: Some("0.11.0".into()),
+    sdk_version: Some("0.12.0".into()),
     platform: Some("rust".into()),
     game_data_format: Some(GameDataEncoding::Json),
     ..SignalFishConfig::new("mb_app_abc123")

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -23,19 +23,19 @@ The equivalent manifest entries are:
 
 ```toml
 [dependencies]
-signal-fish-client = "0.11.0"
+signal-fish-client = "0.12.0"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ```
 
 `signal-fish-client` enables its built-in WebSocket transport by default.
 
 !!! note "Published release and main"
-    **0.11.0** is the current crates.io release. This guide follows unreleased
+    **0.12.0** is the current crates.io release. This guide follows unreleased
     `main`, which may include breaking APIs that have not reached a release
     yet; the
     [changelog](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/blob/main/CHANGELOG.md)
-    says which release added them. Use the [0.11.0
-    docs.rs pages](https://docs.rs/signal-fish-client/0.11.0/) with the versioned
+    says which release added them. Use the [0.12.0
+    docs.rs pages](https://docs.rs/signal-fish-client/0.12.0/) with the versioned
     dependency above. To evaluate unreleased changes, use:
 
     ```toml

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,9 +20,9 @@ polling client that runs inside your game loop.
 [View on GitHub](https://github.com/Ambiguous-Interactive/signal-fish-client-rust){ .md-button .sf-home-action }
 
 !!! note "Release status"
-    **0.11.0** is the current crates.io release and supports Rust **1.87.0** or
-    newer. This site follows unreleased `main`; use the [0.11.0 API
-    docs](https://docs.rs/signal-fish-client/0.11.0/) for the published surface.
+    **0.12.0** is the current crates.io release and supports Rust **1.87.0** or
+    newer. This site follows unreleased `main`; use the [0.12.0 API
+    docs](https://docs.rs/signal-fish-client/0.12.0/) for the published surface.
 
 ## Get connected
 

--- a/docs/mesh-guide.md
+++ b/docs/mesh-guide.md
@@ -15,7 +15,7 @@ drive the whole handshake for you.
     ```
 
     The generation-bearing protocol-v3 mesh APIs in this guide are all
-    published as of client release 0.11.0; the
+    published as of client release 0.12.0; the
     [changelog](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/blob/main/CHANGELOG.md)
     says which release added each.
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -702,7 +702,7 @@ Every message on the wire is a JSON object with two top-level keys:
         "type": "Authenticate",
         "data": {
             "app_id": "mb_app_abc123",
-            "sdk_version": "0.11.0"
+            "sdk_version": "0.12.0"
         }
     }
     ```

--- a/docs/wasm.md
+++ b/docs/wasm.md
@@ -134,7 +134,7 @@ signal-fish-client = { git = "https://github.com/Ambiguous-Interactive/signal-fi
 
 These snippets use `main` because the ownership, bounded-work, and admission
 guarantees documented below are listed under `Unreleased`. Use the published
-`0.11.0` dependency with its [versioned API docs](https://docs.rs/signal-fish-client/0.11.0/)
+`0.12.0` dependency with its [versioned API docs](https://docs.rs/signal-fish-client/0.12.0/)
 when you do not need those fixes yet.
 
 The adapter supports godot-rust 0.4.5 through 0.5.x and requires Rust 1.94 or

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -467,7 +467,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-fish-client"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "base64",
  "futures-util",

--- a/llms.txt
+++ b/llms.txt
@@ -10,7 +10,7 @@ the raw Emscripten transport is only for custom hosts
 that explicitly link Emscripten's WebSocket library.
 
 The GitHub Pages documentation tracks the unreleased `main` branch. Install
-`signal-fish-client = "0.11.0"` for the current crates.io release; use the
+`signal-fish-client = "0.12.0"` for the current crates.io release; use the
 repository git dependency when evaluating APIs and fixes listed under
 `Unreleased` until the next crate version is published.
 

--- a/tests/compatibility.toml
+++ b/tests/compatibility.toml
@@ -1,5 +1,5 @@
 # Canonical client/server protocol compatibility binding.
-client_version = "0.11.0"
+client_version = "0.12.0"
 server_version = "0.8.0"
 server_tag = "v0.8.0"
 server_commit = "d79dcdc7549777c8c2bd9fcb2d132641532d8c86"

--- a/tests/emscripten-harness/Cargo.lock
+++ b/tests/emscripten-harness/Cargo.lock
@@ -209,7 +209,7 @@ dependencies = [
 
 [[package]]
 name = "signal-fish-client"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "rmp",
  "rmp-serde",

--- a/tests/godot-compat-min/Cargo.lock
+++ b/tests/godot-compat-min/Cargo.lock
@@ -497,7 +497,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-fish-client"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "rmp",
  "rmp-serde",
@@ -512,7 +512,7 @@ dependencies = [
 
 [[package]]
 name = "signal-fish-client-godot"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "godot",
  "signal-fish-client",

--- a/tests/godot-web-smoke/Cargo.lock
+++ b/tests/godot-web-smoke/Cargo.lock
@@ -529,7 +529,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-fish-client"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "rmp",
  "rmp-serde",
@@ -544,7 +544,7 @@ dependencies = [
 
 [[package]]
 name = "signal-fish-client-godot"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "godot",
  "signal-fish-client",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Release-metadata and documentation version sync only; no runtime or protocol logic changes appear in the diff.
> 
> **Overview**
> **Prepares the lockstep `0.12.0` release** for `signal-fish-client` and `signal-fish-client-godot`: workspace version, lockfiles, `tests/compatibility.toml`, README/docs dependency pins, and agent publishing notes all move from `0.11.0` to `0.12.0`.
> 
> The **changelog cut** promotes the accumulated `[Unreleased]` notes into **`[0.12.0] - 2026-09-01`** (marked **major** for semver-checks). That release documents breaking API surface (`PayloadTooDeep`, `transport_diagnostics` on `SignalFishClientApi`, `RateLimitInfo` widening, `#[must_use]` diagnostics, Server **0.8.0** compatibility binding, and many fixes) — this PR does not touch `src/`; it only versions and publishes that narrative.
> 
> `[Unreleased]` is left empty and compare links at the bottom of `CHANGELOG.md` are updated for `v0.12.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44392195c5b58349adf880ec9c092c66965ea954. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->