### PR TITLE
Round 41 audit: stateful hostility campaign, agent-corpus truth

### DIFF
--- a/.llm/context.md
+++ b/.llm/context.md
@@ -55,7 +55,7 @@ secret-handling rules verified in session 070).
 ## CI/CD Action Reference Policy
 
 Use `owner/action@vN.N.N` (preferred) or `@vN`, not commit hashes. Exceptions:
-`dtolnay/rust-toolchain@stable|nightly|beta` and `emscripten-core/setup-emsdk@vN`.
+`dtolnay/rust-toolchain@stable|nightly|beta`, `emscripten-core/setup-emsdk@vN`, and `taiki-e/install-action@vN.N.N` (near-daily releases; exempt from the major-only-tag advisory).
 
 ## Changelog Policy
 
@@ -69,7 +69,7 @@ Only add `CHANGELOG.md` entries for user-visible changes.
 Production Rust is safe by default. The core manifest denies `unsafe_code`, the
 Godot adapter forbids it, and the target-gated Emscripten WebSocket module is
 the sole documented exception for the platform C API. Required WASM policy and
-50 checker self-tests enforce close-before-delete callback-state ownership;
+55 checker self-tests enforce close-before-delete callback-state ownership;
 terminal deletion failure intentionally leaks the small allocation instead of
 risking late-callback use-after-free. Change-scoped, scheduled, and manual
 Deep Safety runs Miri protocol tests, ThreadSanitizer, three raw-byte

--- a/.llm/skills/ci-configuration/SKILL.md
+++ b/.llm/skills/ci-configuration/SKILL.md
@@ -280,7 +280,7 @@ A common MSRV breakage pattern: a transitive dependency publishes a new version 
 - uses: dtolnay/rust-toolchain@stable
   with:
     toolchain: 1.87.0
-- uses: Swatinem/rust-cache@v2.9.1
+- uses: Swatinem/rust-cache@v2.9.2
 - run: bash scripts/cargo-retry.sh generate-lockfile
 - run: cargo build --locked --all-features && cargo test --locked --all-features
 ```
@@ -319,7 +319,7 @@ Phase 7 emits non-blocking warnings for major-only pins. Verified by `ci_config_
 
 ### Action version consistency across workflow files
 
-All uses of the same action across workflow `.yml` files must use the same version tag (e.g., `actions/checkout@v6.0.2` everywhere, not `@v6.0.1` in one file). `dtolnay/rust-toolchain` is excluded (uses channel refs). Enforced by `ci_config_tests.rs::workflow_security::all_action_versions_are_consistent_across_workflows`.
+All uses of the same action across workflow `.yml` files must use the same version tag (e.g., `actions/checkout@v7.0.1` everywhere, not `@v7.0.0` in one file). `dtolnay/rust-toolchain` is excluded (uses channel refs). Enforced by `ci_config_tests.rs::workflow_security::all_action_versions_are_consistent_across_workflows`.
 
 ### taiki-e/install-action: pin tool versions
 

--- a/.llm/skills/crate-publishing/SKILL.md
+++ b/.llm/skills/crate-publishing/SKILL.md
@@ -120,39 +120,42 @@ formatting (`\`TypeName\``) instead. See the *ci-configuration* skill for detail
 
 ## cargo-deny Configuration (deny.toml)
 
-`deny.toml` at crate root enforces license, security, and duplicate dependency policies:
+`deny.toml` at the workspace root enforces license, security, and source
+policies. The checked-in file is the authority — keep this quote in sync with
+it:
 
 ```toml
-[graph]
-targets = []  # check all targets
-
 [advisories]
-db-path = "~/.cargo/advisory-db"
-db-urls = ["https://github.com/rustsec/advisory-db"]
-vulnerability = "deny"
-unmaintained = "warn"
-yanked = "deny"
+ignore = []
 
 [licenses]
-allow = ["MIT", "Apache-2.0", "Apache-2.0 WITH LLVM-exception", "ISC", "MPL-2.0", "Unicode-DFS-2016"]
-deny = ["GPL-3.0"]
-copyleft = "warn"
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "MPL-2.0",
+    # webpki-roots ships Mozilla's root-certificate bundle under
+    # CDLA-Permissive-2.0 (pulled by the optional `tls` feature).
+    "CDLA-Permissive-2.0",
+    "Unicode-3.0",
+    "Unicode-DFS-2016",
+    "Zlib",
+]
+confidence-threshold = 0.8
 
 [bans]
 multiple-versions = "warn"
-wildcards = "allow"
-deny = [
-    # No chrono (use String timestamps)
-    { name = "chrono" },
-    # No bytes (use Vec<u8>)
-    { name = "bytes" },
-]
+wildcards = "deny"
 
 [sources]
 unknown-registry = "deny"
 unknown-git = "deny"
-allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 ```
+
+The no-`chrono` / no-`bytes` rules are repository design decisions (see
+`.llm/context.md`), not `cargo-deny` bans.
 
 Run: `cargo deny check`
 
@@ -246,8 +249,8 @@ Follow [Keep a Changelog](https://keepachangelog.com/):
 ### Added
 - Initial release
 - `SignalFishClient` with WebSocket transport
-- 26-variant `SignalFishEvent` enum
-- 50-variant `ErrorCode` enum
+- Typed `SignalFishEvent` event stream
+- Typed `ErrorCode` enum
 
 [Unreleased]: https://github.com/Ambiguous-Interactive/signal-fish-client-rust/compare/v0.2.0...HEAD
 [0.2.0]: https://github.com/Ambiguous-Interactive/signal-fish-client-rust/compare/v0.1.0...v0.2.0

--- a/.llm/skills/error-handling/SKILL.md
+++ b/.llm/skills/error-handling/SKILL.md
@@ -13,6 +13,7 @@ Defined in `src/error.rs` using `thiserror`. This enum is exhaustive.
 
 ```rust
 use crate::error_codes::ErrorCode;
+use crate::RoomRole;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -52,9 +53,36 @@ pub enum SignalFishError {
     #[error("outgoing command queue full (capacity {capacity}): ...")]
     SendBufferFull { capacity: usize },
 
+    /// Directed room operations are refused until the server's
+    /// `Authenticated` confirmation arrives.
+    #[error(
+        "not yet authenticated: wait for SignalFishEvent::Authenticated before room operations"
+    )]
+    NotAuthenticated,
+
     /// Not in a room.
     #[error("not in a room")]
     NotInRoom,
+
+    /// Attempted to join or reconnect while already in a room.
+    #[error("already in a room")]
+    AlreadyInRoom,
+
+    /// Attempted a room operation while a prior room transition awaits a
+    /// matching typed terminal response.
+    #[error("a room join, leave, or reconnect operation is already pending")]
+    RoomOperationPending,
+
+    /// Attempted an operation that is not valid for the current room role.
+    #[error("operation requires the {required} room role, but the current role is {actual}")]
+    WrongRoomRole {
+        required: RoomRole,
+        actual: RoomRole,
+    },
+
+    /// Attempted an operation reserved for the room's current authority.
+    #[error("operation requires the room's current authority role")]
+    AuthorityRequired,
 
     /// The server returned an error message.
     #[error("server error: {message}")]
@@ -69,7 +97,7 @@ pub enum SignalFishError {
     ProtocolUnsupported { mode: &'static str },
 
     /// Signaling was attempted before the current room's first SessionPlan.
-    #[error("WebRTC signaling requires an authoritative SessionPlan ...")]
+    #[error("no authoritative SessionPlan authorizes this WebRTC signal")]
     SessionPlanUnavailable,
 
     /// A generation-bound driver signal raced with a replacement plan.
@@ -83,8 +111,25 @@ pub enum SignalFishError {
     #[error("binary game data requires ...")]
     BinaryFormatNotNegotiated,
 
-    /// An operation timed out.
-    #[error("operation timed out")]
+    /// Caller payload nesting exceeds the maximum depth of `max_depth`
+    /// nested containers (currently 128, matching serde_json's own
+    /// deserialization recursion limit).
+    #[error(
+        "payload nesting exceeds the maximum depth of {max_depth} nested containers; \
+         flatten the payload"
+    )]
+    PayloadTooDeep { max_depth: usize },
+
+    /// Native WebSocket token-binding-v2 setup or outbound protection
+    /// failed. The structured reason contains no secret or proof material.
+    #[error("token binding error: {0}")]
+    TokenBinding(TokenBindingFailure),
+
+    /// The WebSocket handshake did not complete within the deadline given to
+    /// `WebSocketTransport::connect_with_timeout`.
+    #[error(
+        "the WebSocket handshake did not complete within its deadline; retry or raise the connect_with_timeout duration"
+    )]
     Timeout,
 
     /// A caller-supplied configuration value (or required build feature) was

--- a/.llm/skills/godot-websocket/SKILL.md
+++ b/.llm/skills/godot-websocket/SKILL.md
@@ -203,7 +203,7 @@ undefined `emscripten_websocket_new` symbol.
 - [x] Core has no `godot` dependency, feature, module, or re-export.
 - [x] Adapter and core versions match; the adapter requires core exactly.
 - [x] The adapter range remains `>=0.4.5, <0.6` until deliberate compatibility evidence widens it.
-- [x] All 39 fake-backend transport tests pass in the adapter.
+- [x] All 53 fake-backend transport tests pass in the adapter.
 - [x] Minimum and latest fixtures compile natively and for Emscripten with one binding family.
 - [x] Official Godot 4.5 web templates export the fixture.
 - [x] Browser E2E proves connect, authentication, room join, Ping/Pong, relay,

--- a/.llm/skills/public-api-design/SKILL.md
+++ b/.llm/skills/public-api-design/SKILL.md
@@ -198,10 +198,9 @@ has no trait-level `Send` bound. `SignalFishClient::start` adds
 
 ## Semver and Versioning
 
-This crate is pre-1.0 (0.1.0). Under semver:
+This crate is pre-1.0 (0.12.0). Under semver:
 
-- `0.MINOR.PATCH` — MINOR bumps are breaking changes
-- `0.1.PATCH` — patches only for bug fixes
+- `0.MINOR.PATCH` — MINOR bumps are breaking changes (e.g. 0.11 → 0.12)
 
 ### Breaking vs Non-Breaking
 


### PR DESCRIPTION
## Why

Paranoid-audit round 41 (issue #126) ran three never-audited surfaces. Two came back clean and prove the SDK's correctness story; one found that the **agent-facing docs had drifted from the code** — the reference material future agents (and contributors) rely on quoted configs and error variants that no longer exist, which causes wrong guidance to be copied verbatim.

## What changed

**Agent-doc truth fixes (the diff):**
- `crate-publishing`: the quoted `deny.toml` was fictional (`[graph]`, chrono/bytes bans, inverted wildcards, invented license list) — replaced with the actual 27-line file plus a keep-in-sync pointer.
- `error-handling`: the "pinned" `SignalFishError` sketch was missing 7 shipped variants (`NotAuthenticated`, `AlreadyInRoom`, `RoomOperationPending`, `WrongRoomRole`, `AuthorityRequired`, `PayloadTooDeep`, `TokenBinding`) and quoted two stale Display strings (`SessionPlanUnavailable`, `Timeout`) — now complete and byte-exact against `src/error.rs`.
- `godot-websocket`: test count 39 → 53 (runtime-proven).
- `public-api-design`: "pre-1.0 (0.1.0)" → 0.12.0.
- `ci-configuration`: example action pins refreshed (rust-cache v2.9.2, checkout v7.0.1) to match every workflow use.
- `context.md`: action-exception list gained `taiki-e/install-action` (matches the enforcement script); "50 checker self-tests" → 55 (runtime-proven).

**Clean-surface evidence (no diff):**
- **First stateful randomized hostility campaign**: 180,000 polling-client runs / ~7M frames of hostile-but-schema-valid server traffic across all 32 `ServerMessage` variants × 3 violation policies — **zero findings**, under an oracle whose sensitivity is itself proven (a deliberately broken oracle is caught by 12/12 canaries). Follow-up for persisting/extending the harness: #219.
- **Released-authority re-verification**: all vendored artifacts byte-match upstream Server 0.8.0; upstream has exactly one commit since with zero wire-visible changes; error codes verified 54 = 48 + 6 mechanically; E2E matrix and all server-version statements coherent.

## Verification

- Mandatory workflow: fmt clean, clippy `-D warnings` clean, 1104 tests / 0 failed (all features).
- Every corrected claim byte-verified against source/config; test counts runtime-proven; pre-commit 17/17 and pre-push 6/6 hooks green.

No changelog entry: internal agent-facing documentation only (no user-visible behavior change), per the changelog policy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal LLM/contributor documentation only; no runtime, API, or CI workflow file changes in the diff.
> 
> **Overview**
> **Round 41 audit follow-up:** this PR only updates `.llm/` agent reference material so quoted configs, error sketches, and numeric claims match the repository—no SDK or workflow behavior changes.
> 
> **`crate-publishing`** replaces a stale fictional `deny.toml` excerpt with the real workspace file and notes that no-`chrono` / no-`bytes` are design choices in `context.md`, not cargo-deny bans.
> 
> **`error-handling`** expands the documented `SignalFishError` enum to include seven shipped variants and fixes `SessionPlanUnavailable` / `Timeout` display text to match `src/error.rs`.
> 
> **`godot-websocket`** updates the fake-backend transport test count **39 → 53**; **`public-api-design`** documents pre-1.0 version **0.12.0** instead of 0.1.0.
> 
> **`ci-configuration`** refreshes example pins (`Swatinem/rust-cache@v2.9.2`, `actions/checkout@v7.0.1`). **`context.md`** adds `taiki-e/install-action` to the action-pin exception list and bumps checker self-tests **50 → 55**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fb39cf1e6dc97374bf343cb7a1e45e7153c53b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->