### PR TITLE
Round 40 audit: accept authority-valid symbol lists, pin multi-room journeys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Breaking:** `PlayerNameRulesPayload::allowed_symbols` widened from
+  `Vec<char>` to `Vec<String>`, so every schema-valid symbol list decodes
+  instead of failing the frame; update code that matched single `char`s.
+
+### Fixed
+
+- Corrected the WebAssembly guide's published-release guidance and the 0.11
+  migration guide's stale `[Unreleased]` changelog pointer.
+
 ## [0.12.0] - 2026-09-01
 
 <!-- semver-checks: major -->

--- a/docs/migration-0.11.md
+++ b/docs/migration-0.11.md
@@ -113,5 +113,5 @@ own migration notes:
 - The remaining API additions — pre-authentication refusals, token-binding
   connect options, generation-bound driver signaling, and the new error
   variants behind exhaustive matches — are enumerated under `CHANGELOG.md`'s
-  `[Unreleased]` **Breaking** bullets and in the
+  `[0.11.0]` **Breaking** bullets and in the
   [errors guide](errors.md) variant table.

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -412,19 +412,19 @@ pub struct PlayerNameRulesPayload {
     pub allow_unicode_alphanumeric: bool,
     pub allow_spaces: bool,
     pub allow_leading_trailing_whitespace: bool,
-    pub allowed_symbols: Vec<char>,
+    pub allowed_symbols: Vec<String>,
     pub additional_allowed_characters: Option<String>,
 }
 ```
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `max_length` | `usize` | Maximum allowed length for a player name. |
-| `min_length` | `usize` | Minimum allowed length for a player name. |
+| `max_length` | `usize` | Maximum allowed length for a player name. Over-range or negative authority values fail the frame as `DecodeFailed` rather than truncating. |
+| `min_length` | `usize` | Minimum allowed length for a player name, bounded like `max_length`. |
 | `allow_unicode_alphanumeric` | `bool` | Whether Unicode alphanumeric characters are allowed. |
 | `allow_spaces` | `bool` | Whether spaces are allowed in the name. |
 | `allow_leading_trailing_whitespace` | `bool` | Whether leading/trailing whitespace is allowed. |
-| `allowed_symbols` | `Vec<char>` | Specific symbol characters that are permitted. |
+| `allowed_symbols` | `Vec<String>` | Symbol strings that are permitted (current servers emit one character per element). |
 | `additional_allowed_characters` | `Option<String>` | Extra characters beyond the base rules. |
 
 ---

--- a/docs/wasm.md
+++ b/docs/wasm.md
@@ -132,10 +132,12 @@ enable the advanced raw-FFI transport:
 signal-fish-client = { git = "https://github.com/Ambiguous-Interactive/signal-fish-client-rust", default-features = false, features = ["transport-websocket-emscripten"] }
 ```
 
-These snippets use `main` because the ownership, bounded-work, and admission
-guarantees documented below are listed under `Unreleased`. Use the published
-`0.12.0` dependency with its [versioned API docs](https://docs.rs/signal-fish-client/0.12.0/)
-when you do not need those fixes yet.
+These snippets use `main` so the ownership, bounded-work, and admission
+guarantees documented below stay current. The published `0.12.0` dependency
+with its [versioned API docs](https://docs.rs/signal-fish-client/0.12.0/)
+already contains them; the
+[changelog](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/blob/main/CHANGELOG.md)
+says which release added each.
 
 The adapter supports godot-rust 0.4.5 through 0.5.x and requires Rust 1.94 or
 newer; the core remains compatible with Rust 1.87. After changing the direct

--- a/src/client_core.rs
+++ b/src/client_core.rs
@@ -2144,6 +2144,7 @@ impl ClientCore {
         self.retired_signal_peers.clear();
         self.pending_room_operation = None;
         self.absorbed_spectator_leave = None;
+        self.pending_reconnects.clear();
         #[cfg(feature = "tokio-runtime")]
         self.advance_room_revision();
     }
@@ -2168,6 +2169,13 @@ impl ClientCore {
         self.retired_session_generations.clear();
         self.retired_signal_peers.clear();
         self.pending_room_operation = None;
+        // Clearing these two here is unobservable: the fence is cleared in
+        // tandem, every reader is fence-gated, and the SpectatorLeft caller
+        // overwrites the allowance immediately after. Owning the full
+        // room-scoped set locally keeps these transitions correct even if a
+        // future exit kind reaches them.
+        self.absorbed_spectator_leave = None;
+        self.pending_reconnects.clear();
         #[cfg(feature = "tokio-runtime")]
         self.advance_room_revision();
     }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -497,9 +497,12 @@ pub struct ProtocolInfoPayload {
 /// below `min_length` is surfaced verbatim rather than rejected.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PlayerNameRulesPayload {
-    /// Maximum accepted `player_name` length.
+    /// Maximum accepted `player_name` length. `usize` bounds the SDK's model
+    /// at the target's unsigned range: an authority-valid negative or
+    /// over-range value fails the whole frame as `DecodeFailed` rather than
+    /// truncating or sign-flipping the advisory.
     pub max_length: usize,
-    /// Minimum accepted `player_name` length.
+    /// Minimum accepted `player_name` length, bounded like `max_length`.
     pub min_length: usize,
     /// Whether Unicode alphanumeric characters are allowed.
     pub allow_unicode_alphanumeric: bool,
@@ -508,8 +511,12 @@ pub struct PlayerNameRulesPayload {
     /// Whether leading and trailing whitespace is allowed.
     pub allow_leading_trailing_whitespace: bool,
     /// Symbols accepted in addition to the base rules.
+    ///
+    /// Each element is an allowed symbol string passed through verbatim; the
+    /// wire authority types this as an array of strings, and current servers
+    /// emit one-character strings.
     #[serde(default)]
-    pub allowed_symbols: Vec<char>,
+    pub allowed_symbols: Vec<String>,
     /// Additional allowed characters as a free-form string, when advertised.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub additional_allowed_characters: Option<String>,

--- a/tests/client_tests.rs
+++ b/tests/client_tests.rs
@@ -18,8 +18,8 @@ mod common;
 use std::collections::VecDeque;
 
 use signal_fish_client::protocol::{
-    ClientMessage, ConnectionInfo, GameDataEncoding, RelayTransport, ServerMessage,
-    SpectatorStateChangeReason, TransportKind,
+    ClientMessage, ConnectionInfo, GameDataEncoding, LobbyState, PlayerInfo, RelayTransport,
+    RoomJoinedPayload, ServerMessage, SpectatorStateChangeReason, TransportKind,
 };
 use signal_fish_client::transport::TransportFrame;
 use signal_fish_client::{
@@ -389,6 +389,118 @@ async fn room_join_leave_rejoin_flow() {
 
     // After the final RoomJoined, state should reflect the room.
     assert_eq!(client.current_room_code().await.as_deref(), Some("ABC123"));
+
+    client.shutdown().await;
+}
+
+// ════════════════════════════════════════════════════════════════════
+// Sequential different-room journey: room A → leave → room B
+// ════════════════════════════════════════════════════════════════════
+
+/// A `RoomJoined` frame for a specific room identity, so the journey below
+/// exercises distinct room IDs rather than a re-baselined identical room.
+fn room_joined_json_for(room_id: uuid::Uuid, room_code: &str, player_id: uuid::Uuid) -> String {
+    let payload = RoomJoinedPayload {
+        room_id,
+        room_code: room_code.into(),
+        player_id,
+        game_name: "test-game".into(),
+        max_players: 8,
+        supports_authority: true,
+        current_players: vec![PlayerInfo {
+            id: player_id,
+            name: "Alice".into(),
+            is_authority: false,
+            is_ready: false,
+            connected_at: "2026-01-01T00:00:00Z".into(),
+            connection_info: None,
+            epoch: None,
+            seq: None,
+        }],
+        is_authority: false,
+        lobby_state: LobbyState::Waiting,
+        ready_players: vec![],
+        relay_type: "auto".into(),
+        current_spectators: vec![],
+        ice_servers: vec![],
+        reconnection_token: None,
+    };
+    serde_json::to_string(&ServerMessage::RoomJoined(Box::new(payload)))
+        .expect("room joined serialization")
+}
+
+#[tokio::test]
+async fn leaving_and_joining_a_different_room_carries_only_connection_scoped_state() {
+    let room_a = uuid::Uuid::from_u128(0xA);
+    let room_b = uuid::Uuid::from_u128(0xB);
+    let player_a = uuid::Uuid::from_u128(0xA1);
+    let player_b = uuid::Uuid::from_u128(0xB1);
+    let (mut client, mut events, _sent, _closed) = start_client(vec![
+        Some(Ok(authenticated_json())),
+        Some(Ok(protocol_info_json(None))),
+        Some(Ok(room_joined_json_for(room_a, "ROOMA", player_a))),
+        Some(Ok(room_left_json())),
+        Some(Ok(room_joined_json_for(room_b, "ROOMB", player_b))),
+        Some(Ok(room_left_json())),
+    ])
+    .await;
+
+    drain_until_authenticated(&mut events).await;
+    drain_until_protocol_info(&mut events).await;
+
+    // Room A baseline; one admitted send marks the connection-wide counter.
+    let ev = events.recv().await.expect("event");
+    match ev {
+        SignalFishEvent::RoomJoined { room_code, .. } => assert_eq!(room_code, "ROOMA"),
+        other => panic!("expected RoomJoined(ROOMA), got {other:?}"),
+    }
+    assert_eq!(client.snapshot().room_id, Some(room_a));
+    client
+        .send_game_data(serde_json::json!({"room": "A"}))
+        .expect("room A send must be admitted");
+
+    // Leave room A. The FIFO command queue sends the game data before the
+    // leave, so by the time the server-confirmed exit is observed the send
+    // is already counted.
+    client.leave_room().expect("leave must be admitted");
+    let ev = events.recv().await.expect("event");
+    assert!(matches!(ev, SignalFishEvent::RoomLeft));
+    assert_eq!(client.stats().game_data_sent, 1);
+
+    // Join a genuinely different room and observe its baseline.
+    client
+        .join_room(JoinRoomParams::new("test-game", "Alice"))
+        .expect("room B join must be admitted");
+    let ev = events.recv().await.expect("event");
+    match ev {
+        SignalFishEvent::RoomJoined { room_code, .. } => assert_eq!(room_code, "ROOMB"),
+        other => panic!("expected RoomJoined(ROOMB), got {other:?}"),
+    }
+
+    // The snapshot reflects room B only, with no quarantine carryover.
+    let snapshot = client.snapshot();
+    assert_eq!(snapshot.room_id, Some(room_b));
+    assert_eq!(snapshot.room_code.as_deref(), Some("ROOMB"));
+    assert_eq!(snapshot.player_id, Some(player_b));
+    assert!(!snapshot.quarantined);
+
+    // The connection-wide send counter persists across the room boundary by
+    // design, while room-scoped state must not: send once more in room B and
+    // fence it on the second server-confirmed exit.
+    client
+        .send_game_data(serde_json::json!({"room": "B"}))
+        .expect("room B send must be admitted");
+    client.leave_room().expect("second leave must be admitted");
+    let ev = events.recv().await.expect("event");
+    assert!(matches!(ev, SignalFishEvent::RoomLeft));
+    assert_eq!(client.stats().game_data_sent, 2);
+
+    // No further events (in particular no ProtocolViolation) are expected.
+    let ev = tokio::time::timeout(Duration::from_millis(100), events.recv()).await;
+    assert!(
+        ev.is_err(),
+        "no further events (in particular no ProtocolViolation) are expected: {ev:?}"
+    );
 
     client.shutdown().await;
 }

--- a/tests/protocol_tests.rs
+++ b/tests/protocol_tests.rs
@@ -299,7 +299,7 @@ fn server_message_protocol_info_round_trip() {
             allow_unicode_alphanumeric: true,
             allow_spaces: true,
             allow_leading_trailing_whitespace: false,
-            allowed_symbols: vec!['-', '_'],
+            allowed_symbols: vec!["-".to_string(), "_".to_string()],
             additional_allowed_characters: None,
         }),
         protocol_version: None,
@@ -315,7 +315,10 @@ fn server_message_protocol_info_round_trip() {
         assert_eq!(payload.game_data_formats.len(), 2);
         let rules = payload.player_name_rules.expect("rules present");
         assert_eq!(rules.max_length, 32);
-        assert_eq!(rules.allowed_symbols, vec!['-', '_']);
+        assert_eq!(
+            rules.allowed_symbols,
+            vec!["-".to_string(), "_".to_string()]
+        );
     } else {
         panic!("expected ProtocolInfo variant");
     }
@@ -2611,15 +2614,54 @@ fn player_name_rules_payload_round_trip() {
         allow_unicode_alphanumeric: false,
         allow_spaces: false,
         allow_leading_trailing_whitespace: false,
-        allowed_symbols: vec!['_'],
+        allowed_symbols: vec!['_'.to_string()],
         additional_allowed_characters: Some("àé".into()),
     };
     let deser = round_trip(&rules);
     assert_eq!(deser.max_length, 20);
     assert_eq!(deser.min_length, 3);
     assert!(!deser.allow_unicode_alphanumeric);
-    assert_eq!(deser.allowed_symbols, vec!['_']);
+    assert_eq!(deser.allowed_symbols, vec!["_".to_string()]);
     assert_eq!(deser.additional_allowed_characters.as_deref(), Some("àé"));
+}
+
+#[test]
+fn player_name_rules_accepts_every_authority_valid_symbol_shape() {
+    // The AsyncAPI authority types `allowed_symbols` as an array of strings
+    // with no per-element length bound; every schema-valid element must
+    // decode instead of failing the whole ProtocolInfo frame.
+    let raw = r#"{
+        "max_length": 20,
+        "min_length": 3,
+        "allow_unicode_alphanumeric": false,
+        "allow_spaces": false,
+        "allow_leading_trailing_whitespace": false,
+        "allowed_symbols": ["-", "_", "ab", "", "★"]
+    }"#;
+    let rules: PlayerNameRulesPayload =
+        serde_json::from_str(raw).expect("authority-valid symbol strings decode");
+    assert_eq!(
+        rules.allowed_symbols,
+        vec![
+            "-".to_string(),
+            "_".to_string(),
+            "ab".to_string(),
+            String::new(),
+            "★".to_string()
+        ]
+    );
+    // Omission keeps the byte-compatible default.
+    let omitted: PlayerNameRulesPayload = serde_json::from_str(
+        r#"{
+        "max_length": 20,
+        "min_length": 3,
+        "allow_unicode_alphanumeric": false,
+        "allow_spaces": false,
+        "allow_leading_trailing_whitespace": false
+    }"#,
+    )
+    .expect("omitted allowed_symbols keeps the empty default");
+    assert!(omitted.allowed_symbols.is_empty());
 }
 
 // ════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Why

Paranoid-audit round 40 (issue #126) audited three fresh surfaces and found one real wire-correctness defect plus two stale post-release docs. This PR fixes them and pins what the audits proved safe.

## What

- **Accept every schema-valid symbol list** — `PlayerNameRulesPayload::allowed_symbols` widens `Vec<char>` to `Vec<String>`, matching the protocol authority's array-of-strings shape. A conforming server could previously fail the whole `ProtocolInfo` frame with a multi-character symbol. **Breaking** for code matching single `char`s.
- **Document the deliberate `max_length`/`min_length` bound** (same precedent as `max_players`): nonsense values fail the frame loudly instead of being stored.
- **Pin multi-room journeys**: `set_room`/`clear_room` now clear their full room-scoped state locally (behavior-preserving), and a new test proves joining a *different* room after leaving carries only connection-scoped state.
- **Fix post-release doc staleness**: the WebAssembly guide's backwards "use 0.12.0 if you don't need those fixes yet" guidance, and the 0.11 migration guide's changelog pointer.

The exhaustive wire-conformance audit (all 61 protocol variants vs the vendored authority) and the sequential-room-lifecycle audit found no other defects; everything else was refuted with mechanism-level proofs.

## Verification

- `cargo fmt`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo test --workspace --all-features`: all green (23 suites, 0 failures).
- Two-round adversarial review (hostile reviewer + convergence verifier) converged to zero findings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The breaking `allowed_symbols` type change affects downstream matches and wire decoding behavior; room-state clearing is behavior-preserving but touches core lifecycle paths exercised by the new multi-room test.
> 
> **Overview**
> **Breaking wire/API fix:** `PlayerNameRulesPayload::allowed_symbols` changes from `Vec<char>` to `Vec<String>` so `ProtocolInfo` decodes every AsyncAPI-valid symbol list (including multi-character or empty strings) instead of failing the whole frame. Callers that matched single `char`s need to update. Docs and tests document the change and add a decode conformance test.
> 
> **Room lifecycle:** `set_room` and `clear_room` now locally clear `pending_reconnects` (and `absorbed_spectator_leave` on `clear_room`) so room-scoped state does not leak across boundaries. A new client integration test pins leaving room A, joining a different room B, and asserts connection-scoped stats persist while room snapshot/quarantine do not carry over.
> 
> **Docs/changelog:** `[Unreleased]` records the breaking change; `PlayerNameRulesPayload` field docs note `max_length`/`min_length` decode failures; WASM guide corrects 0.12.0 release guidance; 0.11 migration guide points at `[0.11.0]` changelog bullets instead of `[Unreleased]`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25ee9b40a55f173a14091a6b497d117a783ddfa0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->