### PR TITLE
Cap hostile frames at the transport boundary; land DX backlog items

### DIFF
--- a/.llm/context.md
+++ b/.llm/context.md
@@ -114,7 +114,7 @@ Dependabot uses one root-workspace updater; minimum/latest Godot fixtures stay s
 The object-safe surface is pinned verbatim in
 `skills/transport-abstraction/SKILL.md`. Required methods are `poll_send`,
 `poll_recv`, `poll_close`, and `abort`; `begin_poll_cycle`, `diagnostics`,
-`is_ready`, and `close_info` have defaults.
+`is_ready`, `close_info`, and `max_frame_hint` (declared inbound bound the drivers enforce terminally) have defaults.
 
 The trait has no `Send` bound; `SignalFishClient::start` separately requires `Transport + Send + 'static`. Its boundary is one complete, ordered text/binary frame stream for one intended server, not raw bytes, datagrams, or server authentication.
 A backend owns framing, trust/source binding, and loss/duplicate/reorder policy. The SDK owns no UDP envelope; Server 0.8 ignores `RelayTransport::Udp` join metadata, `ConnectionInfo::Relay` is self-declared, and WebRTC drivers yield assembled messages after owning ICE/DTLS/SCTP/UDP.

--- a/.llm/skills/transport-abstraction/SKILL.md
+++ b/.llm/skills/transport-abstraction/SKILL.md
@@ -39,8 +39,16 @@ pub trait Transport {
     fn diagnostics(&self) -> TransportDiagnostics { TransportDiagnostics::default() }
     fn is_ready(&self) -> bool { true }
     fn close_info(&self) -> Option<TransportCloseInfo> { None }
+    fn max_frame_hint(&self) -> Option<usize> { None }
 }
 ```
+
+`max_frame_hint` declares the backend's enforced inbound per-frame bound.
+Both drivers enforce a declared hint themselves: a larger frame is a terminal
+receive error that tears the session down before any decode work (matching
+the built-in WebSocket transport's over-limit close, RFC 6455 1009). Return
+`None` when the backend enforces no bound; keep the value stable per
+connection.
 
 `TransportFrame` has two variants:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `Transport::max_frame_hint()`: backends that enforce an inbound frame bound
+  can declare it, and both client drivers then refuse larger frames as a
+  terminal receive error before any decoding — closing the path where a
+  custom transport with no inbound limit let one hostile frame amplify into
+  large parse memory. The default (`None`) preserves current behavior, and
+  the built-in WebSocket transport now reports its connect-time bound.
+- `SignalFishEvent::redacted_raw_prefix()`: a safe-path view of
+  `DecodeFailed`'s raw frame prefix that masks every string literal's
+  content while preserving the JSON skeleton, for diagnosing undecodable
+  frames without logging attacker-influenced text.
+- Added an Authentication & Credentials guide consolidating what is public
+  (the app ID), what is secret (reconnection tokens, key material), rotation
+  guidance, and log-hygiene rules.
+
 ### Changed
 
+- `SignalFishConfig::with_protocol_version` now logs a `tracing::warn!` for
+  versions outside the known-supported `2..=3` range. The value is still
+  sent unchanged; the server remains the negotiation authority.
 - **Breaking:** `PlayerNameRulesPayload::allowed_symbols` widened from
   `Vec<char>` to `Vec<String>`, so every schema-valid symbol list decodes
   instead of failing the frame; update code that matched single `char`s.
@@ -19,6 +38,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `DecodeFailed`'s `error` text and the SDK's inbound deserialization warning
+  are capped at 512 bytes: serde quotes hostile wire tokens verbatim (the
+  full `type` tag on unknown variants), which previously put unbounded
+  attacker-controlled text into ambient logs and the public event field.
 - Corrected the WebAssembly guide's published-release guidance and the 0.11
   migration guide's stale `[Unreleased]` changelog pointer.
 - Restored the behavioral tails of seven `ErrorCode` descriptions in the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,24 +10,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `Transport::max_frame_hint()`: backends that enforce an inbound frame bound
-  can declare it, and both client drivers then refuse larger frames as a
-  terminal receive error before any decoding — closing the path where a
-  custom transport with no inbound limit let one hostile frame amplify into
-  large parse memory. The default (`None`) preserves current behavior, and
-  the built-in WebSocket transport now reports its connect-time bound.
+  declare it, and both client drivers then refuse larger frames as a terminal
+  receive error before any decoding (the built-in WebSocket and Emscripten
+  transports report their bounds; the default `None` preserves current
+  behavior).
 - `SignalFishEvent::redacted_raw_prefix()`: a safe-path view of
-  `DecodeFailed`'s raw frame prefix that masks every string literal's
-  content while preserving the JSON skeleton, for diagnosing undecodable
-  frames without logging attacker-influenced text.
-- Added an Authentication & Credentials guide consolidating what is public
-  (the app ID), what is secret (reconnection tokens, key material), rotation
-  guidance, and log-hygiene rules.
+  `DecodeFailed`'s raw frame prefix that masks every string literal's content
+  while preserving the JSON skeleton.
+- Added an Authentication & Credentials guide consolidating the public app-ID
+  policy, secret reconnection tokens, rotation guidance, and log-hygiene
+  rules.
 
 ### Changed
 
 - `SignalFishConfig::with_protocol_version` now logs a `tracing::warn!` for
-  versions outside the known-supported `2..=3` range. The value is still
-  sent unchanged; the server remains the negotiation authority.
+  versions outside the known-supported `2..=3` range (the value is still sent
+  unchanged; the server stays the negotiation authority).
 - **Breaking:** `PlayerNameRulesPayload::allowed_symbols` widened from
   `Vec<char>` to `Vec<String>`, so every schema-valid symbol list decodes
   instead of failing the frame; update code that matched single `char`s.
@@ -38,10 +36,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `DecodeFailed`'s `error` text and the SDK's inbound deserialization warning
-  are capped at 512 bytes: serde quotes hostile wire tokens verbatim (the
-  full `type` tag on unknown variants), which previously put unbounded
-  attacker-controlled text into ambient logs and the public event field.
+- `DecodeFailed`'s `error` text and the SDK's inbound deserialization warnings
+  (JSON and MessagePack paths) are capped at 512 bytes: decoders quote hostile
+  wire tokens verbatim, which previously put unbounded attacker-controlled
+  text into ambient logs and the public event field.
 - Corrected the WebAssembly guide's published-release guidance and the 0.11
   migration guide's stale `[Unreleased]` changelog pointer.
 - Restored the behavioral tails of seven `ErrorCode` descriptions in the

--- a/crates/signal-fish-client-godot/src/lib.rs
+++ b/crates/signal-fish-client-godot/src/lib.rs
@@ -409,6 +409,12 @@ pub struct GodotWebSocketTransport {
     /// re-observe the same parked state do not inflate the deferred-send
     /// counters. Cleared when the frame is accepted (or the slot is empty).
     deferred_counted: bool,
+    /// Declared through [`Transport::max_frame_hint`] for SDK-created peers:
+    /// Godot's inbound byte buffer is a total bound, so a single frame larger
+    /// than it can never be delivered on either platform (web drops it at the
+    /// bound; native stalls instead of assembling it). Caller-owned peers
+    /// keep `None` because their configuration is unknown.
+    max_inbound_frame: Option<usize>,
 }
 
 #[derive(Debug, Default)]
@@ -476,6 +482,12 @@ impl GodotWebSocketTransport {
     /// how that bounds a single admitted frame. Use [`Self::from_peer`] when
     /// the application must choose any of these settings.
     ///
+    /// The transport declares the configured inbound buffer through
+    /// [`Transport::max_frame_hint`], so both client drivers refuse any frame
+    /// larger than it as a terminal receive error — a frame that size could
+    /// never be delivered anyway, and the refusal keeps it out of protocol
+    /// decoding.
+    ///
     /// # Errors
     ///
     /// Returns [`SignalFishError::InvalidConfig`] when Godot rejects the URL.
@@ -518,8 +530,12 @@ impl GodotWebSocketTransport {
     }
 
     /// Wrap a connected/configured peer with explicit backpressure options.
+    ///
+    /// The transport declares no `max_frame_hint`: the caller configured the
+    /// peer, so the SDK cannot know its inbound bound and the drivers perform
+    /// no per-frame refusal.
     pub fn from_peer_with_options(peer: Gd<WebSocketPeer>, options: GodotWebSocketOptions) -> Self {
-        Self::from_backend_with_options(Box::new(peer), options)
+        Self::from_backend_with_options(Box::new(peer), options, None)
     }
 
     fn connect_backend_with_options(
@@ -546,17 +562,23 @@ impl GodotWebSocketTransport {
                 "Godot WebSocketPeer connect_to_url failed with {other:?}"
             ))),
         })?;
-        Ok(Self::from_backend_with_options(backend, options))
+        let max_inbound_frame = usize::try_from(inbound_buffer_size).ok();
+        Ok(Self::from_backend_with_options(
+            backend,
+            options,
+            max_inbound_frame,
+        ))
     }
 
     #[cfg(test)]
     fn from_backend(backend: Box<dyn GodotWebSocketBackend>) -> Self {
-        Self::from_backend_with_options(backend, GodotWebSocketOptions::default())
+        Self::from_backend_with_options(backend, GodotWebSocketOptions::default(), None)
     }
 
     fn from_backend_with_options(
         backend: Box<dyn GodotWebSocketBackend>,
         options: GodotWebSocketOptions,
+        max_inbound_frame: Option<usize>,
     ) -> Self {
         let state = backend.state();
         // A peer already CLOSED with genuine post-open close metadata — a
@@ -595,6 +617,7 @@ impl GodotWebSocketTransport {
             one_frame_escape_frames: 0,
             one_frame_escape_bytes: 0,
             deferred_counted: false,
+            max_inbound_frame,
         };
         transport.sample_cycle_at(Instant::now());
         transport
@@ -992,6 +1015,10 @@ impl Transport for GodotWebSocketTransport {
     fn diagnostics(&self) -> TransportDiagnostics {
         self.diagnostics
     }
+
+    fn max_frame_hint(&self) -> Option<usize> {
+        self.max_inbound_frame
+    }
 }
 
 #[cfg(test)]
@@ -1348,6 +1375,7 @@ mod tests {
             GodotWebSocketOptions {
                 backpressure_policy: GodotBackpressurePolicy::NativeCapacity,
             },
+            None,
         );
         let expected = TransportFrame::Text("abc".to_string());
         let mut frame = Some(expected.clone());
@@ -1453,6 +1481,7 @@ mod tests {
             GodotWebSocketOptions {
                 backpressure_policy: GodotBackpressurePolicy::NativeCapacity,
             },
+            None,
         );
         let mut web_frame = Some(TransportFrame::Binary(vec![1, 2, 3]));
         assert!(matches!(
@@ -1470,6 +1499,7 @@ mod tests {
             GodotWebSocketOptions {
                 backpressure_policy: GodotBackpressurePolicy::NativeCapacity,
             },
+            None,
         );
         let mut native_frame = Some(TransportFrame::Binary(vec![1, 2, 3]));
         assert!(matches!(
@@ -1489,7 +1519,7 @@ mod tests {
             },
         };
         let mut transport =
-            GodotWebSocketTransport::from_backend_with_options(Box::new(backend), options);
+            GodotWebSocketTransport::from_backend_with_options(Box::new(backend), options, None);
         let mut oversized = Some(TransportFrame::Binary(vec![0; 8 * 1024]));
 
         assert!(matches!(
@@ -1520,6 +1550,7 @@ mod tests {
             GodotWebSocketOptions {
                 backpressure_policy: GodotBackpressurePolicy::NativeCapacity,
             },
+            None,
         );
         let mut frame = Some(TransportFrame::Binary(vec![3; 64 * 1024]));
 
@@ -1542,6 +1573,7 @@ mod tests {
             GodotWebSocketOptions {
                 backpressure_policy: GodotBackpressurePolicy::NativeCapacity,
             },
+            None,
         );
         let expected = TransportFrame::Text("abc".to_string());
         let mut frame = Some(expected.clone());
@@ -1618,6 +1650,12 @@ mod tests {
             DEFAULT_MAX_QUEUED_PACKETS,
             "SDK-created peers must keep the packet-count bound from becoming the effective inbound limit"
         );
+        // The declared hint mirrors the configured buffer so both drivers
+        // refuse undeliverable oversized frames before decoding.
+        assert_eq!(
+            transport.max_frame_hint(),
+            usize::try_from(DEFAULT_INBOUND_BUFFER_SIZE).ok()
+        );
         assert_eq!(
             &*observed_steps.borrow(),
             &["configure_inbound", "configure_packets", "connect"]
@@ -1690,6 +1728,9 @@ mod tests {
         );
         assert!(observed_steps.borrow().is_empty());
         assert!(transport.is_ready());
+        // The SDK cannot know a caller-configured peer's inbound bound, so
+        // no hint is declared and the drivers perform no per-frame refusal.
+        assert_eq!(transport.max_frame_hint(), None);
     }
 
     #[test]
@@ -1721,6 +1762,7 @@ mod tests {
             GodotWebSocketOptions {
                 backpressure_policy: GodotBackpressurePolicy::NativeCapacity,
             },
+            None,
         );
         assert_eq!(native.diagnostics().effective_watermark_bytes, 9);
 
@@ -1733,6 +1775,7 @@ mod tests {
                     ceiling_bytes: 10,
                 },
             },
+            None,
         );
         assert_eq!(reversed.diagnostics().effective_watermark_bytes, 10);
     }
@@ -1811,6 +1854,7 @@ mod tests {
                     ceiling_bytes: 1_000,
                 },
             },
+            None,
         );
         let base = Instant::now();
         transport.adaptive = AdaptiveState::default();
@@ -1834,6 +1878,7 @@ mod tests {
                     ceiling_bytes: 10_000,
                 },
             },
+            None,
         );
         let base = Instant::now();
         transport.adaptive = AdaptiveState::default();
@@ -2429,6 +2474,7 @@ mod tests {
             GodotWebSocketOptions {
                 backpressure_policy: policy,
             },
+            None,
         )
     }
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -70,16 +70,17 @@ the mTLS fingerprint profile.
 
 The SDK treats ambient logs as a redaction boundary by design:
 
-- `Debug` impls for events, snapshots, protocol messages, close reasons, and
-  transport frames print variants, flags, and byte lengths — never payload
-  text, room codes, tokens, or credentials.
-- The one deliberate carve-out is
-  [`SignalFishEvent::DecodeFailed::raw_prefix`](events.md): undecodable frames
-  are attacker-influencable, and a hostile server can plant
-  credential-looking strings in them. Its `Debug` redacts the prefix
-  entirely; when you need the frame's shape for diagnostics, prefer the
-  `redacted_raw_prefix()` helper, which masks every string literal's content
-  while preserving the JSON skeleton.
+- SDK-internal `Debug` impls for events, snapshots, protocol messages, close
+  reasons, and transport frames print variants, flags, and byte lengths —
+  never payload text, room codes, tokens, or credentials. (Payload structs
+  such as player names format their tested non-secret fields; reconnect
+  tokens and key material are redacted everywhere.)
+- Undecodable inbound frames are attacker-influencable, so their
+  [`DecodeFailed`](events.md#decodefailed) diagnostics are handled with care:
+  the serde error text is capped at 512 bytes, `raw_prefix`'s `Debug` redacts
+  it entirely, and the `redacted_raw_prefix()` helper returns a
+  content-masked view that keeps the frame's shape. Never log `raw_prefix`
+  verbatim.
 
 Follow the same rules in your own code: persist secrets encrypted or in a
 keystore, and keep them out of logs, URLs, and error messages.

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,0 +1,95 @@
+# Authentication & Credentials
+
+One page for everything the SDK authenticates with: what is public, what is a
+secret, how secrets rotate, and how to keep them out of logs. The pieces live
+in several places; this page ties them together.
+
+## What is public: the app ID
+
+The `app_id` is a public application label, not a secret. It is the only
+required field of [`SignalFishConfig`](client.md#signalfishconfig) and the
+first field of the `Authenticate` message the client sends after connecting.
+The server uses it to route the connection to your application; it does not
+authenticate a tenant.
+
+```rust
+let config = SignalFishConfig::new("mb_app_abc123");
+```
+
+Choose the label your server operator allows. Never place a secret credential
+into `app_id` (or into the WebSocket URL) to "smuggle" authentication — the
+value travels in plaintext JSON and can surface in server-side logs, proxies,
+and browser dev tools.
+
+## What is secret
+
+### Reconnection tokens
+
+Protocol v3 rooms issue a reconnection token in `RoomJoined` and rotate it on
+every successful `Reconnected`. The token restores your seat after an
+unexpected disconnect, so it is a **connection secret**:
+
+- Read it from `client.snapshot().reconnection_token` and persist it with the
+  matching `player_id` and `room_id`.
+- Never log it. Every SDK `Debug`/tracing path redacts it — your code must do
+  the same.
+- After `Reconnected`, persist the **rotated** replacement from the fresh
+  snapshot; the old token is void.
+
+The full recovery procedure — persist, fresh transport, `reconnect(...)`,
+adopt the replay and new plan, fall back by error code — is in
+[the `reconnect` section](client.md#reconnect).
+
+### Token-binding and TLS key material
+
+The opt-in `token-binding` feature proves the identity of one physical
+WebSocket handshake; the `tls` feature adds `wss://` encryption, and
+certificate-capable rustls connections can bind proofs to an mTLS client
+certificate fingerprint. None of this key material is reachable through the
+SDK: the handshake key is zeroized after derivation, and token-binding
+failures carry status details only. Two boundaries to respect:
+
+- Token binding authenticates the client to the server **only on `wss://`**.
+  On plain `ws://` an on-path observer sees the handshake key and nonce and
+  can forge proofs.
+- The proof is not confidentiality. Application payloads are as private as
+  your transport (TLS) makes them.
+
+See [WebSocket Token Binding](token-binding.md) for the negotiation modes and
+the mTLS fingerprint profile.
+
+## Rotation guidance
+
+| Secret | Issued | Rotate | On failure |
+|---|---|---|---|
+| Reconnection token | `RoomJoined` | Every `Reconnected` — persist the replacement | `ReconnectionExpired` / `ReconnectionTokenInvalid`: fall back to a normal `join_room` |
+| TLS session | Connect | Every new physical connection (fresh handshake, fresh proofs) | Reconnect with a fresh transport |
+| App ID | Deployment | N/A — it is a public label | The server rejects unknown labels at authentication |
+
+## Keeping secrets out of logs
+
+The SDK treats ambient logs as a redaction boundary by design:
+
+- `Debug` impls for events, snapshots, protocol messages, close reasons, and
+  transport frames print variants, flags, and byte lengths — never payload
+  text, room codes, tokens, or credentials.
+- The one deliberate carve-out is
+  [`SignalFishEvent::DecodeFailed::raw_prefix`](events.md): undecodable frames
+  are attacker-influencable, and a hostile server can plant
+  credential-looking strings in them. Its `Debug` redacts the prefix
+  entirely; when you need the frame's shape for diagnostics, prefer the
+  `redacted_raw_prefix()` helper, which masks every string literal's content
+  while preserving the JSON skeleton.
+
+Follow the same rules in your own code: persist secrets encrypted or in a
+keystore, and keep them out of logs, URLs, and error messages.
+
+## Cloud credentials (status)
+
+Signal Fish Server 0.8 authenticates connections with the public app ID
+alone. If your deployment's control plane issues secret-form application keys
+(`sfk_…`), the SDK has **no surface for them today**: do not pass them as the
+`app_id`, and never embed them in the URL. A dedicated credentials API is
+being designed with the upstream wire contract; it will be explicit,
+redacted in all diagnostics, and announced in the
+[changelog](https://github.com/Ambiguous-Interactive/signal-fish-client-rust/blob/main/CHANGELOG.md).

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -36,6 +36,7 @@ pub trait Transport {
     fn is_ready(&self) -> bool { true }
     fn close_info(&self) -> Option<TransportCloseInfo> { None }
     fn diagnostics(&self) -> TransportDiagnostics { TransportDiagnostics::default() }
+    fn max_frame_hint(&self) -> Option<usize> { None }
 }
 ```
 
@@ -45,6 +46,7 @@ pub trait Transport {
 | `poll_recv` | Poll the next text/binary frame; `Ready(None)` is a clean close. |
 | `poll_close` | Progress idempotent graceful shutdown across calls. |
 | `abort` | Immediately abandon backend work and end driver polling after a deadline, close error, or owner drop. |
+| `max_frame_hint` | Declare the backend's inbound frame bound; the drivers refuse larger frames terminally before decoding. |
 
 The required `abort` method enforces deadline abandonment. It releases or
 safely detaches backend resources, discards accepted sends, and makes later

--- a/docs/events.md
+++ b/docs/events.md
@@ -85,11 +85,20 @@ increments [`ClientStats::messages_undecodable`](client.md#send-queue-and-traffi
 | Field | Type | Description |
 |-------|------|-------------|
 | `message_type` | `Option<String>` | The wire `type` tag when the frame was valid JSON and the failure position allowed tag recovery (frames larger than the 512-byte `raw_prefix` window report `None` even when valid JSON). `Some("Error")` plus a decode failure strongly implies an unknown `error_code`; `None` usually means the frame was not valid JSON at all. |
-| `error` | `String` | The deserialization error text. |
+| `error` | `String` | The deserialization error text, capped at 512 bytes (serde quotes hostile wire tokens verbatim, so the text is bounded). |
 | `raw_prefix` | `String` | The raw frame, truncated to `DECODE_FAILED_RAW_PREFIX_MAX` (512) bytes on a UTF-8 boundary. |
 
 Steady growth of `messages_undecodable` means protocol drift (upgrade this
 SDK) or a corrupting middlebox — log `DecodeFailed` in production builds.
+
+!!! warning "Handle raw_prefix as untrusted text"
+    `raw_prefix` is verbatim frame content: a hostile server can plant
+    credential-looking strings in it for exactly the application that logs
+    decode failures verbatim. `Debug` formatting redacts it entirely; when
+    you need the frame's shape for diagnostics, use
+    [`redacted_raw_prefix()`](https://docs.rs/signal-fish-client/latest/signal_fish_client/struct.SignalFishEvent.html#method.redacted_raw_prefix),
+    which masks every string literal's content while preserving the JSON
+    skeleton. Never log `raw_prefix` verbatim.
 
 `ProtocolViolation` is distinct from `DecodeFailed`: its frame decoded, but
 its sequence, epoch, lifecycle, gap, counter, or causal state contradicted the

--- a/docs/events.md
+++ b/docs/events.md
@@ -96,7 +96,7 @@ SDK) or a corrupting middlebox — log `DecodeFailed` in production builds.
     credential-looking strings in it for exactly the application that logs
     decode failures verbatim. `Debug` formatting redacts it entirely; when
     you need the frame's shape for diagnostics, use
-    [`redacted_raw_prefix()`](https://docs.rs/signal-fish-client/latest/signal_fish_client/struct.SignalFishEvent.html#method.redacted_raw_prefix),
+    [`redacted_raw_prefix()`](https://docs.rs/signal-fish-client/latest/signal_fish_client/event/enum.SignalFishEvent.html#method.redacted_raw_prefix),
     which masks every string literal's content while preserving the JSON
     skeleton. Never log `raw_prefix` verbatim.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -91,6 +91,8 @@ accountability and mesh signaling when your game needs them.
 
 ## When you need more detail
 
+- [Authentication & credentials](authentication.md) separates the public app
+  ID from the secrets your game must protect.
 - [Events](events.md) and [errors](errors.md) describe what your event loop can
   receive.
 - [Protocol versioning](protocol-versioning.md) helps you choose v2 relay or

--- a/docs/transport.md
+++ b/docs/transport.md
@@ -79,9 +79,12 @@ treated as a terminal receive error and tears the session down before any
 decode work, so a hostile frame cannot amplify into parse memory and the
 behavior matches the built-in transport's own over-limit close (RFC 6455
 1009). The default (`None`) accepts every delivered frame. Keep the value
-stable for the lifetime of one connection, and only declare a bound your
-backend actually enforces — the driver treats the hint as a contract, which
-protects callers even when the backend's own enforcement is missing.
+stable for the lifetime of one connection. Declare the bound your backend is
+configured with even where its own enforcement is best-effort: the drivers
+treat the declaration as a contract and reject violations terminally
+themselves, so callers stay protected either way. (The Godot adapter's
+caller-owned peers declare no hint — the SDK cannot know a peer it did not
+configure.)
 
 ## Datagram and raw-stream scope
 

--- a/docs/transport.md
+++ b/docs/transport.md
@@ -31,6 +31,7 @@ pub trait Transport {
     fn diagnostics(&self) -> TransportDiagnostics { TransportDiagnostics::default() }
     fn is_ready(&self) -> bool { true }
     fn close_info(&self) -> Option<TransportCloseInfo> { None }
+    fn max_frame_hint(&self) -> Option<usize> { None }
 }
 ```
 
@@ -58,6 +59,29 @@ protocol-v2 or protocol-v3 game-data envelopes; the public physical binary-send
 APIs are gated on negotiated v3 plus MessagePack. A transport treats binary
 payloads as opaque bytes, preserves frame boundaries, and must not silently
 discard either kind.
+
+## Declaring an inbound frame bound
+
+The built-in WebSocket transport enforces a per-frame and assembled-message
+inbound bound (8 MiB by default) at the socket layer. A custom backend may
+have no such enforcement — in which case one delivered frame reaches
+protocol decoding with whatever size the server chose. Backends that enforce
+a bound should declare it:
+
+```rust,ignore
+fn max_frame_hint(&self) -> Option<usize> {
+    Some(self.max_inbound_frame_bytes)
+}
+```
+
+Both drivers then enforce the declared bound themselves: a larger frame is
+treated as a terminal receive error and tears the session down before any
+decode work, so a hostile frame cannot amplify into parse memory and the
+behavior matches the built-in transport's own over-limit close (RFC 6455
+1009). The default (`None`) accepts every delivered frame. Keep the value
+stable for the lifetime of one connection, and only declare a bound your
+backend actually enforces — the driver treats the hint as a contract, which
+protects callers even when the backend's own enforcement is missing.
 
 ## Datagram and raw-stream scope
 

--- a/llms.txt
+++ b/llms.txt
@@ -19,6 +19,7 @@ repository git dependency when evaluating APIs and fixes listed under
 - [Getting started](https://Ambiguous-Interactive.github.io/signal-fish-client-rust/getting-started/): Installation, features, and first client
 - [Basic lobby walkthrough](https://Ambiguous-Interactive.github.io/signal-fish-client-rust/examples/): A complete lobby client with readiness, game start, and shutdown
 - [Client commands and state](https://Ambiguous-Interactive.github.io/signal-fish-client-rust/client/): Async and polling clients, commands, work budgets, shutdown, and diagnostics
+- [Authentication & credentials](https://Ambiguous-Interactive.github.io/signal-fish-client-rust/authentication/): Public app IDs, secret reconnection tokens, rotation, and log hygiene
 - [Events](https://Ambiguous-Interactive.github.io/signal-fish-client-rust/events/): The event stream and every variant a game loop must handle
 - [Errors](https://Ambiguous-Interactive.github.io/signal-fish-client-rust/errors/): Error types, codes, and recovery guidance
 - [Deterministic testing](https://Ambiguous-Interactive.github.io/signal-fish-client-rust/testing/): Paused-clock and caller-cadence recipes for both drivers

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -145,6 +145,7 @@ nav:
       - Basic Lobby Walkthrough: examples.md
   - Use the SDK:
       - Client API Reference: client.md
+      - Authentication & Credentials: authentication.md
       - Events: events.md
       - Errors: errors.md
       - Deterministic Testing: testing.md

--- a/src/client.rs
+++ b/src/client.rs
@@ -1952,6 +1952,10 @@ impl<T: Transport> Transport for AbortOnDropTransport<T> {
     fn diagnostics(&self) -> crate::transport::TransportDiagnostics {
         self.inner.diagnostics()
     }
+
+    fn max_frame_hint(&self) -> Option<usize> {
+        self.inner.max_frame_hint()
+    }
 }
 
 #[cfg(feature = "tokio-runtime")]

--- a/src/client.rs
+++ b/src/client.rs
@@ -469,9 +469,19 @@ impl SignalFishConfig {
     /// instead. Setting a version without also setting transports/topologies keeps
     /// the room on the relay floor (the server requires both to form a session).
     /// Any `u16` is accepted here; an unknown version surfaces as the server's
-    /// own negotiation or error response.
+    /// own negotiation or error response. A [`tracing::warn!`] is logged at
+    /// builder time for versions outside the known-supported range
+    /// `2..=[PROTOCOL_VERSION](crate::PROTOCOL_VERSION)` — purely diagnostic,
+    /// the value is still sent unchanged and the server stays the authority.
     #[must_use]
     pub fn with_protocol_version(mut self, version: u16) -> Self {
+        if !(2..=crate::PROTOCOL_VERSION).contains(&version) {
+            tracing::warn!(
+                "protocol version {version} is outside the known-supported \
+                 range 2..={}; the server will negotiate it or reject the session",
+                crate::PROTOCOL_VERSION
+            );
+        }
         self.protocol_version = Some(version);
         self
     }
@@ -879,12 +889,14 @@ impl SignalFishClient {
         let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
 
         let mesh_capable = config.advertises_mesh_capability();
-        let state = Arc::new(Mutex::new(ClientCore::new_with_room_operation_ids(
+        let mut core = ClientCore::new_with_room_operation_ids(
             config.game_data_format,
             config.protocol_violation_policy,
             mesh_capable,
             config.requests_room_operation_ids(),
-        )));
+        );
+        core.set_max_inbound_frame(transport.max_frame_hint());
+        let state = Arc::new(Mutex::new(core));
         let loop_state = Arc::clone(&state);
 
         // Send the Authenticate message through the command channel so the
@@ -2285,7 +2297,7 @@ async fn finish_send_failure(
         };
 
         let outcome = lock_core(state).process_frame(frame);
-        let protocol_stop = outcome.disconnect;
+        let protocol_stop = outcome.disconnect || outcome.input_error.is_some();
         if !emit_event_batch(event_tx, shutdown, deadline, outcome.events).await {
             debug!("terminal event delivery was preempted mid-batch after send failure");
             break;
@@ -2479,6 +2491,22 @@ async fn transport_loop(
                     }
                     TransportIo::Received(Some(Ok(frame))) => {
                         let outcome = lock_core(&state).process_frame(frame);
+                        // A frame exceeding the transport's declared inbound
+                        // bound is a terminal receive error regardless of the
+                        // violation policy: the backend's own contract makes
+                        // the input stream unusable, matching how the built-in
+                        // WebSocket transport ends over-limit connections.
+                        if let Some(reason) = outcome.input_error {
+                            emit_core_disconnected_or_shutdown(
+                                &mut transport,
+                                &mut pending_send,
+                                &event_tx,
+                                &mut shutdown,
+                                &state,
+                                TerminalTeardown::starting(shutdown_timeout, Some(reason)),
+                            ).await;
+                            break;
+                        }
                         let disconnect = outcome.disconnect;
                         // A policy-driven disconnect terminates the session,
                         // so its batch shares one shutdown budget with the
@@ -2809,6 +2837,8 @@ mod tests {
         sent_binary: Option<Arc<StdMutex<Vec<Vec<u8>>>>>,
         /// Diagnostics reported by the mocked backend.
         diagnostics: crate::transport::TransportDiagnostics,
+        /// Inbound bound declared through `Transport::max_frame_hint`.
+        max_frame_hint: Option<usize>,
     }
 
     impl MockTransport {
@@ -2861,6 +2891,7 @@ mod tests {
                 frames_taken: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
                 sent_binary: None,
                 diagnostics: crate::transport::TransportDiagnostics::default(),
+                max_frame_hint: None,
             };
             (
                 transport,
@@ -2898,6 +2929,10 @@ mod tests {
     impl Transport for MockTransport {
         fn diagnostics(&self) -> crate::transport::TransportDiagnostics {
             self.diagnostics
+        }
+
+        fn max_frame_hint(&self) -> Option<usize> {
+            self.max_frame_hint
         }
 
         fn abort(&mut self) {
@@ -3520,6 +3555,51 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn max_frame_hint_is_enforced_by_the_async_driver() {
+        let (mut transport, _sent, closed) = MockTransport::new(vec![Some(Ok("x".repeat(17)))]);
+        transport.max_frame_hint = Some(16);
+        let (mut client, mut events) =
+            SignalFishClient::start(transport, SignalFishConfig::new("mb_hint"));
+
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Connected)
+        ));
+        match events.recv().await {
+            Some(SignalFishEvent::Disconnected { reason, .. }) => {
+                let reason = reason.expect("the hint refusal must carry a reason");
+                assert!(reason.contains("17 bytes"), "{reason}");
+                assert!(reason.contains("max frame hint"), "{reason}");
+            }
+            other => panic!("expected Disconnected, got {other:?}"),
+        }
+        assert!(
+            closed.load(Ordering::Relaxed),
+            "the transport must be torn down after the over-hint frame"
+        );
+        client.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn max_frame_hint_boundary_frame_still_decodes() {
+        let (mut transport, _sent, _closed) =
+            MockTransport::new(vec![Some(Ok("not-json-at-all!".into()))]);
+        transport.max_frame_hint = Some(16);
+        let (mut client, mut events) =
+            SignalFishClient::start(transport, SignalFishConfig::new("mb_hint"));
+
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Connected)
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::DecodeFailed { .. })
+        ));
+        client.shutdown().await;
+    }
+
+    #[tokio::test]
     async fn transport_diagnostics_mirror_the_driver_loop_sample() {
         let (mut transport, _sent, _closed) =
             MockTransport::new(vec![Some(Ok(authenticated_json()))]);
@@ -4028,6 +4108,82 @@ mod tests {
         assert_eq!(
             config.supported_topologies,
             Some(vec![Topology::Mesh, Topology::Relay])
+        );
+    }
+
+    /// Builder-time sanity warning: exactly one warn outside the
+    /// known-supported range, none inside — purely diagnostic, the value is
+    /// still sent unchanged.
+    #[test]
+    fn with_protocol_version_warns_only_outside_the_known_range() {
+        use tracing_subscriber::layer::SubscriberExt as _;
+
+        struct MessageVisitor(Option<String>);
+
+        impl tracing::field::Visit for MessageVisitor {
+            fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+                if field.name() == "message" {
+                    self.0 = Some(format!("{value:?}"));
+                }
+            }
+        }
+
+        struct WarnCapture(Arc<std::sync::Mutex<Vec<String>>>);
+
+        impl<S> tracing_subscriber::layer::Layer<S> for WarnCapture
+        where
+            S: tracing::Subscriber,
+        {
+            fn on_event(
+                &self,
+                event: &tracing::Event<'_>,
+                _context: tracing_subscriber::layer::Context<'_, S>,
+            ) {
+                if event.metadata().level() != &tracing::Level::WARN {
+                    return;
+                }
+                let mut visitor = MessageVisitor(None);
+                event.record(&mut visitor);
+                if let Some(message) = visitor.0 {
+                    self.0
+                        .lock()
+                        .expect("warn capture mutex must not be poisoned")
+                        .push(message);
+                }
+            }
+        }
+
+        let capture = Arc::new(std::sync::Mutex::new(Vec::new()));
+        tracing::subscriber::with_default(
+            tracing_subscriber::registry().with(WarnCapture(Arc::clone(&capture))),
+            || {
+                // Known-supported versions stay silent.
+                for version in [2, 3] {
+                    capture.lock().expect("capture mutex").clear();
+                    let config = SignalFishConfig::new("app").with_protocol_version(version);
+                    assert_eq!(config.protocol_version, Some(version));
+                    assert!(
+                        capture.lock().expect("capture mutex").is_empty(),
+                        "version {version} must not warn"
+                    );
+                }
+                // Unknown versions warn exactly once with the value and range.
+                for version in [1, 4, u16::MAX] {
+                    capture.lock().expect("capture mutex").clear();
+                    let config = SignalFishConfig::new("app").with_protocol_version(version);
+                    assert_eq!(config.protocol_version, Some(version));
+                    let messages = capture.lock().expect("capture mutex");
+                    assert_eq!(
+                        messages.len(),
+                        1,
+                        "version {version} must warn exactly once: {messages:?}"
+                    );
+                    assert!(
+                        messages[0].contains(&version.to_string()),
+                        "the warn must name the version: {messages:?}"
+                    );
+                }
+            },
         );
     }
 

--- a/src/client_core.rs
+++ b/src/client_core.rs
@@ -1306,9 +1306,12 @@ impl ClientCore {
             Err(error) => {
                 let disconnect = self.observe_undecodable(&mut outcome.events);
                 self.stats.messages_undecodable = self.stats.messages_undecodable.saturating_add(1);
+                // The binary decoders quote wire-supplied tokens verbatim
+                // (e.g. an unknown encoding string), so the stored text gets
+                // the same bound as the JSON path.
                 outcome.events.push(SignalFishEvent::DecodeFailed {
                     message_type: Some("BinaryGameData".into()),
-                    error,
+                    error: crate::event::bounded_text(&error),
                     raw_prefix: bounded_binary_preview(&bytes),
                 });
                 outcome.disconnect = disconnect;
@@ -4223,6 +4226,46 @@ mod tests {
             outcome.events.as_slice(),
             [SignalFishEvent::DecodeFailed { .. }]
         ));
+    }
+
+    /// The MessagePack decoders quote wire-supplied tokens verbatim (an
+    /// unknown encoding string, for example), so the stored `DecodeFailed`
+    /// error text gets the same 512-byte bound as the JSON path.
+    #[test]
+    fn binary_decode_error_text_is_bounded() {
+        let mut core = ClientCore::new(
+            Some(GameDataEncoding::MessagePack),
+            ProtocolViolationPolicy::Quarantine,
+            false,
+        );
+        let _ = process(&mut core, authenticated());
+        let ServerMessage::ProtocolInfo(mut protocol) = protocol_info(None) else {
+            unreachable!("protocol_info helper always returns ProtocolInfo")
+        };
+        protocol.game_data_formats = vec![GameDataEncoding::Json, GameDataEncoding::MessagePack];
+        let _ = process(&mut core, ServerMessage::ProtocolInfo(protocol));
+        core.record_admission(ClientCore::admission_for(&ClientOperation::JoinRoom(
+            JoinRoomParams::new("game", "local"),
+        )));
+        let _ = process(&mut core, room_joined_v2());
+
+        // Hostile envelope: a map whose `encoding` value is 1 MB of 'A' —
+        // the decode failure quotes the whole value.
+        let mut frame = Vec::new();
+        rmp::encode::write_map_len(&mut frame, 1).expect("map header must encode");
+        rmp::encode::write_str(&mut frame, "encoding").expect("key must encode");
+        rmp::encode::write_str(&mut frame, &"A".repeat(1_000_000))
+            .expect("hostile value must encode");
+        let outcome = core.process_frame(TransportFrame::Binary(frame));
+        let [SignalFishEvent::DecodeFailed { error, .. }] = outcome.events.as_slice() else {
+            panic!("expected one DecodeFailed event, got {:?}", outcome.events);
+        };
+        assert!(
+            error.len() <= crate::event::DECODE_FAILED_RAW_PREFIX_MAX,
+            "binary error text must stay bounded, got {} bytes",
+            error.len()
+        );
+        assert!(error.contains('A'), "a bounded prefix of the token stays");
     }
 
     #[test]

--- a/src/client_core.rs
+++ b/src/client_core.rs
@@ -27,6 +27,11 @@ use crate::transport::TransportFrame;
 pub(crate) struct FrameOutcome {
     pub(crate) events: Vec<SignalFishEvent>,
     pub(crate) disconnect: bool,
+    /// Set when the frame was refused before decoding because it exceeded the
+    /// transport's declared inbound bound. The input stream is unusable under
+    /// the backend's own contract, so both drivers treat this exactly like a
+    /// terminal transport receive error regardless of the violation policy.
+    pub(crate) input_error: Option<String>,
 }
 
 pub(crate) enum CoreCommand {
@@ -148,6 +153,7 @@ impl FrameOutcome {
         Self {
             events: Vec::new(),
             disconnect: false,
+            input_error: None,
         }
     }
 }
@@ -171,6 +177,11 @@ pub(crate) struct ClientCore {
     requested_room_operation_ids: bool,
     room_operation_ids: bool,
     mesh_capable: bool,
+    /// Inbound per-frame bound declared by the transport via
+    /// [`Transport::max_frame_hint`](crate::Transport::max_frame_hint).
+    /// `Some(bound)` makes `process_frame` refuse larger frames before any
+    /// decoding work, so a hostile frame cannot amplify into parse memory.
+    max_inbound_frame: Option<usize>,
     stats: ClientStats,
     // Latest backend-reported scheduling/buffering diagnostics. The async
     // driver refreshes the sample at loop-cycle start and after every
@@ -324,6 +335,7 @@ impl ClientCore {
             requested_room_operation_ids,
             room_operation_ids: false,
             mesh_capable,
+            max_inbound_frame: None,
             stats: ClientStats::default(),
             #[cfg(feature = "tokio-runtime")]
             transport_diagnostics: TransportDiagnostics::default(),
@@ -352,6 +364,12 @@ impl ClientCore {
 
     pub(crate) fn snapshot(&self) -> ClientSnapshot {
         self.snapshot.clone()
+    }
+
+    /// Record the transport's declared inbound frame bound once, at driver
+    /// construction, before any frame can be processed.
+    pub(crate) fn set_max_inbound_frame(&mut self, max_inbound_frame: Option<usize>) {
+        self.max_inbound_frame = max_inbound_frame;
     }
 
     pub(crate) fn stats(&self) -> ClientStats {
@@ -872,6 +890,29 @@ impl ClientCore {
     }
 
     pub(crate) fn process_frame(&mut self, frame: TransportFrame) -> FrameOutcome {
+        if let Some(max_bytes) = self.max_inbound_frame {
+            let frame_bytes = crate::terminal_drain::frame_payload_len(&frame);
+            if frame_bytes > max_bytes {
+                // The backend declared this bound via `max_frame_hint`, so a
+                // larger frame is a backend contract violation — and exactly
+                // the delivery the built-in WebSocket transport terminates on
+                // (RFC 6455 close 1009). Refuse before any decode work: the
+                // response surfaces as a terminal receive error on both
+                // drivers, independent of the protocol violation policy.
+                tracing::warn!(
+                    "inbound frame of {frame_bytes} bytes exceeds the transport \
+                     max frame hint of {max_bytes} bytes; terminating input"
+                );
+                return FrameOutcome {
+                    events: Vec::new(),
+                    disconnect: false,
+                    input_error: Some(format!(
+                        "inbound frame of {frame_bytes} bytes exceeds the \
+                         transport max frame hint of {max_bytes} bytes"
+                    )),
+                };
+            }
+        }
         match frame {
             TransportFrame::Text(text) => self.process_text(text),
             TransportFrame::Binary(bytes) => self.process_binary(bytes),
@@ -883,8 +924,12 @@ impl ClientCore {
         let server_msg = match serde_json::from_str::<ServerMessage>(&text) {
             Ok(message) => message,
             Err(error) => {
+                // serde quotes hostile wire tokens verbatim (the full
+                // `type` tag on unknown variants), so ambient logs get the
+                // same bounded text the public event stores.
+                let error_text = crate::event::bounded_error_text(&error);
                 tracing::warn!(
-                    "failed to deserialize server message ({} bytes): {error}",
+                    "failed to deserialize server message ({} bytes): {error_text}",
                     text.len()
                 );
                 let disconnect = self.observe_undecodable(&mut outcome.events);
@@ -4108,6 +4153,76 @@ mod tests {
         assert!(!core.room_operation_ids);
         assert!(core.pending_room_operation.is_none());
         assert!(core.pending_reconnects.is_empty());
+    }
+
+    #[test]
+    fn max_inbound_frame_refuses_oversized_frames_before_decoding() {
+        let mut core = ClientCore::new(
+            Some(GameDataEncoding::Json),
+            ProtocolViolationPolicy::Quarantine,
+            false,
+        );
+        core.set_max_inbound_frame(Some(16));
+
+        let outcome = core.process_frame(TransportFrame::Text("x".repeat(17)));
+        assert!(outcome.events.is_empty());
+        let reason = outcome
+            .input_error
+            .expect("an oversized text frame must be refused before decoding");
+        assert!(reason.contains("17 bytes"), "{reason}");
+        assert!(reason.contains("16 bytes"), "{reason}");
+        assert_eq!(core.stats.messages_undecodable, 0);
+
+        let outcome = core.process_frame(TransportFrame::Binary(vec![0x81; 17]));
+        assert!(outcome.events.is_empty());
+        assert!(outcome.input_error.is_some());
+        assert_eq!(core.stats.messages_undecodable, 0);
+        assert_eq!(core.stats.game_data_received, 0);
+    }
+
+    #[test]
+    fn max_inbound_frame_boundary_still_decodes() {
+        let mut core = ClientCore::new(
+            Some(GameDataEncoding::Json),
+            ProtocolViolationPolicy::Quarantine,
+            false,
+        );
+        core.set_max_inbound_frame(Some(16));
+
+        // Exactly at the declared bound the ordinary decode path runs:
+        // garbage surfaces as DecodeFailed, not as a terminal refusal.
+        let outcome = core.process_frame(TransportFrame::Text("not-json-at-all!".into()));
+        assert!(outcome.input_error.is_none());
+        assert!(matches!(
+            outcome.events.as_slice(),
+            [SignalFishEvent::DecodeFailed { .. }]
+        ));
+        assert_eq!(core.stats.messages_undecodable, 1);
+
+        // Binary frames pass the size gate and reach their normal
+        // pre-negotiation lifecycle rejection instead.
+        let outcome = core.process_frame(TransportFrame::Binary(vec![0x81; 16]));
+        assert!(outcome.input_error.is_none());
+        assert!(matches!(
+            outcome.events.as_slice(),
+            [SignalFishEvent::ProtocolViolation { .. }]
+        ));
+    }
+
+    #[test]
+    fn without_a_hint_large_frames_still_reach_decoding() {
+        let mut core = ClientCore::new(
+            Some(GameDataEncoding::Json),
+            ProtocolViolationPolicy::Quarantine,
+            false,
+        );
+
+        let outcome = core.process_frame(TransportFrame::Text("x".repeat(80_000)));
+        assert!(outcome.input_error.is_none());
+        assert!(matches!(
+            outcome.events.as_slice(),
+            [SignalFishEvent::DecodeFailed { .. }]
+        ));
     }
 
     #[test]

--- a/src/event.rs
+++ b/src/event.rs
@@ -798,7 +798,15 @@ fn truncate_on_char_boundary(s: &str, max_bytes: usize) -> &str {
 /// itself is recovered separately and boundedly via `message_type`.
 #[cfg(any(feature = "tokio-runtime", feature = "polling-client"))]
 pub(crate) fn bounded_error_text(error: &serde_json::Error) -> String {
-    truncate_on_char_boundary(&error.to_string(), DECODE_FAILED_RAW_PREFIX_MAX).to_string()
+    bounded_text(&error.to_string())
+}
+
+/// Bounded diagnostic text at [`DECODE_FAILED_RAW_PREFIX_MAX`] on a UTF-8
+/// boundary, for error strings that embed wire-supplied tokens (the
+/// MessagePack binary decoders quote the hostile value, for example).
+#[cfg(any(feature = "tokio-runtime", feature = "polling-client"))]
+pub(crate) fn bounded_text(raw: &str) -> String {
+    truncate_on_char_boundary(raw, DECODE_FAILED_RAW_PREFIX_MAX).to_string()
 }
 
 // ── Conversion ──────────────────────────────────────────────────────
@@ -1426,8 +1434,8 @@ mod tests {
         let cases: [(&str, &str); 6] = [
             // Plain JSON: keys and values both mask; structure survives.
             (
-                r#"{"type":"Error","data":{}}"#,
-                r#"{"****":"*****","****":{}}"#,
+                r#"{"type":"Error","data":{"error_code":"abcdef"}}"#,
+                r#"{"****":"*****","****":{"**********":"******"}}"#,
             ),
             // Escape sequences mask in their raw source form, and the
             // closing quote placement is identical.

--- a/src/event.rs
+++ b/src/event.rs
@@ -121,9 +121,13 @@ pub enum SignalFishEvent {
         /// [`DECODE_FAILED_RAW_PREFIX_MAX`] bytes on a UTF-8 boundary.
         ///
         /// This is verbatim frame content and can include sensitive data the
-        /// frame carried (for example SDP inside a signal relay). [`Debug`]
-        /// formatting of this event redacts it; treat the field itself as
-        /// diagnostic-only and never log it verbatim.
+        /// frame carried (for example SDP inside a signal relay) — treat it
+        /// as untrusted: a hostile server can plant credential-looking
+        /// strings for exactly the application that logs it verbatim.
+        /// [`Debug`] formatting of this event redacts it entirely, and
+        /// [`redacted_raw_prefix`](SignalFishEvent::redacted_raw_prefix)
+        /// returns a content-masked view that keeps the frame's shape; when
+        /// raw text is genuinely required, never log it verbatim.
         raw_prefix: String,
     },
 
@@ -713,9 +717,61 @@ impl SignalFishEvent {
         };
         Self::DecodeFailed {
             message_type,
-            error: error.to_string(),
+            error: bounded_error_text(error),
             raw_prefix: prefix.to_string(),
         }
+    }
+
+    /// Returns the [`DecodeFailed`](Self::DecodeFailed) raw frame prefix with
+    /// every string literal's content masked byte-for-byte, or `None` for
+    /// every other event kind.
+    ///
+    /// `raw_prefix` is verbatim frame text and can embed anything the frame
+    /// carried — including credential-looking strings a hostile server
+    /// planted for exactly the application that logs decode failures
+    /// verbatim. [`Debug`](std::fmt::Debug) formatting redacts it entirely;
+    /// when raw text is genuinely needed to diagnose the frame's shape, this
+    /// is the safe path: the JSON skeleton (field names as lengths, nesting,
+    /// punctuation) stays visible while every string literal's content is
+    /// replaced with same-length `*` bytes. Escapes are masked in their raw
+    /// source form and an unterminated final literal (the prefix is
+    /// truncated) masks to the end.
+    #[must_use]
+    pub fn redacted_raw_prefix(&self) -> Option<String> {
+        let Self::DecodeFailed { raw_prefix, .. } = self else {
+            return None;
+        };
+        // Byte-level lexical mask. Outside string literals bytes are copied
+        // verbatim (valid UTF-8 stays valid); inside them every content byte
+        // becomes `*`, so the output length always matches the input and an
+        // unterminated final literal (truncated prefix) masks to the end.
+        let mut masked: Vec<u8> = Vec::with_capacity(raw_prefix.len());
+        let mut in_string = false;
+        let mut escaped_next = false;
+        for byte in raw_prefix.bytes() {
+            if in_string {
+                if escaped_next {
+                    masked.push(b'*');
+                    escaped_next = false;
+                } else {
+                    match byte {
+                        b'"' => {
+                            in_string = false;
+                            masked.push(b'"');
+                        }
+                        b'\\' => {
+                            masked.push(b'*');
+                            escaped_next = true;
+                        }
+                        _ => masked.push(b'*'),
+                    }
+                }
+            } else {
+                masked.push(byte);
+                in_string = byte == b'"';
+            }
+        }
+        Some(String::from_utf8_lossy(&masked).into_owned())
     }
 }
 
@@ -731,6 +787,18 @@ fn truncate_on_char_boundary(s: &str, max_bytes: usize) -> &str {
         end = end.saturating_sub(1);
     }
     s.get(..end).unwrap_or_default()
+}
+
+/// Bounded serde error text for the public event field and ambient logs.
+///
+/// serde embeds hostile wire tokens verbatim in several of its messages
+/// (`unknown variant` quotes the full `type` tag), so the rendered text is
+/// attacker-controlled and unbounded in the frame's size. Both consumers cap
+/// it at [`DECODE_FAILED_RAW_PREFIX_MAX`] on a UTF-8 boundary; the wire tag
+/// itself is recovered separately and boundedly via `message_type`.
+#[cfg(any(feature = "tokio-runtime", feature = "polling-client"))]
+pub(crate) fn bounded_error_text(error: &serde_json::Error) -> String {
+    truncate_on_char_boundary(&error.to_string(), DECODE_FAILED_RAW_PREFIX_MAX).to_string()
 }
 
 // ── Conversion ──────────────────────────────────────────────────────
@@ -1329,5 +1397,78 @@ mod tests {
             }
             other => panic!("expected DecodeFailed, got {other:?}"),
         }
+    }
+
+    /// serde embeds hostile wire tokens verbatim (e.g. the full `type` tag on
+    /// unknown variants), so the stored error text and the ambient warn must
+    /// stay bounded instead of scaling with the frame.
+    #[cfg(any(feature = "tokio-runtime", feature = "polling-client"))]
+    #[test]
+    fn decode_failed_error_text_is_bounded() {
+        let hostile = format!(r#"{{"type":"{}"}}"#, "A".repeat(50_000));
+        let err = serde_json::from_str::<ServerMessage>(&hostile).unwrap_err();
+        match SignalFishEvent::decode_failed(&hostile, &err) {
+            SignalFishEvent::DecodeFailed { error, .. } => {
+                assert!(
+                    error.len() <= DECODE_FAILED_RAW_PREFIX_MAX,
+                    "error text must stay bounded, got {} bytes",
+                    error.len()
+                );
+            }
+            other => panic!("expected DecodeFailed, got {other:?}"),
+        }
+    }
+
+    /// The safe-path mask hides every string literal's content byte-for-byte
+    /// while keeping the JSON skeleton, escapes, and length intact.
+    #[test]
+    fn redacted_raw_prefix_masks_string_content_and_preserves_length() {
+        let cases: [(&str, &str); 6] = [
+            // Plain JSON: keys and values both mask; structure survives.
+            (
+                r#"{"type":"Error","data":{}}"#,
+                r#"{"****":"*****","****":{}}"#,
+            ),
+            // Escape sequences mask in their raw source form, and the
+            // closing quote placement is identical.
+            (r#"{"a":"x\"y\\z"}"#, r#"{"*":"*******"}"#),
+            // Multibyte content masks per byte so length stays equal.
+            ("\"héllo\"", "\"******\""),
+            // Numbers, booleans, and null stay readable.
+            (
+                r#"{"n":12,"t":true,"x":null}"#,
+                r#"{"*":12,"*":true,"*":null}"#,
+            ),
+            // A truncated final literal masks to the end.
+            (r#"{"type":"Err"#, r#"{"****":"***"#),
+            // Empty string literals stay recognizable.
+            (r#"{"a":""}"#, r#"{"*":""}"#),
+        ];
+        for (raw, expected) in cases {
+            let event = SignalFishEvent::DecodeFailed {
+                message_type: None,
+                error: "unused".into(),
+                raw_prefix: raw.to_string(),
+            };
+            let masked = event
+                .redacted_raw_prefix()
+                .expect("DecodeFailed must provide a mask");
+            assert_eq!(masked, expected, "masking {raw:?}");
+            assert_eq!(
+                masked.len(),
+                raw.len(),
+                "the mask must be byte-length-preserving"
+            );
+            // The known secret-looking fragments must not survive.
+            for leak in ["Error", "abcdef", "héllo"] {
+                if raw.contains(leak) {
+                    assert!(!masked.contains(leak), "{leak} leaked through {masked:?}");
+                }
+            }
+        }
+
+        // Every other event kind has no raw prefix to mask.
+        let other = SignalFishEvent::Connected;
+        assert_eq!(other.redacted_raw_prefix(), None);
     }
 }

--- a/src/polling_client.rs
+++ b/src/polling_client.rs
@@ -275,6 +275,7 @@ impl<T: Transport> SignalFishPollingClient<T> {
         });
 
         let shutdown_timeout = config.shutdown_timeout;
+        let max_inbound_frame = transport.max_frame_hint();
         let mut client = Self {
             transport,
             cmd_queue,
@@ -304,6 +305,7 @@ impl<T: Transport> SignalFishPollingClient<T> {
             close_phase: ClosePhase::Open,
         };
         client.refresh_queue_diagnostics_at(now);
+        client.core.set_max_inbound_frame(max_inbound_frame);
         client
     }
 
@@ -449,6 +451,11 @@ impl<T: Transport> SignalFishPollingClient<T> {
                 }
             }
             let outcome = self.core.process_frame(frame);
+            if let Some(reason) = outcome.input_error {
+                error!("transport receive error: {reason}");
+                self.handle_disconnect_at(&mut events, Some(reason), &mut cx, now);
+                return events;
+            }
             events.extend(outcome.events);
             if outcome.disconnect {
                 self.handle_disconnect_at(
@@ -1244,7 +1251,10 @@ impl<T: Transport> SignalFishPollingClient<T> {
                             .receive_budget_exhaustions
                             .saturating_add(1);
                     }
-                    if outcome.disconnect || budget_reached {
+                    // An over-hint frame stops the drain like any other
+                    // terminal input; the send failure remains the
+                    // disconnect cause for the already-tearing-down session.
+                    if outcome.disconnect || outcome.input_error.is_some() || budget_reached {
                         break;
                     }
                 }
@@ -2049,6 +2059,83 @@ mod tests {
             epoch: None,
             seq: None,
         }
+    }
+
+    /// Declares an inbound hint and delivers exactly one scripted frame.
+    struct HintedTransport {
+        hint: Option<usize>,
+        frame: Option<TransportFrame>,
+    }
+
+    impl Transport for HintedTransport {
+        fn abort(&mut self) {}
+
+        fn poll_send(
+            &mut self,
+            _cx: &mut std::task::Context<'_>,
+            frame: &mut Option<TransportFrame>,
+        ) -> std::task::Poll<std::result::Result<(), SignalFishError>> {
+            let _ = frame.take();
+            std::task::Poll::Ready(Ok(()))
+        }
+
+        fn poll_recv(
+            &mut self,
+            _cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<Option<std::result::Result<TransportFrame, SignalFishError>>> {
+            match self.frame.take() {
+                Some(frame) => std::task::Poll::Ready(Some(Ok(frame))),
+                None => std::task::Poll::Pending,
+            }
+        }
+
+        fn poll_close(
+            &mut self,
+            _cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<std::result::Result<(), SignalFishError>> {
+            std::task::Poll::Ready(Ok(()))
+        }
+
+        fn max_frame_hint(&self) -> Option<usize> {
+            self.hint
+        }
+    }
+
+    #[test]
+    fn max_frame_hint_refuses_oversized_frames_as_a_terminal_receive_error() {
+        let transport = HintedTransport {
+            hint: Some(16),
+            frame: Some(TransportFrame::Text("x".repeat(17))),
+        };
+        let mut client = SignalFishPollingClient::new(transport, SignalFishConfig::new("hint"));
+
+        let events = client.poll();
+        assert!(matches!(events.first(), Some(SignalFishEvent::Connected)));
+        let [SignalFishEvent::Disconnected { reason, .. }] = &events[1..] else {
+            panic!("expected only a Disconnected event, got {events:?}");
+        };
+        let reason = reason.as_ref().expect("hint refusal carries a reason");
+        assert!(reason.contains("17 bytes"), "{reason}");
+        assert!(reason.contains("max frame hint"), "{reason}");
+        assert!(!events
+            .iter()
+            .any(|event| matches!(event, SignalFishEvent::DecodeFailed { .. })));
+    }
+
+    #[test]
+    fn max_frame_hint_boundary_frame_still_decodes() {
+        let transport = HintedTransport {
+            hint: Some(16),
+            frame: Some(TransportFrame::Text("not-json-at-all!".into())),
+        };
+        let mut client = SignalFishPollingClient::new(transport, SignalFishConfig::new("hint"));
+
+        let events = client.poll();
+        assert!(matches!(events.first(), Some(SignalFishEvent::Connected)));
+        let [SignalFishEvent::DecodeFailed { .. }] = &events[1..] else {
+            panic!("expected the boundary frame to decode (and fail), got {events:?}");
+        };
+        assert_eq!(events.len(), 2, "no terminal event at the boundary");
     }
 
     #[test]

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -240,6 +240,28 @@ pub trait Transport {
     fn diagnostics(&self) -> TransportDiagnostics {
         TransportDiagnostics::default()
     }
+
+    /// Advisory maximum size in bytes for one complete inbound frame.
+    ///
+    /// Backends that enforce an inbound frame or assembled-message bound (as
+    /// the built-in WebSocket transport does by default) return `Some(bound)`.
+    /// The drivers then enforce that bound themselves before any frame reaches
+    /// protocol decoding: a larger frame is treated as a terminal receive
+    /// error and tears the session down, mirroring how the built-in transport's
+    /// own over-limit delivery ends the connection (RFC 6455 close 1009
+    /// semantics). This keeps a hostile or misbehaving peer from amplifying
+    /// one delivered frame into unbounded client-side parse memory when a
+    /// backend's enforcement cannot be structurally assumed.
+    ///
+    /// Return `None` (the default) when the backend enforces no bound; the
+    /// drivers then accept every delivered frame. A declared hint is a
+    /// contract: the backend must never deliver a larger frame, and the value
+    /// must stay stable for the lifetime of one connection. A backend that
+    /// declares a hint but does not enforce it still gets driver-side
+    /// enforcement, so oversized frames fail fast instead of being decoded.
+    fn max_frame_hint(&self) -> Option<usize> {
+        None
+    }
 }
 
 /// Gate a synchronous backend send without transferring caller ownership until

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -241,7 +241,7 @@ pub trait Transport {
         TransportDiagnostics::default()
     }
 
-    /// Advisory maximum size in bytes for one complete inbound frame.
+    /// Declared maximum size in bytes for one complete inbound frame.
     ///
     /// Backends that enforce an inbound frame or assembled-message bound (as
     /// the built-in WebSocket transport does by default) return `Some(bound)`.
@@ -254,11 +254,12 @@ pub trait Transport {
     /// backend's enforcement cannot be structurally assumed.
     ///
     /// Return `None` (the default) when the backend enforces no bound; the
-    /// drivers then accept every delivered frame. A declared hint is a
+    /// drivers then accept every delivered frame. The declaration is a
     /// contract: the backend must never deliver a larger frame, and the value
-    /// must stay stable for the lifetime of one connection. A backend that
-    /// declares a hint but does not enforce it still gets driver-side
-    /// enforcement, so oversized frames fail fast instead of being decoded.
+    /// must stay stable for the lifetime of one connection. A backend whose
+    /// own enforcement is best-effort still protects its callers by
+    /// declaring the bound, because the drivers reject violations terminally
+    /// before any decode work.
     fn max_frame_hint(&self) -> Option<usize> {
         None
     }

--- a/src/transports/emscripten_inbound_queue.rs
+++ b/src/transports/emscripten_inbound_queue.rs
@@ -98,6 +98,13 @@ impl InboundQueueBound {
         }
     }
 
+    /// The configured inclusive byte ceiling, for `Transport::max_frame_hint`.
+    /// A delivered frame is always at or under this bound: over-limit input
+    /// fuses the queue instead of being admitted.
+    pub(super) const fn limit(&self) -> Option<usize> {
+        self.limit
+    }
+
     /// Permanently fuses the queue without an over-limit refusal, for
     /// terminal corruption detected after a frame was admitted (the invalid
     /// UTF-8 text path). Later input reports
@@ -167,6 +174,12 @@ mod tests {
     #[test]
     fn default_limit_matches_native_eight_mib_policy() {
         assert_eq!(DEFAULT_MAX_INBOUND_QUEUE_BYTES, 8 * 1024 * 1024);
+    }
+
+    #[test]
+    fn limit_accessor_reports_the_configured_ceiling() {
+        assert_eq!(InboundQueueBound::new(Some(LIMIT)).limit(), Some(LIMIT));
+        assert_eq!(InboundQueueBound::new(None).limit(), None);
     }
 
     #[test]

--- a/src/transports/emscripten_websocket.rs
+++ b/src/transports/emscripten_websocket.rs
@@ -1046,6 +1046,10 @@ impl Transport for EmscriptenWebSocketTransport {
             );
         }
     }
+
+    fn max_frame_hint(&self) -> Option<usize> {
+        self.inbound_queue.get().limit()
+    }
 }
 // ── Drop Implementation ─────────────────────────────────────────────────────
 

--- a/src/transports/websocket.rs
+++ b/src/transports/websocket.rs
@@ -649,6 +649,11 @@ impl WebSocketConnectOptions {
 /// the connection and its retained frame.
 pub struct WebSocketTransport {
     state: WebSocketState<WsStream>,
+    /// The connect-time inbound frame/message bound the backend enforces via
+    /// tungstenite, reported through [`Transport::max_frame_hint`] so the
+    /// drivers enforce it too. `from_stream` callers own their codec limits,
+    /// so the transport cannot know one and reports `None`.
+    max_inbound_frame: Option<usize>,
 }
 
 struct WebSocketState<S> {
@@ -923,6 +928,7 @@ impl WebSocketTransport {
 
         Ok(Self {
             state: WebSocketState::new_with_token_binding(stream, token_binding),
+            max_inbound_frame: options.max_inbound_message_size,
         })
     }
 
@@ -1044,6 +1050,7 @@ impl WebSocketTransport {
         );
         Ok(Self {
             state: WebSocketState::new_with_token_binding(stream, token_binding),
+            max_inbound_frame: options.max_inbound_message_size,
         })
     }
 
@@ -1064,6 +1071,7 @@ impl WebSocketTransport {
     pub fn from_stream(stream: WsStream) -> Self {
         Self {
             state: WebSocketState::new(stream),
+            max_inbound_frame: None,
         }
     }
 
@@ -1474,6 +1482,10 @@ impl Transport for WebSocketTransport {
 
     fn abort(&mut self) {
         self.state.abort();
+    }
+
+    fn max_frame_hint(&self) -> Option<usize> {
+        self.max_inbound_frame
     }
 }
 
@@ -3068,6 +3080,7 @@ mod tests {
     fn debug_omits_stream_contents_and_peer_close_reason() {
         let secret = "websocket-debug-secret";
         let transport = WebSocketTransport {
+            max_inbound_frame: None,
             state: WebSocketState {
                 stream: None,
                 closed: true,
@@ -3733,6 +3746,9 @@ mod tests {
                 .get_config();
             assert_eq!(live_config.max_frame_size, limit);
             assert_eq!(live_config.max_message_size, limit);
+            // The declared hint mirrors the enforced connect-time bound so
+            // the drivers can enforce it too; `None` stays `None`.
+            assert_eq!(Transport::max_frame_hint(&transport), limit);
 
             assert_eq!(
                 expect_received_frame(crate::transport::recv_frame(&mut transport).await),
@@ -4068,6 +4084,9 @@ mod tests {
             .expect("recv must return Some")
             .expect("recv must return Ok");
         assert_eq!(msg, TransportFrame::Text("from_stream_msg".into()));
+        // The caller owns the stream's codec limits, so the transport cannot
+        // know a bound and must not declare a false hint.
+        assert_eq!(Transport::max_frame_hint(&transport), None);
         drop(transport);
         finish_mock_server(server_task).await;
     }

--- a/tests/credential_hygiene_tests.rs
+++ b/tests/credential_hygiene_tests.rs
@@ -14,8 +14,11 @@
 //! the SDK — the hygiene failure the future credential API must never
 //! reintroduce.
 //!
-//! The scan is repository-relative and skips itself when the documentation
-//! tree is absent (published crates carry library source only).
+//! The scan is repository-relative and fails loudly when the documentation
+//! tree cannot be found: layout drift must fix the guard, not skip it. (The
+//! published packages exclude `tests/`, so crate-packaging test runs never
+//! execute this file.) Known limitation: a credential wrapped across a line
+//! break stays under the per-line hex-run threshold.
 
 use std::path::{Path, PathBuf};
 
@@ -25,16 +28,19 @@ const CREDENTIAL_PREFIX: &str = "sfk_";
 /// defines the credential story) do not match.
 const MIN_HEX_RUN: usize = 8;
 
-fn repo_root() -> Option<PathBuf> {
+fn repo_root() -> PathBuf {
     let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let mut candidate = Some(manifest);
     while let Some(root) = candidate {
         if root.join("docs").is_dir() && root.join("examples").is_dir() {
-            return Some(root);
+            return root;
         }
         candidate = root.parent().map(Path::to_path_buf);
     }
-    None
+    panic!(
+        "credential scan could not locate the repository tree: layout drift \
+         must be fixed, not silently skipped"
+    );
 }
 
 fn is_credential_literal(line: &str) -> bool {
@@ -90,7 +96,18 @@ fn scanned_targets(root: &Path) -> Vec<PathBuf> {
     files.retain(|path| {
         matches!(
             path.extension().and_then(|ext| ext.to_str()),
-            Some("md" | "rs" | "toml" | "yml" | "yaml" | "html" | "js" | "sh" | "py")
+            Some(
+                "md" | "rs"
+                    | "toml"
+                    | "yml"
+                    | "yaml"
+                    | "html"
+                    | "js"
+                    | "sh"
+                    | "py"
+                    | "json"
+                    | "txt"
+            )
         )
     });
     files
@@ -98,10 +115,7 @@ fn scanned_targets(root: &Path) -> Vec<PathBuf> {
 
 #[test]
 fn no_secret_credential_literals_in_examples_or_docs() {
-    let Some(root) = repo_root() else {
-        // Published-crate test runs have no repository tree to scan.
-        return;
-    };
+    let root = repo_root();
     let files = scanned_targets(&root);
     assert!(
         !files.is_empty(),

--- a/tests/credential_hygiene_tests.rs
+++ b/tests/credential_hygiene_tests.rs
@@ -87,7 +87,7 @@ fn scanned_targets(root: &Path) -> Vec<PathBuf> {
     let mut files = Vec::new();
     collect_files(root, "docs", &mut files);
     collect_files(root, "examples", &mut files);
-    for readme in ["README.md", "CHANGELOG.md"] {
+    for readme in ["README.md", "CHANGELOG.md", "llms.txt"] {
         let path = root.join(readme);
         if path.is_file() {
             files.push(path);

--- a/tests/credential_hygiene_tests.rs
+++ b/tests/credential_hygiene_tests.rs
@@ -1,0 +1,144 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects
+)]
+//! Guard for the cloud-auth credential story (issue #222).
+//!
+//! The SDK has no surface for secret-form application keys (`sfk_…`): the
+//! `app_id` is a public label and the documented credential slot is reserved
+//! for a future wire contract. Until that surface exists, no example, doc
+//! page, or README may normalize pasting a credential-shaped `sfk_` key into
+//! the SDK — the hygiene failure the future credential API must never
+//! reintroduce.
+//!
+//! The scan is repository-relative and skips itself when the documentation
+//! tree is absent (published crates carry library source only).
+
+use std::path::{Path, PathBuf};
+
+const CREDENTIAL_PREFIX: &str = "sfk_";
+/// A credential-shaped literal carries at least this many hex characters
+/// after the prefix. Generic mentions of the prefix (the docs page that
+/// defines the credential story) do not match.
+const MIN_HEX_RUN: usize = 8;
+
+fn repo_root() -> Option<PathBuf> {
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let mut candidate = Some(manifest);
+    while let Some(root) = candidate {
+        if root.join("docs").is_dir() && root.join("examples").is_dir() {
+            return Some(root);
+        }
+        candidate = root.parent().map(Path::to_path_buf);
+    }
+    None
+}
+
+fn is_credential_literal(line: &str) -> bool {
+    let mut rest = line;
+    while let Some(position) = rest.find(CREDENTIAL_PREFIX) {
+        let after = &rest[position + CREDENTIAL_PREFIX.len()..];
+        let hex_run = after.chars().take_while(char::is_ascii_hexdigit).count();
+        if hex_run >= MIN_HEX_RUN {
+            return true;
+        }
+        rest = after;
+    }
+    false
+}
+
+fn collect_files(root: &Path, relative: &str, files: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(root.join(relative)) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        match entry.file_type() {
+            Ok(file_type) if file_type.is_dir() => {
+                let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+                    continue;
+                };
+                // Vendored upstream authorities are copies of external
+                // content; site assets are generated.
+                if matches!(name, "server-spec" | "assets" | "includes" | "javascripts") {
+                    continue;
+                }
+                let Ok(stripped) = path.strip_prefix(root) else {
+                    continue;
+                };
+                collect_files(root, &stripped.to_string_lossy(), files);
+            }
+            Ok(_) => files.push(path),
+            Err(_) => continue,
+        }
+    }
+}
+
+fn scanned_targets(root: &Path) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    collect_files(root, "docs", &mut files);
+    collect_files(root, "examples", &mut files);
+    for readme in ["README.md", "CHANGELOG.md"] {
+        let path = root.join(readme);
+        if path.is_file() {
+            files.push(path);
+        }
+    }
+    files.retain(|path| {
+        matches!(
+            path.extension().and_then(|ext| ext.to_str()),
+            Some("md" | "rs" | "toml" | "yml" | "yaml" | "html" | "js" | "sh" | "py")
+        )
+    });
+    files
+}
+
+#[test]
+fn no_secret_credential_literals_in_examples_or_docs() {
+    let Some(root) = repo_root() else {
+        // Published-crate test runs have no repository tree to scan.
+        return;
+    };
+    let files = scanned_targets(&root);
+    assert!(
+        !files.is_empty(),
+        "the documentation tree must be discoverable for the credential scan"
+    );
+
+    let mut violations = Vec::new();
+    for file in &files {
+        let Ok(content) = std::fs::read_to_string(file) else {
+            continue;
+        };
+        for (index, line) in content.lines().enumerate() {
+            if is_credential_literal(line) {
+                violations.push(format!(
+                    "{}:{}: credential-shaped literal",
+                    file.display(),
+                    index + 1
+                ));
+            }
+        }
+    }
+    assert!(
+        violations.is_empty(),
+        "secret-form credentials must never appear in examples or docs:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn credential_shape_detection_is_precise() {
+    // Credential-shaped: prefix plus a hex run.
+    assert!(is_credential_literal("app_id = \"sfk_0123456789abcdef\""));
+    assert!(is_credential_literal("token: sfk_DEADBEEF"));
+    // Generic mentions stay legal.
+    assert!(!is_credential_literal("secret keys (`sfk_…`)"));
+    assert!(!is_credential_literal("never paste sfk_ keys here"));
+    assert!(!is_credential_literal("no prefix at all"));
+    // Short hex runs are not credentials.
+    assert!(!is_credential_literal("sfk_1234"));
+}


### PR DESCRIPTION
## Why

A hostile server should not be able to turn one delivered frame into a memory blow-up, and decode diagnostics should not leak attacker-controlled text into logs. Round 43 of the recurring correctness audit (#126) found exactly that: with a custom transport that declares no inbound limit, one frame reached protocol decoding with whatever size the server chose (~21x measured memory amplification), and deserialization errors quoted hostile wire tokens verbatim and unbounded.

## What

- **Inbound frame bound**: `Transport::max_frame_hint()` lets a backend declare the frame bound it enforces; both drivers then refuse larger frames terminally before any decoding — same behavior as the built-in WebSocket transport's own over-limit close (RFC 6455 1009). The WebSocket and Emscripten transports report their bounds; the Godot adapter declares its SDK-created 8 MiB buffer (`from_peer` stays `None`).
- **Bounded decode diagnostics**: `DecodeFailed.error` and the SDK's deserialization warnings are capped at 512 bytes on both the JSON and MessagePack paths.
- **`SignalFishEvent::redacted_raw_prefix()`**: the safe path the events docs promised — masks every string literal's content byte-for-byte while keeping the JSON skeleton.
- **`with_protocol_version` sanity warning**: one `tracing::warn!` outside the known-supported `2..=3` range; the server stays the authority.
- **Authentication & credentials guide**: one page tying together the public app ID, secret reconnection tokens, rotation, and log hygiene (#222), plus a guard test that fails if a credential-shaped `sfk_…` literal ever lands in examples or docs.
- **Round-43 audits that came back clean**: secret/credential lifecycle and Godot engine-lifecycle interplay — every candidate mechanically refuted.

Closes the deliverable halves of #223 (items 2–4; item 1 gets a design-proposal comment) and the wire-decision-independent halves of #222. Verification: fmt/clippy `-D warnings` clean, 27/27 test suites green (1,126 tests), semver-checks 196/196 pass, credential-guard and binary-bound red/green probes verified and reverted.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes inbound framing and disconnect paths for hinted transports and tightens what decode failures expose in logs/events; default `None` preserves prior behavior for custom backends.
> 
> **Overview**
> Adds **`Transport::max_frame_hint()`** so backends can declare an inbound per-frame bound; **async and polling drivers** copy the hint into `ClientCore` at startup and **terminate the session** (terminal receive error, no decode) when a delivered frame exceeds it—aligned with built-in WebSocket over-limit behavior. **WebSocket** (connect paths), **Emscripten**, and **Godot SDK-created peers** expose their limits; **`from_stream` / `from_peer`** stay **`None`**.
> 
> **Decode hygiene:** `DecodeFailed.error` and deserialization warnings are **capped at 512 bytes** on JSON and MessagePack paths; new **`SignalFishEvent::redacted_raw_prefix()`** masks string literal contents while keeping JSON shape. Docs add an **Authentication & credentials** page, transport/events updates, and a **repo scan test** blocking credential-shaped `sfk_…` literals in docs/examples.
> 
> **DX:** `SignalFishConfig::with_protocol_version` emits a **single `tracing::warn!`** for versions outside **2..=3** (value still sent unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 806e2ba073419b45b072603a67076448ea2dcb60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->