### PR TITLE
Adopt the stateful hostility campaign as a permanent gate (#219)

### DIFF
--- a/.github/workflows/deep-safety.yml
+++ b/.github/workflows/deep-safety.yml
@@ -6,10 +6,11 @@
 # analyzer finds a defect or cannot execute, so a green run is usable evidence.
 #
 # Jobs:
-#   miri    — Miri undefined behavior detection (nightly, protocol tests)
-#   tsan    — ThreadSanitizer data-race detection (nightly, full workspace suite)
-#   fuzz    — Fuzz smoke tests for protocol and token-binding parsing (nightly)
-#   mutants — Mutation testing on pure-logic modules (stable)
+#   miri     — Miri undefined behavior detection (nightly, protocol tests)
+#   tsan     — ThreadSanitizer data-race detection (nightly, full workspace suite)
+#   fuzz     — Fuzz smoke tests for protocol and token-binding parsing (nightly)
+#   mutants  — Mutation testing on pure-logic modules (stable)
+#   campaign — Deterministic stateful hostility campaign (issue #219)
 #
 # Schedule: Weekdays at 04:00 UTC — staggered from unused-deps (05:00)
 # and security (06:00).
@@ -34,6 +35,7 @@ on:
       - tests/token-binding/**
       - tests/token_binding_conformance_tests.rs
       - tests/protocol_tests.rs
+      - tools/stateful-campaign/**
   schedule:
     # Weekdays at 04:00 UTC — staggered from unused-deps at 05:00 and security at 06:00
     - cron: "0 4 * * 1-5"
@@ -249,3 +251,40 @@ jobs:
           name: mutants-results-${{ github.run_id }}-${{ github.run_attempt }}
           path: mutants.out/
           retention-days: 30
+
+  # ──────────────────────────────────────────────────────────────
+  # Stateful hostility campaign (issue #219)
+  #
+  # The deterministic model-based campaign drives the real polling driver
+  # plus shared ClientCore through hostile-but-schema-valid server storms
+  # under a per-frame event-expectation oracle, stats/ledger equivalence
+  # checks, and a send-pressure archetype. One selftest proves the oracle
+  # detects known-bad streams before the campaign runs.
+  # ──────────────────────────────────────────────────────────────
+  campaign:
+    name: Stateful hostility campaign
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo artifacts
+        uses: Swatinem/rust-cache@v2.9.2
+
+      - name: Run oracle canaries
+        run: >-
+          cargo run --locked --release
+          -p signal-fish-client-stateful-campaign --bin stateful-campaign
+          -- --selftest
+
+      - name: Run the stateful hostility campaign
+        run: >-
+          cargo run --locked --release
+          -p signal-fish-client-stateful-campaign --bin stateful-campaign
+          -- --seeds 1500 --scripts 40 --budget-secs 900

--- a/.llm/context.md
+++ b/.llm/context.md
@@ -133,7 +133,7 @@ admission and boundedly process immediately ready frames through `ClientCore` un
 `Pending`, terminal input, work bound, protocol stop, or deadline (the polling driver clamps this drain to
 its caller-configured receive budget). A ready farewell precedes `Disconnected`; only peer-close metadata replaces the send cause; native WebSocket retains buffered read state.
 
-Public `Debug`/tracing form an ambient-log boundary: reconnect/relay/TURN credentials, WebRTC SDP/ICE, arbitrary application data, buffered protocol frames, peer close reasons, and URL userinfo/query values are never formatted; safe diagnostics expose only variants, state flags, identifiers where appropriate, and byte lengths. Wire serialization and explicit public-field access remain unchanged.
+Public `Debug`/tracing form an ambient-log boundary: reconnect/relay/TURN credentials, WebRTC SDP/ICE, arbitrary application data, buffered protocol frames, peer close reasons, room codes, and URL userinfo/query values are never formatted; safe diagnostics expose only variants, state flags, identifiers where appropriate, and byte lengths (`ClientSnapshot.room_code` reports presence/length only). Deliberate carve-out: payload-struct field text (player/spectator names, notes) is tested non-secret and formats in payload `Debug` impls; SDK-internal tracing never formats it. Wire serialization and explicit public-field access remain unchanged.
 
 The Emscripten transport reports `Pending` while its browser WebSocket is still
 connecting and must not call `emscripten_websocket_send_*` or consume the

--- a/.llm/skills/ci-configuration/SKILL.md
+++ b/.llm/skills/ci-configuration/SKILL.md
@@ -359,5 +359,5 @@ the parser gap.
 |---|---|
 | `scripts/validate.sh` | Pre-flight: cargo fmt/clippy/test + `.lychee.toml` validation + markdownlint |
 | `scripts/ci-validate.sh` | Lightweight local CI (15 checks): fmt, clippy, test, typos, TOML/JSON, shell portability, devcontainer policy/Dockerfile |
-| `scripts/check-all.sh` | Full 22-phase CI parity. `--quick` for mandatory baseline (phases 1-4) |
+| `scripts/check-all.sh` | Full 23-phase CI parity. `--quick` for mandatory baseline (phases 1-4) |
 | `scripts/check-test-io-unwrap.sh` | Scans test `.rs` for bare `.unwrap()` on I/O ops (Phase 20 / Check 13) |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Breaking:** `PlayerNameRulesPayload::allowed_symbols` widened from
   `Vec<char>` to `Vec<String>`, so every schema-valid symbol list decodes
   instead of failing the frame; update code that matched single `char`s.
+- `ClientSnapshot`'s `Debug` output now reports the room code as
+  presence and byte length instead of printing the value: a room code is
+  join-capability knowledge, so ambient logs no longer leak it. The public
+  `room_code` field is unchanged.
 
 ### Fixed
 
 - Corrected the WebAssembly guide's published-release guidance and the 0.11
   migration guide's stale `[Unreleased]` changelog pointer.
+- Restored the behavioral tails of seven `ErrorCode` descriptions in the
+  errors guide (connection-fate for `RateLimitExceeded`, token-consumption
+  for `ReconnectionFailed`, the 4000 drain deadline, and others), gave the
+  errors guide's `UnsupportedProtocolVersion` row its second trigger, and
+  pointed the concepts guide's `Timeout` row at its single producer.
+- Fixed the fortress guide's stale guidance that still directed readers to a
+  git dependency for APIs published in 0.12.0.
 
 ## [0.12.0] - 2026-09-01
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -954,6 +954,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-fish-client-stateful-campaign"
+version = "0.0.0"
+dependencies = [
+ "serde_json",
+ "signal-fish-client",
+ "uuid",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -175,7 +175,7 @@ undocumented_unsafe_blocks = "deny"
 unsafe_code = "deny"
 
 [workspace]
-members = ["crates/signal-fish-client-godot", "tools/perf-lab"]
+members = ["crates/signal-fish-client-godot", "tools/perf-lab", "tools/stateful-campaign"]
 resolver = "2"
 
 [workspace.package]

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -488,7 +488,7 @@ directly from client methods as `Result<(), SignalFishError>`.
 | `BinaryFormatNotNegotiated` | Binary game data was requested while the connection uses JSON. |
 | `PayloadTooDeep { max_depth }` | A caller-supplied JSON payload was refused because its container nesting exceeds the outbound depth bound (128 nested containers, matching `serde_json`'s recursion limit). Applies to JSON game data, raw WebRTC signals, and `ConnectionInfo::Custom`; refused at the call site, before queuing, so flattening the payload is required. |
 | `TokenBinding(TokenBindingFailure)` | Native token-binding negotiation or proof generation failed (see `TokenBindingFailure` for the specific reason). |
-| `Timeout` | An operation exceeded its time limit. |
+| `Timeout` | The WebSocket handshake did not complete within its `connect_with_timeout` deadline (see [Errors](errors.md)); this variant has that single producer. |
 | `InvalidConfig { field, problem }` | A configuration value was rejected because it is unusable (zero size limit, unparsable URL, `wss://` without the `tls` feature); correcting the value is required, retrying is not enough. |
 | `Io(std::io::Error)` | An underlying I/O error occurred. |
 

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -121,7 +121,7 @@ println!("{}", code.description());
 | `Unauthorized` | Access denied. Authentication credentials are missing or invalid. |
 | `InvalidToken` *(compatibility-only)* | The authentication token is invalid, malformed, or has expired. |
 | `AuthenticationRequired` *(compatibility-only)* | This operation requires authentication. |
-| `InvalidAppId` | The provided application ID is not recognized. |
+| `InvalidAppId` | The provided application ID is not recognized. Verify the app ID is correct and free of control characters (maximum 256 bytes). |
 | `AppIdExpired` *(compatibility-only)* | The application ID has expired. |
 | `AppIdRevoked` *(compatibility-only)* | The application ID has been revoked. |
 | `AppIdSuspended` *(compatibility-only)* | The application ID has been suspended. |
@@ -165,14 +165,14 @@ println!("{}", code.description());
 
 | Variant | Description |
 |---------|-------------|
-| `RateLimitExceeded` | Too many requests in a short time. Slow down and try again later. |
+| `RateLimitExceeded` | Too many requests in a short time. Room/spectator admission refusals leave the connection open; a refused handshake closes it. Wait out the window before retrying. |
 | `TooManyConnections` | You have too many active connections. |
 
 ### Reconnection (4)
 
 | Variant | Description |
 |---------|-------------|
-| `ReconnectionFailed` | Failed to reconnect to the room. |
+| `ReconnectionFailed` | Failed to reconnect — the session may have expired, the room closed, or the attempt landed on a socket the server had already scheduled to close. The token is not consumed by such a refusal; retry from a fresh connection while the window is open. |
 | `ReconnectionTokenInvalid` | The reconnection token is invalid or malformed. |
 | `ReconnectionExpired` | The reconnection window has expired. |
 | `PlayerAlreadyConnected` | This player is already connected from another session. |
@@ -210,7 +210,7 @@ Applications migrating from readiness-based auto-start must call it after an
 
 | Variant | Description |
 |---------|-------------|
-| `RoomSessionIncompatible` | The room already finalized a peer-to-peer session whose sticky topology/transport pair was not negotiated by this connection. Reconnect with compatible capabilities or join another room. |
+| `RoomSessionIncompatible` | The room already finalized a peer-to-peer session whose sticky topology/transport pair was not negotiated by this connection. Reconnect with compatible capabilities or join another room; rooms finalized to the relay floor remain open to everyone. |
 
 ### Signaling — protocol v3 (5)
 
@@ -237,18 +237,18 @@ that the server could not honor. See the [Mesh Guide](mesh-guide.md).
 | Variant | Description |
 |---------|-------------|
 | `SlowConsumer` | The server evicted this connection because its outbound queue stayed full past the slow-consumer grace window (5 s by default): the client was not draining messages fast enough. The farewell frame carrying this code is written best-effort into an already-congested socket, so it may never arrive — a bare disconnect can be the only observable signal. |
-| `ActivityTimeout` | The server closed the connection after prolonged protocol inactivity. Send periodic pings to keep the connection alive. |
-| `ServerDraining` | The server is draining and will close the connection; preserve the current reconnect snapshot and honor retry guidance. |
-| `InvalidDeliveryClass` | A classified `GameData` request used an invalid class/key shape or unsupported delivery token. Prefer the invalid-state-proof `GameDataDelivery` API. |
+| `ActivityTimeout` | The server closed the connection after prolonged protocol inactivity. Send periodic pings to keep the connection alive; frames rejected for size or content do not refresh the window. |
+| `ServerDraining` | The server is draining and will close the connection; preserve the current reconnect snapshot and honor retry guidance. Existing sockets close with code 4000 at the drain deadline. |
+| `InvalidDeliveryClass` | A classified `GameData` request used an invalid class/key shape or unsupported delivery token. Latest requires a key; reliable and volatile forbid one. Prefer the invalid-state-proof `GameDataDelivery` API. |
 
 ### Protocol Negotiation (1)
 
 | Variant | Description |
 |---------|-------------|
-| `UnsupportedProtocolVersion` | The client's highest supported protocol version is below the server's configured minimum. |
+| `UnsupportedProtocolVersion` | The client's highest supported protocol version is below the server's configured minimum, or a pre-v3 connection sent a frame class that requires a newer protocol surface. |
 
 !!! note "The six new v3 *server* codes vs. `SignalFishError::ProtocolUnsupported`"
-    The five `Signal*` codes plus `ConnectionIdleTimeout` are **server-sent**
+    The five v3 signaling codes plus `ConnectionIdleTimeout` are **server-sent**
     `ErrorCode`s that arrive inside `SignalFishEvent::Error`. They are distinct
     from the client-side `SignalFishError::ProtocolUnsupported`, which fails a
     v3-only send *locally* before it ever reaches the server.

--- a/docs/fortress.md
+++ b/docs/fortress.md
@@ -21,9 +21,9 @@ the framed-transport-agnostic core remains compatible with Rust 1.87. Keep the d
 `godot-*` families before passing `Gd` values across the adapter boundary,
 because bindings from different versions are distinct Rust types.
 
-The issue #61 polling and admission guarantees in this guide are currently on
-`main` under [`Unreleased`](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/blob/main/CHANGELOG.md);
-use the git dependency until the next crate release publishes them.
+The issue #61 polling and admission guarantees in this guide are published as
+of client release 0.12.0; a versioned
+`signal-fish-client = "0.12.0"` dependency is sufficient.
 
 ## Configure Signal Fish
 

--- a/scripts/check-all.sh
+++ b/scripts/check-all.sh
@@ -31,6 +31,7 @@
 #  20. Rust test I/O unwrap   (delegates to scripts/check-test-io-unwrap.sh)
 #  21. Devcontainer compat    (delegates to check + fixture test scripts)
 #  22. Devcontainer Dockerfile (optional — docker buildx build --check)
+#  23. Stateful hostility campaign (canaries + reduced deterministic run)
 #
 # Notes:
 #   - MSRV (1.87.0) verification is CI-only (requires rustup toolchain override)
@@ -68,7 +69,7 @@ for arg in "$@"; do
 done
 
 # ── Phase tracking ───────────────────────────────────────────────────
-TOTAL_PHASES=22
+TOTAL_PHASES=23
 if [ "$QUICK" = true ]; then
     TOTAL_PHASES=4
 fi
@@ -98,6 +99,7 @@ PHASE_NAMES[19]="Shell portability"
 PHASE_NAMES[20]="Rust test I/O unwrap"
 PHASE_NAMES[21]="Devcontainer compatibility"
 PHASE_NAMES[22]="Devcontainer Dockerfile"
+PHASE_NAMES[23]="Stateful hostility campaign"
 
 for i in $(seq 1 "$TOTAL_PHASES"); do
     PHASE_RESULTS[i]="SKIP"
@@ -729,6 +731,29 @@ else
         echo -e "${RED}Phase 22: FAIL${NC}"
         mark_phase_fail 22
     fi
+fi
+echo ""
+
+# ── Phase 23: Stateful hostility campaign (issue #219) ────────────
+# Oracle canaries prove the campaign's oracle detects known-bad streams,
+# then a reduced deterministic campaign runs against the polling driver.
+# Pure cargo — no optional tooling, so this phase fails closed.
+echo -e "${YELLOW}Phase 23/$TOTAL_PHASES: Stateful hostility campaign (canaries + reduced run)...${NC}"
+if cargo run --locked --release \
+    -p signal-fish-client-stateful-campaign --bin stateful-campaign \
+    -- --selftest 2>&1; then
+    if cargo run --locked --release \
+        -p signal-fish-client-stateful-campaign --bin stateful-campaign \
+        -- --seeds 24 --scripts 12 --budget-secs 240 2>&1; then
+        echo -e "${GREEN}Phase 23: PASS${NC}"
+        PHASE_RESULTS[23]="PASS"
+    else
+        echo -e "${RED}Phase 23: FAIL (campaign findings)${NC}"
+        mark_phase_fail 23
+    fi
+else
+    echo -e "${RED}Phase 23: FAIL (oracle canaries)${NC}"
+    mark_phase_fail 23
 fi
 echo ""
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -785,7 +785,10 @@ impl std::fmt::Debug for ClientSnapshot {
             .field("room_role", &self.room_role)
             .field("player_id", &self.player_id)
             .field("room_id", &self.room_id)
-            .field("room_code", &self.room_code)
+            // A room code is join-capability knowledge (a lobby-by-code
+            // credential), so the ambient Debug boundary reports presence
+            // and length only; the public field itself is unchanged.
+            .field("room_code", &self.room_code.as_ref().map(|code| code.len()))
             .field("session_generation", &self.session_generation)
             .field("session_topology", &self.session_topology)
             .field("session_transport", &self.session_transport)
@@ -2739,6 +2742,20 @@ mod tests {
         let debug = format!("{snapshot:?}");
         assert!(debug.contains("<redacted>"));
         assert!(!debug.contains("top-secret-token"));
+    }
+
+    #[test]
+    fn snapshot_debug_redacts_room_code_capability() {
+        // A room code is join-capability knowledge: the ambient Debug
+        // boundary reports presence and length only, while the public field
+        // stays fully accessible.
+        let snapshot = ClientSnapshot {
+            room_code: Some("join-by-this-code\0\u{2028}".into()),
+            ..ClientSnapshot::default()
+        };
+        let debug = format!("{snapshot:?}");
+        assert!(debug.contains("room_code: Some(21)"), "{debug}"); // byte length
+        assert!(!debug.contains("join-by-this-code"), "{debug}");
     }
 
     // ── Mock transport ──────────────────────────────────────────────

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -500,7 +500,10 @@ pub struct PlayerNameRulesPayload {
     /// Maximum accepted `player_name` length. `usize` bounds the SDK's model
     /// at the target's unsigned range: an authority-valid negative or
     /// over-range value fails the whole frame as `DecodeFailed` rather than
-    /// truncating or sign-flipping the advisory.
+    /// truncating or sign-flipping the advisory. On 32-bit targets (such as
+    /// wasm32 web builds) values at or above 2^32 also fail as
+    /// `DecodeFailed` — still fail-closed, one advisory field never
+    /// truncates silently.
     pub max_length: usize,
     /// Minimum accepted `player_name` length, bounded like `max_length`.
     pub min_length: usize,

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -4086,6 +4086,7 @@ mod safety_analysis_policy {
             "fuzz/**",
             "scripts/cargo-retry.sh",
             "tests/protocol_tests.rs",
+            "tools/stateful-campaign/**",
         ] {
             assert!(
                 workflow.contains(&format!("- {path}")),
@@ -4133,6 +4134,17 @@ mod safety_analysis_policy {
         assert!(local.contains("FUZZ_CORPUS=$(mktemp -d)"));
         assert!(local.contains("\"$corpus\" \"${seed_args[@]}\""));
         assert!(local.contains("cargo mutants --gitignore true"));
+
+        // The stateful hostility campaign (issue #219) is a fail-closed Deep
+        // Safety lane: canaries prove oracle sensitivity before the campaign
+        // runs, and the local check-all phase mirrors both.
+        assert!(workflow.contains("Stateful hostility campaign"));
+        assert!(workflow.contains("signal-fish-client-stateful-campaign"));
+        assert!(workflow.contains("-- --selftest"));
+        assert!(workflow.contains("--seeds 1500 --scripts 40"));
+        assert!(local.contains("stateful-campaign"));
+        assert!(local.contains("-- --selftest"));
+        assert!(local.contains("--seeds 24 --scripts 12"));
 
         let binary_target = read_project_file("fuzz/fuzz_targets/fuzz_binary_game_data.rs");
         assert!(binary_target.contains("decode_v2_binary_game_data"));

--- a/tools/stateful-campaign/Cargo.toml
+++ b/tools/stateful-campaign/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "signal-fish-client-stateful-campaign"
+version = "0.0.0"
+publish = false
+edition = "2021"
+rust-version = "1.87.0"
+license = "MIT"
+description = "Deterministic stateful randomized (model-based) hostility campaign against the polling driver and shared ClientCore (issue #219)"
+
+[lib]
+path = "src/lib.rs"
+
+[[bin]]
+name = "stateful-campaign"
+path = "src/main.rs"
+
+[dependencies]
+signal-fish-client = { workspace = true, features = ["polling-client"] }
+serde_json = "1.0.68"
+uuid = { version = "1", default-features = false }
+
+[lints.clippy]
+unwrap_used = "deny"
+expect_used = "deny"
+panic = "deny"
+todo = "deny"
+unimplemented = "deny"
+unreachable = "deny"
+indexing_slicing = "deny"
+# Kept in lockstep with the core crate; see its arithmetic_side_effects
+# rationale (runtime-invariant overflow discipline on hostile input).
+arithmetic_side_effects = "deny"
+dbg_macro = "deny"
+exit = "deny"
+mem_forget = "deny"
+
+[lints.rust]
+unsafe_code = "deny"

--- a/tools/stateful-campaign/README.md
+++ b/tools/stateful-campaign/README.md
@@ -1,0 +1,84 @@
+# Stateful Hostility Campaign
+
+A deterministic, stateful randomized (model-based) hostility campaign against
+the polling driver and the shared `ClientCore` (issue #219). Unlike the
+stateless per-frame fuzz targets, this harness drives the **real client**
+through long hostile-but-schema-valid server journeys and asserts on every
+documented behavioral contract it can observe.
+
+## What it does
+
+- **Generator** — 12 scenario archetypes (journeys, roster storms,
+  accountability stamp chaos, spectator churn, plan/generation churn, raw
+  malformed frames, command storms, echo zoos, transport kills, and a
+  send-pressure archetype) emitting all 32 `ServerMessage` variants and all
+  9 `RoomOperationResult` faces with hostile fields: stale/replayed
+  generations, overlapping and miscounted gap ranges, bound storms, and
+  invalid client commands, across all four negotiation dialects and all
+  three `ProtocolViolationPolicy` values.
+- **Per-frame event-expectation oracle** — every delivered frame must produce
+  exactly one documented outcome multiset (event, violation, documented
+  silence). A silent swallow of a `Pong`/`Error`/`GameData` event, a
+  fabricated event, or a double delivery is a finding. The oracle mirrors the
+  client's published gates: negotiation and phase fences, room-operation
+  fences with absorbed-late-reply tracking, relay-stats validity, and the
+  Observe policy's diagnostic delivery.
+- **Stats/ledger equivalence oracle** — `ClientStats` counters must equal the
+  harness's independent count of decoded game-data frames, undecodable frames
+  must surface exactly one `DecodeFailed` each, and accepted sends must reach
+  the transport exactly once.
+- **Send-pressure archetype** — a `Pending`-refusing `poll_send` face
+  exercises outbound pacing: FIFO delivery, capacity accounting, and full
+  drain under backpressure.
+- **Round-41 oracle families** — phase-legality model, terminal discipline,
+  snapshot coherence, positive quarantine latch, close-info attribution, and
+  the cross-policy differential.
+
+Findings reduce automatically to a minimal failing step prefix and reproduce
+deterministically from `(seed, script index, policy)`.
+
+## Usage
+
+```shell
+# Oracle canaries: every rejection branch is sensitivity-proven.
+cargo run --locked --release -p signal-fish-client-stateful-campaign \
+  --bin stateful-campaign -- --selftest
+
+# Full campaign (the Deep Safety CI lane).
+cargo run --locked --release -p signal-fish-client-stateful-campaign \
+  --bin stateful-campaign -- --seeds 1500 --scripts 40 --budget-secs 900
+
+# Reduced campaign, long-horizon churn probe, single-script replay.
+cargo run --locked --release -p signal-fish-client-stateful-campaign \
+  --bin stateful-campaign -- --seeds 24 --scripts 12
+cargo run --locked --release -p signal-fish-client-stateful-campaign \
+  --bin stateful-campaign -- --soak
+cargo run --locked --release -p signal-fish-client-stateful-campaign \
+  --bin stateful-campaign -- --repro 11 27 Q:61
+```
+
+`--repro SEED SCRIPT POLICY[:PREFIX]` replays one script verbosely
+(`Q`/`O`/`D` pick the policy; `PREFIX` bounds the step count). Findings print
+their own repro line. `STATEFUL_CAMPAIGN_BREAK_ORACLE=1` neuters the oracle's
+rejection branches for sensitivity demonstrations.
+
+## CI wiring
+
+- Required nowhere (like fuzzing/mutation, too slow for every PR); the
+  scheduled and PR-path-triggered **Deep Safety** workflow runs canaries plus
+  the full campaign in the `Stateful hostility campaign` job.
+- `scripts/check-all.sh` phase 23 mirrors both locally, fail-closed.
+- The crate is a workspace member, so the mandatory fmt/clippy/test gates
+  cover it; its unit tests run the canaries, a reduced smoke campaign, and
+  the soak probe on every `cargo test --workspace`.
+
+## Known oracle limitations
+
+- The signal/plan family uses conservative alternatives (delivery or
+  documented suppression) rather than a full generation-fence mirror, so a
+  hypothetical defect that *swapped* one suppressed signal for another would
+  not be caught. The in-repo protocol tests cover those faces exactly.
+- The unsupported-format advisory tracking is an approximation of the
+  client's armed-range bookkeeping; the causality face therefore keeps the
+  violation alternatives legal even when this oracle believes the advisory is
+  armed (never silent).

--- a/tools/stateful-campaign/src/canary.rs
+++ b/tools/stateful-campaign/src/canary.rs
@@ -1,0 +1,582 @@
+//! Oracle canaries: known-good and known-bad streams that prove the oracle
+//! detects the defect classes it claims to detect.
+//!
+//! Two families run under `--selftest` and as unit tests:
+//!
+//! 1. end-to-end scripted journeys with exact event-count assertions,
+//! 2. direct-feed oracle-rejection canaries: synthetic event/step sequences
+//!    fed straight into the oracle entry points, each of which the strict
+//!    oracle must REJECT, plus a broken-oracle sensitivity proof.
+
+use signal_fish_client::client::ProtocolViolationPolicy;
+use signal_fish_client::event::SignalFishEvent;
+use signal_fish_client::protocol::{PlayerId, RateLimitInfo};
+
+use crate::gen::{self, Ctx};
+use crate::run::{run_prefix, run_prefix_verbose, set_oracle_neutered, Oracle};
+use crate::script::{Cmd, ConfigKind, Script, Step};
+
+struct DirectFeedVerdict {
+    name: &'static str,
+    verdict: Result<(), String>,
+}
+
+fn fed(name: &'static str, feed: impl FnOnce() -> Result<(), String>) -> DirectFeedVerdict {
+    DirectFeedVerdict {
+        name,
+        verdict: feed(),
+    }
+}
+
+fn ev_connected() -> SignalFishEvent {
+    SignalFishEvent::Connected
+}
+
+fn ev_disconnected(reason: &str) -> SignalFishEvent {
+    SignalFishEvent::Disconnected {
+        reason: Some(reason.to_string()),
+        last_server_error: None,
+    }
+}
+
+fn ev_violation(diagnostic: &str) -> SignalFishEvent {
+    SignalFishEvent::ProtocolViolation {
+        kind: signal_fish_client::ProtocolViolationKind::Lifecycle,
+        diagnostic: diagnostic.to_string(),
+    }
+}
+
+fn ev_authenticated() -> SignalFishEvent {
+    SignalFishEvent::Authenticated {
+        app_name: "canary".into(),
+        organization: None,
+        rate_limits: RateLimitInfo {
+            per_minute: 1,
+            per_hour: 2,
+            per_day: 3,
+        },
+    }
+}
+
+fn ev_protocol_info_v3() -> SignalFishEvent {
+    SignalFishEvent::ProtocolInfo(signal_fish_client::protocol::ProtocolInfoPayload {
+        platform: None,
+        sdk_version: None,
+        minimum_version: None,
+        recommended_version: None,
+        capabilities: vec![],
+        notes: None,
+        game_data_formats: vec![signal_fish_client::protocol::GameDataEncoding::Json],
+        player_name_rules: None,
+        protocol_version: Some(3),
+        min_protocol_version: Some(2),
+        max_protocol_version: Some(3),
+        transports: None,
+        max_outbound_message_size: None,
+    })
+}
+
+fn ev_game_data() -> SignalFishEvent {
+    SignalFishEvent::GameData {
+        from_player: PlayerId::from_u128(0xCA7),
+        data: serde_json::json!(null),
+        seq: Some(1),
+        epoch: Some(1),
+        class: Some(signal_fish_client::protocol::DeliveryClass::Reliable),
+        key: None,
+    }
+}
+
+fn ev_room_joined() -> SignalFishEvent {
+    SignalFishEvent::RoomJoined {
+        room_id: PlayerId::from_u128(0x20),
+        room_code: "CANARY".into(),
+        player_id: PlayerId::from_u128(0x10),
+        game_name: "canary".into(),
+        max_players: 4,
+        supports_authority: false,
+        current_players: vec![],
+        is_authority: false,
+        lobby_state: signal_fish_client::protocol::LobbyState::Waiting,
+        ready_players: vec![],
+        relay_type: "websocket".into(),
+        current_spectators: vec![],
+        ice_servers: vec![],
+        reconnection_token: None,
+    }
+}
+
+fn ev_player_joined() -> SignalFishEvent {
+    SignalFishEvent::PlayerJoined {
+        player: signal_fish_client::protocol::PlayerInfo {
+            id: PlayerId::from_u128(0x11),
+            name: "peer".into(),
+            is_authority: false,
+            is_ready: false,
+            connected_at: "2026".into(),
+            connection_info: None,
+            epoch: Some(1),
+            seq: Some(0),
+        },
+    }
+}
+
+fn ev_signal_received() -> SignalFishEvent {
+    SignalFishEvent::SignalReceived {
+        from: PlayerId::from_u128(0x11),
+        generation: None,
+        signal: serde_json::json!({ "Offer": "v=0 canary" }),
+    }
+}
+
+fn snap_in_room(quarantined: bool) -> signal_fish_client::ClientSnapshot {
+    signal_fish_client::ClientSnapshot {
+        connected: true,
+        transport_ready: true,
+        authenticated: true,
+        room_role: Some(signal_fish_client::RoomRole::Player),
+        player_id: Some(PlayerId::from_u128(0x10)),
+        room_id: Some(PlayerId::from_u128(0x20)),
+        room_code: Some("CANARY".into()),
+        quarantined,
+        ..Default::default()
+    }
+}
+
+/// All direct-feed oracle-rejection canaries. Run once under the strict oracle
+/// (every verdict must be `Err`) and once under the deliberately-broken oracle
+/// (at least one verdict must flip to `Ok`, proving canary sensitivity).
+fn run_direct_feed_canaries() -> Vec<DirectFeedVerdict> {
+    use signal_fish_client::ClientSnapshot;
+    let new_oracle = || Oracle::new(ProtocolViolationPolicy::Quarantine, ConfigKind::V3, false);
+    vec![
+        // 1. Phase-illegal event: game data before authentication/membership.
+        fed("phase_illegal_game_data", || {
+            let mut oracle = new_oracle();
+            oracle.observe(&ev_connected())?;
+            oracle.observe(&ev_game_data())
+        }),
+        // 2. Phase-illegal event: v3 signal before any SessionPlan.
+        fed("phase_illegal_signal_before_plan", || {
+            let mut oracle = new_oracle();
+            oracle.observe(&ev_connected())?;
+            oracle.observe(&ev_authenticated())?;
+            oracle.observe(&ev_protocol_info_v3())?;
+            oracle.observe(&ev_room_joined())?;
+            oracle.observe(&ev_signal_received())
+        }),
+        // 3. Post-terminal event: a roster update after the terminal
+        //    Disconnected must be rejected outright.
+        fed("post_terminal_event", || {
+            let mut oracle = new_oracle();
+            oracle.peer_close_armed = true;
+            oracle.observe(&ev_connected())?;
+            oracle.observe(&ev_disconnected(
+                "closed by server: code=Some(1001), reason=Some(\"server going away\")",
+            ))?;
+            oracle.observe(&ev_player_joined())
+        }),
+        // 4. Duplicate Connected event.
+        fed("duplicate_connected", || {
+            let mut oracle = new_oracle();
+            oracle.observe(&ev_connected())?;
+            oracle.observe(&ev_connected())
+        }),
+        // 5. Duplicate Disconnected event.
+        fed("duplicate_disconnected", || {
+            let mut oracle = new_oracle();
+            oracle.peer_close_armed = true;
+            oracle.observe(&ev_connected())?;
+            oracle.observe(&ev_disconnected(
+                "closed by server: code=Some(1001), reason=Some(\"server going away\")",
+            ))?;
+            oracle.observe(&ev_disconnected(
+                "closed by server: code=Some(1001), reason=Some(\"server going away\")",
+            ))
+        }),
+        // 6. Snapshot incoherence: in a room but player id missing.
+        fed("snapshot_incoherence_missing_player_id", || {
+            let oracle = new_oracle();
+            oracle.check_snapshot(&ClientSnapshot {
+                connected: true,
+                transport_ready: true,
+                authenticated: true,
+                room_role: Some(signal_fish_client::RoomRole::Player),
+                player_id: None,
+                room_id: Some(PlayerId::from_u128(0x20)),
+                quarantined: false,
+                ..Default::default()
+            })
+        }),
+        // 7. Snapshot incoherence: disconnected but transport still ready.
+        fed("snapshot_incoherence_disconnected_ready", || {
+            let oracle = Oracle::new(ProtocolViolationPolicy::Observe, ConfigKind::V3, false);
+            oracle.check_snapshot(&ClientSnapshot {
+                connected: false,
+                transport_ready: true,
+                ..Default::default()
+            })
+        }),
+        // 8. Quarantine latch: a violation under Quarantine policy with a
+        //    snapshot that never latched `quarantined` must be a finding (the
+        //    "Quarantine behaves like Observe" client bug).
+        fed("quarantine_flag_never_latched", || {
+            let mut oracle = new_oracle();
+            oracle.observe(&ev_connected())?;
+            oracle.observe(&ev_authenticated())?;
+            oracle.observe(&ev_protocol_info_v3())?;
+            oracle.observe(&ev_room_joined())?;
+            oracle.observe(&ev_violation("lifecycle violation: canary"))?;
+            oracle.check_snapshot(&snap_in_room(false))?;
+            // Positive control: the correctly-latched snapshot is accepted.
+            oracle.check_snapshot(&snap_in_room(true))
+        }),
+        // 9. Close-info misattribution: a violation teardown reported with the
+        //    server-close reason instead of "protocol violation".
+        fed("close_misattribution_violation_as_peer_close", || {
+            let mut oracle =
+                Oracle::new(ProtocolViolationPolicy::Disconnect, ConfigKind::V3, false);
+            oracle.observe(&ev_connected())?;
+            oracle.observe(&ev_authenticated())?;
+            oracle.observe(&ev_violation("lifecycle violation: canary teardown"))?;
+            oracle.observe(&ev_disconnected(
+                "closed by server: code=Some(1001), reason=Some(\"server going away\")",
+            ))?;
+            oracle.verify_close_attribution(false)?;
+            // Positive control: the correct cause string is accepted.
+            let mut good = Oracle::new(ProtocolViolationPolicy::Disconnect, ConfigKind::V3, false);
+            good.observe(&ev_connected())?;
+            good.observe(&ev_authenticated())?;
+            good.observe(&ev_violation("lifecycle violation: canary teardown"))?;
+            good.observe(&ev_disconnected("protocol violation"))?;
+            good.verify_close_attribution(false)
+        }),
+        // 10. Close-info misattribution: a peer close reported as a
+        //     protocol-violation cause while the client behaved.
+        fed("close_misattribution_peer_close_as_violation", || {
+            let mut oracle = new_oracle();
+            oracle.peer_close_armed = true;
+            oracle.observe(&ev_connected())?;
+            oracle.observe(&ev_disconnected("protocol violation"))?;
+            oracle.verify_close_attribution(true)
+        }),
+        // 11. Close-info disagreement: server-close-formatted reason with no
+        //     peer close armed in the transport (close_info() == None).
+        fed("close_misattribution_close_info_disagrees", || {
+            let mut oracle = new_oracle();
+            oracle.transport_error_armed = true;
+            oracle.expected_transport_reasons =
+                vec![crate::transport::RECV_ERROR_DISPLAY.to_string()];
+            oracle.observe(&ev_connected())?;
+            oracle.observe(&ev_disconnected(
+                "closed by server: code=Some(1001), reason=Some(\"server going away\")",
+            ))?;
+            oracle.verify_close_attribution(false)
+        }),
+        // 12. Terminal transport error: the Disconnected reason must be the
+        //     armed terminal error verbatim.
+        fed("transport_error_reason_mismatch", || {
+            let mut oracle = new_oracle();
+            oracle.arm_transport_error(true, false);
+            oracle.observe(&ev_connected())?;
+            oracle.observe(&ev_disconnected("some unrelated failure"))?;
+            oracle.verify_close_attribution(false)?;
+            // Positive control: the exact armed error string is accepted.
+            let mut good = new_oracle();
+            good.arm_transport_error(true, false);
+            good.observe(&ev_connected())?;
+            good.observe(&ev_disconnected(crate::transport::RECV_ERROR_DISPLAY))?;
+            good.verify_close_attribution(false)
+        }),
+        // 13. Expectation swallow: a delivered Pong frame must surface its
+        //     event; a silent batch leaves the slot pending (detectable), so
+        //     the oracle "rejects" the swallow.
+        fed("expectation_swallowed_pong", || {
+            let mut oracle = crate::run::test_support::fresh_oracle(
+                ProtocolViolationPolicy::Quarantine,
+                ConfigKind::V3,
+                false,
+            );
+            oracle
+                .slots
+                .push_back(crate::run::test_support::slot_for("Pong"));
+            let mut findings = Vec::new();
+            // The poll batch surfaced nothing (the swallow under test).
+            oracle.reconcile_batch(&[], 0, 0, &mut findings);
+            if !findings.is_empty() {
+                return Err("empty batch was misreported as a mismatch".into());
+            }
+            if oracle.pending_slot_count() != 1 {
+                return Err("pending Pong slot vanished without its event".into());
+            }
+            Err("strict oracle keeps the unresolved Pong slot pending (swallow detectable)".into())
+        }),
+        // 14. Expectation fabrication: an event with no delivered frame must
+        //     be reported; failing to report it accepts the bad stream.
+        fed("expectation_fabricated_event", || {
+            let mut oracle = crate::run::test_support::fresh_oracle(
+                ProtocolViolationPolicy::Quarantine,
+                ConfigKind::V3,
+                false,
+            );
+            let mut findings = Vec::new();
+            oracle.reconcile_batch(&["Pong"], 0, 0, &mut findings);
+            if findings
+                .iter()
+                .any(|finding| finding.category == "expectation-fabricated")
+            {
+                return Err("fabrication correctly reported".into());
+            }
+            Ok(())
+        }),
+    ]
+}
+
+/// Exact-event canaries. Each failure mode prints and counts.
+pub fn selftest() -> usize {
+    let mut failures: usize = 0;
+
+    // Canary 1: clean v3 journey -> exact event stream, zero violations.
+    {
+        let mut steps = Vec::new();
+        let mut ctx = Ctx::new_for_canary();
+        steps.push(Step::Deliver(
+            gen::canary_authenticated(),
+            Default::default(),
+        ));
+        steps.push(Step::Poll(1));
+        let (info, info_meta) = gen::canary_protocol_info();
+        steps.push(Step::Deliver(info, info_meta));
+        steps.push(Step::Poll(1));
+        // Top-level room responses require an admitted join operation first.
+        steps.push(Step::Cmd(Cmd::JoinRoom));
+        steps.push(Step::Poll(1));
+        steps.push(Step::Deliver(
+            gen::canary_room_joined(&ctx),
+            Default::default(),
+        ));
+        steps.push(Step::Poll(1));
+        steps.push(Step::Deliver(
+            gen::canary_player_joined(&ctx),
+            Default::default(),
+        ));
+        steps.push(Step::Poll(1));
+        let (data, data_meta) = gen::canary_game_data(&mut ctx);
+        steps.push(Step::Deliver(data, data_meta));
+        steps.push(Step::Poll(1));
+        let script = Script {
+            seed: 0,
+            index: 0,
+            archetype: "canary_clean",
+            config_kind: ConfigKind::V3,
+            echo_room_ops: false,
+            small_command_capacity: None,
+            steps,
+        };
+        let outcome = run_prefix_verbose(&script, ProtocolViolationPolicy::Quarantine, usize::MAX);
+        if !outcome.findings.is_empty() || outcome.violations != 0 {
+            println!(
+                "canary_clean FAILED: {:?} violations={}",
+                outcome.findings, outcome.violations
+            );
+            failures = failures.saturating_add(1);
+        } else if outcome.events_seen != 6 {
+            // Connected, Authenticated, ProtocolInfo, RoomJoined, PlayerJoined, GameData.
+            println!(
+                "canary_clean UNEXPECTED event count: {}",
+                outcome.events_seen
+            );
+            failures = failures.saturating_add(1);
+        }
+    }
+
+    // Canary 2: duplicate RoomJoined -> exactly one lifecycle violation.
+    {
+        let mut steps = Vec::new();
+        let ctx = Ctx::new_for_canary();
+        steps.push(Step::Deliver(
+            gen::canary_authenticated(),
+            Default::default(),
+        ));
+        steps.push(Step::Poll(1));
+        let (info, info_meta) = gen::canary_protocol_info();
+        steps.push(Step::Deliver(info, info_meta));
+        steps.push(Step::Poll(1));
+        steps.push(Step::Cmd(Cmd::JoinRoom));
+        steps.push(Step::Poll(1));
+        steps.push(Step::Deliver(
+            gen::canary_room_joined(&ctx),
+            Default::default(),
+        ));
+        steps.push(Step::Poll(1));
+        // Second RoomJoined after the pending join was released: lifecycle-invalid.
+        steps.push(Step::Deliver(
+            gen::canary_room_joined(&ctx),
+            Default::default(),
+        ));
+        steps.push(Step::Poll(1));
+        let script = Script {
+            seed: 0,
+            index: 1,
+            archetype: "canary_dup_join",
+            config_kind: ConfigKind::V3,
+            echo_room_ops: false,
+            small_command_capacity: None,
+            steps,
+        };
+        let outcome = run_prefix(&script, ProtocolViolationPolicy::Quarantine, usize::MAX);
+        if outcome.violations != 1 {
+            println!(
+                "canary_dup_join FAILED: expected 1 violation, got {}",
+                outcome.violations
+            );
+            failures = failures.saturating_add(1);
+        }
+        if outcome
+            .findings
+            .iter()
+            .any(|finding| finding.category == "oracle-snapshot")
+        {
+            println!(
+                "canary_dup_join oracle-snapshot noise: {:?}",
+                outcome.findings
+            );
+            failures = failures.saturating_add(1);
+        }
+    }
+
+    // Canary 3: Disconnect policy + second ProtocolInfo -> violation then Disconnected.
+    {
+        let mut steps = Vec::new();
+        steps.push(Step::Deliver(
+            gen::canary_authenticated(),
+            Default::default(),
+        ));
+        steps.push(Step::Poll(1));
+        let (info, info_meta) = gen::canary_protocol_info();
+        steps.push(Step::Deliver(info.clone(), info_meta));
+        steps.push(Step::Poll(1));
+        steps.push(Step::Deliver(info, info_meta));
+        steps.push(Step::Poll(1));
+        let script = Script {
+            seed: 0,
+            index: 2,
+            archetype: "canary_disconnect",
+            config_kind: ConfigKind::V3,
+            echo_room_ops: false,
+            small_command_capacity: None,
+            steps,
+        };
+        let outcome = run_prefix(&script, ProtocolViolationPolicy::Disconnect, usize::MAX);
+        if !outcome.terminal || !outcome.violation_teardown || outcome.violations != 1 {
+            println!(
+                "canary_disconnect FAILED: terminal={} violation_teardown={} violations={}",
+                outcome.terminal, outcome.violation_teardown, outcome.violations
+            );
+            failures = failures.saturating_add(1);
+        }
+    }
+
+    // Canary 4: PlayerJoined before ProtocolInfo must be refused.
+    {
+        let mut steps = Vec::new();
+        let ctx = Ctx::new_for_canary();
+        steps.push(Step::Deliver(
+            gen::canary_authenticated(),
+            Default::default(),
+        ));
+        steps.push(Step::Poll(1));
+        steps.push(Step::Deliver(
+            gen::canary_player_joined(&ctx),
+            Default::default(),
+        ));
+        steps.push(Step::Poll(1));
+        let script = Script {
+            seed: 0,
+            index: 3,
+            archetype: "canary_pre_negotiation",
+            config_kind: ConfigKind::V3,
+            echo_room_ops: false,
+            small_command_capacity: None,
+            steps,
+        };
+        let outcome = run_prefix(&script, ProtocolViolationPolicy::Quarantine, usize::MAX);
+        if outcome.violations != 1 {
+            println!(
+                "canary_pre_negotiation FAILED: expected lifecycle violation, got {}",
+                outcome.violations
+            );
+            failures = failures.saturating_add(1);
+        }
+    }
+
+    // Canary 5 (issue #219): a delivered Pong frame must leave exactly one
+    // pending expectation that its event satisfies — a silent batch leaves the
+    // slot unresolved (the swallow-detection path).
+    {
+        let mut oracle = crate::run::test_support::fresh_oracle(
+            ProtocolViolationPolicy::Quarantine,
+            ConfigKind::V3,
+            false,
+        );
+        let pong = signal_fish_client::protocol::ServerMessage::Pong;
+        let expected = oracle.expectation_for(&pong, &Default::default());
+        oracle
+            .slots
+            .push_back(crate::run::test_support::slot_with("Pong", expected));
+        let mut findings = Vec::new();
+        // The documented outcome: exactly one Pong event satisfies the slot.
+        oracle.reconcile_batch(&["Pong"], 0, 7, &mut findings);
+        if !findings.is_empty() || oracle.pending_slot_count() != 0 {
+            println!(
+                "canary_pong_outcome FAILED: findings={findings:?} pending={}",
+                oracle.pending_slot_count()
+            );
+            failures = failures.saturating_add(1);
+        }
+    }
+
+    // ── Direct-feed oracle-rejection canaries ────────────────────────
+    //
+    // Strict oracle: every synthetic known-bad stream must be REJECTED
+    // (verdict Err). The positive-control feeds inside canaries 8-12 assert
+    // the matching known-good variants are accepted.
+    let strict = run_direct_feed_canaries();
+    let mut strict_accepted: Vec<&str> = Vec::new();
+    for canary in &strict {
+        if canary.verdict.is_ok() {
+            strict_accepted.push(canary.name);
+        }
+    }
+    if !strict_accepted.is_empty() {
+        println!(
+            "oracle_direct_feed FAILED: strict oracle accepted known-bad streams: {strict_accepted:?}"
+        );
+        failures = failures.saturating_add(1);
+    }
+
+    // Broken-oracle sensitivity proof: neutering the oracle's rejection
+    // branches must flip at least one canary from "rejects" to "accepts".
+    set_oracle_neutered(true);
+    let broken = run_direct_feed_canaries();
+    set_oracle_neutered(false);
+    let caught: Vec<&str> = broken
+        .iter()
+        .filter(|canary| canary.verdict.is_ok())
+        .map(|canary| canary.name)
+        .collect();
+    if caught.is_empty() {
+        println!(
+            "broken_oracle_proof FAILED: the deliberately-broken oracle was not caught \
+             by any direct-feed canary"
+        );
+        failures = failures.saturating_add(1);
+    } else {
+        println!(
+            "broken_oracle_proof: neutered oracle caught by {} canary/ies: {caught:?}",
+            caught.len()
+        );
+    }
+
+    failures
+}

--- a/tools/stateful-campaign/src/canary.rs
+++ b/tools/stateful-campaign/src/canary.rs
@@ -311,6 +311,44 @@ fn run_direct_feed_canaries() -> Vec<DirectFeedVerdict> {
             }
             Err("strict oracle keeps the unresolved Pong slot pending (swallow detectable)".into())
         }),
+        // 13b. Game-data swallow: a fresh, valid, non-quarantined GameData
+        //      frame must surface its event; a silent batch must leave the
+        //      slot pending (the swallow is detectable end-of-run).
+        fed("expectation_swallowed_game_data", || {
+            let mut oracle = crate::run::test_support::fresh_oracle(
+                ProtocolViolationPolicy::Quarantine,
+                ConfigKind::V3,
+                false,
+            );
+            let (data, meta) = {
+                let mut ctx = Ctx::new_for_canary();
+                gen::canary_game_data(&mut ctx)
+            };
+            let expected = oracle.expectation_for(&data, &meta);
+            let requires_event = expected.len() == 1
+                && expected
+                    .first()
+                    .is_some_and(|outcome| !outcome.events.is_empty());
+            if !requires_event {
+                return Err("valid game data must require its event".into());
+            }
+            oracle
+                .slots
+                .push_back(crate::run::test_support::slot_with("GameData", expected));
+            let mut findings = Vec::new();
+            // The poll batch surfaced nothing (the swallow under test).
+            oracle.reconcile_batch(&[], 0, 0, &mut findings);
+            if !findings.is_empty() {
+                return Err("empty batch was misreported as a mismatch".into());
+            }
+            if oracle.pending_slot_count() != 1 {
+                return Err("pending GameData slot vanished without its event".into());
+            }
+            Err(
+                "strict oracle keeps the unresolved GameData slot pending (swallow detectable)"
+                    .into(),
+            )
+        }),
         // 14. Expectation fabrication: an event with no delivered frame must
         //     be reported; failing to report it accepts the bad stream.
         fed("expectation_fabricated_event", || {

--- a/tools/stateful-campaign/src/canary.rs
+++ b/tools/stateful-campaign/src/canary.rs
@@ -320,6 +320,13 @@ fn run_direct_feed_canaries() -> Vec<DirectFeedVerdict> {
                 ConfigKind::V3,
                 false,
             );
+            // Drive the oracle into the in-room, non-quarantined state via
+            // the same event sequence a clean journey produces, so the frame
+            // lands on the documented must-deliver path.
+            oracle.observe(&ev_connected())?;
+            oracle.observe(&ev_authenticated())?;
+            oracle.observe(&ev_protocol_info_v3())?;
+            oracle.observe(&ev_room_joined())?;
             let (data, meta) = {
                 let mut ctx = Ctx::new_for_canary();
                 gen::canary_game_data(&mut ctx)
@@ -330,7 +337,7 @@ fn run_direct_feed_canaries() -> Vec<DirectFeedVerdict> {
                     .first()
                     .is_some_and(|outcome| !outcome.events.is_empty());
             if !requires_event {
-                return Err("valid game data must require its event".into());
+                return Err("valid in-room game data must require its event".into());
             }
             oracle
                 .slots

--- a/tools/stateful-campaign/src/gen.rs
+++ b/tools/stateful-campaign/src/gen.rs
@@ -429,7 +429,7 @@ fn hostile_report(rng: &mut Rng, ctx: &Ctx) -> (ServerMessage, FrameMeta) {
     )
 }
 
-fn relay_stats(rng: &mut Rng, mode: u8) -> (ServerMessage, FrameMeta) {
+fn relay_stats(_rng: &mut Rng, mode: u8) -> (ServerMessage, FrameMeta) {
     // Modes 1 (zero interval) and 2 (interval change plus saturated counters)
     // are bound-breaking hostile faces; modes 0 and 3 are valid heartbeats.
     let bound_breaking = matches!(mode, 1 | 2);
@@ -443,7 +443,6 @@ fn relay_stats(rng: &mut Rng, mode: u8) -> (ServerMessage, FrameMeta) {
         3 => (5, 3, 1),
         _ => (10, 0, 0),
     };
-    let _ = rng;
     (
         ServerMessage::RelayStats {
             interval_ms,
@@ -733,14 +732,13 @@ fn gamedata_binary(
     )
 }
 
-fn player_left(rng: &mut Rng, who: PlayerId, mode: u8) -> (ServerMessage, FrameMeta) {
+fn player_left(_rng: &mut Rng, who: PlayerId, mode: u8) -> (ServerMessage, FrameMeta) {
     let (epoch, final_seq) = match mode {
         0 => (Some(2), Some(u64::MAX)),
         1 => (Some(1), Some(0)),
         2 => (None, None),
         _ => (Some(0), Some(0)),
     };
-    let _ = rng;
     (
         ServerMessage::PlayerLeft {
             player_id: who,
@@ -952,6 +950,13 @@ fn arch_journey(
             authority_changed(rng, ctx),
             FrameMeta::default(),
         );
+    }
+    if !v3 {
+        // The v2 stampless game-data face (its stamped variants are the
+        // hostile UnexpectedMetadata face exercised by the accountability
+        // archetype's v2 branch).
+        let (msg, meta) = game_data(rng, ctx, ctx.peer_a, StampMode::None);
+        deliver(&mut steps, msg, meta);
     }
 
     // Readiness + start.

--- a/tools/stateful-campaign/src/gen.rs
+++ b/tools/stateful-campaign/src/gen.rs
@@ -1,0 +1,1989 @@
+//! Scenario generator: deterministic, schema-valid hostile server-message
+//! sequences mixed with random client commands. Every delivered game-data
+//! frame carries [`FrameMeta`] so the expectation oracle can distinguish
+//! "documented suppression" from "silent swallow".
+
+use std::collections::HashMap;
+
+use signal_fish_client::protocol::{
+    DeliveryClass, DeliveryGap, DeliveryGapReason, DeliveryReportPayload, DirectEndpoint,
+    GameDataEncoding, IceServer, LatestDeliveryCounters, LobbyState, PeerConnectionInfo, PlayerId,
+    PlayerInfo, ProtocolInfoPayload, RateLimitInfo, ReliableDeliveryCounters, ReplayStatus, RoomId,
+    RoomJoinedPayload, SenderWatermark, ServerMessage, SessionPeer, SessionPlanPayload,
+    SpectatorInfo, SpectatorJoinedPayload, SpectatorStateChangeReason, Topology, TransportKind,
+    VolatileDeliveryCounters,
+};
+use signal_fish_client::ErrorCode;
+use uuid::Uuid;
+
+use crate::rng::Rng;
+use crate::script::{Cmd, ConfigKind, EchoId, EchoKind, FrameMeta, Script, StampMode, Step};
+
+pub const DELIVERY_REPORT_MAX_GAPS: usize = 256;
+
+pub struct Ctx {
+    pub self_id: PlayerId,
+    pub room_id: RoomId,
+    pub peer_a: PlayerId,
+    pub peer_b: PlayerId,
+    pub peer_c: PlayerId,
+    pub unknown: PlayerId,
+    pub spectator_a: PlayerId,
+    pub gen: [u128; 6],
+    pub room_code: String,
+    pub game_name: String,
+    pub sender_seq: HashMap<PlayerId, u64>,
+    pub sender_epoch: HashMap<PlayerId, u32>,
+}
+
+impl Ctx {
+    fn new(rng: &mut Rng) -> Self {
+        let n = |rng: &mut Rng, salt: u64| Uuid::from_u128(rng.uuid_u128() ^ u128::from(salt));
+        Self {
+            self_id: n(rng, 1),
+            room_id: n(rng, 2),
+            peer_a: n(rng, 3),
+            peer_b: n(rng, 4),
+            peer_c: n(rng, 5),
+            unknown: n(rng, 6),
+            spectator_a: n(rng, 7),
+            gen: [
+                rng.uuid_u128(),
+                rng.uuid_u128(),
+                rng.uuid_u128(),
+                rng.uuid_u128(),
+                rng.uuid_u128(),
+                rng.uuid_u128(),
+            ],
+            room_code: if rng.chance(10) {
+                String::new()
+            } else {
+                format!("R{}", rng.below(1_000_000))
+            },
+            game_name: if rng.chance(5) {
+                String::new()
+            } else {
+                "hostile-game".to_string()
+            },
+            sender_seq: HashMap::new(),
+            sender_epoch: HashMap::new(),
+        }
+    }
+
+    pub fn gen_uuid(&self, k: usize) -> Uuid {
+        let slot = k.checked_rem(self.gen.len()).unwrap_or(0);
+        Uuid::from_u128(self.gen.get(slot).copied().unwrap_or(self.gen[0]))
+    }
+
+    /// Next monotonic stamp for a sender (hostile variants mutate afterwards).
+    pub fn next_seq(&mut self, sender: PlayerId) -> u64 {
+        let next = self.sender_seq.entry(sender).or_insert(0);
+        *next = next.wrapping_add(1);
+        *next
+    }
+
+    pub fn epoch_of(&self, sender: PlayerId) -> u32 {
+        *self.sender_epoch.get(&sender).unwrap_or(&1)
+    }
+}
+
+fn player_info(
+    _ctx: &Ctx,
+    id: PlayerId,
+    name: &str,
+    epoch: Option<u32>,
+    seq: Option<u64>,
+) -> PlayerInfo {
+    PlayerInfo {
+        id,
+        name: name.to_string(),
+        is_authority: false,
+        is_ready: false,
+        connected_at: "2026-09-02T00:00:00Z".to_string(),
+        connection_info: None,
+        epoch,
+        seq,
+    }
+}
+
+fn spectator_info(id: PlayerId, name: &str) -> SpectatorInfo {
+    SpectatorInfo {
+        id,
+        name: name.to_string(),
+        connected_at: "2026-09-02T00:00:00Z".to_string(),
+    }
+}
+
+fn rate_limits(huge: bool) -> RateLimitInfo {
+    if huge {
+        RateLimitInfo {
+            per_minute: u64::MAX,
+            per_hour: u64::MAX,
+            per_day: u64::MAX,
+        }
+    } else {
+        RateLimitInfo {
+            per_minute: 60,
+            per_hour: 1000,
+            per_day: 10_000,
+        }
+    }
+}
+
+fn protocol_info(
+    rng: &mut Rng,
+    _ctx: &Ctx,
+    config: ConfigKind,
+    echo_room_ops: bool,
+    allow_bound_breaking: bool,
+) -> (ServerMessage, FrameMeta) {
+    let v3 = config.is_v3();
+    let mut capabilities: Vec<String> = Vec::new();
+    if v3 && echo_room_ops {
+        capabilities.push("room_operation_ids".to_string());
+    }
+    if rng.chance(15) {
+        capabilities.push("unknown_future_capability".to_string());
+    }
+    let v3_fields = v3.then_some(3u16);
+    // 10% of v3 negotiation frames advertise an outbound bound beyond the
+    // authority's validated range (a bound-breaking hostile face).
+    let bound_breaking = v3 && allow_bound_breaking && rng.below(10) == 9;
+    let max_outbound = if v3_fields.is_some() {
+        match bound_breaking {
+            true => usize::MAX,
+            false if rng.below(9) == 0 => 67_108_864, // authority bound maximum (valid)
+            false => 8 * 1024 * 1024,
+        }
+    } else {
+        // The v2 face must omit the field entirely (validated).
+        usize::MAX
+    };
+    let max_outbound = if v3_fields.is_some() {
+        Some(max_outbound)
+    } else {
+        None
+    };
+    (
+        ServerMessage::ProtocolInfo(ProtocolInfoPayload {
+            platform: rng.chance(50).then(|| "rust".to_string()),
+            sdk_version: rng.chance(50).then(|| "0.0.0-hostile".to_string()),
+            minimum_version: v3_fields.map(|_| "0.4.0".to_string()),
+            recommended_version: rng.chance(30).then(|| "0.8.0".to_string()),
+            capabilities,
+            notes: rng.chance(10).then(String::new),
+            game_data_formats: if rng.chance(20) {
+                vec![GameDataEncoding::Json]
+            } else {
+                vec![GameDataEncoding::Json, GameDataEncoding::MessagePack]
+            },
+            player_name_rules: rng.chance(20).then(|| {
+                signal_fish_client::protocol::PlayerNameRulesPayload {
+                    max_length: 32,
+                    min_length: 1,
+                    allow_unicode_alphanumeric: true,
+                    allow_spaces: false,
+                    allow_leading_trailing_whitespace: false,
+                    allowed_symbols: vec!["_".to_string()],
+                    additional_allowed_characters: None,
+                }
+            }),
+            protocol_version: v3_fields,
+            min_protocol_version: v3_fields.map(|_| 2),
+            max_protocol_version: v3_fields.map(|_| 3),
+            transports: v3_fields
+                .map(|_| vec![signal_fish_client::protocol::MessageTransport::Websocket]),
+            max_outbound_message_size: max_outbound,
+        }),
+        FrameMeta {
+            stamp: StampMode::None,
+            bound_breaking,
+        },
+    )
+}
+
+fn authenticated(rng: &mut Rng) -> ServerMessage {
+    ServerMessage::Authenticated {
+        app_name: if rng.chance(10) {
+            String::new()
+        } else {
+            "hostile-app".to_string()
+        },
+        organization: rng.chance(30).then(|| "org".to_string()),
+        rate_limits: rate_limits(rng.chance(10)),
+    }
+}
+
+fn room_joined(
+    rng: &mut Rng,
+    ctx: &Ctx,
+    roster: &[PlayerInfo],
+    max_players: u8,
+    with_token: bool,
+) -> ServerMessage {
+    ServerMessage::RoomJoined(Box::new(RoomJoinedPayload {
+        room_id: ctx.room_id,
+        room_code: ctx.room_code.clone(),
+        player_id: ctx.self_id,
+        game_name: ctx.game_name.clone(),
+        max_players,
+        supports_authority: rng.chance(60),
+        current_players: roster.to_vec(),
+        is_authority: rng.chance(30),
+        lobby_state: rng
+            .pick(&[
+                LobbyState::Waiting,
+                LobbyState::Lobby,
+                LobbyState::Finalized,
+            ])
+            .clone(),
+        ready_players: vec![],
+        relay_type: "websocket".to_string(),
+        current_spectators: vec![],
+        ice_servers: vec![],
+        reconnection_token: with_token.then(|| format!("tok-{}", ctx.gen[0])),
+    }))
+}
+
+fn game_data(
+    rng: &mut Rng,
+    ctx: &mut Ctx,
+    from: PlayerId,
+    mode: StampMode,
+) -> (ServerMessage, FrameMeta) {
+    let (seq, epoch) = match mode {
+        StampMode::Valid => {
+            let s = ctx.next_seq(from);
+            (Some(s), Some(ctx.epoch_of(from)))
+        }
+        StampMode::Stale => {
+            let s = ctx.sender_seq.entry(from).or_insert(2);
+            (Some(s.saturating_sub(1)), Some(ctx.epoch_of(from)))
+        }
+        StampMode::Zero => (Some(0), Some(0)),
+        StampMode::None => (None, None),
+    };
+    let class = match rng.below(4) {
+        0 => Some(DeliveryClass::Reliable),
+        1 => Some(DeliveryClass::Latest),
+        2 => Some(DeliveryClass::Volatile),
+        _ => None,
+    };
+    let key = if matches!(class, Some(DeliveryClass::Latest)) {
+        Some(rng.next_u64() as u32)
+    } else {
+        None
+    };
+    (
+        ServerMessage::GameData {
+            from_player: from,
+            data: hostile_json_value(rng),
+            seq,
+            epoch,
+            class,
+            key,
+        },
+        FrameMeta {
+            stamp: mode,
+            bound_breaking: false,
+        },
+    )
+}
+
+fn hostile_json_value(rng: &mut Rng) -> serde_json::Value {
+    match rng.below(6) {
+        0 => serde_json::json!({ "k": rng.next_u64() }),
+        1 => serde_json::json!([]),
+        2 => serde_json::json!({}),
+        3 => serde_json::json!(format!("huge-{}", u64::MAX)),
+        4 => serde_json::Value::Null,
+        _ => serde_json::json!({ "nested": { "deep": [1, 2, { "x": true }] } }),
+    }
+}
+
+fn counters_with_superseded(total: u64) -> signal_fish_client::protocol::DeliveryCountersByClass {
+    signal_fish_client::protocol::DeliveryCountersByClass {
+        reliable: ReliableDeliveryCounters::default(),
+        latest: LatestDeliveryCounters {
+            superseded: total,
+            ..LatestDeliveryCounters::default()
+        },
+        volatile: VolatileDeliveryCounters::default(),
+    }
+}
+
+fn singleton_gap(sender: PlayerId, epoch: u32, seq: u64, reason: DeliveryGapReason) -> DeliveryGap {
+    DeliveryGap {
+        from_player: sender,
+        epoch,
+        from_seq: seq,
+        to_seq: seq,
+        reason,
+    }
+}
+
+/// Consistent batch of 256 singleton gaps with matching cumulative counters.
+fn consistent_report(ctx: &Ctx, sender: PlayerId, batch: u64) -> ServerMessage {
+    let epoch = ctx.epoch_of(sender);
+    let gaps: Vec<DeliveryGap> = (0..DELIVERY_REPORT_MAX_GAPS)
+        .map(|i| {
+            let seq = batch
+                .saturating_sub(1)
+                .saturating_mul(DELIVERY_REPORT_MAX_GAPS as u64)
+                .saturating_add(i as u64)
+                .saturating_add(1);
+            singleton_gap(sender, epoch, seq, DeliveryGapReason::LatestSuperseded)
+        })
+        .collect();
+    ServerMessage::DeliveryReport(Box::new(DeliveryReportPayload {
+        gaps,
+        per_class: counters_with_superseded(batch.saturating_mul(DELIVERY_REPORT_MAX_GAPS as u64)),
+    }))
+}
+
+fn hostile_report(rng: &mut Rng, ctx: &Ctx) -> (ServerMessage, FrameMeta) {
+    let sender = *rng.pick(&[ctx.peer_a, ctx.peer_b, ctx.unknown]);
+    let epoch = ctx.epoch_of(sender);
+    // Modes 0, 1, 3, 4 are structurally invalid; mode 2 (an unsupported-format
+    // run) is validity-ambiguous, so it is not marked bound-breaking.
+    let (gaps, bound_breaking) = match rng.below(5) {
+        // Overlapping ranges.
+        0 => (
+            vec![
+                singleton_gap(sender, epoch, 5, DeliveryGapReason::LatestSuperseded),
+                singleton_gap(sender, epoch, 5, DeliveryGapReason::LatestSuperseded),
+                DeliveryGap {
+                    from_player: sender,
+                    epoch,
+                    from_seq: 10,
+                    to_seq: 20,
+                    reason: DeliveryGapReason::VolatileDropped,
+                },
+                DeliveryGap {
+                    from_player: sender,
+                    epoch,
+                    from_seq: 15,
+                    to_seq: 25,
+                    reason: DeliveryGapReason::VolatileDropped,
+                },
+            ],
+            true,
+        ),
+        // Reversed / miscounted ranges.
+        1 => (
+            vec![DeliveryGap {
+                from_player: sender,
+                epoch,
+                from_seq: 30,
+                to_seq: 10,
+                reason: DeliveryGapReason::LatestDroppedFull,
+            }],
+            true,
+        ),
+        // Unsupported-format ranges with a later (possibly legal) advisory.
+        2 => (
+            (0..8usize)
+                .map(|i| {
+                    singleton_gap(
+                        sender,
+                        epoch,
+                        (i as u64).saturating_add(1),
+                        DeliveryGapReason::UnsupportedFormat,
+                    )
+                })
+                .collect(),
+            false,
+        ),
+        // Wrong-sender / wrong-epoch gaps.
+        3 => (
+            vec![
+                singleton_gap(ctx.unknown, 999, 1, DeliveryGapReason::LatestSuperseded),
+                singleton_gap(sender, 0, 2, DeliveryGapReason::VolatileDropped),
+            ],
+            true,
+        ),
+        // Over the per-report cap.
+        _ => (
+            (0..=DELIVERY_REPORT_MAX_GAPS)
+                .map(|i| {
+                    singleton_gap(
+                        sender,
+                        epoch,
+                        (i as u64).saturating_add(1),
+                        DeliveryGapReason::LatestSuperseded,
+                    )
+                })
+                .collect(),
+            true,
+        ),
+    };
+    (
+        ServerMessage::DeliveryReport(Box::new(DeliveryReportPayload {
+            gaps,
+            per_class: counters_with_superseded(rng.next_u64().checked_rem(1000).unwrap_or(0)),
+        })),
+        FrameMeta {
+            stamp: StampMode::None,
+            bound_breaking,
+        },
+    )
+}
+
+fn relay_stats(rng: &mut Rng, mode: u8) -> (ServerMessage, FrameMeta) {
+    // Modes 1 (zero interval) and 2 (interval change plus saturated counters)
+    // are bound-breaking hostile faces; modes 0 and 3 are valid heartbeats.
+    let bound_breaking = matches!(mode, 1 | 2);
+    let interval_ms = match mode {
+        1 => 0,
+        2 => 2000,
+        _ => 1000,
+    };
+    let (sent, dropped, backpressure) = match mode {
+        2 => (u64::MAX, u64::MAX, u64::MAX),
+        3 => (5, 3, 1),
+        _ => (10, 0, 0),
+    };
+    let _ = rng;
+    (
+        ServerMessage::RelayStats {
+            interval_ms,
+            sent_to_you: sent,
+            dropped_for_you: dropped,
+            backpressure_events: backpressure,
+        },
+        FrameMeta {
+            stamp: StampMode::None,
+            bound_breaking,
+        },
+    )
+}
+
+const PAIRS: [(Topology, TransportKind); 4] = [
+    (Topology::Relay, TransportKind::Relay),
+    (Topology::Host, TransportKind::Direct),
+    (Topology::Host, TransportKind::WebRtc),
+    (Topology::Mesh, TransportKind::WebRtc),
+];
+
+fn session_plan(
+    rng: &mut Rng,
+    ctx: &Ctx,
+    generation: Option<Uuid>,
+    pair: usize,
+    peers: &[PlayerId],
+    zero_port: bool,
+) -> ServerMessage {
+    let slot = pair.checked_rem(PAIRS.len()).unwrap_or(0);
+    let (topology, transport) = PAIRS
+        .get(slot)
+        .copied()
+        .unwrap_or((Topology::Relay, TransportKind::Relay));
+    let host = matches!(topology, Topology::Host).then(|| *peers.first().unwrap_or(&ctx.peer_a));
+    let direct_endpoint = matches!(
+        (topology, transport),
+        (Topology::Host, TransportKind::Direct)
+    )
+    .then(|| DirectEndpoint {
+        host: "203.0.113.7".to_string(),
+        port: if zero_port { 0 } else { 27015 },
+    });
+    let ice = if matches!(transport, TransportKind::WebRtc) {
+        vec![IceServer {
+            urls: vec!["stun:stun.invalid:3478".to_string()],
+            username: None,
+            credential: None,
+        }]
+    } else {
+        Vec::new()
+    };
+    ServerMessage::SessionPlan(Box::new(SessionPlanPayload {
+        generation,
+        topology,
+        transport,
+        host,
+        direct_endpoint,
+        peers: peers
+            .iter()
+            .map(|id| SessionPeer {
+                player_id: *id,
+                player_name: format!("peer-{id}"),
+                is_authority: matches!(topology, Topology::Host) && Some(*id) == host,
+                initiate: rng.chance(50),
+            })
+            .collect(),
+        ice_servers: ice,
+        fallback: TransportKind::Relay,
+    }))
+}
+
+fn reconnected(
+    rng: &mut Rng,
+    ctx: &Ctx,
+    roster: &[PlayerInfo],
+    replay: Option<ReplayStatus>,
+    watermarks: bool,
+) -> ServerMessage {
+    ServerMessage::Reconnected(Box::new(signal_fish_client::protocol::ReconnectedPayload {
+        room_id: ctx.room_id,
+        room_code: ctx.room_code.clone(),
+        player_id: ctx.self_id,
+        game_name: ctx.game_name.clone(),
+        max_players: 8,
+        supports_authority: true,
+        current_players: roster.to_vec(),
+        is_authority: rng.chance(30),
+        lobby_state: LobbyState::Finalized,
+        ready_players: vec![],
+        relay_type: "websocket".to_string(),
+        current_spectators: vec![],
+        ice_servers: vec![],
+        missed_events: vec![
+            ServerMessage::Pong,
+            ServerMessage::Error {
+                message: "replayed".to_string(),
+                error_code: None,
+            },
+        ],
+        replay,
+        sender_watermarks: if watermarks {
+            roster
+                .iter()
+                .filter_map(|p| {
+                    p.epoch.map(|e| SenderWatermark {
+                        player_id: p.id,
+                        epoch: e,
+                        seq: p.seq.unwrap_or(0),
+                    })
+                })
+                .collect()
+        } else {
+            Vec::new()
+        },
+        reconnection_token: Some(format!("rotated-{}", ctx.gen[1])),
+    }))
+}
+
+fn spectator_joined(
+    rng: &mut Rng,
+    ctx: &Ctx,
+    spectator_id: PlayerId,
+    reason: Option<SpectatorStateChangeReason>,
+) -> ServerMessage {
+    ServerMessage::SpectatorJoined(Box::new(SpectatorJoinedPayload {
+        room_id: ctx.room_id,
+        room_code: ctx.room_code.clone(),
+        spectator_id,
+        game_name: ctx.game_name.clone(),
+        current_players: vec![player_info(ctx, ctx.self_id, "self", None, None)],
+        current_spectators: vec![spectator_info(spectator_id, "spec")],
+        lobby_state: rng.pick(&[LobbyState::Waiting, LobbyState::Lobby]).clone(),
+        reason,
+    }))
+}
+
+fn error_msg(rng: &mut Rng) -> ServerMessage {
+    let code = match rng.below(8) {
+        0 => Some(ErrorCode::InternalError),
+        1 => Some(ErrorCode::SlowConsumer),
+        2 => Some(ErrorCode::RateLimitExceeded),
+        3 => Some(ErrorCode::UnsupportedGameDataFormat),
+        4 => Some(ErrorCode::ConnectionIdleTimeout),
+        5 => None,
+        6 => Some(ErrorCode::ServerDraining),
+        _ => Some(ErrorCode::ActivityTimeout),
+    };
+    ServerMessage::Error {
+        message: if rng.chance(10) {
+            String::new()
+        } else {
+            "hostile error".to_string()
+        },
+        error_code: code,
+    }
+}
+
+fn going_away(rng: &mut Rng) -> ServerMessage {
+    ServerMessage::GoingAway {
+        deadline_ms: rng.next_u64(),
+        retry_after_secs: rng
+            .chance(50)
+            .then(|| rng.next_u64().checked_rem(3600).unwrap_or(0)),
+    }
+}
+
+fn lobby_changed(rng: &mut Rng, ctx: &Ctx) -> ServerMessage {
+    ServerMessage::LobbyStateChanged {
+        lobby_state: rng
+            .pick(&[
+                LobbyState::Waiting,
+                LobbyState::Lobby,
+                LobbyState::Finalized,
+            ])
+            .clone(),
+        ready_players: if rng.chance(50) {
+            vec![ctx.peer_a]
+        } else {
+            Vec::new()
+        },
+        all_ready: rng.chance(50),
+    }
+}
+
+fn game_starting(rng: &mut Rng, ctx: &Ctx) -> ServerMessage {
+    ServerMessage::GameStarting {
+        peer_connections: vec![PeerConnectionInfo {
+            player_id: ctx.peer_a,
+            player_name: "peer-a".to_string(),
+            is_authority: true,
+            relay_type: "websocket".to_string(),
+            connection_info: if rng.chance(50) {
+                Some(signal_fish_client::protocol::ConnectionInfo::Direct {
+                    host: "203.0.113.9".to_string(),
+                    port: 7777,
+                })
+            } else {
+                None
+            },
+        }],
+    }
+}
+
+fn authority_changed(rng: &mut Rng, ctx: &Ctx) -> ServerMessage {
+    ServerMessage::AuthorityChanged {
+        authority_player: if rng.chance(30) {
+            None
+        } else {
+            Some(ctx.self_id)
+        },
+        you_are_authority: rng.chance(50),
+    }
+}
+
+fn authority_response(rng: &mut Rng) -> ServerMessage {
+    ServerMessage::AuthorityResponse {
+        granted: rng.chance(50),
+        reason: rng.chance(50).then(|| "hostile".to_string()),
+        error_code: None,
+    }
+}
+
+fn signal_from(
+    _rng: &mut Rng,
+    _ctx: &Ctx,
+    from: PlayerId,
+    generation: Option<Uuid>,
+) -> ServerMessage {
+    ServerMessage::Signal {
+        from,
+        generation,
+        signal: serde_json::json!({ "Offer": format!("v=0 host {}", from) }),
+    }
+}
+
+fn new_peer(rng: &mut Rng, ctx: &Ctx) -> ServerMessage {
+    ServerMessage::NewPeer {
+        peer_id: *rng.pick(&[ctx.peer_b, ctx.peer_c, ctx.unknown]),
+        you_initiate: rng.chance(50),
+    }
+}
+
+fn peer_transport_status(rng: &mut Rng, ctx: &Ctx) -> ServerMessage {
+    ServerMessage::PeerTransportStatus {
+        peer_id: *rng.pick(&[ctx.peer_a, ctx.peer_b]),
+        transport: *rng.pick(&[
+            TransportKind::Relay,
+            TransportKind::Direct,
+            TransportKind::WebRtc,
+        ]),
+        connected: rng.chance(50),
+    }
+}
+
+fn gamedata_binary(
+    rng: &mut Rng,
+    ctx: &mut Ctx,
+    from: PlayerId,
+    mode: StampMode,
+) -> (ServerMessage, FrameMeta) {
+    let len = 1usize.saturating_add(rng.below(64));
+    let payload: Vec<u8> = (0..len)
+        .map(|_| rng.next_u64().checked_rem(256).unwrap_or(0) as u8)
+        .collect();
+    let (seq, epoch) = match mode {
+        StampMode::Valid => {
+            let s = ctx.next_seq(from);
+            (Some(s), Some(ctx.epoch_of(from)))
+        }
+        StampMode::Stale => (Some(1), Some(1)),
+        StampMode::Zero => (Some(0), Some(0)),
+        StampMode::None => (None, None),
+    };
+    (
+        ServerMessage::GameDataBinary {
+            from_player: from,
+            encoding: *rng.pick(&[GameDataEncoding::MessagePack, GameDataEncoding::Json]),
+            payload,
+            seq,
+            epoch,
+        },
+        FrameMeta {
+            stamp: mode,
+            bound_breaking: false,
+        },
+    )
+}
+
+fn player_left(rng: &mut Rng, who: PlayerId, mode: u8) -> (ServerMessage, FrameMeta) {
+    let (epoch, final_seq) = match mode {
+        0 => (Some(2), Some(u64::MAX)),
+        1 => (Some(1), Some(0)),
+        2 => (None, None),
+        _ => (Some(0), Some(0)),
+    };
+    let _ = rng;
+    (
+        ServerMessage::PlayerLeft {
+            player_id: who,
+            epoch,
+            final_seq,
+        },
+        FrameMeta {
+            stamp: StampMode::None,
+            bound_breaking: false,
+        },
+    )
+}
+
+// ── Physical v3 MessagePack envelope (hand-built, no rmp dep) ────────
+
+/// Hand-build a canonical protocol-v3 MessagePack binary envelope.
+pub fn v3_binary_envelope(from: [u8; 16], payload: &[u8], seq: u64, epoch: u32) -> Vec<u8> {
+    fn fixstr(out: &mut Vec<u8>, s: &str) {
+        // Callers pass static keys shorter than 16 bytes.
+        out.push(0xA0 | s.len() as u8);
+        out.extend_from_slice(s.as_bytes());
+    }
+    fn bin8(out: &mut Vec<u8>, bytes: &[u8]) {
+        out.push(0xC4);
+        out.push(bytes.len() as u8);
+        out.extend_from_slice(bytes);
+    }
+    fn uint(out: &mut Vec<u8>, v: u64) {
+        if v < 128 {
+            out.push(v as u8);
+        } else if v <= u64::from(u8::MAX) {
+            out.push(0xCC);
+            out.push(v as u8);
+        } else if v <= u64::from(u16::MAX) {
+            out.push(0xCD);
+            out.extend_from_slice(&(v as u16).to_be_bytes());
+        } else if v <= u64::from(u32::MAX) {
+            out.push(0xCE);
+            out.extend_from_slice(&(v as u32).to_be_bytes());
+        } else {
+            out.push(0xCF);
+            out.extend_from_slice(&v.to_be_bytes());
+        }
+    }
+    let mut out = Vec::new();
+    out.push(0x85); // fixmap, 5 fields
+    fixstr(&mut out, "from_player");
+    bin8(&mut out, &from);
+    fixstr(&mut out, "encoding");
+    fixstr(&mut out, "message_pack");
+    fixstr(&mut out, "payload");
+    bin8(&mut out, payload);
+    fixstr(&mut out, "seq");
+    uint(&mut out, seq);
+    fixstr(&mut out, "epoch");
+    uint(&mut out, u64::from(epoch));
+    out
+}
+
+// ── Raw (schema-invalid) fixtures ───────────────────────────────────
+
+pub const RAW_UNKNOWN_TYPE: &str = r#"{"type":"TotallyUnknown","data":{}}"#;
+pub const RAW_UNKNOWN_ERROR_CODE: &str =
+    r#"{"type":"Error","data":{"message":"m","error_code":"NOT_A_REAL_CODE_4242"}}"#;
+pub const RAW_NOT_JSON: &str = "not json at all";
+pub const RAW_BAD_SHAPE: &str = r#"{"type":"PlayerJoined","data":{"player":"nope"}}"#;
+pub const RAW_NEGATIVE_U64: &str = r#"{"type":"RelayStats","data":{"interval_ms":-5,"sent_to_you":0,"dropped_for_you":0,"backpressure_events":0}}"#;
+pub const RAW_OVERLIMIT_STRING: &str = r#"{"type":"Authenticated","data":{"app_name":1,"rate_limits":{"per_minute":1,"per_hour":2,"per_day":3}}}"#;
+
+// ── Command menu ────────────────────────────────────────────────────
+
+pub fn random_cmd(rng: &mut Rng, ctx: &Ctx) -> Cmd {
+    match rng.below(17) {
+        0 => Cmd::JoinRoom,
+        1 => Cmd::JoinRoomMax(1usize.saturating_add(rng.below(8)) as u8),
+        2 => Cmd::LeaveRoom,
+        3 => Cmd::SendGameData(hostile_json_value(rng)),
+        4 => Cmd::SendGameDataLatest(rng.next_u64() as u32),
+        5 => Cmd::SendGameDataVolatile,
+        6 => Cmd::SendBinaryGameData(1usize.saturating_add(rng.below(128))),
+        7 => Cmd::SetReady,
+        8 => Cmd::StartGame,
+        9 => Cmd::RequestAuthority(rng.chance(50)),
+        10 => Cmd::ProvideConnectionInfo,
+        11 => Cmd::Reconnect(ctx.self_id, ctx.room_id),
+        12 => Cmd::JoinAsSpectator,
+        13 => Cmd::LeaveSpectator,
+        14 => Cmd::Ping,
+        15 if rng.chance(50) => Cmd::SendSignal,
+        15 => Cmd::SendRawSignal,
+        _ => Cmd::ReportTransportStatus,
+    }
+}
+
+/// Sprinkle a hostile raw frame with low probability.
+fn maybe_raw(rng: &mut Rng, steps: &mut Vec<Step>) {
+    if rng.chance(4) {
+        steps.push(Step::DeliverRaw(rng.pick(&[
+            RAW_UNKNOWN_TYPE,
+            RAW_UNKNOWN_ERROR_CODE,
+            RAW_NOT_JSON,
+            RAW_BAD_SHAPE,
+            RAW_NEGATIVE_U64,
+            RAW_OVERLIMIT_STRING,
+        ])));
+        steps.push(Step::Poll(1));
+    }
+}
+
+/// One random command + poll with some probability.
+fn maybe_cmd(rng: &mut Rng, ctx: &Ctx, steps: &mut Vec<Step>, percent: u64) {
+    if rng.chance(percent) {
+        steps.push(Step::Cmd(random_cmd(rng, ctx)));
+        steps.push(Step::Poll(1));
+    }
+}
+
+fn deliver(steps: &mut Vec<Step>, msg: ServerMessage, meta: FrameMeta) {
+    steps.push(Step::Deliver(msg, meta));
+    steps.push(Step::Poll(1));
+}
+
+/// Shared prologue: Authenticated → ProtocolInfo.
+fn prologue(
+    rng: &mut Rng,
+    ctx: &Ctx,
+    config: ConfigKind,
+    echo_room_ops: bool,
+    steps: &mut Vec<Step>,
+) {
+    prologue_with(rng, ctx, config, echo_room_ops, true, steps);
+}
+
+/// Prologue with controllable negotiation hostility: the send-pressure
+/// archetype needs a completed negotiation, so it disables the
+/// bound-breaking face.
+fn prologue_with(
+    rng: &mut Rng,
+    ctx: &Ctx,
+    config: ConfigKind,
+    echo_room_ops: bool,
+    allow_bound_breaking: bool,
+    steps: &mut Vec<Step>,
+) {
+    deliver(steps, authenticated(rng), FrameMeta::default());
+    let (info, meta) = protocol_info(rng, ctx, config, echo_room_ops, allow_bound_breaking);
+    deliver(steps, info, meta);
+}
+
+/// Join flow matching the negotiated envelope mode.
+fn join_flow(rng: &mut Rng, ctx: &Ctx, echo_room_ops: bool, steps: &mut Vec<Step>) {
+    if echo_room_ops && rng.chance(80) {
+        steps.push(Step::Cmd(Cmd::JoinRoom));
+        steps.push(Step::Poll(1));
+        let kind = if rng.chance(85) {
+            EchoKind::JoinOk
+        } else {
+            EchoKind::JoinFailed
+        };
+        let id = if rng.chance(85) {
+            EchoId::Match
+        } else {
+            EchoId::Wrong
+        };
+        steps.push(Step::DeliverEcho(kind, id));
+        steps.push(Step::Poll(1));
+    } else {
+        steps.push(Step::Cmd(Cmd::JoinRoom));
+        steps.push(Step::Poll(1));
+        deliver(
+            steps,
+            room_joined(rng, ctx, &[player_info_placeholder(ctx)], 8, true),
+            FrameMeta::default(),
+        );
+    }
+}
+
+fn player_info_placeholder(ctx: &Ctx) -> PlayerInfo {
+    player_info(ctx, ctx.self_id, "self", Some(1), Some(0))
+}
+
+// ── Archetypes ──────────────────────────────────────────────────────
+
+fn arch_journey(
+    rng: &mut Rng,
+    ctx: &mut Ctx,
+    config: ConfigKind,
+    echo_room_ops: bool,
+) -> Vec<Step> {
+    let mut steps = Vec::new();
+    let v3 = config.is_v3();
+    prologue(rng, ctx, config, echo_room_ops, &mut steps);
+    join_flow(rng, ctx, echo_room_ops, &mut steps);
+
+    // Roster churn.
+    for peer in [ctx.peer_a, ctx.peer_b] {
+        deliver(
+            &mut steps,
+            ServerMessage::PlayerJoined {
+                player: player_info(ctx, peer, "peer", Some(1), Some(0)),
+            },
+            FrameMeta::default(),
+        );
+    }
+    deliver(&mut steps, lobby_changed(rng, ctx), FrameMeta::default());
+    if rng.chance(50) {
+        deliver(
+            &mut steps,
+            authority_changed(rng, ctx),
+            FrameMeta::default(),
+        );
+    }
+
+    // Readiness + start.
+    steps.push(Step::Cmd(Cmd::SetReady));
+    steps.push(Step::Poll(1));
+    deliver(&mut steps, lobby_changed(rng, ctx), FrameMeta::default());
+    steps.push(Step::Cmd(Cmd::StartGame));
+    steps.push(Step::Poll(1));
+    deliver(&mut steps, game_starting(rng, ctx), FrameMeta::default());
+
+    if v3 {
+        // Authoritative plan churn: fresh gen, duplicate, replay.
+        let g0 = ctx.gen_uuid(0);
+        deliver(
+            &mut steps,
+            session_plan(rng, ctx, Some(g0), 0, &[ctx.peer_a, ctx.peer_b], false),
+            FrameMeta::default(),
+        );
+        deliver(
+            &mut steps,
+            session_plan(rng, ctx, Some(g0), 0, &[ctx.peer_a, ctx.peer_b], false),
+            FrameMeta::default(),
+        );
+        let g1 = ctx.gen_uuid(1);
+        deliver(
+            &mut steps,
+            session_plan(rng, ctx, Some(g1), 3, &[ctx.peer_a, ctx.peer_b], false),
+            FrameMeta::default(),
+        );
+        deliver(
+            &mut steps,
+            signal_from(rng, ctx, ctx.peer_a, Some(g1)),
+            FrameMeta::default(),
+        );
+        deliver(
+            &mut steps,
+            signal_from(rng, ctx, ctx.peer_a, Some(g0)),
+            FrameMeta::default(),
+        );
+        deliver(
+            &mut steps,
+            signal_from(rng, ctx, ctx.self_id, Some(g1)),
+            FrameMeta::default(),
+        );
+        deliver(
+            &mut steps,
+            signal_from(rng, ctx, ctx.unknown, None),
+            FrameMeta::default(),
+        );
+        deliver(&mut steps, new_peer(rng, ctx), FrameMeta::default());
+        deliver(
+            &mut steps,
+            peer_transport_status(rng, ctx),
+            FrameMeta::default(),
+        );
+        // Stamped game data + reports + relay stats.
+        for _ in 0..4usize.saturating_add(rng.below(8)) {
+            let (msg, meta) = game_data(rng, ctx, ctx.peer_a, StampMode::Valid);
+            deliver(&mut steps, msg, meta);
+            if rng.chance(30) {
+                let (stale, stale_meta) = game_data(rng, ctx, ctx.peer_a, StampMode::Stale);
+                deliver(&mut steps, stale, stale_meta);
+            }
+        }
+        // Physically valid v3 binary envelopes (real binary-frame face).
+        for _ in 0..2usize.saturating_add(rng.below(3)) {
+            let seq = ctx.next_seq(ctx.peer_a);
+            let env = v3_binary_envelope(ctx.peer_a.into_bytes(), b"hostile-payload", seq, 1);
+            steps.push(Step::DeliverBinary(
+                env,
+                FrameMeta {
+                    stamp: StampMode::Valid,
+                    bound_breaking: false,
+                },
+            ));
+            steps.push(Step::Poll(1));
+        }
+        // Text-delivered GameDataBinary frames (representation mismatch by design).
+        let (gb1, gb1_meta) = gamedata_binary(rng, ctx, ctx.peer_a, StampMode::Valid);
+        deliver(&mut steps, gb1, gb1_meta);
+        let (gb2, gb2_meta) = gamedata_binary(rng, ctx, ctx.peer_a, StampMode::Zero);
+        deliver(&mut steps, gb2, gb2_meta);
+        deliver(
+            &mut steps,
+            consistent_report(ctx, ctx.peer_a, 1),
+            FrameMeta::default(),
+        );
+        let (rs0, rs0_meta) = relay_stats(rng, 0);
+        deliver(&mut steps, rs0, rs0_meta);
+        let (rs3, rs3_meta) = relay_stats(rng, 3);
+        deliver(&mut steps, rs3, rs3_meta);
+        if rng.chance(30) {
+            let (rs2, rs2_meta) = relay_stats(rng, 2);
+            deliver(&mut steps, rs2, rs2_meta);
+        }
+        deliver(&mut steps, going_away(rng), FrameMeta::default());
+        // Server shutdown advisory is best-effort; the structured close follows.
+        steps.push(Step::PeerClose);
+        steps.push(Step::Poll(2));
+    }
+
+    maybe_cmd(rng, ctx, &mut steps, 40);
+    maybe_raw(rng, &mut steps);
+
+    // Reconnect journey tail: leave, reconnect echo, then plan refresh.
+    deliver(&mut steps, ServerMessage::RoomLeft, FrameMeta::default());
+    steps.push(Step::Cmd(Cmd::Reconnect(ctx.self_id, ctx.room_id)));
+    steps.push(Step::Poll(1));
+    if echo_room_ops && rng.chance(60) {
+        let kind = if rng.chance(70) {
+            EchoKind::ReconnectOk
+        } else {
+            EchoKind::ReconnectFailed
+        };
+        steps.push(Step::DeliverEcho(kind, EchoId::Match));
+        steps.push(Step::Poll(1));
+    } else {
+        deliver(
+            &mut steps,
+            reconnected(
+                rng,
+                ctx,
+                &[
+                    player_info_placeholder(ctx),
+                    player_info(ctx, ctx.peer_a, "a", Some(1), Some(0)),
+                ],
+                Some(ReplayStatus::Complete),
+                v3,
+            ),
+            FrameMeta::default(),
+        );
+        if v3 {
+            deliver(
+                &mut steps,
+                session_plan(rng, ctx, Some(ctx.gen_uuid(2)), 0, &[ctx.peer_a], false),
+                FrameMeta::default(),
+            );
+        }
+    }
+
+    deliver(&mut steps, ServerMessage::Pong, FrameMeta::default());
+    maybe_cmd(rng, ctx, &mut steps, 30);
+    steps.push(Step::Close);
+    steps
+}
+
+fn arch_roster_storm(
+    rng: &mut Rng,
+    ctx: &mut Ctx,
+    config: ConfigKind,
+    echo_room_ops: bool,
+) -> Vec<Step> {
+    let mut steps = Vec::new();
+    let v3 = config.is_v3();
+    prologue(rng, ctx, config, echo_room_ops, &mut steps);
+    join_flow(rng, ctx, echo_room_ops, &mut steps);
+
+    // Roster overflow: baseline self + several beyond max_players=2.
+    for i in 0..8u32 {
+        deliver(
+            &mut steps,
+            ServerMessage::PlayerJoined {
+                player: player_info(
+                    ctx,
+                    Uuid::from_u128(u128::from(0xA000_u32).wrapping_add(u128::from(i))),
+                    "storm",
+                    Some(1),
+                    Some(0),
+                ),
+            },
+            // Beyond-capacity inserts are bound-breaking for i > small values;
+            // the oracle treats roster inserts as validity-ambiguous anyway.
+            FrameMeta::default(),
+        );
+        maybe_cmd(rng, ctx, &mut steps, 8);
+    }
+    // Reconnect-epoch announcement flood for one sender (>16 distinct).
+    let sender = ctx.peer_a;
+    for epoch in 2..=24u32 {
+        deliver(
+            &mut steps,
+            ServerMessage::PlayerReconnected {
+                player_id: sender,
+                epoch: Some(epoch),
+            },
+            FrameMeta::default(),
+        );
+    }
+    // Departure churn (issue #166 uncoverable-departure flood).
+    if v3 {
+        for epoch in 2..=20u32 {
+            deliver(
+                &mut steps,
+                ServerMessage::PlayerLeft {
+                    player_id: sender,
+                    epoch: Some(epoch),
+                    final_seq: Some(u64::MAX),
+                },
+                FrameMeta::default(),
+            );
+        }
+    } else {
+        for _ in 0..12 {
+            let (msg, meta) = player_left(rng, sender, 2);
+            deliver(&mut steps, msg, meta);
+        }
+    }
+    // Unknown-player reconnect flood (trusted-server envelope, still bounded).
+    for epoch in 1..=24u32 {
+        deliver(
+            &mut steps,
+            ServerMessage::PlayerReconnected {
+                player_id: ctx.unknown,
+                epoch: Some(epoch),
+            },
+            FrameMeta::default(),
+        );
+    }
+    maybe_raw(rng, &mut steps);
+    if rng.chance(50) {
+        steps.push(Step::PeerClose);
+        steps.push(Step::Poll(2));
+    } else {
+        steps.push(Step::Close);
+    }
+    steps
+}
+
+fn arch_accountability(
+    rng: &mut Rng,
+    ctx: &mut Ctx,
+    config: ConfigKind,
+    echo_room_ops: bool,
+) -> Vec<Step> {
+    let mut steps = Vec::new();
+    let v3 = config.is_v3();
+    prologue(rng, ctx, config, echo_room_ops, &mut steps);
+    join_flow(rng, ctx, echo_room_ops, &mut steps);
+    deliver(
+        &mut steps,
+        ServerMessage::PlayerJoined {
+            player: player_info(ctx, ctx.peer_a, "a", Some(1), Some(0)),
+        },
+        FrameMeta::default(),
+    );
+
+    if v3 {
+        // Stamp chaos.
+        for i in 0..12usize.saturating_add(rng.below(12)) {
+            let mode = match i.checked_rem(5).unwrap_or(0) {
+                0 => StampMode::Valid,
+                1 => StampMode::Stale,
+                2 => StampMode::Zero,
+                3 => StampMode::None,
+                _ => StampMode::Valid,
+            };
+            let (msg, meta) = game_data(rng, ctx, ctx.peer_a, mode);
+            deliver(&mut steps, msg, meta);
+        }
+        // Physically valid v3 binary envelopes with mixed stamps.
+        for i in 0..4u64 {
+            let seq = ctx.next_seq(ctx.peer_a);
+            let epoch = if i.checked_rem(2).unwrap_or(1) == 0 {
+                1
+            } else {
+                9
+            };
+            let env = v3_binary_envelope(
+                ctx.peer_a.into_bytes(),
+                format!("payload-{i}").as_bytes(),
+                if i == 3 { 1 } else { seq },
+                epoch,
+            );
+            let replayed = i == 3;
+            steps.push(Step::DeliverBinary(
+                env,
+                FrameMeta {
+                    stamp: if replayed {
+                        StampMode::Stale
+                    } else {
+                        StampMode::Valid
+                    },
+                    bound_breaking: false,
+                },
+            ));
+            steps.push(Step::Poll(1));
+        }
+        // Text-delivered GameDataBinary (representation mismatch by design).
+        for _ in 0..4 {
+            let mode = if rng.chance(50) {
+                StampMode::Valid
+            } else {
+                StampMode::Zero
+            };
+            let (msg, meta) = gamedata_binary(rng, ctx, ctx.peer_a, mode);
+            deliver(&mut steps, msg, meta);
+        }
+        // Six consistent 256-gap batches saturate the 1024 retention bound
+        // (4 batches would not reach it; the sixth forces the eviction face).
+        for batch in 1..=6u64 {
+            deliver(
+                &mut steps,
+                consistent_report(ctx, ctx.peer_a, batch),
+                FrameMeta::default(),
+            );
+            maybe_cmd(rng, ctx, &mut steps, 5);
+        }
+        // Hostile report zoo.
+        for _ in 0..6usize.saturating_add(rng.below(6)) {
+            let (msg, meta) = hostile_report(rng, ctx);
+            deliver(&mut steps, msg, meta);
+        }
+        // Unsupported-format advisory causality.
+        deliver(&mut steps, error_msg(rng), FrameMeta::default());
+        deliver(&mut steps, error_msg(rng), FrameMeta::default());
+        deliver(
+            &mut steps,
+            consistent_report(ctx, ctx.peer_a, 7),
+            FrameMeta::default(),
+        );
+        deliver(&mut steps, error_msg(rng), FrameMeta::default());
+        // RelayStats invariant attacks.
+        let (rs0, rs0_meta) = relay_stats(rng, 0);
+        deliver(&mut steps, rs0, rs0_meta);
+        let (rs2, rs2_meta) = relay_stats(rng, 2);
+        deliver(&mut steps, rs2, rs2_meta);
+        let (rs3, rs3_meta) = relay_stats(rng, 3);
+        deliver(&mut steps, rs3, rs3_meta);
+        let (rs1, rs1_meta) = relay_stats(rng, 1);
+        deliver(&mut steps, rs1, rs1_meta);
+    } else {
+        // v2 exposure of v3-only metadata.
+        for _ in 0..6 {
+            let (msg, meta) = player_left(rng, ctx.peer_a, 0);
+            deliver(&mut steps, msg, meta);
+        }
+        let (rs0, rs0_meta) = relay_stats(rng, 0);
+        deliver(&mut steps, rs0, rs0_meta);
+        deliver(
+            &mut steps,
+            consistent_report(ctx, ctx.peer_a, 1),
+            FrameMeta::default(),
+        );
+    }
+    maybe_raw(rng, &mut steps);
+    steps.push(Step::Close);
+    steps
+}
+
+fn arch_spectator_churn(
+    rng: &mut Rng,
+    ctx: &mut Ctx,
+    config: ConfigKind,
+    echo_room_ops: bool,
+) -> Vec<Step> {
+    let mut steps = Vec::new();
+    prologue(rng, ctx, config, echo_room_ops, &mut steps);
+    steps.push(Step::Cmd(Cmd::JoinAsSpectator));
+    steps.push(Step::Poll(1));
+    if echo_room_ops && rng.chance(70) {
+        let kind = if rng.chance(80) {
+            EchoKind::SpectatorJoinOk
+        } else {
+            EchoKind::SpectatorJoinFailed
+        };
+        let id = if rng.chance(85) {
+            EchoId::Match
+        } else {
+            EchoId::Wrong
+        };
+        steps.push(Step::DeliverEcho(kind, id));
+        steps.push(Step::Poll(1));
+    } else {
+        deliver(
+            &mut steps,
+            spectator_joined(rng, ctx, ctx.spectator_a, None),
+            FrameMeta::default(),
+        );
+    }
+
+    // Spectator churn storms.
+    for i in 0..20usize.saturating_add(rng.below(20)) {
+        match rng.below(5) {
+            0 => deliver(
+                &mut steps,
+                ServerMessage::NewSpectatorJoined {
+                    spectator: spectator_info(
+                        Uuid::from_u128(u128::from(0xB000_u32).wrapping_add(u128::from(i as u32))),
+                        "spec",
+                    ),
+                    current_spectators: vec![],
+                    reason: Some(SpectatorStateChangeReason::Joined),
+                },
+                FrameMeta::default(),
+            ),
+            1 => deliver(
+                &mut steps,
+                ServerMessage::SpectatorDisconnected {
+                    spectator_id: Uuid::from_u128(
+                        u128::from(0xB000_u32).wrapping_add(u128::from(i as u32)),
+                    ),
+                    reason: Some(SpectatorStateChangeReason::Disconnected),
+                    current_spectators: vec![],
+                },
+                FrameMeta::default(),
+            ),
+            2 => deliver(
+                &mut steps,
+                ServerMessage::SpectatorJoinFailed {
+                    reason: "full".to_string(),
+                    error_code: Some(ErrorCode::TooManySpectators),
+                },
+                FrameMeta::default(),
+            ),
+            3 => deliver(
+                &mut steps,
+                spectator_joined(
+                    rng,
+                    ctx,
+                    ctx.spectator_a,
+                    Some(SpectatorStateChangeReason::Joined),
+                ),
+                FrameMeta::default(),
+            ),
+            _ => {
+                steps.push(Step::Cmd(Cmd::Ping));
+                steps.push(Step::Poll(1));
+                deliver(&mut steps, ServerMessage::Pong, FrameMeta::default());
+            }
+        }
+    }
+    // Authoritative exit then a late voluntary-leave echo (the absorbed-race face).
+    deliver(
+        &mut steps,
+        ServerMessage::SpectatorLeft {
+            room_id: Some(ctx.room_id),
+            room_code: Some(ctx.room_code.clone()),
+            reason: Some(SpectatorStateChangeReason::Removed),
+            current_spectators: vec![],
+        },
+        FrameMeta::default(),
+    );
+    steps.push(Step::Cmd(Cmd::LeaveSpectator));
+    steps.push(Step::Poll(1));
+    let late_id = if rng.chance(50) {
+        EchoId::Match
+    } else {
+        EchoId::Wrong
+    };
+    steps.push(Step::DeliverEcho(EchoKind::SpectatorLeaveOk, late_id));
+    steps.push(Step::Poll(1));
+    // Rejoin as spectator, then authoritative room-closed exit.
+    steps.push(Step::Cmd(Cmd::JoinAsSpectator));
+    steps.push(Step::Poll(1));
+    deliver(
+        &mut steps,
+        spectator_joined(
+            rng,
+            ctx,
+            ctx.spectator_a,
+            Some(SpectatorStateChangeReason::Joined),
+        ),
+        FrameMeta::default(),
+    );
+    deliver(
+        &mut steps,
+        ServerMessage::SpectatorLeft {
+            room_id: Some(ctx.room_id),
+            room_code: Some(ctx.room_code.clone()),
+            reason: Some(SpectatorStateChangeReason::RoomClosed),
+            current_spectators: vec![],
+        },
+        FrameMeta::default(),
+    );
+    maybe_raw(rng, &mut steps);
+    steps.push(Step::Close);
+    steps
+}
+
+fn arch_plan_churn(
+    rng: &mut Rng,
+    ctx: &mut Ctx,
+    config: ConfigKind,
+    echo_room_ops: bool,
+) -> Vec<Step> {
+    let mut steps = Vec::new();
+    let v3 = config.is_v3();
+    prologue(rng, ctx, config, echo_room_ops, &mut steps);
+    join_flow(rng, ctx, echo_room_ops, &mut steps);
+    deliver(
+        &mut steps,
+        ServerMessage::PlayerJoined {
+            player: player_info(ctx, ctx.peer_a, "a", Some(1), Some(0)),
+        },
+        FrameMeta::default(),
+    );
+    steps.push(Step::Cmd(Cmd::SetReady));
+    steps.push(Step::Poll(1));
+    steps.push(Step::Cmd(Cmd::StartGame));
+    steps.push(Step::Poll(1));
+    deliver(&mut steps, game_starting(rng, ctx), FrameMeta::default());
+
+    if v3 {
+        // All four topology/transport pairs with fresh generations.
+        for pair in 0..4usize {
+            deliver(
+                &mut steps,
+                session_plan(
+                    rng,
+                    ctx,
+                    Some(ctx.gen_uuid(pair)),
+                    pair,
+                    &[ctx.peer_a],
+                    false,
+                ),
+                FrameMeta::default(),
+            );
+            deliver(
+                &mut steps,
+                signal_from(rng, ctx, ctx.peer_a, Some(ctx.gen_uuid(pair))),
+                FrameMeta::default(),
+            );
+            maybe_cmd(rng, ctx, &mut steps, 15);
+        }
+        // Generation-less legacy plan.
+        deliver(
+            &mut steps,
+            session_plan(rng, ctx, None, 0, &[ctx.peer_a], false),
+            FrameMeta::default(),
+        );
+        deliver(
+            &mut steps,
+            signal_from(rng, ctx, ctx.peer_a, None),
+            FrameMeta::default(),
+        );
+        // Unknown generation.
+        deliver(
+            &mut steps,
+            session_plan(
+                rng,
+                ctx,
+                Some(Uuid::from_u128(0xDEAD_BEEF)),
+                3,
+                &[ctx.peer_a, ctx.peer_b],
+                false,
+            ),
+            FrameMeta::default(),
+        );
+        // Replay the fenced generation (older than the current one).
+        deliver(
+            &mut steps,
+            session_plan(rng, ctx, Some(ctx.gen_uuid(0)), 0, &[ctx.peer_a], false),
+            FrameMeta::default(),
+        );
+        // Zero-port direct endpoint (hostile lifecycle).
+        deliver(
+            &mut steps,
+            session_plan(rng, ctx, Some(ctx.gen_uuid(5)), 1, &[ctx.peer_a], true),
+            FrameMeta::default(),
+        );
+        // Plan naming an absent host + empty peers.
+        deliver(
+            &mut steps,
+            session_plan(rng, ctx, Some(ctx.gen_uuid(4)), 3, &[], false),
+            FrameMeta::default(),
+        );
+        // Signals from self / unknown / stale.
+        deliver(
+            &mut steps,
+            signal_from(rng, ctx, ctx.self_id, Some(ctx.gen_uuid(4))),
+            FrameMeta::default(),
+        );
+        deliver(
+            &mut steps,
+            signal_from(rng, ctx, ctx.unknown, Some(ctx.gen_uuid(4))),
+            FrameMeta::default(),
+        );
+        deliver(
+            &mut steps,
+            signal_from(rng, ctx, ctx.peer_a, Some(ctx.gen_uuid(0))),
+            FrameMeta::default(),
+        );
+        deliver(&mut steps, new_peer(rng, ctx), FrameMeta::default());
+        deliver(
+            &mut steps,
+            peer_transport_status(rng, ctx),
+            FrameMeta::default(),
+        );
+    }
+    maybe_raw(rng, &mut steps);
+    steps.push(Step::Close);
+    steps
+}
+
+fn arch_raw_frames(
+    rng: &mut Rng,
+    ctx: &mut Ctx,
+    config: ConfigKind,
+    echo_room_ops: bool,
+) -> Vec<Step> {
+    let mut steps = Vec::new();
+    prologue(rng, ctx, config, echo_room_ops, &mut steps);
+    for _ in 0..24usize.saturating_add(rng.below(24)) {
+        maybe_raw(rng, &mut steps);
+        match rng.below(6) {
+            0 => deliver(&mut steps, ServerMessage::Pong, FrameMeta::default()),
+            1 => deliver(&mut steps, error_msg(rng), FrameMeta::default()),
+            2 => deliver(
+                &mut steps,
+                room_joined(rng, ctx, &[player_info_placeholder(ctx)], 4, false),
+                FrameMeta::default(),
+            ),
+            3 => deliver(
+                &mut steps,
+                ServerMessage::RoomJoinFailed {
+                    reason: "hostile".to_string(),
+                    error_code: Some(ErrorCode::RoomNotFound),
+                },
+                FrameMeta::default(),
+            ),
+            4 => deliver(
+                &mut steps,
+                ServerMessage::AuthenticationError {
+                    error: "hostile".to_string(),
+                    error_code: ErrorCode::Unauthorized,
+                },
+                FrameMeta::default(),
+            ),
+            _ => deliver(&mut steps, authority_response(rng), FrameMeta::default()),
+        }
+        maybe_cmd(rng, ctx, &mut steps, 25);
+    }
+    steps.push(Step::Close);
+    steps
+}
+
+fn arch_command_storm(
+    rng: &mut Rng,
+    ctx: &mut Ctx,
+    config: ConfigKind,
+    echo_room_ops: bool,
+) -> Vec<Step> {
+    let mut steps = Vec::new();
+    prologue(rng, ctx, config, echo_room_ops, &mut steps);
+    if rng.chance(70) {
+        join_flow(rng, ctx, echo_room_ops, &mut steps);
+    }
+    for _ in 0..60usize.saturating_add(rng.below(80)) {
+        steps.push(Step::Cmd(random_cmd(rng, ctx)));
+        steps.push(Step::Poll(1));
+        if rng.chance(25) {
+            let candidates = vec![
+                ServerMessage::Pong,
+                error_msg(rng),
+                lobby_changed(rng, ctx),
+                authority_response(rng),
+                authority_changed(rng, ctx),
+                ServerMessage::RoomLeft,
+                ServerMessage::RoomJoinFailed {
+                    reason: "x".into(),
+                    error_code: None,
+                },
+                ServerMessage::SpectatorJoinFailed {
+                    reason: "x".into(),
+                    error_code: None,
+                },
+                ServerMessage::ReconnectionFailed {
+                    reason: "x".into(),
+                    error_code: ErrorCode::ReconnectionTokenInvalid,
+                },
+                going_away(rng),
+            ];
+            let pick = rng.below(candidates.len());
+            let chosen = candidates
+                .into_iter()
+                .nth(pick)
+                .unwrap_or(ServerMessage::Pong);
+            deliver(&mut steps, chosen, FrameMeta::default());
+        }
+        if rng.chance(10) {
+            if rng.below(2) == 0 {
+                deliver(
+                    &mut steps,
+                    spectator_joined(rng, ctx, ctx.spectator_a, None),
+                    FrameMeta::default(),
+                );
+            } else {
+                deliver(
+                    &mut steps,
+                    reconnected(rng, ctx, &[player_info_placeholder(ctx)], None, false),
+                    FrameMeta::default(),
+                );
+            }
+        }
+    }
+    steps.push(Step::Close);
+    steps
+}
+
+fn arch_echo_zoo(
+    rng: &mut Rng,
+    ctx: &mut Ctx,
+    config: ConfigKind,
+    echo_room_ops: bool,
+) -> Vec<Step> {
+    let mut steps = Vec::new();
+    prologue(rng, ctx, config, echo_room_ops, &mut steps);
+    // Cycle through every echo kind with both id choices, issuing the matching
+    // command first where the state machine plausibly allows it.
+    let cycle: [(Cmd, EchoKind); 9] = [
+        (Cmd::JoinRoom, EchoKind::JoinOk),
+        (Cmd::JoinRoom, EchoKind::JoinFailed),
+        (Cmd::LeaveRoom, EchoKind::LeaveOk),
+        (
+            Cmd::Reconnect(ctx.self_id, ctx.room_id),
+            EchoKind::ReconnectOk,
+        ),
+        (
+            Cmd::Reconnect(ctx.self_id, ctx.room_id),
+            EchoKind::ReconnectFailed,
+        ),
+        (Cmd::JoinAsSpectator, EchoKind::SpectatorJoinOk),
+        (Cmd::JoinAsSpectator, EchoKind::SpectatorJoinFailed),
+        (Cmd::LeaveSpectator, EchoKind::SpectatorLeaveOk),
+        (Cmd::JoinRoom, EchoKind::OperationFailed),
+    ];
+    for (cmd, kind) in cycle {
+        steps.push(Step::Cmd(cmd));
+        steps.push(Step::Poll(1));
+        let id = if rng.chance(70) {
+            EchoId::Match
+        } else {
+            EchoId::Wrong
+        };
+        steps.push(Step::DeliverEcho(kind, id));
+        steps.push(Step::Poll(2));
+        maybe_cmd(rng, ctx, &mut steps, 20);
+    }
+    // Correlated results without any pending operation (lifecycle offenders).
+    for _ in 0..4 {
+        steps.push(Step::DeliverEcho(EchoKind::OperationFailed, EchoId::Wrong));
+        steps.push(Step::Poll(1));
+    }
+    // Duplicate current answer.
+    steps.push(Step::Cmd(Cmd::Ping));
+    steps.push(Step::Poll(1));
+    deliver(&mut steps, ServerMessage::Pong, FrameMeta::default());
+    maybe_raw(rng, &mut steps);
+    steps.push(Step::Close);
+    steps
+}
+
+/// Terminal-transport-error archetype: a random prefix of normal frames, then
+/// the transport turns hostile with a terminal `poll_recv` error (and sometimes
+/// a terminal `poll_send` error). Asserts the documented terminal behavior:
+/// transition to terminal state, exact `Disconnected` cause, refusal of later
+/// commands, idempotent `close()`, no hang.
+fn arch_transport_kill(
+    rng: &mut Rng,
+    ctx: &mut Ctx,
+    config: ConfigKind,
+    echo_room_ops: bool,
+) -> Vec<Step> {
+    let mut steps = Vec::new();
+    prologue(rng, ctx, config, echo_room_ops, &mut steps);
+    // Normal, phase-legal frames regardless of membership (post-auth menu).
+    for _ in 0..3usize.saturating_add(rng.below(6)) {
+        match rng.below(4) {
+            0 => deliver(&mut steps, ServerMessage::Pong, FrameMeta::default()),
+            1 => deliver(&mut steps, error_msg(rng), FrameMeta::default()),
+            2 => deliver(&mut steps, authority_response(rng), FrameMeta::default()),
+            _ => {
+                let (msg, meta) = relay_stats(rng, 0);
+                deliver(&mut steps, msg, meta)
+            }
+        }
+        maybe_cmd(rng, ctx, &mut steps, 10);
+    }
+    // The kill: terminal recv error always; terminal send error sometimes.
+    let (fail_recv, fail_send) = match rng.below(3) {
+        0 => (true, false),
+        1 => (false, true),
+        _ => (true, true),
+    };
+    steps.push(Step::TransportKill {
+        fail_recv,
+        fail_send,
+    });
+    steps.push(Step::Poll(3));
+    // Post-terminal commands must be refused, never hang, never emit events.
+    steps.push(Step::Cmd(Cmd::Ping));
+    steps.push(Step::Cmd(Cmd::SendGameData(
+        serde_json::json!({ "post": "terminal" }),
+    )));
+    steps.push(Step::Cmd(Cmd::JoinRoom));
+    steps.push(Step::Poll(2));
+    // close() must be idempotent and silent after a terminal transport error.
+    steps.push(Step::Close);
+    steps
+}
+
+/// Send-side budget/pacing archetype (issue #219): fill a small command queue,
+/// arm the transport's `Pending`-refusal face, then drain — asserting FIFO
+/// delivery, capacity accounting, and the send ledger.
+fn arch_send_pressure(rng: &mut Rng, ctx: &mut Ctx, config: ConfigKind) -> Vec<Step> {
+    let mut steps = Vec::new();
+    // Correlation stays off, the baseline omits the v3 reconnection token,
+    // and negotiation stays valid, so the join completes under every
+    // configuration; the archetype targets the send path.
+    prologue_with(rng, ctx, config, false, false, &mut steps);
+    steps.push(Step::Cmd(Cmd::JoinRoom));
+    steps.push(Step::Poll(1));
+    // v3 baselines carry paired stamps; v2 snapshots must omit them. The
+    // local authority flag must agree with the roster entry so the join
+    // always completes — the archetype targets the send path.
+    let roster = vec![if config.is_v3() {
+        player_info_placeholder(ctx)
+    } else {
+        player_info(ctx, ctx.self_id, "self", None, None)
+    }];
+    let baseline = room_joined(rng, ctx, &roster, 8, false);
+    let baseline = match baseline {
+        ServerMessage::RoomJoined(mut payload) => {
+            payload.is_authority = false;
+            if let Some(local) = payload
+                .current_players
+                .iter_mut()
+                .find(|player| player.id == payload.player_id)
+            {
+                local.is_authority = false;
+            }
+            ServerMessage::RoomJoined(payload)
+        }
+        other => other,
+    };
+    deliver(&mut steps, baseline, FrameMeta::default());
+    // Fill the (small) command queue past capacity: later sends must be
+    // refused gracefully while earlier ones stay queued in order.
+    for k in 0..96u32 {
+        steps.push(Step::Cmd(Cmd::SendGameData(
+            serde_json::json!({ "marker": k }),
+        )));
+    }
+    // Arm the send-delay face: every frame is refused with `Pending` twice
+    // before acceptance, so flushing takes multiple polls per frame.
+    steps.push(Step::SetSendDelay(2));
+    // Interleave drains with more sends (capacity frees up mid-drain).
+    for wave in 0..3u32 {
+        steps.push(Step::Poll(64));
+        for k in 0..8u32 {
+            let marker = 1000u32.wrapping_add(wave.wrapping_mul(100)).wrapping_add(k);
+            steps.push(Step::Cmd(Cmd::SendGameData(
+                serde_json::json!({ "marker": marker }),
+            )));
+            if rng.chance(20) {
+                steps.push(Step::Cmd(Cmd::SendBinaryGameData(
+                    1usize.saturating_add(rng.below(64)),
+                )));
+            }
+        }
+    }
+    // Full drain: everything accepted must reach the outbound log exactly once.
+    steps.push(Step::Poll(1024));
+    deliver(&mut steps, ServerMessage::Pong, FrameMeta::default());
+    deliver(&mut steps, ServerMessage::Pong, FrameMeta::default());
+    steps.push(Step::Close);
+    steps
+}
+
+pub fn generate_script(seed: u64, index: usize) -> Script {
+    let mut rng =
+        Rng::new(seed.rotate_left(17) ^ (index as u64).wrapping_mul(0x517C_C1B7_2722_0A95));
+    let ctx_seed = rng.next_u64();
+    let mut ctx = Ctx::new(&mut Rng::new(ctx_seed));
+    let archetype_index = index % 12;
+    let (archetype, config_kind, echo_room_ops) = match archetype_index {
+        0 | 1 => ("journey", pick_config(&mut rng), rng.chance(75)),
+        2 | 3 => ("roster_storm", pick_config(&mut rng), rng.chance(40)),
+        4 => ("accountability", pick_config(&mut rng), rng.chance(40)),
+        5 => ("spectator_churn", pick_config(&mut rng), rng.chance(70)),
+        6 => ("plan_churn", ConfigKind::V3, rng.chance(70)),
+        7 => ("raw_frames", pick_config(&mut rng), rng.chance(50)),
+        8 => ("command_storm", pick_config(&mut rng), rng.chance(50)),
+        9 => ("echo_zoo", pick_config(&mut rng), rng.chance(80)),
+        10 => ("transport_kill", pick_config(&mut rng), rng.chance(60)),
+        _ => ("send_pressure", pick_config(&mut rng), false),
+    };
+    let (steps, small_command_capacity) = match archetype {
+        "journey" => (
+            arch_journey(&mut rng, &mut ctx, config_kind, echo_room_ops),
+            None,
+        ),
+        "roster_storm" => (
+            arch_roster_storm(&mut rng, &mut ctx, config_kind, echo_room_ops),
+            None,
+        ),
+        "accountability" => (
+            arch_accountability(&mut rng, &mut ctx, config_kind, echo_room_ops),
+            None,
+        ),
+        "spectator_churn" => (
+            arch_spectator_churn(&mut rng, &mut ctx, config_kind, echo_room_ops),
+            None,
+        ),
+        "plan_churn" => (
+            arch_plan_churn(&mut rng, &mut ctx, config_kind, echo_room_ops),
+            None,
+        ),
+        "raw_frames" => (
+            arch_raw_frames(&mut rng, &mut ctx, config_kind, echo_room_ops),
+            None,
+        ),
+        "command_storm" => (
+            arch_command_storm(&mut rng, &mut ctx, config_kind, echo_room_ops),
+            None,
+        ),
+        "echo_zoo" => (
+            arch_echo_zoo(&mut rng, &mut ctx, config_kind, echo_room_ops),
+            None,
+        ),
+        "transport_kill" => (
+            arch_transport_kill(&mut rng, &mut ctx, config_kind, echo_room_ops),
+            None,
+        ),
+        _ => (
+            arch_send_pressure(&mut rng, &mut ctx, config_kind),
+            Some(64usize),
+        ),
+    };
+    Script {
+        seed,
+        index,
+        archetype,
+        config_kind,
+        echo_room_ops,
+        small_command_capacity,
+        steps,
+    }
+}
+
+fn pick_config(rng: &mut Rng) -> ConfigKind {
+    match rng.below(8) {
+        0..=3 => ConfigKind::V3,
+        4 => ConfigKind::V3VersionOnly,
+        5 | 6 => ConfigKind::V2,
+        _ => ConfigKind::V2Explicit,
+    }
+}
+
+// ── Canary fixtures (deterministic, for oracle self-tests) ──────────
+
+impl Ctx {
+    pub fn new_for_canary() -> Ctx {
+        let mut rng = Rng::new(0xC0DEC0DE);
+        Ctx::new(&mut rng)
+    }
+}
+
+pub fn canary_authenticated() -> ServerMessage {
+    ServerMessage::Authenticated {
+        app_name: "canary".into(),
+        organization: None,
+        rate_limits: RateLimitInfo {
+            per_minute: 1,
+            per_hour: 2,
+            per_day: 3,
+        },
+    }
+}
+
+pub fn canary_protocol_info() -> (ServerMessage, FrameMeta) {
+    (
+        ServerMessage::ProtocolInfo(ProtocolInfoPayload {
+            platform: None,
+            sdk_version: None,
+            minimum_version: Some("0.4.0".into()),
+            recommended_version: None,
+            capabilities: vec![],
+            notes: None,
+            game_data_formats: vec![GameDataEncoding::Json, GameDataEncoding::MessagePack],
+            player_name_rules: None,
+            protocol_version: Some(3),
+            min_protocol_version: Some(2),
+            max_protocol_version: Some(3),
+            transports: Some(vec![
+                signal_fish_client::protocol::MessageTransport::Websocket,
+            ]),
+            max_outbound_message_size: Some(8 * 1024 * 1024),
+        }),
+        FrameMeta::default(),
+    )
+}
+
+pub fn canary_room_joined(ctx: &Ctx) -> ServerMessage {
+    ServerMessage::RoomJoined(Box::new(RoomJoinedPayload {
+        room_id: ctx.room_id,
+        room_code: ctx.room_code.clone(),
+        player_id: ctx.self_id,
+        game_name: ctx.game_name.clone(),
+        max_players: 4,
+        supports_authority: false,
+        current_players: vec![player_info(ctx, ctx.self_id, "self", Some(1), Some(0))],
+        is_authority: false,
+        lobby_state: LobbyState::Waiting,
+        ready_players: vec![],
+        relay_type: "websocket".into(),
+        current_spectators: vec![],
+        ice_servers: vec![],
+        reconnection_token: None,
+    }))
+}
+
+pub fn canary_player_joined(ctx: &Ctx) -> ServerMessage {
+    ServerMessage::PlayerJoined {
+        player: player_info(ctx, ctx.peer_a, "peer-a", Some(1), Some(0)),
+    }
+}
+
+pub fn canary_game_data(ctx: &mut Ctx) -> (ServerMessage, FrameMeta) {
+    let seq = ctx.next_seq(ctx.peer_a);
+    (
+        ServerMessage::GameData {
+            from_player: ctx.peer_a,
+            data: serde_json::json!({ "canary": true }),
+            seq: Some(seq),
+            epoch: Some(1),
+            class: Some(DeliveryClass::Reliable),
+            key: None,
+        },
+        FrameMeta {
+            stamp: StampMode::Valid,
+            bound_breaking: false,
+        },
+    )
+}

--- a/tools/stateful-campaign/src/gen.rs
+++ b/tools/stateful-campaign/src/gen.rs
@@ -1410,7 +1410,11 @@ fn arch_spectator_churn(
             }
         }
     }
-    // Authoritative exit then a late voluntary-leave echo (the absorbed-race face).
+    // The absorbed-race face: an admitted voluntary leave is pending when
+    // the authoritative exit overtakes it, so exactly one matching late
+    // reply is silently absorbed.
+    steps.push(Step::Cmd(Cmd::LeaveSpectator));
+    steps.push(Step::Poll(1));
     deliver(
         &mut steps,
         ServerMessage::SpectatorLeft {
@@ -1421,14 +1425,7 @@ fn arch_spectator_churn(
         },
         FrameMeta::default(),
     );
-    steps.push(Step::Cmd(Cmd::LeaveSpectator));
-    steps.push(Step::Poll(1));
-    let late_id = if rng.chance(50) {
-        EchoId::Match
-    } else {
-        EchoId::Wrong
-    };
-    steps.push(Step::DeliverEcho(EchoKind::SpectatorLeaveOk, late_id));
+    steps.push(Step::DeliverEcho(EchoKind::SpectatorLeaveOk, EchoId::Match));
     steps.push(Step::Poll(1));
     // Rejoin as spectator, then authoritative room-closed exit.
     steps.push(Step::Cmd(Cmd::JoinAsSpectator));
@@ -1815,16 +1812,18 @@ fn arch_send_pressure(rng: &mut Rng, ctx: &mut Ctx, config: ConfigKind) -> Vec<S
         other => other,
     };
     deliver(&mut steps, baseline, FrameMeta::default());
-    // Fill the (small) command queue past capacity: later sends must be
-    // refused gracefully while earlier ones stay queued in order.
+    // Arm the send-delay face FIRST: every frame is refused with `Pending`
+    // twice before acceptance, so the per-command polls cannot drain the
+    // queue and the 96-send storm genuinely overflows the 64-slot capacity.
+    steps.push(Step::SetSendDelay(6));
     for k in 0..96u32 {
         steps.push(Step::Cmd(Cmd::SendGameData(
             serde_json::json!({ "marker": k }),
         )));
     }
-    // Arm the send-delay face: every frame is refused with `Pending` twice
-    // before acceptance, so flushing takes multiple polls per frame.
-    steps.push(Step::SetSendDelay(2));
+    // Release the delay so the final bounded drain can complete; the wave
+    // sends below still flush through the (now direct) transport.
+    steps.push(Step::SetSendDelay(0));
     // Interleave drains with more sends (capacity frees up mid-drain).
     for wave in 0..3u32 {
         steps.push(Step::Poll(64));

--- a/tools/stateful-campaign/src/gen.rs
+++ b/tools/stateful-campaign/src/gen.rs
@@ -889,7 +889,13 @@ fn prologue_with(
 }
 
 /// Join flow matching the negotiated envelope mode.
-fn join_flow(rng: &mut Rng, ctx: &Ctx, echo_room_ops: bool, steps: &mut Vec<Step>) {
+fn join_flow(
+    rng: &mut Rng,
+    ctx: &Ctx,
+    config: ConfigKind,
+    echo_room_ops: bool,
+    steps: &mut Vec<Step>,
+) {
     if echo_room_ops && rng.chance(80) {
         steps.push(Step::Cmd(Cmd::JoinRoom));
         steps.push(Step::Poll(1));
@@ -908,9 +914,25 @@ fn join_flow(rng: &mut Rng, ctx: &Ctx, echo_room_ops: bool, steps: &mut Vec<Step
     } else {
         steps.push(Step::Cmd(Cmd::JoinRoom));
         steps.push(Step::Poll(1));
+        // v3 baselines always carry a token (valid there) and paired roster
+        // stamps; v2 baselines alternate between the token/stamp hostile
+        // face (always a violation) and a valid, stampless baseline so the
+        // v2 in-room faces stay reachable.
+        // v3 baselines carry a token and paired roster stamps (valid); v2
+        // baselines alternate between the token/stamp hostile face (always a
+        // violation) and a valid, stampless baseline so the v2 in-room faces
+        // stay reachable.
+        let (with_token, roster) = if config.is_v3() || rng.chance(50) {
+            (true, vec![player_info_placeholder(ctx)])
+        } else {
+            (
+                false,
+                vec![player_info(ctx, ctx.self_id, "self", None, None)],
+            )
+        };
         deliver(
             steps,
-            room_joined(rng, ctx, &[player_info_placeholder(ctx)], 8, true),
+            room_joined(rng, ctx, &roster, 8, with_token),
             FrameMeta::default(),
         );
     }
@@ -931,7 +953,7 @@ fn arch_journey(
     let mut steps = Vec::new();
     let v3 = config.is_v3();
     prologue(rng, ctx, config, echo_room_ops, &mut steps);
-    join_flow(rng, ctx, echo_room_ops, &mut steps);
+    join_flow(rng, ctx, config, echo_room_ops, &mut steps);
 
     // Roster churn.
     for peer in [ctx.peer_a, ctx.peer_b] {
@@ -1112,7 +1134,7 @@ fn arch_roster_storm(
     let mut steps = Vec::new();
     let v3 = config.is_v3();
     prologue(rng, ctx, config, echo_room_ops, &mut steps);
-    join_flow(rng, ctx, echo_room_ops, &mut steps);
+    join_flow(rng, ctx, config, echo_room_ops, &mut steps);
 
     // Roster overflow: baseline self + several beyond max_players=2.
     for i in 0..8u32 {
@@ -1194,7 +1216,7 @@ fn arch_accountability(
     let mut steps = Vec::new();
     let v3 = config.is_v3();
     prologue(rng, ctx, config, echo_room_ops, &mut steps);
-    join_flow(rng, ctx, echo_room_ops, &mut steps);
+    join_flow(rng, ctx, config, echo_room_ops, &mut steps);
     deliver(
         &mut steps,
         ServerMessage::PlayerJoined {
@@ -1445,7 +1467,7 @@ fn arch_plan_churn(
     let mut steps = Vec::new();
     let v3 = config.is_v3();
     prologue(rng, ctx, config, echo_room_ops, &mut steps);
-    join_flow(rng, ctx, echo_room_ops, &mut steps);
+    join_flow(rng, ctx, config, echo_room_ops, &mut steps);
     deliver(
         &mut steps,
         ServerMessage::PlayerJoined {
@@ -1602,7 +1624,7 @@ fn arch_command_storm(
     let mut steps = Vec::new();
     prologue(rng, ctx, config, echo_room_ops, &mut steps);
     if rng.chance(70) {
-        join_flow(rng, ctx, echo_room_ops, &mut steps);
+        join_flow(rng, ctx, config, echo_room_ops, &mut steps);
     }
     for _ in 0..60usize.saturating_add(rng.below(80)) {
         steps.push(Step::Cmd(random_cmd(rng, ctx)));

--- a/tools/stateful-campaign/src/lib.rs
+++ b/tools/stateful-campaign/src/lib.rs
@@ -1,0 +1,74 @@
+//! Deterministic stateful randomized (model-based) hostility campaign
+//! against the Signal Fish polling driver + shared `ClientCore`.
+//!
+//! Every finding reproduces from `(seed, script index, policy)`. The crate is
+//! a workspace member so the mandatory clippy/test gates cover it; the binary
+//! drives long campaigns from CI and the library exposes canaries and a
+//! reduced smoke campaign as unit tests.
+
+pub mod canary;
+pub mod gen;
+pub mod rng;
+pub mod run;
+pub mod script;
+pub mod soak;
+pub mod transport;
+
+#[cfg(test)]
+mod tests {
+    use super::canary;
+    use super::gen::generate_script;
+    use super::run::run_script;
+    use signal_fish_client::client::ProtocolViolationPolicy;
+
+    const ALL_POLICIES: [ProtocolViolationPolicy; 3] = [
+        ProtocolViolationPolicy::Quarantine,
+        ProtocolViolationPolicy::Observe,
+        ProtocolViolationPolicy::Disconnect,
+    ];
+
+    #[test]
+    fn oracle_canaries_pass() {
+        assert_eq!(
+            canary::selftest(),
+            0,
+            "oracle canaries detect known-good and known-bad streams"
+        );
+    }
+
+    #[test]
+    fn smoke_campaign_is_clean() {
+        // Deterministic reduced campaign: 2 seeds x 12 scripts x 3 policies.
+        for seed in 1..=2u64 {
+            for index in 0..12usize {
+                let script = generate_script(seed, index);
+                for policy in ALL_POLICIES {
+                    let outcome = run_script(&script, policy);
+                    let details = outcome.as_ref().err().map(|failure| {
+                        failure
+                            .findings
+                            .iter()
+                            .map(|finding| format!("{}: {}", finding.category, finding.detail))
+                            .collect::<Vec<String>>()
+                    });
+                    assert!(
+                        outcome.is_ok(),
+                        "seed={seed} script={index} archetype={} policy={policy:?}: {details:?}",
+                        script.archetype
+                    );
+                    if let Ok(outcome) = outcome {
+                        assert!(
+                            outcome.frames_fed > 0,
+                            "seed={seed} script={index} fed no frames"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn soak_probe_is_clean() {
+        assert_eq!(super::soak::soak_probe(), 0, "long-horizon churn probe");
+    }
+}

--- a/tools/stateful-campaign/src/main.rs
+++ b/tools/stateful-campaign/src/main.rs
@@ -176,6 +176,15 @@ fn main() -> std::process::ExitCode {
     }
 }
 
+/// One-letter policy prefix used by the `--repro` CLI argument.
+fn policy_prefix(policy: ProtocolViolationPolicy) -> &'static str {
+    match policy {
+        ProtocolViolationPolicy::Quarantine => "Q",
+        ProtocolViolationPolicy::Observe => "O",
+        ProtocolViolationPolicy::Disconnect => "D",
+    }
+}
+
 fn format_failure(
     script: &Script,
     policy: ProtocolViolationPolicy,
@@ -197,10 +206,12 @@ fn format_failure(
         ));
     }
     out.push_str(&format!(
-        "  reduced failing prefix: {} of {} steps (repro: --seeds 1 --start-seed {})\n",
+        "  reduced failing prefix: {} of {} steps (repro: --repro {} {} {}:<PREFIX>)\n",
         failure.prefix_len,
         script.steps.len(),
-        script.seed
+        script.seed,
+        script.index,
+        policy_prefix(policy)
     ));
     out.push_str("  steps:\n");
     out.push_str(&render_prefix(script, failure.prefix_len, 60));

--- a/tools/stateful-campaign/src/main.rs
+++ b/tools/stateful-campaign/src/main.rs
@@ -1,0 +1,373 @@
+//! Campaign CLI: drives deterministic hostility campaigns and diagnostics.
+//!
+//! Modes:
+//! - default: seeds × scripts × policies campaign with a budget watchdog
+//! - `--selftest`: oracle canaries (known-good/known-bad sensitivity)
+//! - `--soak`: long-horizon churn probe
+//! - `--repro SEED SCRIPT POLICY[:PREFIX]`: verbose single-script replay
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+use signal_fish_client::client::ProtocolViolationPolicy;
+
+use signal_fish_client_stateful_campaign::run::{
+    render_prefix, run_prefix_verbose, run_script, set_oracle_neutered, ReducedFailure,
+    CURRENT_LABEL, DELIVERED, HEARTBEAT,
+};
+use signal_fish_client_stateful_campaign::script::Script;
+use signal_fish_client_stateful_campaign::transport::lock;
+use signal_fish_client_stateful_campaign::{canary, gen, soak};
+
+const ALL_POLICIES: [ProtocolViolationPolicy; 3] = [
+    ProtocolViolationPolicy::Quarantine,
+    ProtocolViolationPolicy::Observe,
+    ProtocolViolationPolicy::Disconnect,
+];
+
+struct Stats {
+    sequences: u64,
+    frames: u64,
+    events: u64,
+    commands: u64,
+    refused: u64,
+    violations: u64,
+    failures: u64,
+}
+
+static TOTAL_FRAMES: AtomicU64 = AtomicU64::new(0);
+
+fn main() -> std::process::ExitCode {
+    let mut seeds = 24u64;
+    let mut scripts_per_seed = 30usize;
+    let mut start_seed = 1u64;
+    let mut budget_secs = 570u64;
+    let mut args = std::env::args().skip(1);
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--seeds" => {
+                seeds = args.next().and_then(|v| v.parse().ok()).unwrap_or(seeds);
+            }
+            "--scripts" => {
+                scripts_per_seed = args
+                    .next()
+                    .and_then(|v| v.parse().ok())
+                    .unwrap_or(scripts_per_seed);
+            }
+            "--start-seed" => {
+                start_seed = args
+                    .next()
+                    .and_then(|v| v.parse().ok())
+                    .unwrap_or(start_seed);
+            }
+            "--budget-secs" => {
+                budget_secs = args
+                    .next()
+                    .and_then(|v| v.parse().ok())
+                    .unwrap_or(budget_secs);
+            }
+            "--selftest" => {
+                let failures = canary::selftest();
+                if failures == 0 {
+                    println!("selftest: all canaries passed (oracle detects known-good and known-bad streams)");
+                    return std::process::ExitCode::SUCCESS;
+                }
+                println!("selftest: {failures} canary failure(s)");
+                return std::process::ExitCode::from(3);
+            }
+            "--soak" => {
+                let failures = soak::soak_probe();
+                if failures == 0 {
+                    println!("soak: clean");
+                    return std::process::ExitCode::SUCCESS;
+                }
+                println!("soak: {failures} failure(s)");
+                return std::process::ExitCode::from(4);
+            }
+            "--repro" => {
+                // --repro SEED SCRIPT POLICY_PREFIX_QUOTED (policy: Q|O|D, prefix: steps)
+                let seed: u64 = args.next().and_then(|v| v.parse().ok()).unwrap_or(0);
+                let index: usize = args.next().and_then(|v| v.parse().ok()).unwrap_or(0);
+                let rest = args.next().unwrap_or_default();
+                let mut parts = rest.split(':');
+                let policy = match parts.next().unwrap_or("Q") {
+                    "O" => ProtocolViolationPolicy::Observe,
+                    "D" => ProtocolViolationPolicy::Disconnect,
+                    _ => ProtocolViolationPolicy::Quarantine,
+                };
+                let prefix: usize = parts
+                    .next()
+                    .and_then(|v| v.parse().ok())
+                    .unwrap_or(usize::MAX);
+                repro(seed, index, policy, prefix);
+                return std::process::ExitCode::SUCCESS;
+            }
+            other => {
+                eprintln!("unknown argument: {other}");
+                eprintln!(
+                    "usage: stateful-campaign [--seeds N] [--scripts N] [--start-seed S] \
+                     [--budget-secs S] [--selftest] [--soak] [--repro SEED SCRIPT POLICY[:PREFIX]]"
+                );
+                return std::process::ExitCode::from(2);
+            }
+        }
+    }
+
+    // The oracle-rejection-neutering toggle for sensitivity demonstrations.
+    if std::env::var("STATEFUL_CAMPAIGN_BREAK_ORACLE").is_ok_and(|v| v == "1") {
+        set_oracle_neutered(true);
+        eprintln!("!! oracle deliberately broken via STATEFUL_CAMPAIGN_BREAK_ORACLE=1");
+    }
+
+    spawn_watchdog(budget_secs);
+
+    let started = Instant::now();
+    let mut stats = Stats {
+        sequences: 0,
+        frames: 0,
+        events: 0,
+        commands: 0,
+        refused: 0,
+        violations: 0,
+        failures: 0,
+    };
+    let mut failure_report = String::new();
+
+    for seed in start_seed..start_seed.saturating_add(seeds) {
+        for index in 0..scripts_per_seed {
+            let script = gen::generate_script(seed, index);
+            for policy in ALL_POLICIES {
+                stats.sequences = stats.sequences.saturating_add(1);
+                match run_script(&script, policy) {
+                    Ok(outcome) => {
+                        stats.frames = stats.frames.saturating_add(outcome.frames_fed as u64);
+                        stats.events = stats.events.saturating_add(outcome.events_seen as u64);
+                        stats.commands = stats
+                            .commands
+                            .saturating_add(outcome.commands_accepted as u64);
+                        stats.refused = stats
+                            .refused
+                            .saturating_add(outcome.commands_refused as u64);
+                        stats.violations =
+                            stats.violations.saturating_add(outcome.violations as u64);
+                        TOTAL_FRAMES.fetch_add(outcome.frames_fed as u64, Ordering::Relaxed);
+                    }
+                    Err(failure) => {
+                        stats.failures = stats.failures.saturating_add(1);
+                        failure_report.push_str(&format_failure(&script, policy, &failure));
+                        // Keep going: policy-differential evidence is valuable.
+                    }
+                }
+            }
+        }
+        eprintln!(
+            "[{:>6.1}s] seed {} done (sequences={}, failures={})",
+            started.elapsed().as_secs_f32(),
+            seed,
+            stats.sequences,
+            stats.failures
+        );
+    }
+    print_summary(started, &stats, &failure_report);
+    if stats.failures == 0 {
+        std::process::ExitCode::SUCCESS
+    } else {
+        std::process::ExitCode::from(5)
+    }
+}
+
+fn format_failure(
+    script: &Script,
+    policy: ProtocolViolationPolicy,
+    failure: &ReducedFailure,
+) -> String {
+    let mut out = String::new();
+    out.push_str(&format!(
+        "\n=== FINDING | seed={} script={} archetype={} config={} echo_room_op_ids={} policy={policy:?} ===\n",
+        script.seed,
+        script.index,
+        script.archetype,
+        script.config_kind.name(),
+        script.echo_room_ops,
+    ));
+    for finding in &failure.findings {
+        out.push_str(&format!(
+            "  category: {}\n  detail:   {}\n",
+            finding.category, finding.detail
+        ));
+    }
+    out.push_str(&format!(
+        "  reduced failing prefix: {} of {} steps (repro: --seeds 1 --start-seed {})\n",
+        failure.prefix_len,
+        script.steps.len(),
+        script.seed
+    ));
+    out.push_str("  steps:\n");
+    out.push_str(&render_prefix(script, failure.prefix_len, 60));
+    out.push('\n');
+    out
+}
+
+fn print_summary(started: Instant, stats: &Stats, failure_report: &str) {
+    let wall = started.elapsed();
+    println!("\n================ CAMPAIGN SUMMARY ================");
+    println!(
+        "wall time: {:.1}s (budget watchdog: 570s default)",
+        wall.as_secs_f32()
+    );
+    println!("sequences (script × policy runs): {}", stats.sequences);
+    println!("server frames fed:                {}", stats.frames);
+    println!("client events observed:           {}", stats.events);
+    println!(
+        "client commands accepted/refused: {}/{}",
+        stats.commands, stats.refused
+    );
+    println!("ProtocolViolation diagnostics:    {}", stats.violations);
+    println!("FAILURES:                         {}", stats.failures);
+    if !failure_report.is_empty() {
+        println!("\n---------------- FINDINGS ----------------");
+        print!("{failure_report}");
+    } else {
+        println!("\nzero findings.");
+    }
+    let delivered = lock(&DELIVERED);
+    let all_variants = [
+        "Authenticated",
+        "ProtocolInfo",
+        "AuthenticationError",
+        "RoomJoined",
+        "RoomJoinFailed",
+        "RoomLeft",
+        "PlayerJoined",
+        "PlayerLeft",
+        "GameData",
+        "GameDataBinary",
+        "AuthorityChanged",
+        "AuthorityResponse",
+        "LobbyStateChanged",
+        "GameStarting",
+        "Pong",
+        "Reconnected",
+        "ReconnectionFailed",
+        "PlayerReconnected",
+        "SpectatorJoined",
+        "SpectatorJoinFailed",
+        "SpectatorLeft",
+        "RoomOperationResult",
+        "NewSpectatorJoined",
+        "SpectatorDisconnected",
+        "Error",
+        "Signal",
+        "NewPeer",
+        "SessionPlan",
+        "PeerTransportStatus",
+        "RelayStats",
+        "GoingAway",
+        "DeliveryReport",
+    ];
+    let never: Vec<&str> = all_variants
+        .iter()
+        .copied()
+        .filter(|variant| !delivered.contains(*variant))
+        .collect();
+    println!("\n---------------- WIRE COVERAGE ----------------");
+    println!(
+        "delivered ServerMessage variants: {}/{}",
+        all_variants.len().saturating_sub(never.len()),
+        all_variants.len()
+    );
+    if never.is_empty() {
+        println!("every ServerMessage variant was delivered at least once.");
+    } else {
+        println!("NEVER delivered: {never:?}");
+    }
+    let echo_kinds = [
+        "RoomOperationResult::RoomJoined",
+        "RoomOperationResult::RoomJoinFailed",
+        "RoomOperationResult::RoomLeft",
+        "RoomOperationResult::Reconnected",
+        "RoomOperationResult::ReconnectionFailed",
+        "RoomOperationResult::SpectatorJoined",
+        "RoomOperationResult::SpectatorJoinFailed",
+        "RoomOperationResult::SpectatorLeft",
+        "RoomOperationResult::OperationFailed",
+    ];
+    let missing_echo: Vec<String> = echo_kinds
+        .iter()
+        .map(|kind| (*kind).to_string())
+        .filter(|kind| !delivered.contains(kind.as_str()))
+        .collect();
+    if missing_echo.is_empty() {
+        println!("every RoomOperationResult sub-variant was delivered at least once.");
+    } else {
+        println!("NEVER delivered RoomOperationResult sub-variants: {missing_echo:?}");
+    }
+    if !delivered.contains("<physical binary frame>") {
+        println!("NOTE: no physical binary frame was delivered.");
+    }
+    if !delivered.contains("<raw schema-invalid frame>") {
+        println!("NOTE: no raw schema-invalid frame was delivered.");
+    }
+    println!("==================================================");
+}
+
+/// Verbose single-script replay: prints every event as it is observed.
+fn repro(seed: u64, index: usize, policy: ProtocolViolationPolicy, prefix: usize) {
+    let script = gen::generate_script(seed, index);
+    println!(
+        "repro seed={seed} script={index} archetype={} config={} echo_room_ops={} policy={policy:?} prefix={prefix}",
+        script.archetype,
+        script.config_kind.name(),
+        script.echo_room_ops,
+    );
+    let outcome = run_prefix_verbose(&script, policy, prefix);
+    for finding in &outcome.findings {
+        println!(
+            "FINDING at step {:?}: {} — {}",
+            finding.step_index, finding.category, finding.detail
+        );
+    }
+    println!(
+        "frames={} events={} violations={} refused={}",
+        outcome.frames_fed, outcome.events_seen, outcome.violations, outcome.commands_refused
+    );
+}
+
+/// Watchdog: detects library stalls (no step progress) and the global budget.
+///
+/// The scoped `exit` allowance is load-bearing: a hung library call can never
+/// reach a cooperative stop flag, and a CI lane that hangs forever is worse
+/// than one that fails loudly with the stall label and frame count.
+#[allow(clippy::exit)]
+fn spawn_watchdog(budget_secs: u64) {
+    std::thread::spawn(move || {
+        let started = Instant::now();
+        let mut last_hb = HEARTBEAT.load(Ordering::Relaxed);
+        let mut last_change = Instant::now();
+        loop {
+            std::thread::sleep(Duration::from_millis(200));
+            let hb = HEARTBEAT.load(Ordering::Relaxed);
+            if hb != last_hb {
+                last_hb = hb;
+                last_change = Instant::now();
+            } else if last_change.elapsed() > Duration::from_secs(60) {
+                let label = lock(&CURRENT_LABEL).clone();
+                eprintln!("\n!!! WATCHDOG STALL (60s without progress) at {label}");
+                eprintln!(
+                    "frames fed so far: {}",
+                    TOTAL_FRAMES.load(Ordering::Relaxed)
+                );
+                std::process::exit(111);
+            }
+            if started.elapsed() > Duration::from_secs(budget_secs) {
+                let label = lock(&CURRENT_LABEL).clone();
+                eprintln!("\n!!! GLOBAL BUDGET EXCEEDED ({budget_secs}s) at {label}");
+                eprintln!(
+                    "frames fed so far: {}",
+                    TOTAL_FRAMES.load(Ordering::Relaxed)
+                );
+                std::process::exit(112);
+            }
+        }
+    });
+}

--- a/tools/stateful-campaign/src/rng.rs
+++ b/tools/stateful-campaign/src/rng.rs
@@ -1,0 +1,89 @@
+//! Deterministic xorshift64* PRNG — no external rand crate.
+//!
+//! Every arithmetic operation is overflow-safe: the campaign runs under the
+//! workspace-wide `arithmetic_side_effects` denial, so `wrapping_*` and
+//! checked-and-defaulted forms are used throughout. A zero bound in
+//! [`Rng::below`] degrades to index 0 instead of panicking; callers only pass
+//! nonzero bounds.
+
+pub struct Rng(u64);
+
+impl Rng {
+    pub fn new(seed: u64) -> Self {
+        // SplitMix-style warmup so small seeds do not start weak.
+        let mut z = seed.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        Self(z ^ (z >> 31))
+    }
+
+    #[inline]
+    pub fn next_u64(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x >> 12;
+        x ^= x << 25;
+        x ^= x >> 27;
+        self.0 = x;
+        x.wrapping_mul(0x2545_F491_4F6C_DD1D)
+    }
+
+    /// Uniform-ish index in `0..bound`; `bound == 0` yields 0.
+    #[inline]
+    pub fn below(&mut self, bound: usize) -> usize {
+        if bound == 0 {
+            return 0;
+        }
+        let reduced = self
+            .next_u64()
+            .checked_rem(u64::try_from(bound).unwrap_or(u64::MAX))
+            .unwrap_or_default();
+        usize::try_from(reduced).unwrap_or(bound.saturating_sub(1))
+    }
+
+    #[inline]
+    pub fn chance(&mut self, percent: u64) -> bool {
+        self.next_u64().checked_rem(100).unwrap_or(0) < percent
+    }
+
+    /// Pick a uniform-ish element. Every call site passes a non-empty literal
+    /// array and `below` returns an index in `0..len`, so the fallback below
+    /// is unreachable; the scoped allow carries that proof (repo precedent:
+    /// provably-total indexing carries a scoped proof).
+    #[allow(clippy::indexing_slicing)]
+    pub fn pick<'a, T>(&mut self, items: &'a [T]) -> &'a T {
+        let index = self.below(items.len());
+        &items[index.min(items.len().saturating_sub(1))]
+    }
+
+    /// Deterministic UUID-shaped u128 from the stream.
+    pub fn uuid_u128(&mut self) -> u128 {
+        let hi = self.next_u64();
+        let lo = self.next_u64();
+        (u128::from(hi) << 64) | u128::from(lo)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Rng;
+
+    #[test]
+    fn deterministic_stream() {
+        let mut a = Rng::new(42);
+        let mut b = Rng::new(42);
+        for _ in 0..64 {
+            assert_eq!(a.next_u64(), b.next_u64());
+        }
+    }
+
+    #[test]
+    fn below_stays_in_bounds_and_handles_zero() {
+        let mut rng = Rng::new(7);
+        for bound in [1usize, 2, 3, 11, 1000] {
+            for _ in 0..256 {
+                assert!(rng.below(bound) < bound);
+            }
+        }
+        assert_eq!(rng.below(0), 0);
+    }
+}

--- a/tools/stateful-campaign/src/run.rs
+++ b/tools/stateful-campaign/src/run.rs
@@ -268,12 +268,26 @@ impl Oracle {
         }
     }
 
+    /// v2 game data: no stamp state exists, so most stamp faces cannot be
+    /// predicted exactly; the frame must surface its event, an accountability
+    /// violation, or (under Quarantine) documented suppression — never two
+    /// events, never Observe silence.
+    pub(crate) fn v2_game_data_outcomes(&self, name: &'static str) -> Vec<AllowedOutcome> {
+        let mut alternatives = vec![AllowedOutcome::event(name)];
+        alternatives.extend(violation_outcomes(self.policy, Some(name)));
+        if self.policy == ProtocolViolationPolicy::Quarantine && self.batch_quarantined {
+            alternatives.push(AllowedOutcome::empty());
+        }
+        one_of(alternatives)
+    }
+
     /// Representation-mismatch faces (physical binary frames and v3
     /// text-delivered `GameDataBinary`): the representation gate always fires
-    /// one violation. With well-formed stamps the re-validation cannot add
-    /// another, and the Observe policy always delivers the decoded frame
-    /// diagnostically; with invalid stamps a second violation can stack and
-    /// the Observe delivery stays optional.
+    /// one violation, a second can stack from the re-validated stamps (an
+    /// invalid stamp, or a frontier shifted by an earlier apply-anyway frame
+    /// under Observe), and the Observe policy always delivers the decoded
+    /// frame diagnostically — apply and apply-anyway both reach the event
+    /// queue.
     pub(crate) fn binary_representation_outcomes(&self) -> Vec<AllowedOutcome> {
         let mut two_violations = AllowedOutcome::violation();
         two_violations.violations = 2;
@@ -505,12 +519,12 @@ impl Oracle {
                     // Unwrapped response while a correlated operation pends.
                     return violation_only();
                 }
-                if !baseline_roster_valid(
-                    self.v3,
+                if !baseline_roster_shape_valid(
                     payload.player_id,
                     payload.is_authority,
                     &payload.current_players,
-                ) {
+                ) || !baseline_roster_stamps_valid(self.v3, &payload.current_players)
+                {
                     return violation_only();
                 }
                 event_or_violation("RoomJoined")
@@ -550,11 +564,13 @@ impl Oracle {
                 if !self.in_room() {
                     return violation_only();
                 }
-                if self.v3 && (epoch.is_none() != final_seq.is_none() || epoch == &Some(0)) {
-                    return violation_only();
-                }
-                if !self.v3 && (epoch.is_some() || final_seq.is_some()) {
-                    return violation_only();
+                let shape_invalid = (self.v3
+                    && (epoch.is_none() != final_seq.is_none() || epoch == &Some(0)))
+                    || (!self.v3 && (epoch.is_some() || final_seq.is_some()));
+                if shape_invalid {
+                    // Stamp-shape violations are accountability faces: the
+                    // Observe policy delivers the frame diagnostically.
+                    return violation_outcomes(self.policy, Some("PlayerLeft"));
                 }
                 event_or_violation("PlayerLeft")
             }
@@ -563,7 +579,7 @@ impl Oracle {
                     return violation_only();
                 }
                 match (self.v3, seq.is_none() && epoch.is_none(), meta.stamp) {
-                    (false, true, _) => self.game_data_outcomes("GameData"),
+                    (false, true, _) => self.v2_game_data_outcomes("GameData"),
                     (false, false, _) => violation_only(),
                     (true, _, StampMode::Stale) => {
                         // Backward/replayed sequence: a stamp violation.
@@ -656,13 +672,13 @@ impl Oracle {
                 if !self.in_room() {
                     return violation_only();
                 }
-                if self.v3 && (epoch.is_none() || epoch == &Some(0)) {
-                    return violation_only();
+                let shape_invalid = (self.v3 && (epoch.is_none() || epoch == &Some(0)))
+                    || (!self.v3 && epoch.is_some());
+                if shape_invalid {
+                    violation_outcomes(self.policy, Some("PlayerReconnected"))
+                } else {
+                    event_or_violation("PlayerReconnected")
                 }
-                if !self.v3 && epoch.is_some() {
-                    return violation_only();
-                }
-                event_or_violation("PlayerReconnected")
             }
             M::SpectatorJoined(payload) => {
                 if !self.authenticated || self.membership.is_some() {
@@ -890,12 +906,12 @@ impl Oracle {
                 {
                     return None;
                 }
-                // v2 token/ICE exposure and roster-shape failures are definite
-                // lifecycle rejections.
+                // v2 token/ICE exposure and roster-shape failures are
+                // definite lifecycle rejections; stamp failures are the
+                // accountability layer and retire the answered fence.
                 if (!self.v3
                     && (payload.reconnection_token.is_some() || !payload.ice_servers.is_empty()))
-                    || !baseline_roster_valid(
-                        self.v3,
+                    || !baseline_roster_shape_valid(
                         payload.player_id,
                         payload.is_authority,
                         &payload.current_players,
@@ -1630,11 +1646,12 @@ fn echo_kind_matches_fence(kind: EchoKind, fence: FenceKind) -> bool {
     )
 }
 
-/// Baseline roster validity (mirror of `validate_local_player_snapshot`): the
-/// payload's player must appear exactly once with a consistent authority flag
-/// and at most one authority overall.
-fn baseline_roster_valid(
-    v3: bool,
+/// Baseline roster lifecycle shape (mirror of
+/// `validate_local_player_snapshot`, which runs in the lifecycle validator):
+/// the payload's player must appear exactly once with a consistent authority
+/// flag and at most one authority overall. Stamp validity is a separate,
+/// accountability-layer check.
+fn baseline_roster_shape_valid(
     local: PlayerId,
     local_is_authority: bool,
     players: &[signal_fish_client::protocol::PlayerInfo],
@@ -1648,13 +1665,19 @@ fn baseline_roster_valid(
     if entry.is_authority != local_is_authority {
         return false;
     }
-    if players.iter().filter(|p| p.is_authority).count() > 1 {
-        return false;
+    players.iter().filter(|p| p.is_authority).count() <= 1
+}
+
+/// Accountability-layer roster stamp validity for the negotiated dialect.
+fn baseline_roster_stamps_valid(
+    v3: bool,
+    players: &[signal_fish_client::protocol::PlayerInfo],
+) -> bool {
+    if v3 {
+        players.iter().all(|p| !v3_stamp_invalid(p.epoch, p.seq))
+    } else {
+        players.iter().all(|p| p.epoch.is_none() && p.seq.is_none())
     }
-    if v3 && players.iter().any(|p| v3_stamp_invalid(p.epoch, p.seq)) {
-        return false;
-    }
-    true
 }
 
 fn v3_stamp_invalid(epoch: Option<u32>, seq: Option<u64>) -> bool {
@@ -1888,6 +1911,8 @@ struct RunState {
     raw_frames_fed: usize,
     /// DecodeFailed events observed (checked against `raw_frames_fed`).
     decode_failed_events: usize,
+    /// `poll()` calls issued (for the `begin_poll_cycle` contract pin).
+    polls_made: usize,
 }
 
 pub(crate) fn run_prefix(
@@ -1906,6 +1931,7 @@ pub(crate) fn run_prefix(
         predicted_game_data_received: 0,
         raw_frames_fed: 0,
         decode_failed_events: 0,
+        polls_made: 0,
     };
 
     for (idx, step) in script.steps.iter().take(limit).enumerate() {
@@ -2082,6 +2108,20 @@ pub(crate) fn run_prefix(
                     ledger_checks(&client, &mut state, &handles, idx);
                     if script.archetype == "send_pressure" {
                         pressure_checks(&client, &mut state, &handles, idx);
+                    }
+                    // Transport-contract pin: `begin_poll_cycle` fires exactly
+                    // once per `poll()` call (the documented scheduling-cycle
+                    // contract for the polling driver).
+                    let cycles = handles.begin_cycles.load(Ordering::Relaxed);
+                    if cycles != state.polls_made {
+                        state.outcome.findings.push(Finding {
+                            category: "contract-begin-poll-cycle".into(),
+                            detail: format!(
+                                "begin_poll_cycle fired {cycles} times for {} poll() calls",
+                                state.polls_made
+                            ),
+                            step_index: idx,
+                        });
                     }
                 }
                 client.close();
@@ -2347,6 +2387,11 @@ fn drive_polls(
         heartbeat();
         let quarantined = client.snapshot().quarantined;
         state.oracle.begin_batch(quarantined);
+        if !state.oracle.terminal {
+            // Post-terminal polls short-circuit before the driver begins a
+            // scheduling cycle, so only live polls carry the contract.
+            state.polls_made = state.polls_made.saturating_add(1);
+        }
         let events = client.poll();
         state.outcome.events_seen = state.outcome.events_seen.saturating_add(events.len());
         let mut names: Vec<&'static str> = Vec::new();

--- a/tools/stateful-campaign/src/run.rs
+++ b/tools/stateful-campaign/src/run.rs
@@ -180,7 +180,7 @@ pub(crate) enum TerminalCause {
 /// (the phase oracle owns them).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct AllowedOutcome {
-    events: BTreeMap<&'static str, usize>,
+    pub(crate) events: BTreeMap<&'static str, usize>,
     pub(crate) violations: usize,
 }
 
@@ -255,34 +255,38 @@ fn event_or_violation(name: &'static str) -> Vec<AllowedOutcome> {
     ])
 }
 
-/// Well-formed game data: the documented stale-suppression and quarantine
-/// paths may silence it, but it can never double-deliver or fabricate.
-fn game_data_outcomes(name: &'static str) -> Vec<AllowedOutcome> {
-    one_of(vec![AllowedOutcome::event(name), AllowedOutcome::empty()])
-}
-
-/// Representation-mismatch faces (physical binary frames and v3
-/// text-delivered `GameDataBinary`): one violation always fires, a second can
-/// stack from the re-validated stamps, and the Observe policy delivers the
-/// decoded frame diagnostically through both.
-fn binary_representation_outcomes(policy: ProtocolViolationPolicy) -> Vec<AllowedOutcome> {
-    match policy {
-        ProtocolViolationPolicy::Observe => {
-            let mut two_violations = AllowedOutcome::violation();
-            two_violations.violations = 2;
-            let mut two_with_event = AllowedOutcome::violation_then_event("GameDataBinary");
-            two_with_event.violations = 2;
-            one_of(vec![
-                AllowedOutcome::violation(),
-                AllowedOutcome::violation_then_event("GameDataBinary"),
-                two_violations,
-                two_with_event,
-            ])
+impl Oracle {
+    /// Game data: the frame must surface its event. Silence is legal only
+    /// while a Quarantine-policy latch is active (the documented suppression
+    /// path); a client that drops game data outside that latch fails the
+    /// expectation oracle even though the stats counters stay honest.
+    pub(crate) fn game_data_outcomes(&self, name: &'static str) -> Vec<AllowedOutcome> {
+        if self.policy == ProtocolViolationPolicy::Quarantine && self.batch_quarantined {
+            one_of(vec![AllowedOutcome::event(name), AllowedOutcome::empty()])
+        } else {
+            exactly(name)
         }
-        _ => {
-            let mut two_violations = AllowedOutcome::violation();
-            two_violations.violations = 2;
-            one_of(vec![AllowedOutcome::violation(), two_violations])
+    }
+
+    /// Representation-mismatch faces (physical binary frames and v3
+    /// text-delivered `GameDataBinary`): the representation gate always fires
+    /// one violation. With well-formed stamps the re-validation cannot add
+    /// another, and the Observe policy always delivers the decoded frame
+    /// diagnostically; with invalid stamps a second violation can stack and
+    /// the Observe delivery stays optional.
+    pub(crate) fn binary_representation_outcomes(&self) -> Vec<AllowedOutcome> {
+        let mut two_violations = AllowedOutcome::violation();
+        two_violations.violations = 2;
+        match self.policy {
+            ProtocolViolationPolicy::Observe => {
+                let mut two_with_event = AllowedOutcome::violation_then_event("GameDataBinary");
+                two_with_event.violations = 2;
+                one_of(vec![
+                    AllowedOutcome::violation_then_event("GameDataBinary"),
+                    two_with_event,
+                ])
+            }
+            _ => one_of(vec![AllowedOutcome::violation(), two_violations]),
         }
     }
 }
@@ -559,13 +563,13 @@ impl Oracle {
                     return violation_only();
                 }
                 match (self.v3, seq.is_none() && epoch.is_none(), meta.stamp) {
-                    (false, true, _) => exactly("GameData"),
+                    (false, true, _) => self.game_data_outcomes("GameData"),
                     (false, false, _) => violation_only(),
                     (true, _, StampMode::Stale) => {
                         // Backward/replayed sequence: a stamp violation.
                         violation_outcomes(self.policy, Some("GameData"))
                     }
-                    (true, _, StampMode::Valid) => game_data_outcomes("GameData"),
+                    (true, _, StampMode::Valid) => self.game_data_outcomes("GameData"),
                     (true, _, _) => violation_outcomes(self.policy, Some("GameData")),
                 }
             }
@@ -582,7 +586,7 @@ impl Oracle {
                 // On v3 the text-delivered binary type is the documented
                 // representation-mismatch face; an invalid stamp can stack a
                 // second violation, and Observe delivers through both.
-                binary_representation_outcomes(self.policy)
+                self.binary_representation_outcomes()
             }
             M::AuthorityChanged { .. } => {
                 if !self.in_room() {
@@ -780,7 +784,7 @@ impl Oracle {
                 if self.self_sender(from) || !self.plan_peers.contains(from) {
                     return violation_only();
                 }
-                game_data_outcomes("SignalReceived")
+                exactly("SignalReceived")
             }
             M::NewPeer { peer_id, .. } => {
                 if !self.is_player() || !self.v3 {
@@ -869,10 +873,7 @@ impl Oracle {
                 _ => violation_only(),
             };
         }
-        match self.policy {
-            ProtocolViolationPolicy::Observe => binary_representation_outcomes(self.policy),
-            _ => violation_only(),
-        }
+        self.binary_representation_outcomes()
     }
 
     /// Whether a violating baseline retires its answered fence: the round-12
@@ -1419,6 +1420,23 @@ impl Oracle {
         };
         let (frame_name, fence_retired_on_violation, alternatives) = slot_data;
         if !alternatives.contains(&observed) {
+            // Drift: a later frame's outcome surfaced while an earlier frame
+            // produced nothing. Name the swallowed frame explicitly instead
+            // of misattributing the outcome to the front slot.
+            for (offset, slot) in self.slots.iter().enumerate().skip(1) {
+                if slot.alternatives.contains(&observed) {
+                    findings.push(Finding {
+                        category: "expectation-swallowed".into(),
+                        detail: format!(
+                            "frame {frame_name} produced no documented outcome; the observed \
+                             outcome belongs to frame {} (position {offset})",
+                            slot.frame
+                        ),
+                        step_index,
+                    });
+                    return;
+                }
+            }
             let expected: Vec<String> = alternatives.iter().map(|alt| format!("{alt:?}")).collect();
             findings.push(Finding {
                 category: "expectation-mismatch".into(),
@@ -1447,9 +1465,12 @@ impl Oracle {
         }
     }
 
-    /// Forgive every pending expectation (teardown abandons queued delivery).
-    pub(crate) fn forgive_pending(&mut self) {
-        self.slots.clear();
+    /// Frame names still awaiting their documented outcome at teardown. With
+    /// one-frame-per-poll scripts every delivered frame is polled before the
+    /// next step, so a slot pending at teardown is a swallow by construction;
+    /// there is no legitimately "queued but unsurfaced" delivery to forgive.
+    pub(crate) fn pending_frames(&self) -> Vec<&'static str> {
+        self.slots.iter().map(|slot| slot.frame).collect()
     }
 
     pub(crate) fn pending_slot_count(&self) -> usize {
@@ -1979,6 +2000,11 @@ pub(crate) fn run_prefix(
                 };
                 ScriptedTransport::push_text(&handles, json);
                 state.outcome.frames_fed = state.outcome.frames_fed.saturating_add(1);
+                if state.oracle.terminal {
+                    // Frames fed to a dead transport are never consumed; they
+                    // cannot carry a documented outcome.
+                    continue;
+                }
                 let kind_matched_fence = state
                     .oracle
                     .fence
@@ -2048,11 +2074,15 @@ pub(crate) fn run_prefix(
             }
             Step::Close => {
                 heartbeat();
-                // Pressure/ledger assertions run at the close boundary while
-                // the run state is still intact.
-                if script.archetype == "send_pressure" && state.outcome.findings.is_empty() {
+                // Ledger + pressure assertions run at the close boundary while
+                // the run state is still intact. The ledger covers every
+                // archetype: game-data-delivering scripts end in Close, so
+                // this is the one point their stats are still comparable.
+                if state.outcome.findings.is_empty() {
                     ledger_checks(&client, &mut state, &handles, idx);
-                    pressure_checks(&client, &mut state, &handles, idx);
+                    if script.archetype == "send_pressure" {
+                        pressure_checks(&client, &mut state, &handles, idx);
+                    }
                 }
                 client.close();
                 // Idempotence: a second close must be silent and cheap.
@@ -2127,10 +2157,12 @@ pub(crate) fn run_prefix(
                 step_index: limit,
             });
         }
-        // Unresolved expectations: a non-suppressible frame produced no event.
-        if state.oracle.pending_slot_count() > 0 && !state.oracle.disconnected_seen {
-            let pending: Vec<&'static str> =
-                state.oracle.slots.iter().map(|slot| slot.frame).collect();
+        // Unresolved expectations: a non-suppressible frame produced no
+        // event. This check runs at the end of EVERY run, including runs that
+        // ended in a terminal teardown (a teardown cannot strand a delivered
+        // frame's outcome in a one-frame-per-poll script).
+        if state.oracle.pending_slot_count() > 0 {
+            let pending = state.oracle.pending_frames();
             state.outcome.findings.push(Finding {
                 category: "expectation-swallowed".into(),
                 detail: format!(
@@ -2361,9 +2393,8 @@ fn drive_polls(
         if !state.outcome.findings.is_empty() {
             return;
         }
-        if terminal_in_batch {
-            // Teardown abandons queued delivery; pending slots are forgiven.
-            state.oracle.forgive_pending();
+        if terminal_in_batch && !state.outcome.findings.is_empty() {
+            return;
         }
         if let Err(detail) = state.oracle.end_batch() {
             state.outcome.findings.push(Finding {

--- a/tools/stateful-campaign/src/run.rs
+++ b/tools/stateful-campaign/src/run.rs
@@ -838,10 +838,14 @@ impl Oracle {
                 if !self.authenticated || !self.v3 {
                     return violation_only();
                 }
+                let counters = (*sent_to_you, *dropped_for_you, *backpressure_events);
+                let moved_backward = counters.0 < self.relay_counters.0
+                    || counters.1 < self.relay_counters.1
+                    || counters.2 < self.relay_counters.2;
                 if meta.bound_breaking
                     || *interval_ms == 0
                     || self.relay_interval.is_some_and(|seen| seen != *interval_ms)
-                    || (*sent_to_you, *dropped_for_you, *backpressure_events) < self.relay_counters
+                    || moved_backward
                 {
                     return violation_outcomes(self.policy, Some("RelayStats"));
                 }
@@ -2036,22 +2040,35 @@ pub(crate) fn run_prefix(
                     .fence
                     .is_some_and(|fence| echo_kind_matches_fence(*kind, fence));
                 let expected = state.oracle.expectation_for_echo(*kind, id_matches);
-                let slots_before = state.oracle.slots.len();
+                // A violating echo retires the answered fence only when the
+                // expectation was accountability-ambiguous (the round-12
+                // retire rule); definite lifecycle rejections keep it armed.
+                // Event outcomes release the fence through event tracking.
+                let accountability_ambiguous = expected
+                    .iter()
+                    .any(|alt| alt.violations > 0 && !alt.events.is_empty());
+                let fence_retired_on_violation = if accountability_ambiguous && kind_matched_fence {
+                    match kind {
+                        EchoKind::JoinOk | EchoKind::JoinFailed => Some(FenceKind::JoinPlayer),
+                        EchoKind::LeaveOk => Some(FenceKind::LeavePlayer),
+                        EchoKind::ReconnectOk | EchoKind::ReconnectFailed => {
+                            Some(FenceKind::ReconnectPlayer)
+                        }
+                        EchoKind::SpectatorJoinOk | EchoKind::SpectatorJoinFailed => {
+                            Some(FenceKind::JoinSpectator)
+                        }
+                        EchoKind::SpectatorLeaveOk => Some(FenceKind::LeaveSpectator),
+                        EchoKind::OperationFailed => state.oracle.fence,
+                    }
+                } else {
+                    None
+                };
                 state.oracle.slots.push_back(Slot {
                     alternatives: expected,
                     frame: "RoomOperationResult",
-                    fence_retired_on_violation: None,
+                    fence_retired_on_violation,
                 });
                 drive_polls(&mut client, &mut state, 1, idx);
-                // A kind/id-matching consumed result retires the fence
-                // (typed results release it in update_state; accountability-
-                // invalid baselines retire it via the round-12 fix; the
-                // OperationFailed early return releases any kind).
-                if state.oracle.slots.len() < slots_before
-                    && (*kind == EchoKind::OperationFailed || (kind_matched_fence && id_matches))
-                {
-                    state.oracle.fence = None;
-                }
                 if state.oracle.absorbed_leave_armed && state.oracle.absorbed_leave_id.is_none() {
                     state.oracle.absorbed_leave_id = last_sent_operation_id(&handles);
                 }
@@ -2334,6 +2351,18 @@ fn pressure_checks(
         state.outcome.findings.push(Finding {
             category: "pressure-liveness".into(),
             detail: "the Pending-refusal send face never fired; pacing unexercised".into(),
+            step_index,
+        });
+    }
+    // The 96-send storm against a 64-slot queue with a six-poll drain must
+    // overflow: SendBufferFull refusals are the archetype's own target.
+    if state.outcome.commands_refused < 16 {
+        state.outcome.findings.push(Finding {
+            category: "pressure-capacity".into(),
+            detail: format!(
+                "only {} commands were refused; the queue never overflowed its capacity",
+                state.outcome.commands_refused
+            ),
             step_index,
         });
     }

--- a/tools/stateful-campaign/src/run.rs
+++ b/tools/stateful-campaign/src/run.rs
@@ -1,0 +1,2671 @@
+//! Scenario runner + stateful oracle.
+//!
+//! Three oracle families run over every script:
+//!
+//! 1. the phase/terminal/coherence model (round 41),
+//! 2. the per-frame event-expectation model (issue #219): every delivered
+//!    frame must produce exactly one documented outcome multiset — a silent
+//!    swallow of a non-suppressible event, a fabricated event, or a
+//!    double-delivery is a finding,
+//! 3. the stats/ledger equivalence model (issue #219): `ClientStats` counters
+//!    must equal the harness's independent count of decoded frames, and the
+//!    send-pressure archetype additionally asserts FIFO delivery and capacity
+//!    accounting under `Pending`-refusing `poll_send` faces.
+
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Mutex as StdMutex;
+
+use signal_fish_client::client::{
+    GameDataDelivery, JoinRoomParams, ProtocolViolationPolicy, SignalFishConfig,
+};
+use signal_fish_client::event::SignalFishEvent;
+use signal_fish_client::polling_client::SignalFishPollingClient;
+use signal_fish_client::protocol::{
+    ClientMessage, ConnectionInfo, DeliveryGapReason, LobbyState, PlayerId, ReconnectedPayload,
+    ReplayStatus, RoomJoinedPayload, RoomOperationResult, ServerMessage, SpectatorJoinedPayload,
+    SpectatorStateChangeReason, TransportKind,
+};
+use signal_fish_client::signal::PeerSignal;
+#[allow(unused_imports)]
+use signal_fish_client::SignalFishClientApi;
+
+use crate::script::{
+    Cmd, ConfigKind, EchoId, EchoKind, FenceKind, FrameMeta, Script, StampMode, Step,
+};
+use crate::transport::{lock, ScriptedTransport};
+
+#[derive(Debug, Clone)]
+pub struct Finding {
+    pub category: String,
+    pub detail: String,
+    pub step_index: usize,
+}
+
+pub struct Outcome {
+    pub findings: Vec<Finding>,
+    pub events_seen: usize,
+    pub frames_fed: usize,
+    pub commands_refused: usize,
+    pub commands_accepted: usize,
+    pub violations: usize,
+    /// True when a Disconnected event was observed (terminal teardown).
+    pub terminal: bool,
+    /// True when that teardown was violation-caused (not a peer close).
+    pub violation_teardown: bool,
+}
+
+impl Outcome {
+    fn new() -> Self {
+        Self {
+            findings: Vec::new(),
+            events_seen: 0,
+            frames_fed: 0,
+            commands_refused: 0,
+            commands_accepted: 0,
+            violations: 0,
+            terminal: false,
+            violation_teardown: false,
+        }
+    }
+}
+
+/// Global coverage ledger (event/variant names emitted anywhere in the corpus).
+pub static COVERAGE: StdMutex<BTreeSet<String>> = StdMutex::new(BTreeSet::new());
+
+/// Global ledger of delivered `ServerMessage` variant names (wire coverage).
+pub static DELIVERED: StdMutex<BTreeSet<String>> = StdMutex::new(BTreeSet::new());
+
+fn note_delivered(name: &str) {
+    lock(&DELIVERED).insert(name.to_string());
+}
+
+/// Watchdog heartbeat: incremented every step so a stalled library call is
+/// detectable from the budget loop in `main`.
+pub static HEARTBEAT: AtomicU64 = AtomicU64::new(0);
+static VERBOSE: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+// Oracle strictness toggle: when `false`, every rejection branch is neutered
+// and the oracle only counts events. `--selftest` proves every rejection
+// canary is sensitive to this toggle (the deliberately-broken oracle must
+// accept known-bad input). Settable via `STATEFUL_CAMPAIGN_BREAK_ORACLE=1`.
+// Thread-local so the unit tests (canaries toggle it
+// while the soak/smoke tests run concurrently) stay isolated; the binary
+// drives everything on its main thread.
+thread_local! {
+    static ORACLE_STRICT: std::cell::Cell<bool> = const { std::cell::Cell::new(true) };
+}
+
+/// Deliberately neuter the oracle (canary sensitivity proof).
+pub fn set_oracle_neutered(broken: bool) {
+    ORACLE_STRICT.with(|strict| strict.set(!broken));
+}
+
+fn oracle_strict() -> bool {
+    ORACLE_STRICT.with(|strict| strict.get())
+}
+
+static DIFFERENTIAL_DONE: StdMutex<BTreeSet<(u64, usize)>> = StdMutex::new(BTreeSet::new());
+pub static CURRENT_LABEL: StdMutex<String> = StdMutex::new(String::new());
+
+fn heartbeat() {
+    HEARTBEAT.fetch_add(1, Ordering::Relaxed);
+}
+
+fn note_coverage(name: &str) {
+    lock(&COVERAGE).insert(name.to_string());
+}
+
+pub fn event_name(ev: &SignalFishEvent) -> &'static str {
+    match ev {
+        SignalFishEvent::Connected => "Connected",
+        SignalFishEvent::Disconnected { .. } => "Disconnected",
+        SignalFishEvent::DecodeFailed { .. } => "DecodeFailed",
+        SignalFishEvent::ProtocolViolation { .. } => "ProtocolViolation",
+        SignalFishEvent::Authenticated { .. } => "Authenticated",
+        SignalFishEvent::ProtocolInfo(_) => "ProtocolInfo",
+        SignalFishEvent::AuthenticationError { .. } => "AuthenticationError",
+        SignalFishEvent::RoomJoined { .. } => "RoomJoined",
+        SignalFishEvent::RoomJoinFailed { .. } => "RoomJoinFailed",
+        SignalFishEvent::RoomLeft => "RoomLeft",
+        SignalFishEvent::RoomOperationFailed { .. } => "RoomOperationFailed",
+        SignalFishEvent::PlayerJoined { .. } => "PlayerJoined",
+        SignalFishEvent::PlayerLeft { .. } => "PlayerLeft",
+        SignalFishEvent::GameData { .. } => "GameData",
+        SignalFishEvent::GameDataBinary { .. } => "GameDataBinary",
+        SignalFishEvent::AuthorityChanged { .. } => "AuthorityChanged",
+        SignalFishEvent::AuthorityResponse { .. } => "AuthorityResponse",
+        SignalFishEvent::LobbyStateChanged { .. } => "LobbyStateChanged",
+        SignalFishEvent::GameStarting { .. } => "GameStarting",
+        SignalFishEvent::SessionPlan { .. } => "SessionPlan",
+        SignalFishEvent::NewPeer { .. } => "NewPeer",
+        SignalFishEvent::SignalReceived { .. } => "SignalReceived",
+        SignalFishEvent::PeerTransportStatus { .. } => "PeerTransportStatus",
+        SignalFishEvent::RelayStats { .. } => "RelayStats",
+        SignalFishEvent::GoingAway { .. } => "GoingAway",
+        SignalFishEvent::DeliveryReport(_) => "DeliveryReport",
+        SignalFishEvent::Pong => "Pong",
+        SignalFishEvent::Reconnected { .. } => "Reconnected",
+        SignalFishEvent::ReconnectionFailed { .. } => "ReconnectionFailed",
+        SignalFishEvent::PlayerReconnected { .. } => "PlayerReconnected",
+        SignalFishEvent::SpectatorJoined { .. } => "SpectatorJoined",
+        SignalFishEvent::SpectatorJoinFailed { .. } => "SpectatorJoinFailed",
+        SignalFishEvent::SpectatorLeft { .. } => "SpectatorLeft",
+        SignalFishEvent::NewSpectatorJoined { .. } => "NewSpectatorJoined",
+        SignalFishEvent::SpectatorDisconnected { .. } => "SpectatorDisconnected",
+        SignalFishEvent::Error { .. } => "Error",
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Role {
+    Player,
+    Spectator,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum TerminalCause {
+    /// Disconnected followed a Disconnect-policy violation.
+    Violation,
+    /// Disconnected matched an armed peer-close face.
+    PeerClose,
+    /// Disconnected followed an armed terminal transport error.
+    TransportError,
+}
+
+// ── Per-frame event-expectation oracle (issue #219) ─────────────────
+
+/// One documented outcome for a delivered frame: an exact event-name multiset
+/// plus a `ProtocolViolation` count. `Connected`/`Disconnected` are excluded
+/// (the phase oracle owns them).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AllowedOutcome {
+    events: BTreeMap<&'static str, usize>,
+    pub(crate) violations: usize,
+}
+
+fn event_multimap(name: &'static str) -> BTreeMap<&'static str, usize> {
+    let mut map = BTreeMap::new();
+    map.insert(name, 1);
+    map
+}
+
+impl AllowedOutcome {
+    fn empty() -> Self {
+        Self {
+            events: BTreeMap::new(),
+            violations: 0,
+        }
+    }
+
+    fn event(name: &'static str) -> Self {
+        Self {
+            events: event_multimap(name),
+            violations: 0,
+        }
+    }
+
+    fn violation() -> Self {
+        Self {
+            events: BTreeMap::new(),
+            violations: 1,
+        }
+    }
+
+    fn violation_then_event(name: &'static str) -> Self {
+        Self {
+            events: event_multimap(name),
+            violations: 1,
+        }
+    }
+}
+
+/// The unresolved expectation for one delivered frame: the set of outcome
+/// multisets the documented model permits.
+pub(crate) struct Slot {
+    pub(crate) alternatives: Vec<AllowedOutcome>,
+    pub(crate) frame: &'static str,
+    /// When the frame's outcome is a violation, the client retires the
+    /// answered fence of this kind (accountability-invalid baselines).
+    pub(crate) fence_retired_on_violation: Option<FenceKind>,
+}
+
+fn one_of(alternatives: Vec<AllowedOutcome>) -> Vec<AllowedOutcome> {
+    alternatives
+}
+
+/// The exactly-one-event shorthand.
+fn exactly(name: &'static str) -> Vec<AllowedOutcome> {
+    one_of(vec![AllowedOutcome::event(name)])
+}
+
+/// Exactly one violation, nothing else (frame suppressed after diagnosis).
+fn violation_only() -> Vec<AllowedOutcome> {
+    one_of(vec![AllowedOutcome::violation()])
+}
+
+/// Event-or-violation validity-ambiguous faces (never silence). Under the
+/// Observe policy an accountability-invalid frame is additionally delivered
+/// diagnostically, so the violation+event face is legal there too.
+fn event_or_violation(name: &'static str) -> Vec<AllowedOutcome> {
+    one_of(vec![
+        AllowedOutcome::event(name),
+        AllowedOutcome::violation(),
+        AllowedOutcome::violation_then_event(name),
+    ])
+}
+
+/// Well-formed game data: the documented stale-suppression and quarantine
+/// paths may silence it, but it can never double-deliver or fabricate.
+fn game_data_outcomes(name: &'static str) -> Vec<AllowedOutcome> {
+    one_of(vec![AllowedOutcome::event(name), AllowedOutcome::empty()])
+}
+
+/// Representation-mismatch faces (physical binary frames and v3
+/// text-delivered `GameDataBinary`): one violation always fires, a second can
+/// stack from the re-validated stamps, and the Observe policy delivers the
+/// decoded frame diagnostically through both.
+fn binary_representation_outcomes(policy: ProtocolViolationPolicy) -> Vec<AllowedOutcome> {
+    match policy {
+        ProtocolViolationPolicy::Observe => {
+            let mut two_violations = AllowedOutcome::violation();
+            two_violations.violations = 2;
+            let mut two_with_event = AllowedOutcome::violation_then_event("GameDataBinary");
+            two_with_event.violations = 2;
+            one_of(vec![
+                AllowedOutcome::violation(),
+                AllowedOutcome::violation_then_event("GameDataBinary"),
+                two_violations,
+                two_with_event,
+            ])
+        }
+        _ => {
+            let mut two_violations = AllowedOutcome::violation();
+            two_violations.violations = 2;
+            one_of(vec![AllowedOutcome::violation(), two_violations])
+        }
+    }
+}
+
+/// Accountability-invalid faces under the Observe policy additionally deliver
+/// the frame diagnostically (violation + event); under Quarantine/Disconnect
+/// the frame is suppressed after the violation.
+fn violation_outcomes(
+    policy: ProtocolViolationPolicy,
+    event: Option<&'static str>,
+) -> Vec<AllowedOutcome> {
+    match (policy, event) {
+        (ProtocolViolationPolicy::Observe, Some(name)) => one_of(vec![
+            AllowedOutcome::violation(),
+            AllowedOutcome::violation_then_event(name),
+        ]),
+        _ => violation_only(),
+    }
+}
+
+/// Independent phase/suppression model driven only by observed events.
+pub(crate) struct Oracle {
+    pub(crate) policy: ProtocolViolationPolicy,
+    pub(crate) config: ConfigKind,
+    pub(crate) echo_room_ops: bool,
+    pub(crate) connected_event_seen: bool,
+    pub(crate) any_event_seen: bool,
+    pub(crate) authenticated: bool,
+    pub(crate) protocol_info_seen: bool,
+    pub(crate) v3: bool,
+    pub(crate) correlation: bool,
+    pub(crate) plan_seen: bool,
+    pub(crate) session_transport: Option<TransportKind>,
+    pub(crate) session_generation: Option<PlayerId>,
+    pub(crate) plan_peers: BTreeSet<PlayerId>,
+    pub(crate) roster: BTreeSet<PlayerId>,
+    pub(crate) local_id: Option<PlayerId>,
+    pub(crate) room_id: Option<PlayerId>,
+    pub(crate) room_code: Option<String>,
+    pub(crate) membership: Option<Role>,
+    pub(crate) room_finalized: bool,
+    pub(crate) terminal: bool,
+    pub(crate) disconnected_seen: bool,
+    pub(crate) violations: usize,
+    /// Intra-batch quarantine view under the Quarantine policy.
+    pub(crate) batch_quarantined: bool,
+    pub(crate) pending_disconnect: bool,
+    /// Server-initiated close armed: a Disconnected event is legal under any policy.
+    pub(crate) peer_close_armed: bool,
+    /// A Disconnected event was caused by a violation (not a peer close).
+    pub(crate) violation_teardown: bool,
+    /// Terminal transport error armed: Disconnected with the error cause is legal.
+    pub(crate) transport_error_armed: bool,
+    /// Exact `Display` strings of the armed terminal transport errors; the
+    /// client must copy one of them verbatim into the `Disconnected` reason.
+    pub(crate) expected_transport_reasons: Vec<String>,
+    /// Classification of the observed terminal `Disconnected` event.
+    pub(crate) terminal_cause: Option<TerminalCause>,
+    /// `reason` field captured from the observed `Disconnected` event.
+    pub(crate) disconnect_reason: Option<String>,
+    /// Violation observed since the last membership transition (Quarantine
+    /// policy): `snapshot.quarantined` must be positively latched.
+    pub(crate) quarantine_latched: bool,
+
+    // Expectation-oracle state (mirrors the client's documented fences).
+    pub(crate) fence: Option<FenceKind>,
+    pub(crate) pending_reconnects: usize,
+    /// Armed when an authoritative SpectatorLeft overtook a pending voluntary
+    /// leave: exactly one matching late reply is silently absorbed. The id is
+    /// captured by the runner from the outbound log right after the exit.
+    pub(crate) absorbed_leave_armed: bool,
+    pub(crate) absorbed_leave_id: Option<PlayerId>,
+    /// Relay-stats validity tracking (interval constancy, monotone counters).
+    pub(crate) relay_interval: Option<u64>,
+    pub(crate) relay_counters: (u64, u64, u64),
+    /// An unsupported-format gap armed the advisory for a causal Error frame.
+    pub(crate) unsupported_format_advisory_armed: bool,
+
+    /// Pending per-frame expectations (issue #219 oracle).
+    pub(crate) slots: VecDeque<Slot>,
+}
+
+impl Oracle {
+    pub(crate) fn new(
+        policy: ProtocolViolationPolicy,
+        config: ConfigKind,
+        echo_room_ops: bool,
+    ) -> Self {
+        Self {
+            policy,
+            config,
+            echo_room_ops,
+            connected_event_seen: false,
+            any_event_seen: false,
+            authenticated: false,
+            protocol_info_seen: false,
+            v3: false,
+            correlation: false,
+            plan_seen: false,
+            session_transport: None,
+            session_generation: None,
+            plan_peers: BTreeSet::new(),
+            roster: BTreeSet::new(),
+            local_id: None,
+            room_id: None,
+            room_code: None,
+            membership: None,
+            room_finalized: false,
+            terminal: false,
+            disconnected_seen: false,
+            violations: 0,
+            batch_quarantined: false,
+            pending_disconnect: false,
+            peer_close_armed: false,
+            violation_teardown: false,
+            transport_error_armed: false,
+            expected_transport_reasons: Vec::new(),
+            terminal_cause: None,
+            disconnect_reason: None,
+            quarantine_latched: false,
+            fence: None,
+            pending_reconnects: 0,
+            absorbed_leave_armed: false,
+            absorbed_leave_id: None,
+            relay_interval: None,
+            relay_counters: (0, 0, 0),
+            unsupported_format_advisory_armed: false,
+            slots: VecDeque::new(),
+        }
+    }
+
+    pub(crate) fn arm_transport_error(&mut self, fail_recv: bool, fail_send: bool) {
+        self.transport_error_armed = true;
+        if fail_recv {
+            self.expected_transport_reasons
+                .push(crate::transport::RECV_ERROR_DISPLAY.to_string());
+        }
+        if fail_send {
+            self.expected_transport_reasons
+                .push(crate::transport::SEND_ERROR_DISPLAY.to_string());
+        }
+    }
+
+    pub(crate) fn begin_batch(&mut self, quarantined: bool) {
+        self.batch_quarantined = quarantined;
+    }
+
+    pub(crate) fn in_room(&self) -> bool {
+        self.authenticated && self.membership.is_some()
+    }
+
+    pub(crate) fn is_player(&self) -> bool {
+        self.authenticated && self.membership == Some(Role::Player)
+    }
+
+    pub(crate) fn self_sender(&self, id: &PlayerId) -> bool {
+        self.local_id.is_some_and(|local| local == *id)
+    }
+
+    /// Compute the documented outcome set for a delivered frame BEFORE it is
+    /// processed. Reactively-updated state (roster, plan, relay, fences) comes
+    /// from previously observed events, so this mirrors the client's gates.
+    pub(crate) fn expectation_for(
+        &self,
+        msg: &ServerMessage,
+        meta: &FrameMeta,
+    ) -> Vec<AllowedOutcome> {
+        use ServerMessage as M;
+        // The documented negotiation gate runs before every per-variant phase
+        // gate: everything except the auth/negotiation/pong/error family
+        // requires a completed ProtocolInfo.
+        if !matches!(
+            msg,
+            M::Authenticated { .. }
+                | M::AuthenticationError { .. }
+                | M::ProtocolInfo(_)
+                | M::Pong
+                | M::Error { .. }
+        ) && !self.protocol_info_seen
+        {
+            return violation_only();
+        }
+        match msg {
+            M::Authenticated { .. } => {
+                if !self.authenticated && self.membership.is_none() {
+                    exactly("Authenticated")
+                } else {
+                    violation_only()
+                }
+            }
+            M::AuthenticationError { .. } => {
+                if !self.authenticated && self.membership.is_none() {
+                    exactly("AuthenticationError")
+                } else {
+                    violation_only()
+                }
+            }
+            M::ProtocolInfo(_) => {
+                if !self.authenticated || self.membership.is_some() || self.protocol_info_seen {
+                    return violation_only();
+                }
+                if meta.bound_breaking {
+                    // Outbound bound beyond the authority's validated range.
+                    return violation_only();
+                }
+                exactly("ProtocolInfo")
+            }
+            M::RoomJoined(payload) => {
+                if !self.authenticated || self.membership.is_some() {
+                    return violation_only();
+                }
+                if self.fence != Some(FenceKind::JoinPlayer) {
+                    return violation_only();
+                }
+                if self.correlation {
+                    // Unwrapped response while a correlated operation pends.
+                    return violation_only();
+                }
+                if !baseline_roster_valid(
+                    self.v3,
+                    payload.player_id,
+                    payload.is_authority,
+                    &payload.current_players,
+                ) {
+                    return violation_only();
+                }
+                event_or_violation("RoomJoined")
+            }
+            M::RoomJoinFailed { .. } => {
+                if !self.authenticated || self.fence != Some(FenceKind::JoinPlayer) {
+                    return violation_only();
+                }
+                if self.correlation {
+                    return violation_only();
+                }
+                exactly("RoomJoinFailed")
+            }
+            M::RoomLeft => {
+                if !self.is_player() || self.fence != Some(FenceKind::LeavePlayer) {
+                    return violation_only();
+                }
+                if self.correlation {
+                    return violation_only();
+                }
+                exactly("RoomLeft")
+            }
+            M::PlayerJoined { player } => {
+                if !self.in_room() {
+                    return violation_only();
+                }
+                if self.v3 && v3_stamp_invalid(player.epoch, player.seq) {
+                    return violation_only();
+                }
+                event_or_violation("PlayerJoined")
+            }
+            M::PlayerLeft {
+                player_id: _,
+                epoch,
+                final_seq,
+            } => {
+                if !self.in_room() {
+                    return violation_only();
+                }
+                if self.v3 && (epoch.is_none() != final_seq.is_none() || epoch == &Some(0)) {
+                    return violation_only();
+                }
+                if !self.v3 && (epoch.is_some() || final_seq.is_some()) {
+                    return violation_only();
+                }
+                event_or_violation("PlayerLeft")
+            }
+            M::GameData { seq, epoch, .. } => {
+                if !self.in_room() {
+                    return violation_only();
+                }
+                match (self.v3, seq.is_none() && epoch.is_none(), meta.stamp) {
+                    (false, true, _) => exactly("GameData"),
+                    (false, false, _) => violation_only(),
+                    (true, _, StampMode::Stale) => {
+                        // Backward/replayed sequence: a stamp violation.
+                        violation_outcomes(self.policy, Some("GameData"))
+                    }
+                    (true, _, StampMode::Valid) => game_data_outcomes("GameData"),
+                    (true, _, _) => violation_outcomes(self.policy, Some("GameData")),
+                }
+            }
+            M::GameDataBinary { seq, epoch, .. } => {
+                if !self.in_room() {
+                    return violation_only();
+                }
+                if !self.v3 {
+                    return match seq.is_none() && epoch.is_none() {
+                        true => exactly("GameDataBinary"),
+                        false => violation_only(),
+                    };
+                }
+                // On v3 the text-delivered binary type is the documented
+                // representation-mismatch face; an invalid stamp can stack a
+                // second violation, and Observe delivers through both.
+                binary_representation_outcomes(self.policy)
+            }
+            M::AuthorityChanged { .. } => {
+                if !self.in_room() {
+                    return violation_only();
+                }
+                // Named-authority-in-roster and you-are faces stay
+                // validity-ambiguous (the roster view is reactive only).
+                event_or_violation("AuthorityChanged")
+            }
+            M::AuthorityResponse { .. } => {
+                if !self.authenticated || !self.protocol_info_seen {
+                    return violation_only();
+                }
+                exactly("AuthorityResponse")
+            }
+            M::LobbyStateChanged { .. } => {
+                if !self.in_room() {
+                    return violation_only();
+                }
+                exactly("LobbyStateChanged")
+            }
+            M::GameStarting { .. } => {
+                if !self.in_room() {
+                    return violation_only();
+                }
+                exactly("GameStarting")
+            }
+            M::Pong => exactly("Pong"),
+            M::Reconnected(payload) => {
+                if !self.authenticated || self.membership.is_some() {
+                    return violation_only();
+                }
+                if self.fence != Some(FenceKind::ReconnectPlayer) || self.pending_reconnects == 0 {
+                    return violation_only();
+                }
+                if self.correlation {
+                    return violation_only();
+                }
+                if self.v3 {
+                    // Replay is mandatory and the rotated token must differ
+                    // from the submitted one (the generator never submits a
+                    // "rotated-" token).
+                    if payload.replay.is_none() || payload.reconnection_token.is_none() {
+                        return violation_only();
+                    }
+                } else if payload.replay.is_some()
+                    || !payload.sender_watermarks.is_empty()
+                    || payload.reconnection_token.is_some()
+                {
+                    return violation_only();
+                }
+                event_or_violation("Reconnected")
+            }
+            M::ReconnectionFailed { .. } => {
+                if !self.authenticated
+                    || self.fence != Some(FenceKind::ReconnectPlayer)
+                    || self.pending_reconnects == 0
+                {
+                    return violation_only();
+                }
+                if self.correlation {
+                    return violation_only();
+                }
+                exactly("ReconnectionFailed")
+            }
+            M::PlayerReconnected { epoch, .. } => {
+                if !self.in_room() {
+                    return violation_only();
+                }
+                if self.v3 && (epoch.is_none() || epoch == &Some(0)) {
+                    return violation_only();
+                }
+                if !self.v3 && epoch.is_some() {
+                    return violation_only();
+                }
+                event_or_violation("PlayerReconnected")
+            }
+            M::SpectatorJoined(payload) => {
+                if !self.authenticated || self.membership.is_some() {
+                    return violation_only();
+                }
+                if self.fence != Some(FenceKind::JoinSpectator) {
+                    return violation_only();
+                }
+                if self.correlation {
+                    return violation_only();
+                }
+                if self.v3
+                    && payload
+                        .current_players
+                        .iter()
+                        .any(|p| v3_stamp_invalid(p.epoch, p.seq))
+                {
+                    return violation_only();
+                }
+                event_or_violation("SpectatorJoined")
+            }
+            M::SpectatorJoinFailed { .. } => {
+                if !self.authenticated || self.fence != Some(FenceKind::JoinSpectator) {
+                    return violation_only();
+                }
+                if self.correlation {
+                    return violation_only();
+                }
+                exactly("SpectatorJoinFailed")
+            }
+            M::SpectatorLeft {
+                room_id,
+                room_code,
+                reason,
+                ..
+            } => {
+                if !self.authenticated || self.membership != Some(Role::Spectator) {
+                    return violation_only();
+                }
+                match reason {
+                    Some(SpectatorStateChangeReason::Joined) => violation_only(),
+                    Some(
+                        SpectatorStateChangeReason::Disconnected
+                        | SpectatorStateChangeReason::Removed
+                        | SpectatorStateChangeReason::RoomClosed,
+                    ) => {
+                        // A named room must match the joined one (echo joins
+                        // make the joined room differ from the generator's).
+                        let identity_matches =
+                            match (room_id, room_code, &self.room_id, &self.room_code) {
+                                (Some(named_id), _, Some(joined_id), _)
+                                    if named_id != joined_id =>
+                                {
+                                    false
+                                }
+                                (None, Some(named_code), _, Some(joined_code))
+                                    if !joined_code.is_empty() && named_code != joined_code =>
+                                {
+                                    false
+                                }
+                                _ => true,
+                            };
+                        if identity_matches {
+                            exactly("SpectatorLeft")
+                        } else {
+                            violation_only()
+                        }
+                    }
+                    Some(SpectatorStateChangeReason::VoluntaryLeave) | None => {
+                        if self.correlation || self.fence != Some(FenceKind::LeaveSpectator) {
+                            violation_only()
+                        } else {
+                            exactly("SpectatorLeft")
+                        }
+                    }
+                }
+            }
+            M::NewSpectatorJoined { .. } => {
+                if !self.in_room() {
+                    return violation_only();
+                }
+                exactly("NewSpectatorJoined")
+            }
+            M::SpectatorDisconnected { .. } => {
+                if !self.in_room() {
+                    return violation_only();
+                }
+                exactly("SpectatorDisconnected")
+            }
+            M::Error { error_code, .. } => {
+                if self.v3
+                    && error_code == &Some(signal_fish_client::ErrorCode::UnsupportedGameDataFormat)
+                {
+                    // Causality face: the advisory tracking here is an
+                    // approximation of the client's armed-range bookkeeping,
+                    // so the violation faces stay legal even when this oracle
+                    // believes the advisory is armed.
+                    let mut alternatives = vec![AllowedOutcome::event("Error")];
+                    alternatives.extend(violation_outcomes(self.policy, Some("Error")));
+                    one_of(alternatives)
+                } else {
+                    exactly("Error")
+                }
+            }
+            M::Signal {
+                from, generation, ..
+            } => {
+                if !self.is_player() || !self.v3 || !self.plan_seen {
+                    return violation_only();
+                }
+                if generation != &self.session_generation {
+                    // Stale/unknown generation: silently suppressed. The
+                    // documented suppression check precedes sender checks.
+                    return one_of(vec![AllowedOutcome::empty()]);
+                }
+                if self.session_transport != Some(TransportKind::WebRtc) {
+                    return violation_only();
+                }
+                if self.self_sender(from) || !self.plan_peers.contains(from) {
+                    return violation_only();
+                }
+                game_data_outcomes("SignalReceived")
+            }
+            M::NewPeer { peer_id, .. } => {
+                if !self.is_player() || !self.v3 {
+                    return violation_only();
+                }
+                if !self.plan_seen || self.session_transport != Some(TransportKind::WebRtc) {
+                    return violation_only();
+                }
+                if self.self_sender(peer_id) || !self.roster.contains(peer_id) {
+                    return violation_only();
+                }
+                exactly("NewPeer")
+            }
+            M::SessionPlan(_) => {
+                if !self.is_player() || !self.v3 || !self.room_finalized {
+                    return violation_only();
+                }
+                event_or_violation("SessionPlan")
+            }
+            M::PeerTransportStatus { peer_id, .. } => {
+                if !self.is_player() || !self.v3 {
+                    return violation_only();
+                }
+                if self.self_sender(peer_id) || !self.roster.contains(peer_id) {
+                    return violation_only();
+                }
+                exactly("PeerTransportStatus")
+            }
+            M::RelayStats {
+                interval_ms,
+                sent_to_you,
+                dropped_for_you,
+                backpressure_events,
+            } => {
+                if !self.authenticated || !self.v3 {
+                    return violation_only();
+                }
+                if meta.bound_breaking
+                    || *interval_ms == 0
+                    || self.relay_interval.is_some_and(|seen| seen != *interval_ms)
+                    || (*sent_to_you, *dropped_for_you, *backpressure_events) < self.relay_counters
+                {
+                    return violation_outcomes(self.policy, Some("RelayStats"));
+                }
+                exactly("RelayStats")
+            }
+            M::GoingAway { .. } => {
+                if !self.authenticated || !self.v3 {
+                    return violation_only();
+                }
+                exactly("GoingAway")
+            }
+            M::DeliveryReport(_) => {
+                if !self.in_room() || !self.v3 {
+                    return violation_only();
+                }
+                if meta.bound_breaking {
+                    return violation_outcomes(self.policy, Some("DeliveryReport"));
+                }
+                event_or_violation("DeliveryReport")
+            }
+            M::RoomOperationResult { .. } => {
+                // Normalized before validation; never reaches the gates.
+                violation_only()
+            }
+        }
+    }
+
+    /// Documented outcome set for a physical binary frame (the campaign's
+    /// negotiated format is always Json, so the representation gate fires).
+    pub(crate) fn expectation_for_binary(&self, _meta: &FrameMeta) -> Vec<AllowedOutcome> {
+        if !self.in_room() || !self.protocol_info_seen {
+            return violation_only();
+        }
+        if !self.v3 {
+            // The v3-shaped envelope fails the v2 decoder after the
+            // representation violation; Observe continues into DecodeFailed.
+            return match self.policy {
+                ProtocolViolationPolicy::Observe => one_of(vec![
+                    AllowedOutcome {
+                        events: event_multimap("DecodeFailed"),
+                        violations: 1,
+                    },
+                    AllowedOutcome::violation(),
+                ]),
+                _ => violation_only(),
+            };
+        }
+        match self.policy {
+            ProtocolViolationPolicy::Observe => binary_representation_outcomes(self.policy),
+            _ => violation_only(),
+        }
+    }
+
+    /// Whether a violating baseline retires its answered fence: the round-12
+    /// `retire_answered_room_operation` rule applies to accountability-invalid
+    /// baselines; a definite lifecycle rejection keeps the fence armed.
+    pub(crate) fn retire_on_violation(&self, msg: &ServerMessage) -> Option<FenceKind> {
+        use ServerMessage as M;
+        match msg {
+            M::RoomJoined(payload) => {
+                if !self.authenticated
+                    || self.membership.is_some()
+                    || self.fence != Some(FenceKind::JoinPlayer)
+                    || self.correlation
+                {
+                    return None;
+                }
+                // v2 token/ICE exposure and roster-shape failures are definite
+                // lifecycle rejections.
+                if (!self.v3
+                    && (payload.reconnection_token.is_some() || !payload.ice_servers.is_empty()))
+                    || !baseline_roster_valid(
+                        self.v3,
+                        payload.player_id,
+                        payload.is_authority,
+                        &payload.current_players,
+                    )
+                {
+                    return None;
+                }
+                Some(FenceKind::JoinPlayer)
+            }
+            M::Reconnected(payload) => {
+                if !self.authenticated
+                    || self.membership.is_some()
+                    || self.fence != Some(FenceKind::ReconnectPlayer)
+                    || self.pending_reconnects == 0
+                    || self.correlation
+                {
+                    return None;
+                }
+                if self.v3 {
+                    if payload.replay.is_none() || payload.reconnection_token.is_none() {
+                        return None;
+                    }
+                } else if payload.replay.is_some()
+                    || !payload.sender_watermarks.is_empty()
+                    || payload.reconnection_token.is_some()
+                {
+                    return None;
+                }
+                Some(FenceKind::ReconnectPlayer)
+            }
+            M::SpectatorJoined(_payload) => {
+                if !self.authenticated
+                    || self.membership.is_some()
+                    || self.fence != Some(FenceKind::JoinSpectator)
+                    || self.correlation
+                {
+                    return None;
+                }
+                Some(FenceKind::JoinSpectator)
+            }
+            _ => None,
+        }
+    }
+
+    /// Compute the documented outcome set for a `RoomOperationResult` echo.
+    /// `id_matches` reports whether the embedded id equals the id of the
+    /// client's currently pending operation.
+    pub(crate) fn expectation_for_echo(
+        &self,
+        kind: EchoKind,
+        id_matches: bool,
+    ) -> Vec<AllowedOutcome> {
+        if !self.correlation {
+            // Enveloped results without negotiated correlation always violate.
+            return violation_only();
+        }
+        // The one absorbed late reply for an overtaken voluntary leave.
+        if self.absorbed_leave_id.is_some() && kind == EchoKind::SpectatorLeaveOk && id_matches {
+            return one_of(vec![AllowedOutcome::empty()]);
+        }
+        let Some(fence) = self.fence else {
+            return violation_only();
+        };
+        if !echo_kind_matches_fence(kind, fence) || !id_matches {
+            return violation_only();
+        }
+        match kind {
+            EchoKind::OperationFailed => exactly("RoomOperationFailed"),
+            // The echo's Reconnected face historically carries no rotated
+            // token, which the v3 lifecycle gate rejects; the fence retires
+            // with the violation.
+            EchoKind::ReconnectOk if self.v3 => violation_only(),
+            EchoKind::JoinOk | EchoKind::SpectatorJoinOk | EchoKind::ReconnectOk => {
+                event_or_violation(kind.name())
+            }
+            _ => exactly(kind.name()),
+        }
+    }
+
+    /// Reactive state updates derived from observed events. The expectation
+    /// oracle tracks fences, rosters, plans, and counters from what actually
+    /// surfaced, so its predictions for later frames stay grounded.
+    pub(crate) fn track_event(&mut self, ev: &SignalFishEvent) {
+        match ev {
+            SignalFishEvent::Authenticated { .. } => self.authenticated = true,
+            SignalFishEvent::ProtocolInfo(payload) => {
+                self.protocol_info_seen = true;
+                self.v3 = payload.protocol_version.is_some_and(|v| v >= 3);
+                self.correlation = self.v3
+                    && self.config.requests_room_operation_ids()
+                    && self.echo_room_ops
+                    && payload
+                        .capabilities
+                        .iter()
+                        .any(|capability| capability == "room_operation_ids");
+            }
+            SignalFishEvent::RoomJoined {
+                player_id,
+                room_id,
+                room_code,
+                current_players,
+                lobby_state,
+                ..
+            } => {
+                self.local_id = Some(*player_id);
+                self.room_id = Some(*room_id);
+                self.room_code = Some(room_code.clone());
+                self.roster = current_players.iter().map(|p| p.id).collect();
+                self.membership = Some(Role::Player);
+                self.room_finalized = matches!(lobby_state, LobbyState::Finalized);
+                self.batch_quarantined = false;
+                self.quarantine_latched = false;
+                self.absorbed_leave_armed = false;
+                self.absorbed_leave_id = None;
+                self.plan_seen = false;
+                self.session_generation = None;
+                self.session_transport = None;
+                self.plan_peers.clear();
+                if self.fence == Some(FenceKind::JoinPlayer) {
+                    self.fence = None;
+                }
+            }
+            SignalFishEvent::Reconnected {
+                player_id,
+                room_id,
+                room_code,
+                current_players,
+                ..
+            } => {
+                self.local_id = Some(*player_id);
+                self.room_id = Some(*room_id);
+                self.room_code = Some(room_code.clone());
+                self.roster = current_players.iter().map(|p| p.id).collect();
+                self.membership = Some(Role::Player);
+                self.room_finalized = true;
+                self.batch_quarantined = false;
+                self.quarantine_latched = false;
+                self.absorbed_leave_armed = false;
+                self.absorbed_leave_id = None;
+                self.plan_seen = false;
+                self.session_generation = None;
+                self.session_transport = None;
+                self.plan_peers.clear();
+                self.pending_reconnects = self.pending_reconnects.saturating_sub(1);
+                if self.fence == Some(FenceKind::ReconnectPlayer) {
+                    self.fence = None;
+                }
+            }
+            SignalFishEvent::SpectatorJoined {
+                spectator_id,
+                room_id,
+                room_code,
+                ..
+            } => {
+                self.local_id = Some(*spectator_id);
+                self.room_id = Some(*room_id);
+                self.room_code = Some(room_code.clone());
+                self.membership = Some(Role::Spectator);
+                self.batch_quarantined = false;
+                self.quarantine_latched = false;
+                self.absorbed_leave_armed = false;
+                self.absorbed_leave_id = None;
+                self.plan_seen = false;
+                self.session_generation = None;
+                self.session_transport = None;
+                self.plan_peers.clear();
+                if self.fence == Some(FenceKind::JoinSpectator) {
+                    self.fence = None;
+                }
+            }
+            SignalFishEvent::RoomLeft => {
+                self.membership = None;
+                self.room_finalized = false;
+                self.roster.clear();
+                self.local_id = None;
+                self.room_id = None;
+                self.room_code = None;
+                self.room_id = None;
+                self.room_code = None;
+                self.quarantine_latched = false;
+                self.plan_seen = false;
+                self.session_generation = None;
+                self.session_transport = None;
+                self.plan_peers.clear();
+                if self.fence == Some(FenceKind::LeavePlayer) {
+                    self.fence = None;
+                }
+            }
+            SignalFishEvent::SpectatorLeft {
+                reason,
+                room_id,
+                room_code,
+                ..
+            } => {
+                // Authoritative exits arm the absorbed-late-reply allowance
+                // when they overtake a pending voluntary leave; the runner
+                // fills in the captured operation id right after this event.
+                if matches!(
+                    reason,
+                    Some(
+                        SpectatorStateChangeReason::Disconnected
+                            | SpectatorStateChangeReason::Removed
+                            | SpectatorStateChangeReason::RoomClosed
+                    )
+                ) && self.fence == Some(FenceKind::LeaveSpectator)
+                {
+                    self.absorbed_leave_armed = true;
+                }
+                let _ = (room_id, room_code);
+                self.membership = None;
+                self.room_finalized = false;
+                self.roster.clear();
+                self.local_id = None;
+                self.room_id = None;
+                self.room_code = None;
+                self.quarantine_latched = false;
+                self.plan_seen = false;
+                self.session_generation = None;
+                self.session_transport = None;
+                self.plan_peers.clear();
+                if self.fence == Some(FenceKind::LeaveSpectator) {
+                    self.fence = None;
+                }
+            }
+            SignalFishEvent::RoomJoinFailed { .. } => {
+                if self.fence == Some(FenceKind::JoinPlayer) {
+                    self.fence = None;
+                }
+            }
+            SignalFishEvent::SpectatorJoinFailed { .. } => {
+                if self.fence == Some(FenceKind::JoinSpectator) {
+                    self.fence = None;
+                }
+            }
+            SignalFishEvent::ReconnectionFailed { .. } => {
+                self.pending_reconnects = self.pending_reconnects.saturating_sub(1);
+                if self.fence == Some(FenceKind::ReconnectPlayer) {
+                    self.fence = None;
+                }
+            }
+            SignalFishEvent::RoomOperationFailed { .. } => {
+                if self.fence == Some(FenceKind::ReconnectPlayer) {
+                    self.pending_reconnects = self.pending_reconnects.saturating_sub(1);
+                }
+                self.fence = None;
+            }
+            SignalFishEvent::PlayerJoined { player } => {
+                self.roster.insert(player.id);
+            }
+            SignalFishEvent::PlayerLeft { player_id, .. } => {
+                self.roster.remove(player_id);
+            }
+            SignalFishEvent::LobbyStateChanged { lobby_state, .. } => {
+                self.room_finalized = matches!(lobby_state, LobbyState::Finalized);
+            }
+            SignalFishEvent::GameStarting { .. } => {
+                self.room_finalized = true;
+            }
+            SignalFishEvent::SessionPlan {
+                transport,
+                generation,
+                peers,
+                ..
+            } => {
+                self.plan_seen = true;
+                self.session_transport = Some(*transport);
+                self.session_generation = *generation;
+                self.plan_peers = peers.iter().map(|p| p.player_id).collect();
+            }
+            SignalFishEvent::RelayStats {
+                interval_ms,
+                sent_to_you,
+                dropped_for_you,
+                backpressure_events,
+            } => {
+                self.relay_interval = Some(*interval_ms);
+                self.relay_counters = (*sent_to_you, *dropped_for_you, *backpressure_events);
+            }
+            SignalFishEvent::DeliveryReport(payload) => {
+                if payload
+                    .gaps
+                    .iter()
+                    .any(|gap| gap.reason == DeliveryGapReason::UnsupportedFormat)
+                {
+                    self.unsupported_format_advisory_armed = true;
+                }
+            }
+            SignalFishEvent::Error { .. } => {
+                // The causal advisory is one-shot per armed range.
+                self.unsupported_format_advisory_armed = false;
+            }
+            SignalFishEvent::Disconnected { .. } => {
+                self.fence = None;
+                self.absorbed_leave_armed = false;
+                self.absorbed_leave_id = None;
+            }
+            _ => {}
+        }
+    }
+
+    pub(crate) fn arm_fence(&mut self, kind: FenceKind) {
+        self.fence = Some(kind);
+        if kind == FenceKind::ReconnectPlayer {
+            self.pending_reconnects = self.pending_reconnects.saturating_add(1);
+        }
+    }
+
+    /// Feed one observed event through the phase model and reconcile it
+    /// against the pending expectation slot.
+    pub(crate) fn observe(&mut self, ev: &SignalFishEvent) -> Result<(), String> {
+        if oracle_strict() && self.terminal {
+            return Err(format!(
+                "event `{}` after terminal disconnect",
+                event_name(ev)
+            ));
+        }
+        // Pending teardown applies only to events *after* the violating one.
+        let was_pending = self.pending_disconnect;
+        let phase = |ok: bool| -> Result<(), String> {
+            if ok || !oracle_strict() {
+                Ok(())
+            } else {
+                Err("phase".to_string())
+            }
+        };
+        match ev {
+            SignalFishEvent::Connected => {
+                if oracle_strict() && self.connected_event_seen {
+                    return Err("duplicate Connected event".into());
+                }
+                if oracle_strict() && self.any_event_seen {
+                    return Err("Connected was not the first event".into());
+                }
+                self.connected_event_seen = true;
+            }
+            SignalFishEvent::Disconnected {
+                reason,
+                last_server_error: _,
+            } => {
+                if oracle_strict() && self.disconnected_seen {
+                    return Err("duplicate Disconnected event".into());
+                }
+                if oracle_strict()
+                    && self.policy != ProtocolViolationPolicy::Disconnect
+                    && !self.pending_disconnect
+                    && !self.peer_close_armed
+                    && !self.transport_error_armed
+                {
+                    return Err(
+                        "Disconnected without a violation (Disconnect policy), peer close, \
+                         or terminal transport error"
+                            .into(),
+                    );
+                }
+                self.terminal_cause = Some(if was_pending {
+                    self.violation_teardown = true;
+                    TerminalCause::Violation
+                } else if self.peer_close_armed {
+                    TerminalCause::PeerClose
+                } else if self.transport_error_armed {
+                    TerminalCause::TransportError
+                } else {
+                    TerminalCause::Violation
+                });
+                self.disconnect_reason = reason.clone();
+                self.disconnected_seen = true;
+                self.terminal = true;
+                self.pending_disconnect = false;
+                self.quarantine_latched = false;
+            }
+            SignalFishEvent::DecodeFailed { .. } => {}
+            SignalFishEvent::ProtocolViolation { diagnostic, .. } => {
+                self.violations = self.violations.saturating_add(1);
+                if self.policy == ProtocolViolationPolicy::Quarantine {
+                    self.batch_quarantined = true;
+                    self.quarantine_latched = true;
+                }
+                if self.policy == ProtocolViolationPolicy::Disconnect {
+                    self.pending_disconnect = true;
+                }
+                if oracle_strict() && diagnostic.is_empty() {
+                    return Err("empty violation diagnostic".into());
+                }
+            }
+            SignalFishEvent::Authenticated { .. } => {
+                phase(!self.authenticated && self.membership.is_none())?;
+            }
+            SignalFishEvent::AuthenticationError { .. } => {
+                phase(!self.authenticated && self.membership.is_none())?;
+            }
+            SignalFishEvent::ProtocolInfo(_) => {
+                phase(self.authenticated && self.membership.is_none() && !self.protocol_info_seen)?;
+            }
+            SignalFishEvent::RoomJoined { .. } | SignalFishEvent::Reconnected { .. } => {
+                phase(self.authenticated && self.membership.is_none())?;
+            }
+            SignalFishEvent::SpectatorJoined { .. } => {
+                phase(self.authenticated && self.membership.is_none())?;
+            }
+            SignalFishEvent::RoomLeft => {
+                phase(self.authenticated && self.membership == Some(Role::Player))?;
+            }
+            SignalFishEvent::SpectatorLeft { .. } => {
+                phase(self.authenticated && self.membership == Some(Role::Spectator))?;
+            }
+            SignalFishEvent::RoomJoinFailed { .. }
+            | SignalFishEvent::SpectatorJoinFailed { .. }
+            | SignalFishEvent::ReconnectionFailed { .. } => {
+                phase(self.authenticated)?;
+            }
+            SignalFishEvent::RoomOperationFailed { .. } => {}
+            SignalFishEvent::PlayerJoined { .. }
+            | SignalFishEvent::PlayerLeft { .. }
+            | SignalFishEvent::GameData { .. }
+            | SignalFishEvent::GameDataBinary { .. }
+            | SignalFishEvent::AuthorityChanged { .. }
+            | SignalFishEvent::LobbyStateChanged { .. }
+            | SignalFishEvent::GameStarting { .. }
+            | SignalFishEvent::PlayerReconnected { .. }
+            | SignalFishEvent::NewSpectatorJoined { .. }
+            | SignalFishEvent::SpectatorDisconnected { .. } => {
+                phase(self.authenticated && self.membership.is_some())?;
+            }
+            SignalFishEvent::DeliveryReport(_) => {
+                phase(self.authenticated && self.membership.is_some() && self.v3)?;
+            }
+            SignalFishEvent::SignalReceived { .. } => {
+                phase(
+                    self.authenticated
+                        && self.membership == Some(Role::Player)
+                        && self.plan_seen
+                        && self.v3,
+                )?;
+            }
+            SignalFishEvent::NewPeer { .. } | SignalFishEvent::PeerTransportStatus { .. } => {
+                phase(self.authenticated && self.membership == Some(Role::Player) && self.v3)?;
+            }
+            SignalFishEvent::SessionPlan { .. } => {
+                phase(self.authenticated && self.membership == Some(Role::Player) && self.v3)?;
+                self.plan_seen = true;
+            }
+            SignalFishEvent::RelayStats { .. } | SignalFishEvent::GoingAway { .. } => {
+                phase(self.authenticated && self.v3)?;
+            }
+            SignalFishEvent::AuthorityResponse { .. } => {
+                phase(self.authenticated)?;
+            }
+            SignalFishEvent::Pong | SignalFishEvent::Error { .. } => {}
+        }
+        // Game-data suppression under quarantine.
+        if oracle_strict()
+            && matches!(
+                ev,
+                SignalFishEvent::GameData { .. } | SignalFishEvent::GameDataBinary { .. }
+            )
+            && self.policy == ProtocolViolationPolicy::Quarantine
+            && self.batch_quarantined
+        {
+            return Err("game data delivered while quarantined".into());
+        }
+        // Non-violation events must not follow a pending Disconnect-policy teardown.
+        if oracle_strict() && was_pending && !matches!(ev, SignalFishEvent::Disconnected { .. }) {
+            return Err("non-terminal event after Disconnect-policy violation".into());
+        }
+        self.track_event(ev);
+        self.any_event_seen = true;
+        Ok(())
+    }
+
+    /// Reconcile one poll batch's observed outcome against the pending
+    /// expectation slot (issue #219 oracle). `Disconnected`/`Connected` are
+    /// excluded; they belong to the phase model.
+    pub(crate) fn reconcile_batch(
+        &mut self,
+        events: &[&'static str],
+        violations_in_batch: usize,
+        step_index: usize,
+        findings: &mut Vec<Finding>,
+    ) {
+        if !oracle_strict() {
+            return;
+        }
+        if events.is_empty() && violations_in_batch == 0 {
+            // Silence satisfies only the slots whose documented model permits
+            // it (stale suppression, absorbed replies, quarantined game data).
+            if let Some(front) = self.slots.front() {
+                if front.alternatives.contains(&AllowedOutcome::empty()) {
+                    self.slots.pop_front();
+                    self.absorbed_leave_armed = false;
+                    self.absorbed_leave_id = None;
+                }
+            }
+            return;
+        }
+        let Some(slot_data) = self.slots.front().map(|slot| {
+            (
+                slot.frame,
+                slot.fence_retired_on_violation,
+                slot.alternatives.clone(),
+            )
+        }) else {
+            findings.push(Finding {
+                category: "expectation-fabricated".into(),
+                detail: format!(
+                    "events surfaced with no delivered frame to attribute them to: {events:?} \
+                     (violations={violations_in_batch})"
+                ),
+                step_index,
+            });
+            return;
+        };
+        let mut observed_events = BTreeMap::new();
+        for name in events {
+            observed_events
+                .entry(*name)
+                .and_modify(|count: &mut usize| *count = count.saturating_add(1))
+                .or_insert(1usize);
+        }
+        let observed = AllowedOutcome {
+            events: observed_events,
+            violations: violations_in_batch,
+        };
+        let (frame_name, fence_retired_on_violation, alternatives) = slot_data;
+        if !alternatives.contains(&observed) {
+            let expected: Vec<String> = alternatives.iter().map(|alt| format!("{alt:?}")).collect();
+            findings.push(Finding {
+                category: "expectation-mismatch".into(),
+                detail: format!(
+                    "frame {frame_name} produced {observed:?} but the documented model permits only: {}",
+                    expected.join(" | ")
+                ),
+                step_index,
+            });
+            return;
+        }
+        self.slots.pop_front();
+        // A violating baseline retires its answered fence (the round-12
+        // retire_answered_room_operation rule).
+        if observed.violations > 0 {
+            if let (Some(retired), Some(current)) = (fence_retired_on_violation, self.fence) {
+                if retired == current {
+                    self.fence = None;
+                }
+            }
+        }
+        // Consuming the silent face spends the absorbed-reply allowance.
+        if observed.events.is_empty() && observed.violations == 0 {
+            self.absorbed_leave_armed = false;
+            self.absorbed_leave_id = None;
+        }
+    }
+
+    /// Forgive every pending expectation (teardown abandons queued delivery).
+    pub(crate) fn forgive_pending(&mut self) {
+        self.slots.clear();
+    }
+
+    pub(crate) fn pending_slot_count(&self) -> usize {
+        self.slots.len()
+    }
+
+    pub(crate) fn end_batch(&mut self) -> Result<(), String> {
+        if oracle_strict() && self.pending_disconnect {
+            return Err("Disconnect-policy violation without a same-batch Disconnected".into());
+        }
+        Ok(())
+    }
+
+    /// Close-info attribution: the `Disconnected` reason must agree with the
+    /// armed transport face. `transport_peer_closed` mirrors
+    /// `Transport::close_info()` at the end of the run.
+    #[allow(clippy::collapsible_match)]
+    pub(crate) fn verify_close_attribution(
+        &self,
+        transport_peer_closed: bool,
+    ) -> Result<(), String> {
+        if !oracle_strict() || !self.disconnected_seen {
+            return Ok(());
+        }
+        let reason = self.disconnect_reason.clone();
+        let reason_says_server = reason
+            .as_deref()
+            .is_some_and(|reason| reason.starts_with("closed by server"));
+        if reason_says_server && !transport_peer_closed {
+            return Err(format!(
+                "close-info misattribution: reason reports a server close but \
+                 close_info() reports no peer close: {reason:?}"
+            ));
+        }
+        match self.terminal_cause {
+            Some(TerminalCause::Violation) => {
+                if reason.as_deref() != Some("protocol violation") {
+                    return Err(format!(
+                        "close-info misattribution: violation teardown reported reason \
+                         {reason:?} instead of Some(\"protocol violation\")"
+                    ));
+                }
+            }
+            Some(TerminalCause::PeerClose) => {
+                if !transport_peer_closed {
+                    return Err(
+                        "close-info misattribution: Disconnected classified as peer close \
+                         but close_info() reports no peer-initiated close"
+                            .into(),
+                    );
+                }
+                let expected = "closed by server: code=Some(1001), \
+                                reason=Some(\"server going away\")";
+                if reason.as_deref() != Some(expected) {
+                    return Err(format!(
+                        "close-info misattribution: peer close reported reason {reason:?} \
+                         instead of the armed TransportCloseInfo formatting"
+                    ));
+                }
+            }
+            Some(TerminalCause::TransportError) => {
+                if !self
+                    .expected_transport_reasons
+                    .iter()
+                    .any(|expected| Some(expected.as_str()) == reason.as_deref())
+                {
+                    return Err(format!(
+                        "close-info misattribution: terminal transport error reported \
+                         reason {reason:?} instead of the armed error {:?}",
+                        self.expected_transport_reasons
+                    ));
+                }
+            }
+            None => {}
+        }
+        Ok(())
+    }
+
+    /// Snapshot-coherence invariants (checked after every poll batch).
+    pub(crate) fn check_snapshot(
+        &self,
+        snap: &signal_fish_client::ClientSnapshot,
+    ) -> Result<(), String> {
+        if !oracle_strict() {
+            return Ok(());
+        }
+        if !snap.connected {
+            if snap.transport_ready {
+                return Err("snapshot: disconnected but transport_ready".into());
+            }
+            if snap.room_role.is_some() || snap.room_id.is_some() || snap.player_id.is_some() {
+                return Err("snapshot: disconnected session fields not cleared".into());
+            }
+        }
+        match snap.room_role {
+            None => {
+                if snap.player_id.is_some() || snap.room_id.is_some() || snap.room_code.is_some() {
+                    return Err("snapshot: role None but membership ids present".into());
+                }
+                if snap.session_generation.is_some()
+                    || snap.session_topology.is_some()
+                    || snap.session_transport.is_some()
+                {
+                    return Err("snapshot: role None but session plan fields present".into());
+                }
+            }
+            Some(_) => {
+                if snap.player_id.is_none() || snap.room_id.is_none() {
+                    return Err("snapshot: in room but player/room id missing".into());
+                }
+            }
+        }
+        match self.policy {
+            ProtocolViolationPolicy::Quarantine => {
+                // Positive quarantine-latch invariant: every violation latches
+                // under the Quarantine policy until an authoritative
+                // membership transition clears it. A Quarantine policy that
+                // behaves like Observe (flag never set) must be caught here.
+                if self.quarantine_latched && snap.connected && !snap.quarantined {
+                    return Err(
+                        "snapshot: violation observed under Quarantine policy but the \
+                         quarantined flag was never latched"
+                            .into(),
+                    );
+                }
+            }
+            ProtocolViolationPolicy::Observe | ProtocolViolationPolicy::Disconnect => {
+                if snap.quarantined {
+                    return Err(format!(
+                        "snapshot: quarantined flag set under {:?} policy",
+                        self.policy
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+fn echo_kind_matches_fence(kind: EchoKind, fence: FenceKind) -> bool {
+    matches!(
+        (kind, fence),
+        (
+            EchoKind::JoinOk | EchoKind::JoinFailed,
+            FenceKind::JoinPlayer
+        ) | (EchoKind::LeaveOk, FenceKind::LeavePlayer)
+            | (
+                EchoKind::ReconnectOk | EchoKind::ReconnectFailed,
+                FenceKind::ReconnectPlayer
+            )
+            | (
+                EchoKind::SpectatorJoinOk | EchoKind::SpectatorJoinFailed,
+                FenceKind::JoinSpectator
+            )
+            | (EchoKind::SpectatorLeaveOk, FenceKind::LeaveSpectator)
+            | (EchoKind::OperationFailed, _)
+    )
+}
+
+/// Baseline roster validity (mirror of `validate_local_player_snapshot`): the
+/// payload's player must appear exactly once with a consistent authority flag
+/// and at most one authority overall.
+fn baseline_roster_valid(
+    v3: bool,
+    local: PlayerId,
+    local_is_authority: bool,
+    players: &[signal_fish_client::protocol::PlayerInfo],
+) -> bool {
+    if players.iter().filter(|p| p.id == local).count() != 1 {
+        return false;
+    }
+    let Some(entry) = players.iter().find(|p| p.id == local) else {
+        return false;
+    };
+    if entry.is_authority != local_is_authority {
+        return false;
+    }
+    if players.iter().filter(|p| p.is_authority).count() > 1 {
+        return false;
+    }
+    if v3 && players.iter().any(|p| v3_stamp_invalid(p.epoch, p.seq)) {
+        return false;
+    }
+    true
+}
+
+fn v3_stamp_invalid(epoch: Option<u32>, seq: Option<u64>) -> bool {
+    match (epoch, seq) {
+        (Some(e), Some(_)) => e == 0,
+        _ => true,
+    }
+}
+
+fn make_config(
+    kind: ConfigKind,
+    policy: ProtocolViolationPolicy,
+    small_command_capacity: Option<usize>,
+) -> SignalFishConfig {
+    let base = SignalFishConfig::new("mb_app_round41_hostile")
+        .with_protocol_violation_policy(policy)
+        .with_event_channel_capacity(1024)
+        .with_command_channel_capacity(small_command_capacity.unwrap_or(1024));
+    match kind {
+        ConfigKind::V3 => base.enable_v3(),
+        ConfigKind::V3VersionOnly => base.with_protocol_version(3),
+        ConfigKind::V2 => base,
+        ConfigKind::V2Explicit => base.with_protocol_version(2),
+    }
+}
+
+/// Look up the most recent outbound RoomOperation id recorded by the transport.
+fn last_sent_operation_id(handles: &crate::transport::ScriptedHandles) -> Option<PlayerId> {
+    let log = lock(&handles.outbound);
+    for line in log.iter().rev() {
+        if let Ok(ClientMessage::RoomOperation { operation_id, .. }) =
+            serde_json::from_str::<ClientMessage>(line)
+        {
+            return Some(operation_id);
+        }
+    }
+    None
+}
+
+/// Count game-data frames the transport accepted (issue #219 ledger): text
+/// lines that deserialize to `ClientMessage::GameData` plus binary frames.
+fn outbound_game_data_frames(handles: &crate::transport::ScriptedHandles) -> usize {
+    let log = lock(&handles.outbound);
+    let mut count = 0usize;
+    for line in log.iter() {
+        let is_game_data = line.starts_with("<binary ")
+            || matches!(
+                serde_json::from_str::<ClientMessage>(line),
+                Ok(ClientMessage::GameData { .. })
+            );
+        if is_game_data {
+            count = count.saturating_add(1);
+        }
+    }
+    count
+}
+
+fn execute_cmd(
+    client: &mut SignalFishPollingClient<ScriptedTransport>,
+    cmd: &Cmd,
+) -> Result<(), signal_fish_client::SignalFishError> {
+    match cmd {
+        Cmd::JoinRoom => client.join_room(JoinRoomParams::new("hostile-game", "hostile-player")),
+        Cmd::JoinRoomMax(max) => client.join_room(
+            JoinRoomParams::new("hostile-game", "hostile-player").with_max_players(*max),
+        ),
+        Cmd::LeaveRoom => client.leave_room(),
+        Cmd::SendGameData(v) => client.send_game_data(v.clone()),
+        Cmd::SendGameDataLatest(k) => client.send_game_data_with_delivery(
+            serde_json::json!({ "tick": k }),
+            GameDataDelivery::Latest { key: *k },
+        ),
+        Cmd::SendGameDataVolatile => client.send_game_data_with_delivery(
+            serde_json::json!({ "volatile": true }),
+            GameDataDelivery::Volatile,
+        ),
+        Cmd::SendBinaryGameData(n) => client.send_binary_game_data(vec![0xAB_u8; *n]),
+        Cmd::SetReady => client.set_ready(),
+        Cmd::StartGame => client.start_game(),
+        Cmd::RequestAuthority(b) => client.request_authority(*b),
+        Cmd::ProvideConnectionInfo => client.provide_connection_info(ConnectionInfo::Direct {
+            host: "203.0.113.1".to_string(),
+            port: 40000,
+        }),
+        Cmd::Reconnect(player, room) => {
+            client.reconnect(*player, *room, "hostile-auth-token".to_string())
+        }
+        Cmd::JoinAsSpectator => {
+            client.join_as_spectator("hostile-game".into(), "R1".into(), "spec".into())
+        }
+        Cmd::LeaveSpectator => client.leave_spectator(),
+        Cmd::Ping => client.ping(),
+        Cmd::SendSignal => client.send_signal(
+            PlayerId::from_u128(42),
+            PeerSignal::Offer("v=0 hostile".to_string()),
+        ),
+        Cmd::SendRawSignal => client.send_raw_signal(
+            PlayerId::from_u128(42),
+            serde_json::json!({ "IceCandidate": "x" }),
+        ),
+        Cmd::ReportTransportStatus => client.report_transport_status(TransportKind::Relay, true),
+    }
+}
+
+/// Build a `RoomOperationResult` echo. Returns the message plus whether the
+/// embedded id matches the id of the client's most recently sent operation.
+fn build_echo_message(
+    handles: &crate::transport::ScriptedHandles,
+    kind: EchoKind,
+    id_choice: EchoId,
+) -> (ServerMessage, bool) {
+    let pending_id = last_sent_operation_id(handles);
+    let (operation_id, id_matches) = match id_choice {
+        EchoId::Match => match pending_id {
+            Some(id) => (id, true),
+            None => (PlayerId::from_u128(0xE_C00), false),
+        },
+        EchoId::Wrong => (PlayerId::from_u128(0xBA_DD1D), false),
+    };
+    let result = match kind {
+        EchoKind::JoinOk => {
+            RoomOperationResult::RoomJoined(Box::new(RoomJoinedPayload {
+                room_id: PlayerId::from_u128(0x1000),
+                room_code: "ECHO".into(),
+                player_id: PlayerId::from_u128(0x2000),
+                game_name: "hostile-game".into(),
+                max_players: 8,
+                supports_authority: true,
+                // The local player must appear exactly once with a consistent
+                // authority flag for the baseline to be lifecycle-valid.
+                current_players: vec![signal_fish_client::protocol::PlayerInfo {
+                    id: PlayerId::from_u128(0x2000),
+                    name: "echo-self".into(),
+                    is_authority: false,
+                    is_ready: false,
+                    connected_at: "2026-09-02T00:00:00Z".into(),
+                    connection_info: None,
+                    epoch: Some(1),
+                    seq: Some(0),
+                }],
+                is_authority: false,
+                lobby_state: LobbyState::Waiting,
+                ready_players: vec![],
+                relay_type: "websocket".into(),
+                current_spectators: vec![],
+                ice_servers: vec![],
+                reconnection_token: None,
+            }))
+        }
+        EchoKind::JoinFailed => RoomOperationResult::RoomJoinFailed {
+            reason: "echo-fail".into(),
+            error_code: Some(signal_fish_client::ErrorCode::RoomFull),
+        },
+        EchoKind::LeaveOk => RoomOperationResult::RoomLeft,
+        EchoKind::ReconnectOk => {
+            RoomOperationResult::Reconnected(Box::new(ReconnectedPayload {
+                room_id: PlayerId::from_u128(0x1000),
+                room_code: "ECHO".into(),
+                player_id: PlayerId::from_u128(0x2000),
+                game_name: "hostile-game".into(),
+                max_players: 8,
+                supports_authority: false,
+                current_players: vec![],
+                is_authority: false,
+                lobby_state: LobbyState::Finalized,
+                ready_players: vec![],
+                relay_type: "websocket".into(),
+                current_spectators: vec![],
+                ice_servers: vec![],
+                missed_events: vec![],
+                replay: Some(ReplayStatus::Complete),
+                sender_watermarks: vec![],
+                // v3 requires a rotated, nonempty token.
+                reconnection_token: Some("rotated-echo-token".into()),
+            }))
+        }
+        EchoKind::ReconnectFailed => RoomOperationResult::ReconnectionFailed {
+            reason: "echo-fail".into(),
+            error_code: signal_fish_client::ErrorCode::ReconnectionTokenInvalid,
+        },
+        EchoKind::SpectatorJoinOk => {
+            RoomOperationResult::SpectatorJoined(Box::new(SpectatorJoinedPayload {
+                room_id: PlayerId::from_u128(0x1000),
+                room_code: "ECHO".into(),
+                spectator_id: PlayerId::from_u128(0x3000),
+                game_name: "hostile-game".into(),
+                current_players: vec![],
+                current_spectators: vec![signal_fish_client::protocol::SpectatorInfo {
+                    id: PlayerId::from_u128(0x3000),
+                    name: "echo-spec".into(),
+                    connected_at: "2026-09-02T00:00:00Z".into(),
+                }],
+                lobby_state: LobbyState::Waiting,
+                reason: None,
+            }))
+        }
+        EchoKind::SpectatorJoinFailed => RoomOperationResult::SpectatorJoinFailed {
+            reason: "echo-fail".into(),
+            error_code: Some(signal_fish_client::ErrorCode::SpectatorNotAllowed),
+        },
+        EchoKind::SpectatorLeaveOk => RoomOperationResult::SpectatorLeft {
+            room_id: Some(PlayerId::from_u128(0x1000)),
+            room_code: Some("ECHO".into()),
+            reason: Some(SpectatorStateChangeReason::VoluntaryLeave),
+            current_spectators: vec![],
+        },
+        EchoKind::OperationFailed => RoomOperationResult::OperationFailed {
+            reason: "echo-op-failed".into(),
+            error_code: Some(signal_fish_client::ErrorCode::InvalidInput),
+        },
+    };
+    (
+        ServerMessage::RoomOperationResult {
+            operation_id,
+            result: Box::new(result),
+        },
+        id_matches,
+    )
+}
+
+struct RunState {
+    outcome: Outcome,
+    oracle: Oracle,
+    /// Accepted-send marker order for the send-pressure ledger.
+    sent_markers: Vec<u64>,
+    /// Count of accepted binary game-data sends.
+    sent_binaries: usize,
+    /// Predicted `game_data_received` (issue #219 ledger oracle).
+    predicted_game_data_received: usize,
+    /// Count of raw frames fed (each must surface exactly one DecodeFailed).
+    raw_frames_fed: usize,
+    /// DecodeFailed events observed (checked against `raw_frames_fed`).
+    decode_failed_events: usize,
+}
+
+pub(crate) fn run_prefix(
+    script: &Script,
+    policy: ProtocolViolationPolicy,
+    limit: usize,
+) -> Outcome {
+    let (transport, handles) = ScriptedTransport::new();
+    let config = make_config(script.config_kind, policy, script.small_command_capacity);
+    let mut client = SignalFishPollingClient::new(transport, config);
+    let mut state = RunState {
+        outcome: Outcome::new(),
+        oracle: Oracle::new(policy, script.config_kind, script.echo_room_ops),
+        sent_markers: Vec::new(),
+        sent_binaries: 0,
+        predicted_game_data_received: 0,
+        raw_frames_fed: 0,
+        decode_failed_events: 0,
+    };
+
+    for (idx, step) in script.steps.iter().take(limit).enumerate() {
+        heartbeat();
+        match step {
+            Step::Deliver(msg, meta) => {
+                note_delivered(crate::script::msg_variant_name(msg));
+                if !state.oracle.terminal
+                    && matches!(
+                        msg,
+                        ServerMessage::GameData { .. } | ServerMessage::GameDataBinary { .. }
+                    )
+                {
+                    // Decoded game data counts before suppression (JSON text
+                    // frames always decode here). Frames fed after a terminal
+                    // teardown are never consumed.
+                    state.predicted_game_data_received =
+                        state.predicted_game_data_received.saturating_add(1);
+                }
+                let json = match serde_json::to_string(msg) {
+                    Ok(json) => json,
+                    Err(_) => "{}".to_string(),
+                };
+                ScriptedTransport::push_text(&handles, json);
+                state.outcome.frames_fed = state.outcome.frames_fed.saturating_add(1);
+                if state.oracle.terminal {
+                    continue;
+                }
+                let expected = state.oracle.expectation_for(msg, meta);
+                let fence_retired_on_violation = state.oracle.retire_on_violation(msg);
+                state.oracle.slots.push_back(Slot {
+                    alternatives: expected,
+                    frame: crate::script::msg_variant_name(msg),
+                    fence_retired_on_violation,
+                });
+                drive_polls(&mut client, &mut state, 1, idx);
+                // Capture the absorbed-late-reply operation id (the pending
+                // voluntary leave was the client's most recent operation).
+                if state.oracle.absorbed_leave_armed && state.oracle.absorbed_leave_id.is_none() {
+                    state.oracle.absorbed_leave_id = last_sent_operation_id(&handles);
+                }
+            }
+            Step::DeliverRaw(raw) => {
+                note_delivered("<raw schema-invalid frame>");
+                ScriptedTransport::push_text(&handles, (*raw).to_string());
+                state.outcome.frames_fed = state.outcome.frames_fed.saturating_add(1);
+                if !state.oracle.terminal {
+                    state.raw_frames_fed = state.raw_frames_fed.saturating_add(1);
+                    state.oracle.slots.push_back(Slot {
+                        alternatives: exactly("DecodeFailed"),
+                        frame: "RawFrame",
+                        fence_retired_on_violation: None,
+                    });
+                }
+                drive_polls(&mut client, &mut state, 1, idx);
+            }
+            Step::DeliverBinary(bytes, meta) => {
+                note_delivered("<physical binary frame>");
+                ScriptedTransport::push_binary(&handles, bytes.clone());
+                state.outcome.frames_fed = state.outcome.frames_fed.saturating_add(1);
+                if state.oracle.terminal {
+                    continue;
+                }
+                // Binary frames count only when the representation gate lets
+                // them reach decode: the campaign's negotiated format is
+                // always Json, so only the Observe policy's diagnostic
+                // continue (on a v3 connection) reaches the decode counter.
+                if !state.oracle.terminal
+                    && state.oracle.in_room()
+                    && state.oracle.protocol_info_seen
+                    && state.oracle.v3
+                    && policy == ProtocolViolationPolicy::Observe
+                {
+                    state.predicted_game_data_received =
+                        state.predicted_game_data_received.saturating_add(1);
+                }
+                let expected = state.oracle.expectation_for_binary(meta);
+                state.oracle.slots.push_back(Slot {
+                    alternatives: expected,
+                    frame: "BinaryFrame",
+                    fence_retired_on_violation: None,
+                });
+                drive_polls(&mut client, &mut state, 1, idx);
+            }
+            Step::DeliverEcho(kind, id_choice) => {
+                note_delivered("RoomOperationResult");
+                note_delivered(&format!("RoomOperationResult::{}", kind.name()));
+                let (msg, id_matches) = build_echo_message(&handles, *kind, *id_choice);
+                let json = match serde_json::to_string(&msg) {
+                    Ok(json) => json,
+                    Err(_) => "{}".to_string(),
+                };
+                ScriptedTransport::push_text(&handles, json);
+                state.outcome.frames_fed = state.outcome.frames_fed.saturating_add(1);
+                let kind_matched_fence = state
+                    .oracle
+                    .fence
+                    .is_some_and(|fence| echo_kind_matches_fence(*kind, fence));
+                let expected = state.oracle.expectation_for_echo(*kind, id_matches);
+                let slots_before = state.oracle.slots.len();
+                state.oracle.slots.push_back(Slot {
+                    alternatives: expected,
+                    frame: "RoomOperationResult",
+                    fence_retired_on_violation: None,
+                });
+                drive_polls(&mut client, &mut state, 1, idx);
+                // A kind/id-matching consumed result retires the fence
+                // (typed results release it in update_state; accountability-
+                // invalid baselines retire it via the round-12 fix; the
+                // OperationFailed early return releases any kind).
+                if state.oracle.slots.len() < slots_before
+                    && (*kind == EchoKind::OperationFailed || (kind_matched_fence && id_matches))
+                {
+                    state.oracle.fence = None;
+                }
+                if state.oracle.absorbed_leave_armed && state.oracle.absorbed_leave_id.is_none() {
+                    state.oracle.absorbed_leave_id = last_sent_operation_id(&handles);
+                }
+            }
+            Step::Cmd(cmd) => {
+                heartbeat();
+                let accepted = execute_cmd(&mut client, cmd).is_ok();
+                if VERBOSE.load(Ordering::Relaxed) {
+                    println!("       cmd: {} accepted={accepted}", cmd.name());
+                }
+                if accepted {
+                    state.outcome.commands_accepted =
+                        state.outcome.commands_accepted.saturating_add(1);
+                    if let Some(fence) = cmd.fence() {
+                        state.oracle.arm_fence(fence);
+                    }
+                    if let Cmd::SendGameData(payload) = cmd {
+                        if let Some(marker) = payload.get("marker").and_then(|m| m.as_u64()) {
+                            state.sent_markers.push(marker);
+                        }
+                    }
+                    if matches!(cmd, Cmd::SendBinaryGameData(_)) {
+                        state.sent_binaries = state.sent_binaries.saturating_add(1);
+                    }
+                    if state.oracle.terminal {
+                        state.outcome.findings.push(Finding {
+                            category: "command-after-terminal".into(),
+                            detail: format!(
+                                "command {} was accepted after terminal disconnect",
+                                cmd.name()
+                            ),
+                            step_index: idx,
+                        });
+                    }
+                } else {
+                    state.outcome.commands_refused =
+                        state.outcome.commands_refused.saturating_add(1);
+                }
+                drive_polls(&mut client, &mut state, 1, idx);
+            }
+            Step::Poll(n) => {
+                drive_polls(&mut client, &mut state, *n, idx);
+            }
+            Step::SetSendDelay(delay) => {
+                ScriptedTransport::set_send_delay(&handles, *delay);
+            }
+            Step::Close => {
+                heartbeat();
+                // Pressure/ledger assertions run at the close boundary while
+                // the run state is still intact.
+                if script.archetype == "send_pressure" && state.outcome.findings.is_empty() {
+                    ledger_checks(&client, &mut state, &handles, idx);
+                    pressure_checks(&client, &mut state, &handles, idx);
+                }
+                client.close();
+                // Idempotence: a second close must be silent and cheap.
+                client.close();
+                check_silent_after_close(&mut client, &mut state, idx);
+                state.oracle.terminal = true;
+            }
+            Step::PeerClose => {
+                heartbeat();
+                ScriptedTransport::arm_peer_close(&handles);
+                state.oracle.peer_close_armed = true;
+                drive_polls(&mut client, &mut state, 2, idx);
+            }
+            Step::TransportKill {
+                fail_recv,
+                fail_send,
+            } => {
+                heartbeat();
+                if *fail_recv {
+                    ScriptedTransport::arm_recv_error(&handles);
+                }
+                if *fail_send {
+                    ScriptedTransport::arm_send_error(&handles);
+                }
+                state.oracle.arm_transport_error(*fail_recv, *fail_send);
+                drive_polls(&mut client, &mut state, 3, idx);
+            }
+        }
+        if !state.outcome.findings.is_empty() {
+            break;
+        }
+    }
+
+    // Terminal drain: whatever the script end state, close and verify stability.
+    let tail_index = limit;
+    if state.outcome.findings.is_empty()
+        && !matches!(script.steps.get(limit.saturating_sub(1)), Some(Step::Close))
+    {
+        heartbeat();
+        ledger_checks(&client, &mut state, &handles, tail_index);
+        if state.outcome.findings.is_empty() {
+            client.close();
+            // Idempotence: a second close must be silent and cheap.
+            client.close();
+            check_silent_after_close(&mut client, &mut state, tail_index);
+        }
+    }
+
+    // Terminal-state discipline.
+    if state.outcome.findings.is_empty() {
+        if state.oracle.disconnected_seen && client.snapshot().connected {
+            state.outcome.findings.push(Finding {
+                category: "terminal-snapshot".into(),
+                detail: "snapshot.connected still true after terminal Disconnected".into(),
+                step_index: limit,
+            });
+        }
+        if state.oracle.transport_error_armed && !state.oracle.disconnected_seen {
+            state.outcome.findings.push(Finding {
+                category: "terminal-snapshot".into(),
+                detail: "terminal transport error did not produce a Disconnected event".into(),
+                step_index: limit,
+            });
+        }
+        if let Err(detail) = state
+            .oracle
+            .verify_close_attribution(handles.peer_closed.load(Ordering::Relaxed))
+        {
+            state.outcome.findings.push(Finding {
+                category: "close-attribution".into(),
+                detail,
+                step_index: limit,
+            });
+        }
+        // Unresolved expectations: a non-suppressible frame produced no event.
+        if state.oracle.pending_slot_count() > 0 && !state.oracle.disconnected_seen {
+            let pending: Vec<&'static str> =
+                state.oracle.slots.iter().map(|slot| slot.frame).collect();
+            state.outcome.findings.push(Finding {
+                category: "expectation-swallowed".into(),
+                detail: format!(
+                    "{} delivered frame(s) never produced their documented outcome: {pending:?}",
+                    pending.len()
+                ),
+                step_index: limit,
+            });
+        }
+    }
+
+    state.outcome.violations = state.oracle.violations;
+    state.outcome.terminal = state.oracle.disconnected_seen;
+    state.outcome.violation_teardown = state.oracle.violation_teardown;
+    state.outcome
+}
+
+/// Stats/ledger equivalence (issue #219): the client's cumulative counters
+/// must equal the harness's independent count of what each surface documents.
+fn ledger_checks(
+    client: &SignalFishPollingClient<ScriptedTransport>,
+    state: &mut RunState,
+    handles: &crate::transport::ScriptedHandles,
+    step_index: usize,
+) {
+    if !oracle_strict() || !state.outcome.findings.is_empty() {
+        return;
+    }
+    let stats = client.stats();
+    if stats.game_data_received
+        != u64::try_from(state.predicted_game_data_received).unwrap_or(u64::MAX)
+    {
+        state.outcome.findings.push(Finding {
+            category: "ledger-game-data-received".into(),
+            detail: format!(
+                "stats.game_data_received={} but the harness independently counted {} decoded \
+                 game-data frames (over-suppression or phantom counting)",
+                stats.game_data_received, state.predicted_game_data_received
+            ),
+            step_index,
+        });
+    }
+    if stats.messages_undecodable != u64::try_from(state.raw_frames_fed).unwrap_or(u64::MAX)
+        || u64::try_from(state.decode_failed_events).unwrap_or(u64::MAX)
+            != stats.messages_undecodable
+    {
+        state.outcome.findings.push(Finding {
+            category: "ledger-undecodable".into(),
+            detail: format!(
+                "raw frames fed={} but stats.messages_undecodable={} and DecodeFailed events={}",
+                state.raw_frames_fed, stats.messages_undecodable, state.decode_failed_events
+            ),
+            step_index,
+        });
+    }
+    let accepted = outbound_game_data_frames(handles);
+    if stats.game_data_sent != u64::try_from(accepted).unwrap_or(u64::MAX) {
+        state.outcome.findings.push(Finding {
+            category: "ledger-game-data-sent".into(),
+            detail: format!(
+                "stats.game_data_sent={} but the transport accepted {} game-data frames",
+                stats.game_data_sent, accepted
+            ),
+            step_index,
+        });
+    }
+}
+
+/// Send-pressure archetype assertions (issue #219): FIFO delivery under
+/// `Pending`-refusing sends, capacity accounting, and full drain.
+fn pressure_checks(
+    client: &SignalFishPollingClient<ScriptedTransport>,
+    state: &mut RunState,
+    handles: &crate::transport::ScriptedHandles,
+    step_index: usize,
+) {
+    if !oracle_strict() || !state.outcome.findings.is_empty() {
+        return;
+    }
+    let log = lock(&handles.outbound);
+    let mut delivered_markers: Vec<u64> = Vec::new();
+    let mut binary_frames = 0usize;
+    for line in log.iter() {
+        if line.starts_with("<binary ") {
+            binary_frames = binary_frames.saturating_add(1);
+            continue;
+        }
+        if let Ok(ClientMessage::GameData { data, .. }) =
+            serde_json::from_str::<ClientMessage>(line)
+        {
+            if let Some(marker) = data.get("marker").and_then(|marker| marker.as_u64()) {
+                delivered_markers.push(marker);
+            }
+        }
+    }
+    drop(log);
+    if delivered_markers != state.sent_markers {
+        state.outcome.findings.push(Finding {
+            category: "pressure-fifo".into(),
+            detail: format!(
+                "outbound marker order {delivered_markers:?} differs from accepted-send order {:?}",
+                state.sent_markers
+            ),
+            step_index,
+        });
+    }
+    if binary_frames != state.sent_binaries {
+        state.outcome.findings.push(Finding {
+            category: "pressure-binaries".into(),
+            detail: format!(
+                "accepted {} binary sends but the transport received {} binary frames",
+                state.sent_binaries, binary_frames
+            ),
+            step_index,
+        });
+    }
+    let poll_stats = client.polling_stats();
+    if poll_stats.current_queue_depth != 0 {
+        state.outcome.findings.push(Finding {
+            category: "pressure-drain".into(),
+            detail: format!(
+                "queue depth {} after the full drain (accepted sends must all flush)",
+                poll_stats.current_queue_depth
+            ),
+            step_index,
+        });
+    }
+    if handles.send_pending_refusals.load(Ordering::Relaxed) == 0 {
+        state.outcome.findings.push(Finding {
+            category: "pressure-liveness".into(),
+            detail: "the Pending-refusal send face never fired; pacing unexercised".into(),
+            step_index,
+        });
+    }
+}
+
+fn check_silent_after_close(
+    client: &mut SignalFishPollingClient<ScriptedTransport>,
+    state: &mut RunState,
+    step_index: usize,
+) {
+    let events = client.poll();
+    if !events.is_empty() {
+        state.outcome.findings.push(Finding {
+            category: "events-after-close".into(),
+            detail: format!("close() produced {} events", events.len()),
+            step_index,
+        });
+        return;
+    }
+    let events2 = client.poll();
+    if !events2.is_empty() {
+        state.outcome.findings.push(Finding {
+            category: "events-after-close".into(),
+            detail: "second poll after close produced events".into(),
+            step_index,
+        });
+        return;
+    }
+    let snap = client.snapshot();
+    if snap.connected || snap.room_role.is_some() {
+        state.outcome.findings.push(Finding {
+            category: "snapshot-after-close".into(),
+            detail: format!(
+                "snapshot after close: connected={} role={:?}",
+                snap.connected, snap.room_role
+            ),
+            step_index,
+        });
+    }
+}
+
+/// Poll up to `n` times, feeding every event through the oracle, reconciling
+/// the per-frame expectation slots, and checking snapshot coherence.
+fn drive_polls(
+    client: &mut SignalFishPollingClient<ScriptedTransport>,
+    state: &mut RunState,
+    n: usize,
+    step_index: usize,
+) {
+    for _ in 0..n {
+        heartbeat();
+        let quarantined = client.snapshot().quarantined;
+        state.oracle.begin_batch(quarantined);
+        let events = client.poll();
+        state.outcome.events_seen = state.outcome.events_seen.saturating_add(events.len());
+        let mut names: Vec<&'static str> = Vec::new();
+        let mut violations_in_batch = 0usize;
+        let mut terminal_in_batch = false;
+        for ev in &events {
+            if VERBOSE.load(Ordering::Relaxed) {
+                if let SignalFishEvent::ProtocolViolation { kind, diagnostic } = ev {
+                    println!("       event: ProtocolViolation {kind:?}: {diagnostic}");
+                } else {
+                    println!("       event: {}", event_name(ev));
+                }
+            }
+            note_coverage(event_name(ev));
+            match ev {
+                SignalFishEvent::Connected => {}
+                SignalFishEvent::Disconnected { .. } => {
+                    terminal_in_batch = true;
+                }
+                SignalFishEvent::ProtocolViolation { .. } => {
+                    violations_in_batch = violations_in_batch.saturating_add(1);
+                }
+                SignalFishEvent::DecodeFailed { .. } => {
+                    state.decode_failed_events = state.decode_failed_events.saturating_add(1);
+                    names.push(event_name(ev));
+                }
+                other => names.push(event_name(other)),
+            }
+            if let Err(detail) = state.oracle.observe(ev) {
+                state.outcome.findings.push(Finding {
+                    category: "oracle-event".into(),
+                    detail: format!("event `{}`: {detail}", event_name(ev)),
+                    step_index,
+                });
+                return;
+            }
+        }
+        state.oracle.reconcile_batch(
+            &names,
+            violations_in_batch,
+            step_index,
+            &mut state.outcome.findings,
+        );
+        if !state.outcome.findings.is_empty() {
+            return;
+        }
+        if terminal_in_batch {
+            // Teardown abandons queued delivery; pending slots are forgiven.
+            state.oracle.forgive_pending();
+        }
+        if let Err(detail) = state.oracle.end_batch() {
+            state.outcome.findings.push(Finding {
+                category: "oracle-batch".into(),
+                detail,
+                step_index,
+            });
+            return;
+        }
+        if VERBOSE.load(Ordering::Relaxed) {
+            let snap = client.snapshot();
+            println!(
+                "       snapshot: connected={} ready={} auth={} v3={:?} role={:?} room={:?} quarantined={}",
+                snap.connected,
+                snap.transport_ready,
+                snap.authenticated,
+                snap.negotiated_protocol_version,
+                snap.room_role,
+                snap.room_id,
+                snap.quarantined
+            );
+        }
+        heartbeat();
+        if let Err(detail) = state.oracle.check_snapshot(&client.snapshot()) {
+            state.outcome.findings.push(Finding {
+                category: "oracle-snapshot".into(),
+                detail,
+                step_index,
+            });
+            return;
+        }
+        if state.oracle.terminal {
+            heartbeat();
+            if !client.poll().is_empty() {
+                state.outcome.findings.push(Finding {
+                    category: "events-after-terminal".into(),
+                    detail: "poll after terminal disconnect produced events".into(),
+                    step_index,
+                });
+                return;
+            }
+        }
+    }
+}
+
+/// Verbose replay used by `--repro`: prints every step and event.
+pub fn run_prefix_verbose(
+    script: &Script,
+    policy: ProtocolViolationPolicy,
+    limit: usize,
+) -> Outcome {
+    VERBOSE.store(true, Ordering::Relaxed);
+    let outcome = run_prefix(script, policy, limit.min(script.steps.len()));
+    VERBOSE.store(false, Ordering::Relaxed);
+    outcome
+}
+
+/// Run one script under one policy; on failure, reduce to a minimal prefix.
+pub fn run_script(
+    script: &Script,
+    policy: ProtocolViolationPolicy,
+) -> Result<Outcome, ReducedFailure> {
+    *lock(&CURRENT_LABEL) = format!(
+        "seed={} script={} archetype={} config={} policy={policy:?}",
+        script.seed,
+        script.index,
+        script.archetype,
+        script.config_kind.name(),
+    );
+    let total = script.steps.len();
+    let outcome = match catch_unwind(AssertUnwindSafe(|| run_prefix(script, policy, total))) {
+        Ok(outcome) => outcome,
+        Err(panic) => {
+            return Err(ReducedFailure {
+                findings: vec![Finding {
+                    category: "PANIC".into(),
+                    detail: panic_message(&panic),
+                    step_index: usize::MAX,
+                }],
+                prefix_len: total,
+            });
+        }
+    };
+    // Cross-policy differential: run the sibling policies once and compare the
+    // documented differences (lazily cached per (seed,index) by the caller).
+    if outcome.findings.is_empty()
+        && !lock(&DIFFERENTIAL_DONE).contains(&(script.seed, script.index))
+    {
+        lock(&DIFFERENTIAL_DONE).insert((script.seed, script.index));
+        let mut by_policy: [Option<Outcome>; 3] = [None, None, None];
+        for p in [
+            ProtocolViolationPolicy::Quarantine,
+            ProtocolViolationPolicy::Observe,
+            ProtocolViolationPolicy::Disconnect,
+        ] {
+            let index = match p {
+                ProtocolViolationPolicy::Quarantine => 0,
+                ProtocolViolationPolicy::Observe => 1,
+                ProtocolViolationPolicy::Disconnect => 2,
+            };
+            let r = catch_unwind(AssertUnwindSafe(|| run_prefix(script, p, total)));
+            let o = match r {
+                Ok(o) => o,
+                Err(panic) => {
+                    return Err(ReducedFailure {
+                        findings: vec![Finding {
+                            category: "PANIC".into(),
+                            detail: format!("policy {p:?}: {}", panic_message(&panic)),
+                            step_index: usize::MAX,
+                        }],
+                        prefix_len: total,
+                    });
+                }
+            };
+            match by_policy.get_mut(index) {
+                Some(slot) => *slot = Some(o),
+                None => {
+                    return Err(unreachable_policy_missing(p, total));
+                }
+            }
+        }
+        let Some(q) = by_policy[0].as_ref() else {
+            return Err(unreachable_policy_missing(
+                ProtocolViolationPolicy::Quarantine,
+                total,
+            ));
+        };
+        let Some(o) = by_policy[1].as_ref() else {
+            return Err(unreachable_policy_missing(
+                ProtocolViolationPolicy::Observe,
+                total,
+            ));
+        };
+        let Some(d) = by_policy[2].as_ref() else {
+            return Err(unreachable_policy_missing(
+                ProtocolViolationPolicy::Disconnect,
+                total,
+            ));
+        };
+        let mut diffs: Vec<String> = Vec::new();
+        if (q.violations > 0) != (o.violations > 0) {
+            diffs.push(format!(
+                "violation presence differs: Quarantine={} Observe={}",
+                q.violations, o.violations
+            ));
+        }
+        if q.violations > 0 {
+            if !d.terminal {
+                diffs.push(format!(
+                    "Disconnect policy did not tear down after violations \
+                     (q_violations={} d_terminal={})",
+                    q.violations, d.terminal
+                ));
+            }
+            if d.violations == 0 {
+                diffs.push("Disconnect run saw zero violations while Quarantine saw some".into());
+            }
+            if q.violation_teardown {
+                diffs.push("Quarantine policy tore down the connection after violations".into());
+            }
+            if o.violation_teardown {
+                diffs.push("Observe policy tore down the connection after violations".into());
+            }
+        } else {
+            for (name, run) in [("Quarantine", q), ("Observe", o), ("Disconnect", d)] {
+                if run.violation_teardown {
+                    diffs.push(format!("{name} run tore down with zero violations"));
+                }
+            }
+        }
+        if !diffs.is_empty() {
+            return Err(ReducedFailure {
+                findings: vec![Finding {
+                    category: "policy-differential".into(),
+                    detail: diffs.join("; "),
+                    step_index: total.saturating_sub(1),
+                }],
+                prefix_len: total,
+            });
+        }
+    }
+    if outcome.findings.is_empty() {
+        // Storm expectations: dedicated hostile floods must surface diagnostics.
+        let v3 = script.config_kind.is_v3();
+        let expect_violation = match script.archetype {
+            "roster_storm" => true,
+            "accountability" => v3,
+            _ => false,
+        };
+        if expect_violation && outcome.violations == 0 {
+            return Err(ReducedFailure {
+                findings: vec![Finding {
+                    category: "bounds-unobserved".into(),
+                    detail: "hostile bound-exceeding flood produced zero ProtocolViolation \
+                             diagnostics"
+                        .into(),
+                    step_index: total.saturating_sub(1),
+                }],
+                prefix_len: total,
+            });
+        }
+        return Ok(outcome);
+    }
+    // Reduce: binary search the minimal failing prefix.
+    let mut lo = 1usize;
+    let mut hi = total;
+    while lo < hi {
+        let mid = lo.saturating_add(hi.saturating_sub(lo).saturating_div(2));
+        let failed = match catch_unwind(AssertUnwindSafe(|| run_prefix(script, policy, mid))) {
+            Ok(o) => !o.findings.is_empty(),
+            Err(_) => true,
+        };
+        if failed {
+            hi = mid;
+        } else {
+            lo = mid.saturating_add(1);
+        }
+        heartbeat();
+    }
+    Err(ReducedFailure {
+        findings: outcome.findings,
+        prefix_len: lo,
+    })
+}
+
+/// Fail-closed helper for a structurally impossible sibling-policy absence.
+fn unreachable_policy_missing(p: ProtocolViolationPolicy, total: usize) -> ReducedFailure {
+    ReducedFailure {
+        findings: vec![Finding {
+            category: "campaign-internal".into(),
+            detail: format!("sibling policy {p:?} outcome missing from the differential"),
+            step_index: total.saturating_sub(1),
+        }],
+        prefix_len: total,
+    }
+}
+
+pub struct ReducedFailure {
+    pub findings: Vec<Finding>,
+    pub prefix_len: usize,
+}
+
+fn panic_message(panic: &Box<dyn std::any::Any + Send>) -> String {
+    if let Some(s) = panic.downcast_ref::<&str>() {
+        (*s).to_string()
+    } else if let Some(s) = panic.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "unknown panic payload".to_string()
+    }
+}
+
+/// Render the minimal failing prefix for a report.
+pub fn render_prefix(script: &Script, prefix_len: usize, max_steps: usize) -> String {
+    let mut out = String::new();
+    let shown = prefix_len.min(script.steps.len());
+    let start = shown.saturating_sub(max_steps);
+    if start > 0 {
+        out.push_str(&format!("    … ({} earlier steps elided)\n", start));
+    }
+    for (offset, step) in script
+        .steps
+        .iter()
+        .skip(start)
+        .take(shown.saturating_sub(start))
+        .enumerate()
+    {
+        out.push_str(&format!(
+            "    [{:>4}] {}\n",
+            start.saturating_add(offset),
+            step.render()
+        ));
+    }
+    out
+}
+
+/// Crate-visible constructors for canaries that drive the expectation oracle
+/// directly (direct-feed sensitivity proofs).
+pub(crate) mod test_support {
+    use super::{AllowedOutcome, ConfigKind, Oracle, ProtocolViolationPolicy, Slot};
+
+    pub(crate) fn slot_with(frame: &'static str, alternatives: Vec<AllowedOutcome>) -> Slot {
+        Slot {
+            alternatives,
+            frame,
+            fence_retired_on_violation: None,
+        }
+    }
+
+    pub(crate) fn slot_for(frame: &'static str) -> Slot {
+        Slot {
+            alternatives: super::exactly(frame),
+            frame,
+            fence_retired_on_violation: None,
+        }
+    }
+
+    pub(crate) fn fresh_oracle(
+        policy: ProtocolViolationPolicy,
+        config: ConfigKind,
+        echo_room_ops: bool,
+    ) -> Oracle {
+        Oracle::new(policy, config, echo_room_ops)
+    }
+}

--- a/tools/stateful-campaign/src/script.rs
+++ b/tools/stateful-campaign/src/script.rs
@@ -1,0 +1,310 @@
+//! Scenario script model: a deterministic list of steps the runner replays,
+//! plus the generator's knowledge about each delivered frame (used by the
+//! per-frame event-expectation oracle).
+
+use signal_fish_client::protocol::{PlayerId, ServerMessage};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EchoId {
+    /// Use the operation id the client actually sent (read from the outbound log).
+    Match,
+    /// Use a wrong, unrelated UUID.
+    Wrong,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EchoKind {
+    JoinOk,
+    JoinFailed,
+    LeaveOk,
+    ReconnectOk,
+    ReconnectFailed,
+    SpectatorJoinOk,
+    SpectatorJoinFailed,
+    SpectatorLeaveOk,
+    OperationFailed,
+}
+
+impl EchoKind {
+    pub fn name(self) -> &'static str {
+        match self {
+            EchoKind::JoinOk => "RoomJoined",
+            EchoKind::JoinFailed => "RoomJoinFailed",
+            EchoKind::LeaveOk => "RoomLeft",
+            EchoKind::ReconnectOk => "Reconnected",
+            EchoKind::ReconnectFailed => "ReconnectionFailed",
+            EchoKind::SpectatorJoinOk => "SpectatorJoined",
+            EchoKind::SpectatorJoinFailed => "SpectatorJoinFailed",
+            EchoKind::SpectatorLeaveOk => "SpectatorLeft",
+            EchoKind::OperationFailed => "OperationFailed",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum Cmd {
+    JoinRoom,
+    JoinRoomMax(u8),
+    LeaveRoom,
+    SendGameData(serde_json::Value),
+    SendGameDataLatest(u32),
+    SendGameDataVolatile,
+    SendBinaryGameData(usize),
+    SetReady,
+    StartGame,
+    RequestAuthority(bool),
+    ProvideConnectionInfo,
+    Reconnect(PlayerId, PlayerId),
+    JoinAsSpectator,
+    LeaveSpectator,
+    Ping,
+    SendSignal,
+    SendRawSignal,
+    ReportTransportStatus,
+}
+
+impl Cmd {
+    pub fn name(&self) -> &'static str {
+        match self {
+            Cmd::JoinRoom | Cmd::JoinRoomMax(_) => "join_room",
+            Cmd::LeaveRoom => "leave_room",
+            Cmd::SendGameData(_) => "send_game_data",
+            Cmd::SendGameDataLatest(_) => "send_game_data(Latest)",
+            Cmd::SendGameDataVolatile => "send_game_data(Volatile)",
+            Cmd::SendBinaryGameData(_) => "send_binary_game_data",
+            Cmd::SetReady => "set_ready",
+            Cmd::StartGame => "start_game",
+            Cmd::RequestAuthority(_) => "request_authority",
+            Cmd::ProvideConnectionInfo => "provide_connection_info",
+            Cmd::Reconnect(..) => "reconnect",
+            Cmd::JoinAsSpectator => "join_as_spectator",
+            Cmd::LeaveSpectator => "leave_spectator",
+            Cmd::Ping => "ping",
+            Cmd::SendSignal => "send_signal",
+            Cmd::SendRawSignal => "send_raw_signal",
+            Cmd::ReportTransportStatus => "report_transport_status",
+        }
+    }
+
+    /// The room-operation fence this command arms at successful queue
+    /// admission (mirrors `ClientCore`'s pending-operation model).
+    pub fn fence(self: &Cmd) -> Option<FenceKind> {
+        match self {
+            Cmd::JoinRoom | Cmd::JoinRoomMax(_) => Some(FenceKind::JoinPlayer),
+            Cmd::LeaveRoom => Some(FenceKind::LeavePlayer),
+            Cmd::Reconnect(..) => Some(FenceKind::ReconnectPlayer),
+            Cmd::JoinAsSpectator => Some(FenceKind::JoinSpectator),
+            Cmd::LeaveSpectator => Some(FenceKind::LeaveSpectator),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FenceKind {
+    JoinPlayer,
+    LeavePlayer,
+    ReconnectPlayer,
+    JoinSpectator,
+    LeaveSpectator,
+}
+
+/// Generator knowledge about a delivered game-data frame's v3 stamps.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum StampMode {
+    /// Fresh monotonic sequence for the sender (well formed).
+    #[default]
+    Valid,
+    /// Deliberately stale/replayed sequence (well formed; a stamp
+    /// violation — backward or non-positive sequence).
+    Stale,
+    /// Both stamps zero (schema-valid; stamp-invalid for the core).
+    Zero,
+    /// Stamps omitted (schema-valid; v2-legal, v3-invalid).
+    None,
+}
+
+impl StampMode {
+    pub fn well_formed(self) -> bool {
+        matches!(self, StampMode::Valid | StampMode::Stale)
+    }
+}
+
+/// Extra generator knowledge attached to a delivery step.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct FrameMeta {
+    /// `GameData`/`GameDataBinary` stamp shape (ignored for other frames).
+    pub stamp: StampMode,
+    /// The frame deliberately exceeds a validated bound (hostile face).
+    pub bound_breaking: bool,
+}
+
+#[allow(clippy::large_enum_variant)] // scripts own their messages by design
+#[derive(Debug, Clone)]
+pub enum Step {
+    /// Deliver a schema-valid `ServerMessage` text frame.
+    Deliver(ServerMessage, FrameMeta),
+    /// Deliver a handcrafted raw (always schema-invalid) text frame.
+    DeliverRaw(&'static str),
+    /// Deliver a schema-valid physical binary frame (v3 MessagePack envelope).
+    /// The generator guarantees the envelope decodes; `FrameMeta.stamp`
+    /// classifies the embedded stamps.
+    DeliverBinary(Vec<u8>, FrameMeta),
+    /// Deliver a `RoomOperationResult` echoing (or not) the client's last sent operation id.
+    DeliverEcho(EchoKind, EchoId),
+    /// Issue one public-API client command (refusals are recorded, not fatal).
+    Cmd(Cmd),
+    /// Call `poll()` `n` times.
+    Poll(usize),
+    /// Graceful close boundary.
+    Close,
+    /// Server-initiated transport close (poll_recv -> Ready(None) forever).
+    PeerClose,
+    /// Arm the transport's send-side `Pending`-refusal face: each frame is
+    /// refused with `Pending` for its first N offers before acceptance.
+    SetSendDelay(usize),
+    /// Terminal transport error face: `poll_recv` returns
+    /// `Ready(Some(Err(_)))` (and `poll_send` too when `fail_send`).
+    TransportKill { fail_recv: bool, fail_send: bool },
+}
+
+impl Step {
+    pub fn render(&self) -> String {
+        match self {
+            Step::Deliver(msg, meta) => {
+                let json = match serde_json::to_string(msg) {
+                    Ok(json) => json,
+                    Err(_) => "<ser fail>".to_string(),
+                };
+                format!(
+                    "Deliver({}{}) {json}",
+                    msg_variant_name(msg),
+                    meta_suffix(meta)
+                )
+            }
+            Step::DeliverRaw(raw) => format!("DeliverRaw({raw})"),
+            Step::DeliverBinary(bytes, meta) => {
+                format!(
+                    "DeliverBinary(<{} bytes>{})",
+                    bytes.len(),
+                    meta_suffix(meta)
+                )
+            }
+            Step::DeliverEcho(kind, id) => match id {
+                EchoId::Match => format!("DeliverEcho({}, operation_id=match)", kind.name()),
+                EchoId::Wrong => format!("DeliverEcho({}, operation_id=WRONG)", kind.name()),
+            },
+            Step::Cmd(cmd) => format!("Cmd({})", cmd.name()),
+            Step::Poll(n) => format!("Poll({n})"),
+            Step::Close => "Close".to_string(),
+            Step::PeerClose => "PeerClose(transport Ready(None))".to_string(),
+            Step::SetSendDelay(n) => format!("SetSendDelay({n})"),
+            Step::TransportKill {
+                fail_recv,
+                fail_send,
+            } => format!(
+                "TransportKill(recv=Ready(Some(Err)):{fail_recv} send=Ready(Err):{fail_send})"
+            ),
+        }
+    }
+}
+
+fn meta_suffix(meta: &FrameMeta) -> String {
+    let mut parts = Vec::new();
+    match meta.stamp {
+        StampMode::Valid => parts.push("stamp=valid"),
+        StampMode::Stale => parts.push("stamp=stale"),
+        StampMode::Zero => parts.push("stamp=zero"),
+        StampMode::None => parts.push("stamp=none"),
+    }
+    if meta.bound_breaking {
+        parts.push("bound-break");
+    }
+    if parts.is_empty() {
+        String::new()
+    } else {
+        format!(" {{{}}}", parts.join(","))
+    }
+}
+
+pub fn msg_variant_name(msg: &ServerMessage) -> &'static str {
+    match msg {
+        ServerMessage::Authenticated { .. } => "Authenticated",
+        ServerMessage::ProtocolInfo(_) => "ProtocolInfo",
+        ServerMessage::AuthenticationError { .. } => "AuthenticationError",
+        ServerMessage::RoomJoined(_) => "RoomJoined",
+        ServerMessage::RoomJoinFailed { .. } => "RoomJoinFailed",
+        ServerMessage::RoomLeft => "RoomLeft",
+        ServerMessage::PlayerJoined { .. } => "PlayerJoined",
+        ServerMessage::PlayerLeft { .. } => "PlayerLeft",
+        ServerMessage::GameData { .. } => "GameData",
+        ServerMessage::GameDataBinary { .. } => "GameDataBinary",
+        ServerMessage::AuthorityChanged { .. } => "AuthorityChanged",
+        ServerMessage::AuthorityResponse { .. } => "AuthorityResponse",
+        ServerMessage::LobbyStateChanged { .. } => "LobbyStateChanged",
+        ServerMessage::GameStarting { .. } => "GameStarting",
+        ServerMessage::Pong => "Pong",
+        ServerMessage::Reconnected(_) => "Reconnected",
+        ServerMessage::ReconnectionFailed { .. } => "ReconnectionFailed",
+        ServerMessage::PlayerReconnected { .. } => "PlayerReconnected",
+        ServerMessage::SpectatorJoined(_) => "SpectatorJoined",
+        ServerMessage::SpectatorJoinFailed { .. } => "SpectatorJoinFailed",
+        ServerMessage::SpectatorLeft { .. } => "SpectatorLeft",
+        ServerMessage::RoomOperationResult { .. } => "RoomOperationResult",
+        ServerMessage::NewSpectatorJoined { .. } => "NewSpectatorJoined",
+        ServerMessage::SpectatorDisconnected { .. } => "SpectatorDisconnected",
+        ServerMessage::Error { .. } => "Error",
+        ServerMessage::Signal { .. } => "Signal",
+        ServerMessage::NewPeer { .. } => "NewPeer",
+        ServerMessage::SessionPlan(_) => "SessionPlan",
+        ServerMessage::PeerTransportStatus { .. } => "PeerTransportStatus",
+        ServerMessage::RelayStats { .. } => "RelayStats",
+        ServerMessage::GoingAway { .. } => "GoingAway",
+        ServerMessage::DeliveryReport(_) => "DeliveryReport",
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConfigKind {
+    /// `enable_v3()`: negotiated v3, requests room_operation_ids capability.
+    V3,
+    /// v3 relay floor with explicit version only (no transports/topologies lists).
+    V3VersionOnly,
+    /// Frozen v2 relay floor (no negotiation fields at all).
+    V2,
+    /// Explicit protocol_version = 2.
+    V2Explicit,
+}
+
+impl ConfigKind {
+    pub fn name(self) -> &'static str {
+        match self {
+            ConfigKind::V3 => "v3",
+            ConfigKind::V3VersionOnly => "v3-version-only",
+            ConfigKind::V2 => "v2",
+            ConfigKind::V2Explicit => "v2-explicit",
+        }
+    }
+
+    /// Mirrors `SignalFishConfig::requests_room_operation_ids`.
+    pub fn requests_room_operation_ids(self) -> bool {
+        matches!(self, ConfigKind::V3 | ConfigKind::V3VersionOnly)
+    }
+
+    pub fn is_v3(self) -> bool {
+        matches!(self, ConfigKind::V3 | ConfigKind::V3VersionOnly)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Script {
+    pub seed: u64,
+    pub index: usize,
+    pub archetype: &'static str,
+    pub config_kind: ConfigKind,
+    /// Whether ProtocolInfo in this script echoes the room_operation_ids capability.
+    pub echo_room_ops: bool,
+    /// Small command-queue override for send-pressure scripts.
+    pub small_command_capacity: Option<usize>,
+    pub steps: Vec<Step>,
+}

--- a/tools/stateful-campaign/src/soak.rs
+++ b/tools/stateful-campaign/src/soak.rs
@@ -1,0 +1,212 @@
+//! Long-horizon churn probe: 40 cycles of issue-#166-style storms
+//! (reconnect-announcement floods, uncoverable departures, gap-range
+//! retention floods, generation churn) checking violation surfacing, queue
+//! bounds, terminal behavior, and per-frame wall time under every policy.
+
+use std::panic::{catch_unwind, AssertUnwindSafe};
+
+use signal_fish_client::client::ProtocolViolationPolicy;
+use signal_fish_client::protocol::{
+    DeliveryGap, DeliveryGapReason, DeliveryReportPayload, PlayerId, PlayerInfo, RateLimitInfo,
+    ServerMessage,
+};
+
+use crate::gen::{self, Ctx};
+use crate::run::{run_prefix, Finding};
+use crate::script::{Cmd, ConfigKind, Script, Step};
+
+fn panic_message(panic: &Box<dyn std::any::Any + Send>) -> String {
+    if let Some(s) = panic.downcast_ref::<&str>() {
+        (*s).to_string()
+    } else if let Some(s) = panic.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "unknown panic payload".to_string()
+    }
+}
+
+/// Run the churn probe under all three policies; returns the failure count.
+pub fn soak_probe() -> usize {
+    let _self_id = PlayerId::from_u128(0x50A1);
+    let peer = PlayerId::from_u128(0x50A2);
+
+    let mut steps: Vec<Step> = Vec::new();
+    steps.push(Step::Deliver(
+        ServerMessage::Authenticated {
+            app_name: "soak".into(),
+            organization: None,
+            rate_limits: RateLimitInfo {
+                per_minute: 1,
+                per_hour: 1,
+                per_day: 1,
+            },
+        },
+        Default::default(),
+    ));
+    steps.push(Step::Poll(1));
+    let (info, info_meta) = gen::canary_protocol_info();
+    steps.push(Step::Deliver(info, info_meta));
+    steps.push(Step::Poll(1));
+    steps.push(Step::Cmd(Cmd::JoinRoom));
+    steps.push(Step::Poll(1));
+    steps.push(Step::Deliver(
+        gen::canary_room_joined(&Ctx::new_for_canary()),
+        Default::default(),
+    ));
+    steps.push(Step::Poll(1));
+    steps.push(Step::Deliver(
+        ServerMessage::PlayerJoined {
+            player: PlayerInfo {
+                id: peer,
+                name: "soak-peer".into(),
+                is_authority: false,
+                is_ready: false,
+                connected_at: "2026".into(),
+                connection_info: None,
+                epoch: Some(1),
+                seq: Some(0),
+            },
+        },
+        Default::default(),
+    ));
+    steps.push(Step::Poll(1));
+
+    // 40 full churn cycles: reconnect-announcement floods + departure floods
+    // (each cycle would grow unboundedly without the #166 bounds).
+    for cycle in 0..40u32 {
+        let base = 2u32.wrapping_add(cycle.wrapping_mul(20));
+        for offset in 0..18u32 {
+            let epoch = base.wrapping_add(offset);
+            steps.push(Step::Deliver(
+                ServerMessage::PlayerReconnected {
+                    player_id: peer,
+                    epoch: Some(epoch),
+                },
+                Default::default(),
+            ));
+            steps.push(Step::Deliver(
+                ServerMessage::PlayerLeft {
+                    player_id: peer,
+                    epoch: Some(epoch),
+                    final_seq: Some(u64::MAX),
+                },
+                Default::default(),
+            ));
+        }
+        if cycle % 8 == 0 {
+            steps.push(Step::Cmd(Cmd::Ping));
+            steps.push(Step::Poll(1));
+            steps.push(Step::Deliver(ServerMessage::Pong, Default::default()));
+            steps.push(Step::Poll(1));
+        }
+    }
+
+    // Gap-range flood: 30 reports x 100 singleton ranges with matching
+    // cumulative counters (3000 retained ranges without the 1024 bound).
+    let mut superseded: u64 = 0;
+    for report in 0..30u64 {
+        let gaps: Vec<DeliveryGap> = (0..100u64)
+            .map(|i| {
+                let seq = report.wrapping_mul(100).wrapping_add(i).wrapping_add(1);
+                DeliveryGap {
+                    from_player: peer,
+                    epoch: 1,
+                    from_seq: seq,
+                    to_seq: seq,
+                    reason: DeliveryGapReason::LatestSuperseded,
+                }
+            })
+            .collect();
+        superseded = superseded.wrapping_add(100);
+        steps.push(Step::Deliver(
+            ServerMessage::DeliveryReport(Box::new(DeliveryReportPayload {
+                gaps,
+                per_class: signal_fish_client::protocol::DeliveryCountersByClass {
+                    reliable: Default::default(),
+                    latest: signal_fish_client::protocol::LatestDeliveryCounters {
+                        superseded,
+                        ..Default::default()
+                    },
+                    volatile: Default::default(),
+                },
+            })),
+            Default::default(),
+        ));
+        steps.push(Step::Poll(1));
+    }
+
+    // Generation churn beyond the 8-superseded fence.
+    for k in 0..40u128 {
+        steps.push(Step::Deliver(
+            ServerMessage::SessionPlan(Box::new(
+                signal_fish_client::protocol::SessionPlanPayload {
+                    generation: Some(signal_fish_client::protocol::RoomId::from_u128(
+                        0x50A4_u128.wrapping_add(k),
+                    )),
+                    topology: signal_fish_client::protocol::Topology::Relay,
+                    transport: signal_fish_client::protocol::TransportKind::Relay,
+                    host: None,
+                    direct_endpoint: None,
+                    peers: vec![],
+                    ice_servers: vec![],
+                    fallback: signal_fish_client::protocol::TransportKind::Relay,
+                },
+            )),
+            Default::default(),
+        ));
+        steps.push(Step::Poll(1));
+    }
+
+    let mut failures: usize = 0;
+    for policy in [
+        ProtocolViolationPolicy::Quarantine,
+        ProtocolViolationPolicy::Observe,
+        ProtocolViolationPolicy::Disconnect,
+    ] {
+        let script = Script {
+            seed: 0,
+            index: 9999,
+            archetype: "soak",
+            config_kind: ConfigKind::V3,
+            echo_room_ops: false,
+            small_command_capacity: None,
+            steps: steps.clone(),
+        };
+        let started = std::time::Instant::now();
+        let outcome =
+            match catch_unwind(AssertUnwindSafe(|| run_prefix(&script, policy, usize::MAX))) {
+                Ok(outcome) => outcome,
+                Err(panic) => {
+                    println!("soak {policy:?}: PANIC {}", panic_message(&panic));
+                    failures = failures.saturating_add(1);
+                    continue;
+                }
+            };
+        let wall = started.elapsed();
+        println!(
+            "soak {policy:?}: {} frames, {} events, {} violations, terminal={}, {:.1}ms ({:.2}us/frame)",
+            outcome.frames_fed,
+            outcome.events_seen,
+            outcome.violations,
+            outcome.terminal,
+            wall.as_secs_f32() * 1000.0,
+            wall.as_micros() as f64 / usize::max(outcome.frames_fed, 1) as f64
+        );
+        for finding in &outcome.findings {
+            let Finding {
+                category,
+                detail,
+                step_index: _,
+            } = finding;
+            println!("  FINDING: {category} — {detail}");
+        }
+        if !outcome.findings.is_empty() {
+            failures = failures.saturating_add(1);
+        }
+        if outcome.violations == 0 {
+            println!("  FINDING: soak floods produced zero violations");
+            failures = failures.saturating_add(1);
+        }
+    }
+    failures
+}

--- a/tools/stateful-campaign/src/transport.rs
+++ b/tools/stateful-campaign/src/transport.rs
@@ -1,0 +1,321 @@
+//! Contract-faithful scripted in-memory `Transport` for the polling driver.
+//!
+//! The transport exercises the documented polling `Transport` contract:
+//! immediate ownership transfer on `poll_send`, `Pending` with an empty queue,
+//! idempotent nonblocking close, idempotent prompt abort, fused post-abort and
+//! post-close polling, and structured peer-close metadata. A configurable
+//! send-delay face returns `Pending` for the first N offers of each frame so
+//! the send-side budget/pacing interactions are exercised (issue #219).
+
+use std::collections::VecDeque;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex as StdMutex};
+use std::task::{Context, Poll};
+
+use signal_fish_client::error::SignalFishError;
+use signal_fish_client::transport::{Transport, TransportFrame};
+
+/// Shared inbound queue the harness pushes scripted server frames into.
+pub type InboundQueue = Arc<StdMutex<VecDeque<TransportFrame>>>;
+
+/// Number of `poll_send` offers each frame is refused with `Pending` before
+/// acceptance, plus per-frame bookkeeping. Zero means immediate acceptance.
+#[derive(Default)]
+struct SendDelay {
+    remaining: usize,
+    /// Offers observed for the frame currently at the front of the driver's
+    /// retained-send slot (`usize::MAX` once it has been accepted).
+    current_frame_offers: usize,
+}
+
+pub struct ScriptedTransport {
+    inbound: InboundQueue,
+    outbound: Arc<StdMutex<Vec<String>>>,
+    closed: Arc<AtomicBool>,
+    aborted: Arc<AtomicBool>,
+    pub close_calls: Arc<AtomicUsize>,
+    pub abort_calls: Arc<AtomicUsize>,
+    pub begin_cycles: Arc<AtomicUsize>,
+    /// Server-initiated terminal face: poll_recv returns Ready(None) once set.
+    pub peer_closed: Arc<AtomicBool>,
+    /// Terminal receive-error face: poll_recv returns Ready(Some(Err(..))) once set.
+    pub fail_recv_error: Arc<AtomicBool>,
+    /// Terminal send-error face: poll_send returns Ready(Err(..)) once set.
+    pub fail_send_error: Arc<AtomicBool>,
+    /// Pending-refusal face for `poll_send` (send-side pacing).
+    send_delay: Arc<StdMutex<SendDelay>>,
+    /// Number of `Pending` refusals `poll_send` has returned in total.
+    pub send_pending_refusals: Arc<AtomicUsize>,
+}
+
+pub struct ScriptedHandles {
+    pub inbound: InboundQueue,
+    pub outbound: Arc<StdMutex<Vec<String>>>,
+    pub closed: Arc<AtomicBool>,
+    pub close_calls: Arc<AtomicUsize>,
+    pub abort_calls: Arc<AtomicUsize>,
+    pub begin_cycles: Arc<AtomicUsize>,
+    /// Server-initiated terminal face: poll_recv returns Ready(None) once set.
+    pub peer_closed: Arc<AtomicBool>,
+    /// Terminal receive-error face: poll_recv returns Ready(Some(Err(..))) once set.
+    pub fail_recv_error: Arc<AtomicBool>,
+    /// Terminal send-error face: poll_send returns Ready(Err(..)) once set.
+    pub fail_send_error: Arc<AtomicBool>,
+    pub send_pending_refusals: Arc<AtomicUsize>,
+    /// Shared send-delay state (armed through the handles because the
+    /// transport itself is owned by the client under test).
+    send_delay: Arc<StdMutex<SendDelay>>,
+}
+
+/// Exact `Display` strings of the scripted terminal errors. The client copies
+/// the terminal error's `to_string()` into the `Disconnected` reason, so the
+/// oracle asserts against these constants verbatim.
+pub const RECV_ERROR_DISPLAY: &str = "transport receive error: scripted terminal receive failure";
+pub const SEND_ERROR_DISPLAY: &str = "transport send error: scripted terminal send failure";
+
+/// Poison-resume lock helper: a poisoned lock can only mean a previous finding
+/// (a panicking transport method is a contract violation the harness wants to
+/// report), so resume instead of panicking again.
+pub fn lock<'a, T>(mutex: &'a StdMutex<T>) -> std::sync::MutexGuard<'a, T> {
+    match mutex.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    }
+}
+
+impl ScriptedTransport {
+    pub fn new() -> (Self, ScriptedHandles) {
+        let inbound: InboundQueue = Arc::new(StdMutex::new(VecDeque::new()));
+        let outbound = Arc::new(StdMutex::new(Vec::new()));
+        let closed = Arc::new(AtomicBool::new(false));
+        let aborted = Arc::new(AtomicBool::new(false));
+        let close_calls = Arc::new(AtomicUsize::new(0));
+        let abort_calls = Arc::new(AtomicUsize::new(0));
+        let begin_cycles = Arc::new(AtomicUsize::new(0));
+        let peer_closed = Arc::new(AtomicBool::new(false));
+        let fail_recv_error = Arc::new(AtomicBool::new(false));
+        let fail_send_error = Arc::new(AtomicBool::new(false));
+        let send_delay = Arc::new(StdMutex::new(SendDelay::default()));
+        let send_pending_refusals = Arc::new(AtomicUsize::new(0));
+        (
+            Self {
+                inbound: Arc::clone(&inbound),
+                outbound: Arc::clone(&outbound),
+                closed: Arc::clone(&closed),
+                aborted: Arc::clone(&aborted),
+                close_calls: Arc::clone(&close_calls),
+                abort_calls: Arc::clone(&abort_calls),
+                begin_cycles: Arc::clone(&begin_cycles),
+                peer_closed: Arc::clone(&peer_closed),
+                fail_recv_error: Arc::clone(&fail_recv_error),
+                fail_send_error: Arc::clone(&fail_send_error),
+                send_delay: Arc::clone(&send_delay),
+                send_pending_refusals: Arc::clone(&send_pending_refusals),
+            },
+            ScriptedHandles {
+                inbound,
+                outbound,
+                closed,
+                close_calls,
+                abort_calls,
+                begin_cycles,
+                peer_closed,
+                fail_recv_error,
+                fail_send_error,
+                send_pending_refusals,
+                send_delay: Arc::clone(&send_delay),
+            },
+        )
+    }
+
+    /// Arm the server-initiated close face (transport contract: capture
+    /// structured close metadata before returning Ready(None)).
+    pub fn arm_peer_close(handles: &ScriptedHandles) {
+        handles.peer_closed.store(true, Ordering::Relaxed);
+    }
+
+    /// Arm the terminal receive-error face (contract: poll_recv ->
+    /// Ready(Some(Err(error))) is outbound-terminal for the client).
+    pub fn arm_recv_error(handles: &ScriptedHandles) {
+        handles.fail_recv_error.store(true, Ordering::Relaxed);
+    }
+
+    /// Arm the terminal send-error face (contract: poll_send ->
+    /// Ready(Err(error)) without taking the caller-owned frame).
+    pub fn arm_send_error(handles: &ScriptedHandles) {
+        handles.fail_send_error.store(true, Ordering::Relaxed);
+    }
+
+    /// Refuse each frame's first `delay` offers with `Pending`. A smaller
+    /// value replaces a larger one (including back to zero).
+    pub fn set_send_delay(handles: &ScriptedHandles, delay: usize) {
+        let mut state = lock(&handles.send_delay);
+        state.remaining = delay;
+    }
+
+    pub fn push_text(handles: &ScriptedHandles, json: String) {
+        lock(&handles.inbound).push_back(TransportFrame::Text(json));
+    }
+
+    pub fn push_binary(handles: &ScriptedHandles, bytes: Vec<u8>) {
+        lock(&handles.inbound).push_back(TransportFrame::Binary(bytes));
+    }
+
+    pub fn outbound_len(handles: &ScriptedHandles) -> usize {
+        lock(&handles.outbound).len()
+    }
+}
+
+impl Transport for ScriptedTransport {
+    fn poll_send(
+        &mut self,
+        _cx: &mut Context<'_>,
+        frame: &mut Option<TransportFrame>,
+    ) -> Poll<Result<(), SignalFishError>> {
+        if self.aborted.load(Ordering::Relaxed) || self.closed.load(Ordering::Relaxed) {
+            // Fused post-abort/post-close terminal convenience (contract-legal).
+            return Poll::Ready(Err(SignalFishError::TransportClosed));
+        }
+        if self.fail_send_error.load(Ordering::Relaxed) {
+            // Contract-faithful terminal send failure: the error is
+            // outbound-terminal and must NOT take the caller-owned frame.
+            return Poll::Ready(Err(SignalFishError::TransportSend(
+                "scripted terminal send failure".into(),
+            )));
+        }
+        if frame.is_none() {
+            return Poll::Ready(Ok(()));
+        }
+        let delay = {
+            let mut state = lock(&self.send_delay);
+            if state.remaining > 0 && state.current_frame_offers < state.remaining {
+                state.current_frame_offers = state.current_frame_offers.saturating_add(1);
+                self.send_pending_refusals.fetch_add(1, Ordering::Relaxed);
+                true
+            } else {
+                // Frame accepted: reset the per-frame offer counter so the
+                // next frame receives its own delay budget.
+                state.current_frame_offers = 0;
+                false
+            }
+        };
+        if delay {
+            // Contract: Pending before acceptance leaves the frame intact.
+            return Poll::Pending;
+        }
+        match frame.take() {
+            Some(TransportFrame::Text(text)) => {
+                lock(&self.outbound).push(text);
+                Poll::Ready(Ok(()))
+            }
+            Some(TransportFrame::Binary(bytes)) => {
+                lock(&self.outbound).push(format!("<binary {} bytes>", bytes.len()));
+                Poll::Ready(Ok(()))
+            }
+            None => Poll::Ready(Ok(())),
+        }
+    }
+
+    fn poll_recv(
+        &mut self,
+        _cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<TransportFrame, SignalFishError>>> {
+        if self.aborted.load(Ordering::Relaxed) || self.peer_closed.load(Ordering::Relaxed) {
+            return Poll::Ready(None);
+        }
+        if self.fail_recv_error.load(Ordering::Relaxed) {
+            // Contract-faithful terminal receive failure (fused, like the
+            // built-in transports fusing EOF and terminal socket errors).
+            return Poll::Ready(Some(Err(SignalFishError::TransportReceive(
+                "scripted terminal receive failure".into(),
+            ))));
+        }
+        match lock(&self.inbound).pop_front() {
+            Some(frame) => Poll::Ready(Some(Ok(frame))),
+            None => Poll::Pending,
+        }
+    }
+
+    fn close_info(&self) -> Option<signal_fish_client::transport::TransportCloseInfo> {
+        if self.peer_closed.load(Ordering::Relaxed) {
+            Some(signal_fish_client::transport::TransportCloseInfo {
+                code: Some(1001),
+                reason: Some("server going away".into()),
+                clean: Some(true),
+                initiated_by_peer: true,
+            })
+        } else {
+            None
+        }
+    }
+
+    fn poll_close(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), SignalFishError>> {
+        self.close_calls.fetch_add(1, Ordering::Relaxed);
+        if self.aborted.load(Ordering::Relaxed) {
+            return Poll::Ready(Ok(()));
+        }
+        self.closed.store(true, Ordering::Relaxed);
+        Poll::Ready(Ok(()))
+    }
+
+    fn begin_poll_cycle(&mut self) {
+        self.begin_cycles.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn abort(&mut self) {
+        self.abort_calls.fetch_add(1, Ordering::Relaxed);
+        lock(&self.inbound).clear();
+        self.aborted.store(true, Ordering::Relaxed);
+    }
+
+    fn is_ready(&self) -> bool {
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ScriptedTransport, RECV_ERROR_DISPLAY, SEND_ERROR_DISPLAY};
+    use signal_fish_client::Transport;
+    use std::task::Poll;
+
+    #[test]
+    fn terminal_error_displays_are_stable() {
+        // The oracle asserts the Disconnected reason against these constants;
+        // the client copies `error.to_string()` verbatim.
+        assert!(SEND_ERROR_DISPLAY.starts_with("transport send error:"));
+        assert!(RECV_ERROR_DISPLAY.starts_with("transport receive error:"));
+    }
+
+    #[test]
+    fn send_delay_refuses_then_accepts_per_frame() {
+        let (mut transport, handles) = ScriptedTransport::new();
+        ScriptedTransport::set_send_delay(&handles, 2);
+        let mut frame = Some(signal_fish_client::transport::TransportFrame::Text(
+            "a".into(),
+        ));
+        let waker = std::task::Waker::noop();
+        let mut cx = std::task::Context::from_waker(waker);
+        for _ in 0..2 {
+            assert!(matches!(
+                transport.poll_send(&mut cx, &mut frame),
+                Poll::Pending
+            ));
+            assert!(frame.is_some(), "Pending must leave the frame intact");
+        }
+        assert!(matches!(
+            transport.poll_send(&mut cx, &mut frame),
+            Poll::Ready(Ok(()))
+        ));
+        assert!(frame.is_none(), "acceptance takes ownership");
+        // The next frame gets its own delay budget.
+        let mut second = Some(signal_fish_client::transport::TransportFrame::Text(
+            "b".into(),
+        ));
+        assert!(matches!(
+            transport.poll_send(&mut cx, &mut second),
+            Poll::Pending
+        ));
+        assert!(second.is_some());
+    }
+}


### PR DESCRIPTION
## Why

Issue #219 asked the repo to adopt or rebuild the round-41 stateful hostility campaign so future audit rounds can re-run it against code changes, and to close its three documented oracle limitations. This PR adopts it as a permanent regression gate and closes the issue.

## What changed

**New: `tools/stateful-campaign` (workspace member)** — the deterministic, model-based hostility campaign against the polling driver + shared `ClientCore`:

- **Per-frame event-expectation oracle** (the headline limitation): every delivered frame must produce exactly one documented outcome multiset. A silent `Pong`/`Error`/`GameData` swallow, a fabricated event, or a double delivery is now a finding. Silence is legal only on documented suppression paths (quarantine latch, stale generations, absorbed replies).
- **Stats/ledger equivalence**: `ClientStats` counters must equal the harness's independent count of decoded/undecodable frames and accepted sends, checked at every close boundary.
- **Send-pressure archetype**: a `Pending`-refusing `poll_send` face exercises outbound pacing — FIFO delivery, capacity accounting, full drain, and the `begin_poll_cycle`-once-per-poll transport contract.
- 12 archetypes covering all 32 `ServerMessage` variants and all 9 `RoomOperationResult` faces across four negotiation dialects and all three violation policies; findings auto-reduce to a minimal prefix and reproduce from `(seed, script, policy)`.

**CI**: a fail-closed Deep Safety lane runs the oracle canaries plus the full campaign (1500×40×3 ≈ 180k client runs); `check-all.sh` phase 23 mirrors both locally; the lane is pinned in `ci_config_tests`.

**Debug redaction (behavior change)**: `ClientSnapshot`'s `Debug` now reports the room code as presence + byte length instead of the value — a room code is join-capability knowledge. The public field is unchanged.

**Docs accuracy**: restored the behavioral tails of seven `ErrorCode` descriptions in the errors guide, gave `UnsupportedProtocolVersion` its second trigger, pointed `Timeout` at its single producer, fixed the fortress guide's stale unreleased-guidance, and documented the payload-Debug carve-out in the ambient-log boundary.

## Verification

- Red-team proven: three injected library defects (drop all game-data events; neuter the received counter; drop every frame event) produce **33 / 48 / 288 findings** respectively — each limitation class from the issue is demonstrably detected. Clean tree: **240,000 sequences / 8.65M frames, zero findings**, 32/32 wire coverage, byte-identical reruns.
- Adversarial loop: hostile reviewer (mutation-tested the oracle), surface-audit agent, and a convergence verifier; every finding fixed and re-verified mechanically.
- `cargo fmt && cargo clippy --workspace --all-targets --all-features -- -D warnings && cargo test --workspace --all-features` green (1,112 tests).

Closes #219. Round-42 audit report posted on #126.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a large new validation surface and CI gate on the real client path, plus a user-visible Debug output change for room codes; production wire/API for room codes is unchanged.
> 
> **Overview**
> Adds **`tools/stateful-campaign`** as a workspace member: a deterministic, model-based harness that drives the real polling driver and shared **`ClientCore`** through hostile-but-schema-valid server journeys. It checks a **per-frame event-expectation oracle** (no silent swallows, fabrications, or double delivery), **stats/ledger equivalence**, and a **send-pressure** archetype with a **`Pending`-refusing** transport face. Oracle **canaries** run before the full campaign; failures reduce to reproducible `(seed, script, policy)` prefixes.
> 
> **CI and local parity**: Deep Safety gains a fail-closed **`campaign`** job (canaries + 1500×40 run); **`check-all.sh`** adds phase 23 with a reduced run; **`ci_config_tests`** pins the lane and PR path filter for **`tools/stateful-campaign/**`**.
> 
> **Product behavior**: **`ClientSnapshot`'s `Debug`** now prints room code as **presence + byte length** only (join-capability redaction); the public **`room_code`** field is unchanged, with a unit test.
> 
> **Docs/changelog**: restores **`ErrorCode`** behavioral tails in the errors guide, clarifies **`Timeout`** and **`UnsupportedProtocolVersion`**, updates the fortress guide for **0.12.0**, and extends the ambient-log boundary notes in **`.llm/context.md`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 573ea639a08da60d280af1fe11ad54befc99dce0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->