### PR TITLE
feat!: opt-in automatic reconnection with backoff (issue #223) + round-44 audits

### DIFF
--- a/.llm/context.md
+++ b/.llm/context.md
@@ -169,8 +169,7 @@ SDK-created Godot peers set an 8 MiB inbound buffer and raise the independent qu
 blocking workflow covers official native/web Godot 4.5, requires a valid frame
 over the legacy 65,535-byte default, and runs clean, seeded-netem impaired, and
 3,600-frame soak jobs on Server 0.8 plus a clean Server 0.4 gate. It checksum-verifies and builds iproute2
-6.6.0 for seeded netem rather
-than relying on the runner's older `tc`.
+6.6.0 for seeded netem rather than relying on the runner's older `tc`.
 The fixture uses a peer-independent fixed 18 Hz simulation cadence with a
 20-frame Fortress prediction window (60-frame renderer/JIT warm-up bounded by
 it; steady-state and final lag capped at eight frames clean or 13 impaired/soak),
@@ -196,8 +195,10 @@ counters.
 
 Connect a transport, construct `SignalFishConfig`, and pass both to `SignalFishClient::start`, which returns the handle and event receiver and
 queues `Authenticate`. Wait for `Authenticated` before room commands; drain
-events continuously and call `shutdown().await` for graceful teardown. The
-complete compiling example is `examples/basic_lobby.rs`.
+events continuously and call `shutdown().await` for graceful teardown (the
+complete compiling example is `examples/basic_lobby.rs`). Opt the async client
+into automatic reconnection (factory transport, exponential backoff, automatic
+player-room `reconnect`) with `.with_reconnect_policy`; polling stays manual.
 
 ### SignalFishConfig
 
@@ -357,7 +358,7 @@ Core tests additionally use full-featured `tokio` and `tracing-subscriber` (the 
 
 The `Transport` trait decouples protocol logic from framed network I/O. Tests use
 in-memory transports; Server 0.8 production I/O exposes only WebSocket. Custom
-backends must provide one complete, ordered text/binary stream for the intended
+backends provide one complete, ordered text/binary stream for the intended
 server and own trust/source binding plus raw stream/datagram policy.
 
 Concrete engine bindings live outside core. In particular, all Godot bindings,
@@ -415,9 +416,9 @@ exact gap ranges; roster inserts beyond the advertised `max_players`
 (wire-absolute `u8::MAX + 1` fallback when the latest baseline cannot
 advertise one) — servers swapping players on a full room must order the
 departure before the replacement join. Unknown-player `PlayerReconnected`
-sender cursors remain the
-one documented trusted-server envelope: containment gates would reject
-legitimate reconnects of players absent from the local roster snapshot.
+sender cursors remain the one documented trusted-server envelope:
+containment gates would reject legitimate reconnects of players absent from
+the local roster snapshot.
 
 ### No Heavy Dependencies
 
@@ -473,10 +474,10 @@ Planning records are local-only working notes: session logs/evidence under `prog
 ## Documentation Rendering (MkDocs)
 
 MkDocs Material + pymdownx powers Pages. `hooks/rustdoc_codeblocks.py` strips
-rustdoc fence annotations for Pygments; `hooks/llms_txt.py` generates model text.
+rustdoc fence annotations; `hooks/llms_txt.py` generates model text.
 Mermaid requires `custom_fences` in `mkdocs.yml`. Approved Vector assets use pinned provenance and local OFL fonts preloaded via `overrides/main.html`; both palettes retain AA contrast, visible focus, reduced-motion behavior, and responsive scrolling (`docs_brand_policy` pins these contracts; evidence under local-only `progress/assets/`). CI runs strict MkDocs
 (`.github/workflows/docs-deploy.yml`) and the 17 rendering checks in
-`scripts/check-docs-rendering.sh` (invoked by `.github/workflows/docs-validation.yml`); see `skills/markdown-and-doc-validation/SKILL.md`.
+`scripts/check-docs-rendering.sh` (invoked by `docs-validation.yml`); see `skills/markdown-and-doc-validation/SKILL.md`.
 
 ## Pre-commit Enforcement
 
@@ -495,6 +496,4 @@ A pre-commit hook enforces:
 10. MkDocs admonition/details titles are well-formed (`scripts/check-admonitions.py`) — no embedded double quotes
 
 `cargo test` runs on push, not every commit (too slow for a blocking hook) —
-run it manually before opening a PR.
-
-Install hooks with: `bash scripts/install-hooks.sh`
+run it manually before opening a PR. Install hooks with `bash scripts/install-hooks.sh`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   attempt, next_backoff }` and `ReconnectAbandoned { attempts, last_reason }`
   (the reconnect policy's per-attempt and terminal events); add two arms to
   exhaustive matches.
+- `MeshController` now keeps draining across a reconnect-policy round: a
+  `Disconnected` event clears the data plane (peers disconnected, view
+  cleared) but only true end-of-stream fuses the controller, so mesh
+  consumers survive automatic reconnection.
 - `impl Transport for Box<dyn Transport + Send>` so owned trait objects
   (including the reconnect factory's products) flow through the same driver
   plumbing as concrete transports.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Opt-in automatic reconnection for the async client:
-  `ReconnectPolicy` (via `SignalFishConfig::with_reconnect_policy`)
-  rebuilds the transport from a caller factory with deterministic
-  exponential backoff, emits per-attempt events, re-authenticates, and —
-  when the client left a player room on the dead connection — issues the
-  directed `reconnect` automatically. Exhaustion ends the client with a
-  terminal event; shutdown, dropped handles, and `Disconnect`-policy
-  teardowns are never retried. The polling client stays caller-driven.
+- Opt-in automatic reconnection for the async client: `ReconnectPolicy`
+  (via **Breaking:** new `SignalFishConfig` field
+  `reconnect_policy` — exhaustive struct literals must add the field,
+  usually `reconnect_policy: None`) rebuilds the transport from a caller
+  factory with deterministic exponential backoff, re-authenticates, and
+  issues the directed `reconnect` automatically when the dead connection
+  ended inside a player room; shutdown, dropped handles, and
+  `Disconnect`-policy teardowns are never retried, and the polling client
+  stays caller-driven.
+- **Breaking:** the exhaustive `SignalFishEvent` enum gains `Reconnecting {
+  attempt, next_backoff }` and `ReconnectAbandoned { attempts, last_reason }`
+  (the reconnect policy's per-attempt and terminal events); add two arms to
+  exhaustive matches.
+- `impl Transport for Box<dyn Transport + Send>` so owned trait objects
+  (including the reconnect factory's products) flow through the same driver
+  plumbing as concrete transports.
 - `Transport::max_frame_hint()`: backends that enforce an inbound frame bound
   declare it, and both client drivers then refuse larger frames as a terminal
   receive error before any decoding (the built-in WebSocket and Emscripten
@@ -31,15 +39,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Breaking:** the exhaustive `SignalFishEvent` enum gains `Reconnecting {
-  attempt, next_backoff }` and `ReconnectAbandoned { attempts, last_reason }`
-  (the opt-in reconnect policy's per-attempt and terminal events); add two
-  arms to exhaustive matches.
-- **Breaking:** `SpectatorJoinedPayload` and `JoinRoomParams` `Debug` output
-  now redact the room code (presence/length only, matching
-  `ClientSnapshot`): a room code is join-capability knowledge, so ambient
-  logs no longer leak it from a payload or a builder. Public fields and wire
-  serialization are unchanged.
+- **Breaking:** `JoinRoomParams`'s `Debug` output now reports its room code
+  as presence and byte length (the `ClientSnapshot` form), and
+  **Breaking:** `SpectatorJoinedPayload`'s `Debug` is now fully opaque
+  (matching the other room-baseline payloads): a room code is
+  join-capability knowledge, so ambient logs no longer leak it from a
+  payload or a builder. Public fields and wire serialization are unchanged.
 - `SignalFishConfig::with_protocol_version` now logs a `tracing::warn!` for
   versions outside the known-supported `2..=3` range (the value is still sent
   unchanged; the server stays the negotiation authority).
@@ -66,6 +71,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   pointed the concepts guide's `Timeout` row at its single producer.
 - Fixed the fortress guide's stale guidance that still directed readers to a
   git dependency for APIs published in 0.12.0.
+- Documented the `WebRtcDriver` seam's drain contract (the controller stops
+  at the first surfacing event, refused relay, or idle poll — not at
+  exhaustion), its panic boundary, the one-time `set_ready_waker` timing,
+  the plan catch-up suppression of driver output, duplicate edge surfacing,
+  and the `with_pump_interval` 1 ms floor.
 
 ## [0.12.0] - 2026-09-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Opt-in automatic reconnection for the async client:
+  `ReconnectPolicy` (via `SignalFishConfig::with_reconnect_policy`)
+  rebuilds the transport from a caller factory with deterministic
+  exponential backoff, emits per-attempt events, re-authenticates, and —
+  when the client left a player room on the dead connection — issues the
+  directed `reconnect` automatically. Exhaustion ends the client with a
+  terminal event; shutdown, dropped handles, and `Disconnect`-policy
+  teardowns are never retried. The polling client stays caller-driven.
 - `Transport::max_frame_hint()`: backends that enforce an inbound frame bound
   declare it, and both client drivers then refuse larger frames as a terminal
   receive error before any decoding (the built-in WebSocket and Emscripten
@@ -23,6 +31,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Breaking:** the exhaustive `SignalFishEvent` enum gains `Reconnecting {
+  attempt, next_backoff }` and `ReconnectAbandoned { attempts, last_reason }`
+  (the opt-in reconnect policy's per-attempt and terminal events); add two
+  arms to exhaustive matches.
+- **Breaking:** `SpectatorJoinedPayload` and `JoinRoomParams` `Debug` output
+  now redact the room code (presence/length only, matching
+  `ClientSnapshot`): a room code is join-capability knowledge, so ambient
+  logs no longer leak it from a payload or a builder. Public fields and wire
+  serialization are unchanged.
 - `SignalFishConfig::with_protocol_version` now logs a `tracing::warn!` for
   versions outside the known-supported `2..=3` range (the value is still sent
   unchanged; the server stays the negotiation authority).

--- a/docs/client.md
+++ b/docs/client.md
@@ -45,6 +45,7 @@ let config = SignalFishConfig::new("mb_app_abc123");
 | `command_channel_capacity` | `usize` | `1024` | Capacity of the bounded outgoing command queue. When full, the synchronous send methods fail fast with [`SignalFishError::SendBufferFull`](errors.md#handling-sendbufferfull); the `*_reliable` variants wait for a slot instead. Values below 1 are clamped to 1; values above tokio's semaphore permit ceiling (`usize::MAX >> 3`) are clamped to that ceiling. |
 | `shutdown_timeout` | `Duration` | `1 second` | Deadline for async shutdown and polling-client close (including optional queued-work flush). A zero timeout aborts immediately. |
 | `protocol_violation_policy` | `ProtocolViolationPolicy` | `Quarantine` | Response to invalid v3 delivery-accountability state: quarantine room data, disconnect, or observe. |
+| `reconnect_policy` | `Option<ReconnectPolicy>` | `None` | Opt the async client into automatic reconnection with backoff (`None` keeps recovery fully manual). See [Automatic reconnection](#automatic-reconnection-opt-in). |
 
 ### Builder Methods
 
@@ -61,6 +62,7 @@ All builder methods are `#[must_use]` — you must chain or assign the return va
 | `.with_transports(values)` | `impl IntoIterator<Item = TransportKind>` | Advertise data-path transports the application can fulfill. Power-user API. |
 | `.with_topologies(values)` | `impl IntoIterator<Item = Topology>` | Advertise supported session topologies. Power-user API. |
 | `.with_protocol_violation_policy(policy)` | `ProtocolViolationPolicy` | Select `Quarantine` (default), `Disconnect`, or `Observe`. |
+| `.with_reconnect_policy(policy)` | `ReconnectPolicy` | Automate fresh transports, backoff, re-authentication, and player-room reconnects after retryable disconnects. Async client only. |
 
 ### Full Example
 
@@ -593,6 +595,55 @@ writing down as one procedure:
 
 Peers stay fenced against your signals until the post-reconnect
 `SessionPlan` arrives, so gate mesh/relay work on it as on a first join.
+
+##### Automatic reconnection (opt-in)
+
+The procedure above is fully manual by default. The async client can automate
+the transport-and-authentication core of it with a
+`ReconnectPolicy` on
+`SignalFishConfig::with_reconnect_policy`:
+
+```rust,ignore
+let config = SignalFishConfig::new("mb_app_abc123").with_reconnect_policy(
+    ReconnectPolicy::new(|| Box::new(my_transport_factory.spawn())),
+);
+
+let (mut client, events) = SignalFishClient::start(transport, config);
+```
+
+With a policy configured, a terminal disconnect that the client did not cause
+(shutdown, dropped handle, or a `ProtocolViolationPolicy::Disconnect`
+teardown) becomes a retryable edge:
+
+1. The usual bounded teardown delivers `Disconnected`, exactly as without a
+   policy.
+2. The loop emits `Reconnecting { attempt, next_backoff }`, waits the
+   deterministic exponential delay (`min(initial_backoff * 2^(n-1),
+   max_backoff)`, tokio-timed so paused clocks advance it in tests), then
+   opens a fresh transport from the policy's factory.
+3. The fresh connection runs the normal `Connected` → `Authenticated`
+   sequence, and queued-but-unsent commands of the dead connection stay
+   discarded with it.
+4. If the client was a **player** in a room, the retained
+   `player_id`/`room_id`/token context is consumed automatically: the client
+   issues the same directed `reconnect` as step 3 of the manual procedure,
+   and the server answers with `Reconnected` or `ReconnectionFailed`. The
+   context refreshes from every `RoomJoined`/`Reconnected` baseline and is
+   discarded by a voluntary `leave_room`, so a policy never rejoins a room
+   you chose to leave.
+
+On `ReconnectionFailed` the connection stays up but room recovery stops —
+apply the same `error_code` decision tree as the manual flow (fall back to
+`join_room`, wait out `PlayerAlreadyConnected`, or give up). When the attempt
+budget (`max_attempts`, reset whenever a connection reaches `Authenticated`)
+runs out, the client emits `ReconnectAbandoned { attempts, last_reason }` and
+the event stream ends.
+
+The polling client is caller-driven by design and ignores this option —
+recover it by constructing a new client inside your game loop. There is
+deliberately **no jitter**: the SDK pins determinism and carries no RNG
+dependency; de-synchronize retry storms by varying `initial_backoff` per
+client or add jitter inside your factory.
 
 ---
 

--- a/docs/client.md
+++ b/docs/client.md
@@ -611,9 +611,10 @@ let config = SignalFishConfig::new("mb_app_abc123").with_reconnect_policy(
 let (mut client, events) = SignalFishClient::start(transport, config);
 ```
 
-With a policy configured, a terminal disconnect that the client did not cause
-(shutdown, dropped handle, or a `ProtocolViolationPolicy::Disconnect`
-teardown) becomes a retryable edge:
+With a policy configured, a terminal disconnect **other than** shutdown, a
+dropped handle, or a `ProtocolViolationPolicy::Disconnect` teardown (a
+protocol violation is a correctness signal, never masked) becomes a
+retryable edge:
 
 1. The usual bounded teardown delivers `Disconnected`, exactly as without a
    policy.
@@ -624,13 +625,22 @@ teardown) becomes a retryable edge:
 3. The fresh connection runs the normal `Connected` → `Authenticated`
    sequence, and queued-but-unsent commands of the dead connection stay
    discarded with it.
-4. If the client was a **player** in a room, the retained
-   `player_id`/`room_id`/token context is consumed automatically: the client
-   issues the same directed `reconnect` as step 3 of the manual procedure,
-   and the server answers with `Reconnected` or `ReconnectionFailed`. The
-   context refreshes from every `RoomJoined`/`Reconnected` baseline and is
-   discarded by a voluntary `leave_room`, so a policy never rejoins a room
-   you chose to leave.
+4. If the client was a **player** in a room when the connection ended, the
+   retained `player_id`/`room_id`/token context is consumed automatically:
+   the client issues the same directed `reconnect` as step 3 of the manual
+   procedure, and the server answers with `Reconnected` or
+   `ReconnectionFailed`. The context refreshes from every
+   `RoomJoined`/`Reconnected` baseline and is discarded by a voluntary
+   `leave_room`, so a policy never rejoins a room you chose to leave. One
+   deliberate gap: if the connection dies again *before* the automatic
+   reconnect is answered, that attempt is lost with the round and the next
+   round is connection-only — recovery then continues manually.
+
+The `Reconnecting`/`ReconnectAbandoned` deliveries share the terminal
+farewell's bounded budget: a consumer that stops draining delays each round
+by at most `shutdown_timeout` instead of parking the loop, and an undelivered
+scheduling event falls back to one nonblocking attempt (so a wedged consumer
+may miss a `Reconnecting` marker while reconnection itself continues).
 
 On `ReconnectionFailed` the connection stays up but room recovery stops —
 apply the same `error_code` decision tree as the manual flow (fall back to

--- a/docs/events.md
+++ b/docs/events.md
@@ -45,6 +45,8 @@ Use these to track the raw connection lifecycle.
 |---------|--------|-------------|
 | `Connected` | — | The driver first observed `Transport::is_ready() == true` and marked `ClientSnapshot::transport_ready` true; a later terminal transition resets it. Synthetic — see [Connection timing](wasm.md#connection-timing) for details. |
 | `Disconnected` | `reason: Option<String>`, `last_server_error: Option<ServerErrorInfo>` | The transport connection was closed or errored. |
+| `Reconnecting` | `attempt: u32`, `next_backoff: Duration` | A configured [`ReconnectPolicy`](client.md#automatic-reconnection-opt-in) scheduled a fresh connection after a retryable disconnect. |
+| `ReconnectAbandoned` | `attempts: u32`, `last_reason: Option<String>` | The configured reconnect policy exhausted its attempts; the event stream ends after this event. |
 | `DecodeFailed` | `message_type: Option<String>`, `error: String`, `raw_prefix: String` | An inbound frame could not be decoded into a `ServerMessage`; the connection stays open. |
 | `ProtocolViolation` | `kind: ProtocolViolationKind`, `diagnostic: String` | A decoded message violated lifecycle, version, session-plan, signaling, or delivery-accountability invariants; configured policy decides quarantine, disconnect, or continued observation. Lifecycle/plan/signaling offenders are suppressed. |
 
@@ -73,6 +75,20 @@ the [Delivery Contract](delivery.md#the-wedged-consumer-hazard).
     channel closing (`recv()`
     returns `None`) is the guaranteed end-of-stream signal — rely on it, not
     on always observing a final `Disconnected`.
+
+### `Reconnecting` / `ReconnectAbandoned`
+
+Emitted only when a
+[`ReconnectPolicy`](client.md#automatic-reconnection-opt-in) is configured on
+the async client. `Reconnecting { attempt, next_backoff }` precedes each
+fresh-transport attempt (1-based `attempt`, deterministic exponential
+`next_backoff`); a successful attempt continues with a fresh `Connected` →
+`Authenticated` sequence and, when the client left a player room on the
+previous connection, an automatic directed reconnect. `ReconnectAbandoned {
+attempts, last_reason }` is the terminal event when the budget runs out;
+shutdown, a dropped handle, and `ProtocolViolationPolicy::Disconnect`
+teardowns end the client without attempting reconnection and never produce
+these events.
 
 ### `DecodeFailed`
 

--- a/docs/events.md
+++ b/docs/events.md
@@ -83,8 +83,8 @@ Emitted only when a
 the async client. `Reconnecting { attempt, next_backoff }` precedes each
 fresh-transport attempt (1-based `attempt`, deterministic exponential
 `next_backoff`); a successful attempt continues with a fresh `Connected` →
-`Authenticated` sequence and, when the client left a player room on the
-previous connection, an automatic directed reconnect. `ReconnectAbandoned {
+`Authenticated` sequence and, when the client was a player in a room when
+the previous connection ended, an automatic directed reconnect. `ReconnectAbandoned {
 attempts, last_reason }` is the terminal event when the budget runs out;
 shutdown, a dropped handle, and `ProtocolViolationPolicy::Disconnect`
 teardowns end the client without attempting reconnection and never produce

--- a/docs/mesh-guide.md
+++ b/docs/mesh-guide.md
@@ -170,8 +170,11 @@ a transport-status boundary, the controller retains one coalescing latest-state
 report and retries it on later pumps; this never blocks signaling events or
 driver data, and room/connection teardown discards obsolete status.
 
-`Disconnected` and signaling-stream closure are terminal controller boundaries.
-Before returning `MeshEvent::Signaling(Disconnected)`, or returning `None` for
+Signaling-stream closure is the terminal controller boundary; a `Disconnected`
+event clears the dead connection's data plane but — with a
+[`ReconnectPolicy`](client.md#automatic-reconnection-opt-in) continuing the
+same client — the controller keeps draining and rebuilds on the fresh
+connection's plan. Before returning `None` for
 stream closure, the controller clears its session view and disconnects every
 known driver peer. It is then fused: later `recv()` calls return `None` without
 polling the driver, and `send_to` ignores data. Explicit `shutdown()` performs
@@ -222,7 +225,7 @@ mesh.shutdown().await;
 | API | Purpose |
 |-----|---------|
 | `MeshController::start(transport, config, driver)` | Build the controller; ensure v3, WebRTC, and a P2P topology while preserving compatible custom choices. |
-| `recv().await -> Option<MeshEvent>` | Drive the handshake and yield the next high-level event. A returned `Disconnected` has already cleared the session and disconnected known peers; after it or stream closure, the controller is fused and returns `None` without polling the driver. |
+| `recv().await -> Option<MeshEvent>` | Drive the handshake and yield the next high-level event. A returned `Disconnected` has already cleared the session and disconnected known peers; stream closure fuses the controller (`None` forever), while a configured reconnect policy keeps it draining across reconnect rounds. |
 | `send_to(peer, &[u8])` | Send application bytes to a peer over its data channel; ignored after the controller becomes terminal. |
 | `with_pump_interval(Duration)` | Tune the periodic driver pump (default 20 ms). |
 | `join_room` / `set_ready` / `start_game` / `leave_room` / `client()` | Room-lifecycle delegations to the inner client. |

--- a/docs/mesh-guide.md
+++ b/docs/mesh-guide.md
@@ -83,7 +83,7 @@ pub trait WebRtcDriver {
     fn on_signal(&mut self, peer: PlayerId, generation: Option<SessionGeneration>, signal: PeerSignal);
     fn send(&mut self, peer: PlayerId, data: &[u8]);
     fn disconnect(&mut self, peer: PlayerId);
-    fn poll(&mut self) -> Option<DriverEvent>; // do real I/O here
+    fn poll(&mut self) -> Option<DriverEvent>; // drain your backend's non-blocking event queue
 }
 ```
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -722,7 +722,14 @@ const DEFAULT_RECONNECT_MAX_BACKOFF: Duration = Duration::from_secs(10);
 /// budget instead of parking the loop (or the reliable senders parked on the
 /// command queue) forever.
 pub struct ReconnectPolicy {
-    factory: std::sync::Arc<dyn Fn() -> Box<dyn Transport + Send> + Send + Sync>,
+    // `AssertUnwindSafe` keeps `SignalFishConfig`'s historical
+    // `UnwindSafe`/`RefUnwindSafe` auto traits: a panicking factory kills the
+    // transport loop task (the documented panic boundary), so there is no
+    // state to protect across unwinding — only the config's own surface to
+    // preserve.
+    factory: std::panic::AssertUnwindSafe<
+        std::sync::Arc<dyn Fn() -> Box<dyn Transport + Send> + Send + Sync>,
+    >,
     max_attempts: u32,
     initial_backoff: Duration,
     max_backoff: Duration,
@@ -731,7 +738,7 @@ pub struct ReconnectPolicy {
 impl Clone for ReconnectPolicy {
     fn clone(&self) -> Self {
         Self {
-            factory: std::sync::Arc::clone(&self.factory),
+            factory: std::panic::AssertUnwindSafe(std::sync::Arc::clone(&self.factory)),
             max_attempts: self.max_attempts,
             initial_backoff: self.initial_backoff,
             max_backoff: self.max_backoff,
@@ -757,7 +764,7 @@ impl ReconnectPolicy {
     /// attempts, 250 ms initial backoff, 10 s maximum backoff.
     pub fn new(factory: impl Fn() -> Box<dyn Transport + Send> + Send + Sync + 'static) -> Self {
         Self {
-            factory: std::sync::Arc::new(factory),
+            factory: std::panic::AssertUnwindSafe(std::sync::Arc::new(factory)),
             max_attempts: DEFAULT_RECONNECT_MAX_ATTEMPTS,
             initial_backoff: DEFAULT_RECONNECT_INITIAL_BACKOFF,
             max_backoff: DEFAULT_RECONNECT_MAX_BACKOFF,

--- a/src/client.rs
+++ b/src/client.rs
@@ -216,7 +216,7 @@ pub(crate) fn decode_binary_server_message(
 ///     .with_event_channel_capacity(512)
 ///     .with_shutdown_timeout(Duration::from_secs(5));
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone)]
 pub struct SignalFishConfig {
     /// Public App ID that identifies the game application.
     pub app_id: String,
@@ -292,6 +292,76 @@ pub struct SignalFishConfig {
     pub shutdown_timeout: Duration,
     /// Response to a protocol-v3 delivery-accountability violation.
     pub protocol_violation_policy: ProtocolViolationPolicy,
+    /// Opt-in automatic reconnection policy for the async client.
+    ///
+    /// `None` (the default) keeps recovery fully manual. See
+    /// [`ReconnectPolicy`] for the automated behavior and
+    /// [`with_reconnect_policy`](Self::with_reconnect_policy) to opt in.
+    #[cfg(feature = "tokio-runtime")]
+    pub reconnect_policy: Option<ReconnectPolicy>,
+}
+
+#[cfg(feature = "tokio-runtime")]
+impl std::fmt::Debug for SignalFishConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SignalFishConfig")
+            .field("app_id", &self.app_id)
+            .field("sdk_version", &self.sdk_version)
+            .field("platform", &self.platform)
+            .field("game_data_format", &self.game_data_format)
+            .field("protocol_version", &self.protocol_version)
+            .field("supported_transports", &self.supported_transports)
+            .field("supported_topologies", &self.supported_topologies)
+            .field("event_channel_capacity", &self.event_channel_capacity)
+            .field("command_channel_capacity", &self.command_channel_capacity)
+            .field("shutdown_timeout", &self.shutdown_timeout)
+            .field("protocol_violation_policy", &self.protocol_violation_policy)
+            .field(
+                "reconnect_policy",
+                &self
+                    .reconnect_policy
+                    .as_ref()
+                    .map(|_| "ReconnectPolicy { .. }"),
+            )
+            .finish()
+    }
+}
+
+#[cfg(feature = "tokio-runtime")]
+impl PartialEq for SignalFishConfig {
+    fn eq(&self, other: &Self) -> bool {
+        self.app_id == other.app_id
+            && self.sdk_version == other.sdk_version
+            && self.platform == other.platform
+            && self.game_data_format == other.game_data_format
+            && self.protocol_version == other.protocol_version
+            && self.supported_transports == other.supported_transports
+            && self.supported_topologies == other.supported_topologies
+            && self.event_channel_capacity == other.event_channel_capacity
+            && self.command_channel_capacity == other.command_channel_capacity
+            && self.shutdown_timeout == other.shutdown_timeout
+            && self.protocol_violation_policy == other.protocol_violation_policy
+            && Self::reconnect_tuning(self.reconnect_policy.as_ref())
+                == Self::reconnect_tuning(other.reconnect_policy.as_ref())
+    }
+}
+
+#[cfg(feature = "tokio-runtime")]
+impl Eq for SignalFishConfig {}
+
+#[cfg(feature = "tokio-runtime")]
+impl SignalFishConfig {
+    /// Comparable view of a configured policy: the observable tuning without
+    /// the uncomparable transport factory.
+    fn reconnect_tuning(policy: Option<&ReconnectPolicy>) -> Option<(u32, Duration, Duration)> {
+        policy.map(|policy| {
+            (
+                policy.max_attempts,
+                policy.initial_backoff,
+                policy.max_backoff,
+            )
+        })
+    }
 }
 
 impl SignalFishConfig {
@@ -317,6 +387,8 @@ impl SignalFishConfig {
             command_channel_capacity: DEFAULT_COMMAND_CHANNEL_CAPACITY,
             shutdown_timeout: DEFAULT_SHUTDOWN_TIMEOUT,
             protocol_violation_policy: ProtocolViolationPolicy::Quarantine,
+            #[cfg(feature = "tokio-runtime")]
+            reconnect_policy: None,
         }
     }
 
@@ -357,6 +429,25 @@ impl SignalFishConfig {
     #[must_use]
     pub fn with_protocol_violation_policy(mut self, policy: ProtocolViolationPolicy) -> Self {
         self.protocol_violation_policy = policy;
+        self
+    }
+
+    /// Opt the async client into automatic reconnection with backoff.
+    ///
+    /// Without a policy (the default) a terminal disconnect ends the client
+    /// and recovery stays fully manual. See [`ReconnectPolicy`] for the
+    /// automated behavior: fresh transports from the configured factory,
+    /// deterministic exponential backoff, per-attempt
+    /// [`Reconnecting`](crate::SignalFishEvent::Reconnecting) events, and an
+    /// automatic directed `reconnect` for the player room the client was in
+    /// when the connection ended.
+    ///
+    /// The [polling client](crate::SignalFishPollingClient) is caller-driven
+    /// by design and ignores this option.
+    #[cfg(feature = "tokio-runtime")]
+    #[must_use]
+    pub fn with_reconnect_policy(mut self, policy: ReconnectPolicy) -> Self {
+        self.reconnect_policy = Some(policy);
         self
     }
 
@@ -538,6 +629,219 @@ pub enum ProtocolViolationPolicy {
     Observe,
 }
 
+// ── ReconnectPolicy ─────────────────────────────────────────────────
+
+/// Default bound on reconnection attempts per episode:
+/// [`ReconnectPolicy::max_attempts`].
+const DEFAULT_RECONNECT_MAX_ATTEMPTS: u32 = 5;
+
+/// Default first-wait duration of the reconnection backoff schedule:
+/// [`ReconnectPolicy::initial_backoff`].
+const DEFAULT_RECONNECT_INITIAL_BACKOFF: Duration = Duration::from_millis(250);
+
+/// Default ceiling of the reconnection backoff schedule:
+/// [`ReconnectPolicy::max_backoff`].
+const DEFAULT_RECONNECT_MAX_BACKOFF: Duration = Duration::from_secs(10);
+
+/// Opt-in automatic reconnection policy for the async client.
+///
+/// Without a policy, a terminal disconnect ends the client and recovery is
+/// fully manual: the consumer rebuilds a transport, calls
+/// [`SignalFishClient::start`] again, re-authenticates, and — for a player
+/// room — issues [`reconnect`](crate::SignalFishClientApi::reconnect) with a
+/// server-issued token. With a policy (see
+/// [`with_reconnect_policy`](SignalFishConfig::with_reconnect_policy)), the
+/// transport loop itself rebuilds the connection:
+///
+/// 1. A retryable terminal disconnect still delivers
+///    [`Disconnected`](SignalFishEvent::Disconnected) and its full bounded
+///    teardown, exactly as today.
+/// 2. The loop emits [`Reconnecting`](SignalFishEvent::Reconnecting), waits
+///    the schedule's delay (tokio-timed, so paused clocks advance it in
+///    tests), then opens a fresh transport from the configured factory.
+/// 3. The fresh connection runs the normal
+///    [`Connected`](SignalFishEvent::Connected) →
+///    [`Authenticated`](SignalFishEvent::Authenticated) sequence.
+/// 4. If the client was a **player** in a room when the connection ended, the
+///    retained reconnection context is consumed automatically after
+///    re-authentication: the loop issues the same directed `reconnect`
+///    operation the documented manual procedure uses, so the server answers
+///    with [`Reconnected`](SignalFishEvent::Reconnected) (full v3 replay and
+///    watermark semantics, rotated token) or
+///    [`ReconnectionFailed`](SignalFishEvent::ReconnectionFailed). A failed
+///    automatic rejoin is **not** retried or replaced with an automatic
+///    `join_room` — the caller decides the fallback. Voluntarily leaving a
+///    room discards the context, so a policy never rejoins a room the caller
+///    chose to leave.
+///
+/// # Retryable terminal edges
+///
+/// Peer close, transport receive errors, terminal send failures, inbound
+/// frames violating the transport's declared
+/// [`max_frame_hint`](crate::Transport::max_frame_hint), and frames received
+/// before transport readiness are all retried: every one of them can be
+/// caused by a dead or misbehaving *backend*, which is exactly what a fresh
+/// transport from the factory replaces. Not retried — the client ends as
+/// today:
+///
+/// - [`shutdown`](SignalFishClient::shutdown) (at any point, including
+///   during a backoff wait),
+/// - a dropped client handle,
+/// - a [`ProtocolViolationPolicy::Disconnect`] teardown (a protocol
+///   violation is a correctness signal; automatic reconnection would mask
+///   it), and
+/// - an exhausted attempt budget, reported via
+///   [`ReconnectAbandoned`](SignalFishEvent::ReconnectAbandoned).
+///
+/// # Backoff schedule
+///
+/// The delay before attempt *n* is deterministic exponential backoff:
+/// `min(initial_backoff * 2^(n-1), max_backoff)`. There is deliberately **no
+/// jitter** (the SDK pins determinism and carries no RNG dependency); when a
+/// deployment needs de-synchronized retry storms, vary `initial_backoff`
+/// per client or add jitter inside the factory.
+///
+/// The attempt counter resets whenever a connection reaches the
+/// authenticated state again, so each *episode* (a run of failed attempts)
+/// gets the full budget.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// let config = SignalFishConfig::new("mb_app_abc123").with_reconnect_policy(
+///     ReconnectPolicy::new(|| Box::new(WebSocketTransport::connect(url))),
+/// );
+/// ```
+///
+/// The factory is called at most once per attempt and must not block; a
+/// panicking factory kills the transport loop task exactly like a panicking
+/// [`Transport`](crate::Transport) method (the documented panic-boundary
+/// contract).
+#[cfg(feature = "tokio-runtime")]
+pub struct ReconnectPolicy {
+    factory: std::sync::Arc<dyn Fn() -> Box<dyn Transport + Send> + Send + Sync>,
+    max_attempts: u32,
+    initial_backoff: Duration,
+    max_backoff: Duration,
+}
+
+#[cfg(feature = "tokio-runtime")]
+impl Clone for ReconnectPolicy {
+    fn clone(&self) -> Self {
+        Self {
+            factory: std::sync::Arc::clone(&self.factory),
+            max_attempts: self.max_attempts,
+            initial_backoff: self.initial_backoff,
+            max_backoff: self.max_backoff,
+        }
+    }
+}
+
+#[cfg(feature = "tokio-runtime")]
+impl std::fmt::Debug for ReconnectPolicy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ReconnectPolicy")
+            .field("max_attempts", &self.max_attempts)
+            .field("initial_backoff", &self.initial_backoff)
+            .field("max_backoff", &self.max_backoff)
+            .finish_non_exhaustive()
+    }
+}
+
+#[cfg(feature = "tokio-runtime")]
+impl ReconnectPolicy {
+    /// Build a policy that rebuilds connections from `factory`.
+    ///
+    /// The factory returns a fresh, unconnected [`Transport`] and must be
+    /// `Send + Sync` because the transport loop invokes it. Defaults: 5
+    /// attempts, 250 ms initial backoff, 10 s maximum backoff.
+    pub fn new(factory: impl Fn() -> Box<dyn Transport + Send> + Send + Sync + 'static) -> Self {
+        Self {
+            factory: std::sync::Arc::new(factory),
+            max_attempts: DEFAULT_RECONNECT_MAX_ATTEMPTS,
+            initial_backoff: DEFAULT_RECONNECT_INITIAL_BACKOFF,
+            max_backoff: DEFAULT_RECONNECT_MAX_BACKOFF,
+        }
+    }
+
+    /// Bound the reconnection attempts per episode.
+    ///
+    /// Defaults to **5**. `0` never retries: the first disconnect beyond the
+    /// initial connection ends the client with a
+    /// [`ReconnectAbandoned`](SignalFishEvent::ReconnectAbandoned) event
+    /// carrying `attempts: 0`.
+    #[must_use]
+    pub fn with_max_attempts(mut self, max_attempts: u32) -> Self {
+        self.max_attempts = max_attempts;
+        self
+    }
+
+    /// Set the wait before the first reconnection attempt.
+    ///
+    /// Defaults to **250 ms**. `Duration::ZERO` retries immediately. Values
+    /// above [`max_backoff`](Self::with_max_backoff) are still scaled by the
+    /// schedule's ceiling, so the effective first wait is
+    /// `min(initial_backoff, max_backoff)`.
+    #[must_use]
+    pub fn with_initial_backoff(mut self, initial_backoff: Duration) -> Self {
+        self.initial_backoff = initial_backoff;
+        self
+    }
+
+    /// Set the ceiling of the backoff schedule.
+    ///
+    /// Defaults to **10 s**. Every computed delay is capped at this value.
+    #[must_use]
+    pub fn with_max_backoff(mut self, max_backoff: Duration) -> Self {
+        self.max_backoff = max_backoff;
+        self
+    }
+
+    /// The configured attempt budget per episode.
+    #[must_use]
+    pub fn max_attempts(&self) -> u32 {
+        self.max_attempts
+    }
+
+    /// The configured wait before the first reconnection attempt.
+    #[must_use]
+    pub fn initial_backoff(&self) -> Duration {
+        self.initial_backoff
+    }
+
+    /// The configured backoff ceiling.
+    #[must_use]
+    pub fn max_backoff(&self) -> Duration {
+        self.max_backoff
+    }
+
+    /// The deterministic delay before the 1-based `attempt`-th
+    /// reconnection: `min(initial_backoff * 2^(attempt-1), max_backoff)`.
+    ///
+    /// Exposed so callers can mirror the schedule (tests, progress UIs);
+    /// the driver uses the same computation.
+    #[must_use]
+    pub fn backoff_for_attempt(&self, attempt: u32) -> Duration {
+        // Doubling saturates instead of overflowing: attempt counts beyond
+        // the schedule's doubling horizon all produce the same capped delay.
+        let mut delay = self.initial_backoff;
+        let mut doublings = attempt.saturating_sub(1);
+        while doublings > 0 {
+            delay = delay.saturating_mul(2);
+            if delay >= self.max_backoff {
+                return self.max_backoff;
+            }
+            doublings = doublings.saturating_sub(1);
+        }
+        delay.min(self.max_backoff)
+    }
+
+    /// Open the next transport.
+    fn create_transport(&self) -> Box<dyn Transport + Send> {
+        (self.factory)()
+    }
+}
+
 /// The local client's authoritative role in its current room.
 ///
 /// A client outside a room has no role, represented by `None` in
@@ -581,7 +885,7 @@ impl std::fmt::Display for RoomRole {
 /// assert_eq!(params.game_name, "my-game");
 /// assert_eq!(params.max_players, Some(4));
 /// ```
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Clone, Default, PartialEq, Eq)]
 pub struct JoinRoomParams {
     /// Name of the game to join.
     pub game_name: String,
@@ -599,6 +903,23 @@ pub struct JoinRoomParams {
     /// [`crate::Transport`] or add raw datagram support. Signal Fish
     /// Server 0.8 accepts but ignores it.
     pub relay_transport: Option<RelayTransport>,
+}
+
+impl std::fmt::Debug for JoinRoomParams {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // A room code is join-capability knowledge (a lobby-by-code
+        // credential), so the ambient `Debug` path reports presence and byte
+        // length instead of the value — the same form
+        // [`ClientSnapshot`]'s `Debug` uses after a join.
+        f.debug_struct("JoinRoomParams")
+            .field("game_name", &self.game_name)
+            .field("player_name", &self.player_name)
+            .field("room_code", &self.room_code.as_ref().map(|code| code.len()))
+            .field("max_players", &self.max_players)
+            .field("supports_authority", &self.supports_authority)
+            .field("relay_transport", &self.relay_transport)
+            .finish()
+    }
 }
 
 impl JoinRoomParams {
@@ -896,6 +1217,12 @@ impl SignalFishClient {
             config.requests_room_operation_ids(),
         );
         core.set_max_inbound_frame(transport.max_frame_hint());
+        if config.reconnect_policy.is_some() {
+            // Opt-in retention: the player-room reconnection context
+            // survives a terminal disconnect so the policy can issue the
+            // automatic directed reconnect after re-authentication.
+            core.set_reconnect_retention(true);
+        }
         let state = Arc::new(Mutex::new(core));
         let loop_state = Arc::clone(&state);
 
@@ -908,15 +1235,20 @@ impl SignalFishClient {
 
         // Arm backend abandonment before constructing/spawning the future so
         // cancellation before its first poll cannot bypass `Transport::abort`.
-        let guarded_transport = AbortOnDropTransport::new(transport);
-        let task = tokio::spawn(transport_loop(
-            guarded_transport,
+        // The transport is boxed so reconnection rounds opened by the
+        // policy's factory (`Box<dyn Transport + Send>`) share one type.
+        let guarded_transport =
+            AbortOnDropTransport::new(Box::new(transport) as Box<dyn Transport + Send>);
+        let loop_ctx = LoopState::new(
             cmd_rx,
             event_tx,
             loop_state,
             shutdown_rx,
             config.shutdown_timeout,
-        ));
+            config.reconnect_policy.clone(),
+            ClientCore::authenticate_message(&config),
+        );
+        let task = tokio::spawn(transport_loop(guarded_transport, loop_ctx));
 
         let client = Self {
             cmd_tx,
@@ -2330,48 +2662,255 @@ async fn finish_send_failure(
     let ((), ()) = tokio::join!(deliver_disconnected, close);
 }
 
-/// Background transport loop that multiplexes send/receive via `tokio::select!`.
-///
-/// Exits when:
-/// - The command channel closes (client handle dropped or shutdown called)
-/// - The transport returns `None` (server closed connection)
-/// - A transport error occurs
+/// How one connection lifetime (one transport) ended inside the transport
+/// loop.
 #[cfg(feature = "tokio-runtime")]
-async fn transport_loop(
-    mut transport: impl Transport + Send + 'static,
-    mut cmd_rx: mpsc::Receiver<ClientCommand>,
+enum ConnectionRoundExit {
+    /// The client ended deliberately: shutdown was requested, the client
+    /// handle was dropped, or a protocol-violation teardown fired. The loop
+    /// must terminate.
+    Terminal,
+    /// The transport died without any client-side intent, so a configured
+    /// [`ReconnectPolicy`] may open a fresh connection. `reason` is the
+    /// farewell attribution already delivered via the
+    /// [`Disconnected`](SignalFishEvent::Disconnected) event; `authenticated`
+    /// records whether this round had reached the authenticated state (a
+    /// successful round resets the policy's attempt budget).
+    Retryable {
+        reason: Option<String>,
+        authenticated: bool,
+    },
+}
+
+/// Classify a teardown the loop just completed: an observed (sticky) shutdown
+/// signal always wins over retrying, because the client was asked to end.
+#[cfg(feature = "tokio-runtime")]
+fn classify_round_exit(
+    shutdown: &ShutdownSignal,
+    authenticated: bool,
+    reason: Option<String>,
+) -> ConnectionRoundExit {
+    if shutdown.is_observed() {
+        ConnectionRoundExit::Terminal
+    } else {
+        ConnectionRoundExit::Retryable {
+            reason,
+            authenticated,
+        }
+    }
+}
+
+/// Loop-carried state shared by every reconnection round of one client.
+#[cfg(feature = "tokio-runtime")]
+struct LoopState {
+    cmd_rx: mpsc::Receiver<ClientCommand>,
     event_tx: mpsc::Sender<SignalFishEvent>,
     state: Arc<Mutex<ClientCore>>,
-    shutdown_rx: tokio::sync::oneshot::Receiver<()>,
+    shutdown: ShutdownSignal,
     shutdown_timeout: Duration,
+    reconnect: Option<ReconnectPolicy>,
+    auth_message: ClientMessage,
+}
+
+#[cfg(feature = "tokio-runtime")]
+impl LoopState {
+    fn new(
+        cmd_rx: mpsc::Receiver<ClientCommand>,
+        event_tx: mpsc::Sender<SignalFishEvent>,
+        state: Arc<Mutex<ClientCore>>,
+        shutdown_rx: tokio::sync::oneshot::Receiver<()>,
+        shutdown_timeout: Duration,
+        reconnect: Option<ReconnectPolicy>,
+        auth_message: ClientMessage,
+    ) -> Self {
+        Self {
+            cmd_rx,
+            event_tx,
+            state,
+            shutdown: ShutdownSignal::new(shutdown_rx),
+            shutdown_timeout,
+            reconnect,
+            auth_message,
+        }
+    }
+}
+
+/// Background transport loop that multiplexes send/receive via `tokio::select!`.
+///
+/// Each connection lifetime is one *round* of [`connection_round`]. Exits
+/// when:
+/// - shutdown was requested (or the handle was dropped)
+/// - a [`ProtocolViolationPolicy::Disconnect`] teardown fires
+/// - a transport error occurs and no [`ReconnectPolicy`] is configured
+/// - a configured reconnect policy exhausts its attempt budget (after
+///   delivering [`ReconnectAbandoned`](SignalFishEvent::ReconnectAbandoned))
+///
+/// With a policy, a transport death without client-side intent instead
+/// schedules a fresh round: backoff wait, fresh transport from the factory,
+/// re-seeded `Authenticate`, and — when the previous connection ended inside
+/// a player room — an automatic directed `reconnect`.
+#[cfg(feature = "tokio-runtime")]
+async fn transport_loop(
+    mut transport: AbortOnDropTransport<Box<dyn Transport + Send>>,
+    mut loop_state: LoopState,
 ) {
     debug!("transport loop started");
 
-    let mut pending_send = None;
+    // Reconnection attempts made in the current episode. Reset whenever a
+    // round reaches the authenticated state, so each run of failed attempts
+    // gets the full budget.
+    let mut attempts: u32 = 0;
+    // First-round rounds reuse the Authenticate already seeded into the
+    // command channel; policy-opened rounds reseed it directly.
+    let mut seed: Option<PendingSend> = None;
+
+    loop {
+        let exit = connection_round(&mut transport, &mut loop_state, seed.take()).await;
+        let ConnectionRoundExit::Retryable {
+            reason,
+            authenticated,
+        } = exit
+        else {
+            break;
+        };
+        let Some(policy) = loop_state.reconnect.as_ref() else {
+            debug!("transport died without a reconnect policy; ending transport loop");
+            break;
+        };
+        if authenticated {
+            attempts = 0;
+        }
+        if attempts >= policy.max_attempts() {
+            debug!("reconnect policy exhausted after {attempts} attempt(s); ending transport loop");
+            let abandoned = SignalFishEvent::ReconnectAbandoned {
+                attempts,
+                last_reason: reason,
+            };
+            if matches!(
+                emit_event_or_shutdown(&loop_state.event_tx, &mut loop_state.shutdown, abandoned)
+                    .await,
+                EmitOutcome::ShutdownRequested
+            ) {
+                debug!("shutdown preempted the ReconnectAbandoned delivery");
+            }
+            break;
+        }
+        attempts = attempts.saturating_add(1);
+        let backoff = policy.backoff_for_attempt(attempts);
+        if matches!(
+            emit_event_or_shutdown(
+                &loop_state.event_tx,
+                &mut loop_state.shutdown,
+                SignalFishEvent::Reconnecting {
+                    attempt: attempts,
+                    next_backoff: backoff,
+                },
+            )
+            .await,
+            EmitOutcome::ShutdownRequested
+        ) {
+            debug!("shutdown preempted the reconnection wait");
+            break;
+        }
+        // Tokio-timed so paused-clock tests advance the wait and production
+        // runs scale with the runtime clock (docs/testing.md contract).
+        tokio::select! {
+            () = tokio::time::sleep(backoff) => {}
+            () = loop_state.shutdown.fired() => {
+                debug!("shutdown arrived during the reconnection backoff");
+                break;
+            }
+        }
+
+        let created = policy.create_transport();
+        {
+            let mut core = lock_core(&loop_state.state);
+            core.set_max_inbound_frame(created.max_frame_hint());
+            core.begin_connection_round();
+        }
+        // Commands still queued for the ended connection are discarded with
+        // it (`queued` is not `delivered`, surfaced by the `Disconnected`
+        // event); the fresh round starts from the re-seeded Authenticate.
+        while loop_state.cmd_rx.try_recv().is_ok() {}
+        let Ok(json) = serialize_client_message(&loop_state.auth_message) else {
+            error!("failed to serialize Authenticate for a reconnection round");
+            break;
+        };
+        transport = AbortOnDropTransport::new(created);
+        seed = Some(PendingSend {
+            frame: Some(TransportFrame::Text(json)),
+            is_game_data: false,
+        });
+    }
+    debug!("transport loop exited");
+}
+
+/// Run one connection lifetime to a terminal edge and classify it.
+///
+/// The body is the original single-connection transport loop, unchanged in
+/// behavior: a shutdown request, a dropped handle, or a protocol-violation
+/// teardown classify as [`ConnectionRoundExit::Terminal`]; a transport-level
+/// death classifies as [`ConnectionRoundExit::Retryable`] so the owning loop
+/// can consult the reconnect policy. When `reconnect_enabled`, the
+/// send-failure teardown leaves the command receiver open (the receiver
+/// cannot be unclosed for the next round) — the frozen admission and
+/// disconnected core still fail every send fast — and an authenticated
+/// player-room context is offered to the automatic reconnection after
+/// re-authentication.
+#[cfg(feature = "tokio-runtime")]
+async fn connection_round(
+    transport: &mut AbortOnDropTransport<Box<dyn Transport + Send>>,
+    loop_state: &mut LoopState,
+    mut pending_send: Option<PendingSend>,
+) -> ConnectionRoundExit {
+    let LoopState {
+        cmd_rx,
+        event_tx,
+        state,
+        shutdown,
+        shutdown_timeout,
+        reconnect,
+        auth_message: _,
+    } = loop_state;
+    let shutdown_timeout = *shutdown_timeout;
+    let reconnect_enabled = reconnect.is_some();
     let mut connected_emitted = false;
-    let mut shutdown = ShutdownSignal::new(shutdown_rx);
+    // The automatic room reconnection is staged here between its admission
+    // (right after `Authenticated` is observed) and the next free outbound
+    // slot, then handed to the transport like any dequeued command.
+    let mut queued_auto_reconnect: Option<ClientCommand> = None;
+    // Definite-assignment: every break below classifies the exit first.
+    let exit;
 
     loop {
         // One driver scheduling cycle per loop iteration, mirroring each
         // polling-client `poll` call: backends may sample once per cycle.
         transport.begin_poll_cycle();
         let diagnostics = transport.diagnostics();
-        lock_core(&state).record_transport_diagnostics(diagnostics);
-        if !connected_emitted && transport.is_ready() && lock_core(&state).mark_transport_ready() {
+        lock_core(state).record_transport_diagnostics(diagnostics);
+        if !connected_emitted && transport.is_ready() && lock_core(state).mark_transport_ready() {
             connected_emitted = true;
             if matches!(
-                emit_event_or_shutdown(&event_tx, &mut shutdown, SignalFishEvent::Connected).await,
+                emit_event_or_shutdown(event_tx, shutdown, SignalFishEvent::Connected).await,
                 EmitOutcome::ShutdownRequested
             ) {
                 finish_core_shutdown(
-                    &mut transport,
+                    transport,
                     &mut pending_send,
-                    &event_tx,
-                    &state,
+                    event_tx,
+                    state,
                     shutdown_timeout,
                 )
                 .await;
+                exit = ConnectionRoundExit::Terminal;
                 break;
+            }
+        }
+        // An automatic reconnect staged by a previous frame's admission goes
+        // out before anything newly dequeued.
+        if pending_send.is_none() {
+            if let Some(command) = queued_auto_reconnect.take() {
+                stage_command(command, &mut pending_send, state);
             }
         }
         // Arm selection among simultaneously-ready arms is deliberately
@@ -2386,91 +2925,74 @@ async fn transport_loop(
             command = cmd_rx.recv(), if pending_send.is_none() => {
                 let Some(command) = command else {
                     emit_core_disconnected_or_shutdown(
-                        &mut transport,
+                        transport,
                         &mut pending_send,
-                        &event_tx,
-                        &mut shutdown,
-                        &state,
+                        event_tx,
+                        shutdown,
+                        state,
                         TerminalTeardown::starting(
                             shutdown_timeout,
                             Some("client shut down".into()),
                         ),
                     ).await;
+                    exit = ConnectionRoundExit::Terminal;
                     break;
                 };
-                let (frame, is_game_data) = match command {
-                    ClientCommand::Message(message) => match serialize_client_message(&message) {
-                        Ok(json) => (
-                            Some(TransportFrame::Text(json)),
-                            matches!(message, ClientMessage::GameData { .. }),
-                        ),
-                        Err(error) => {
-                            error!("failed to serialize ClientMessage: {error}");
-                            lock_core(&state).dequeue_serialization_failed(&message);
-                            (None, false)
-                        }
-                    },
-                    ClientCommand::Binary(payload) => {
-                        (Some(TransportFrame::Binary(payload)), true)
-                    }
-                };
-                if let Some(frame) = frame {
-                    pending_send = Some(PendingSend {
-                        frame: Some(frame),
-                        is_game_data,
-                    });
-                }
+                stage_command(command, &mut pending_send, state);
             }
             _ = shutdown.fired() => {
                 finish_core_shutdown(
-                    &mut transport,
+                    transport,
                     &mut pending_send,
-                    &event_tx,
-                    &state,
+                    event_tx,
+                    state,
                     shutdown_timeout,
                 ).await;
+                exit = ConnectionRoundExit::Terminal;
                 break;
             }
             io = poll_transport_io(
-                &mut transport,
+                transport,
                 &mut pending_send,
-                &state,
+                state,
                 !connected_emitted,
             ) => {
                 if !connected_emitted
                     && transport.is_ready()
-                    && lock_core(&state).mark_transport_ready()
+                    && lock_core(state).mark_transport_ready()
                 {
                     connected_emitted = true;
                     if matches!(
-                        emit_event_or_shutdown(&event_tx, &mut shutdown, SignalFishEvent::Connected)
+                        emit_event_or_shutdown(event_tx, shutdown, SignalFishEvent::Connected)
                             .await,
                         EmitOutcome::ShutdownRequested
                     ) {
                         finish_core_shutdown(
-                            &mut transport,
+                            transport,
                             &mut pending_send,
-                            &event_tx,
-                            &state,
+                            event_tx,
+                            state,
                             shutdown_timeout,
                         ).await;
+                        exit = ConnectionRoundExit::Terminal;
                         break;
                     }
                 }
                 if !connected_emitted
                     && matches!(&io, TransportIo::Received(Some(Ok(_))))
                 {
+                    let authenticated = lock_core(state).is_authenticated();
+                    let reason: Option<String> =
+                        Some("transport received a protocol frame before readiness".into());
                     emit_core_disconnected_or_shutdown(
-                        &mut transport,
+                        transport,
                         &mut pending_send,
-                        &event_tx,
-                        &mut shutdown,
-                        &state,
-                        TerminalTeardown::starting(
-                            shutdown_timeout,
-                            Some("transport received a protocol frame before readiness".into()),
-                        ),
+                        event_tx,
+                        shutdown,
+                        state,
+                        TerminalTeardown::starting(shutdown_timeout, reason.clone()),
                     ).await;
+                    exit = classify_round_exit(shutdown, authenticated, reason);
                     break;
                 }
                 match io {
@@ -2480,35 +3002,50 @@ async fn transport_loop(
                         // admission before processing any already-ready
                         // inbound farewell frames so no concurrent caller can
                         // enqueue work that will never be attempted.
-                        lock_core(&state).freeze_admission();
-                        cmd_rx.close();
+                        let authenticated = lock_core(state).is_authenticated();
+                        lock_core(state).freeze_admission();
+                        if reconnect_enabled {
+                            // The next round reuses this receiver, and a
+                            // tokio receiver cannot be unclosed. Admission
+                            // stays frozen and the core is disconnected by
+                            // the farewell below, so every concurrent send
+                            // still fails fast during the teardown window.
+                        } else {
+                            cmd_rx.close();
+                        }
+                        let error_text = error.to_string();
                         finish_send_failure(
-                            &mut transport,
+                            transport,
                             &mut pending_send,
-                            &event_tx,
-                            &mut shutdown,
-                            &state,
+                            event_tx,
+                            shutdown,
+                            state,
                             error,
                             shutdown_timeout,
                         ).await;
+                        let reason = peer_close_reason(transport).or(Some(error_text));
+                        exit = classify_round_exit(shutdown, authenticated, reason);
                         break;
                     }
                     TransportIo::Received(Some(Ok(frame))) => {
-                        let outcome = lock_core(&state).process_frame(frame);
+                        let outcome = lock_core(state).process_frame(frame);
                         // A frame exceeding the transport's declared inbound
                         // bound is a terminal receive error regardless of the
                         // violation policy: the backend's own contract makes
                         // the input stream unusable, matching how the built-in
                         // WebSocket transport ends over-limit connections.
                         if let Some(reason) = outcome.input_error {
+                            let authenticated = lock_core(state).is_authenticated();
+                            let reason_text = Some(reason.clone());
                             emit_core_disconnected_or_shutdown(
-                                &mut transport,
+                                transport,
                                 &mut pending_send,
-                                &event_tx,
-                                &mut shutdown,
-                                &state,
+                                event_tx,
+                                shutdown,
+                                state,
                                 TerminalTeardown::starting(shutdown_timeout, Some(reason)),
                             ).await;
+                            exit = classify_round_exit(shutdown, authenticated, reason_text);
                             break;
                         }
                         let disconnect = outcome.disconnect;
@@ -2525,19 +3062,20 @@ async fn transport_loop(
                             )
                         });
                         let delivered = emit_event_batch(
-                            &event_tx,
-                            &mut shutdown,
+                            event_tx,
+                            shutdown,
                             violation_teardown.as_ref().and_then(|t| t.deadline),
                             outcome.events,
                         ).await;
                         if !delivered && !disconnect {
                             finish_core_shutdown(
-                                &mut transport,
+                                transport,
                                 &mut pending_send,
-                                &event_tx,
-                                &state,
+                                event_tx,
+                                state,
                                 shutdown_timeout,
                             ).await;
+                            exit = ConnectionRoundExit::Terminal;
                             break;
                         }
                         if let Some(teardown) = violation_teardown {
@@ -2546,17 +3084,19 @@ async fn transport_loop(
                             // passed, so the farewell's bounded wait always
                             // collapses within one poll — exactly like the
                             // send-failure teardown — and never parks beside
-                            // the already-spent budget.
+                            // the already-spent budget. A violation teardown
+                            // never retries: a protocol violation is a
+                            // correctness signal the policy must not mask.
                             let TerminalTeardown {
                                 reason,
                                 deadline,
                                 timeout,
                             } = teardown;
-                            let event = lock_core(&state).disconnect(reason);
+                            let event = lock_core(state).disconnect(reason);
                             let deliver_farewell = async {
                                 if !emit_terminal_event(
-                                    &event_tx,
-                                    &mut shutdown,
+                                    event_tx,
+                                    shutdown,
                                     deadline,
                                     event.clone(),
                                 )
@@ -2566,43 +3106,110 @@ async fn transport_loop(
                                 }
                             };
                             let close = finish_send_and_close_bounded(
-                                &mut transport,
+                                transport,
                                 &mut pending_send,
-                                &state,
+                                state,
                                 remaining_shutdown_budget(timeout, deadline),
                             );
                             let ((), ()) = tokio::join!(deliver_farewell, close);
+                            exit = ConnectionRoundExit::Terminal;
                             break;
                         }
+                        // Freshly authenticated on a policy-opened round with
+                        // a retained player-room context: arm the directed
+                        // reconnect fence and stage the automatic operation.
+                        maybe_queue_auto_reconnect(state, &mut queued_auto_reconnect);
                     }
                     TransportIo::Received(Some(Err(error))) => {
+                        let authenticated = lock_core(state).is_authenticated();
+                        let reason = Some(error.to_string());
                         emit_core_disconnected_or_shutdown(
-                            &mut transport,
+                            transport,
                             &mut pending_send,
-                            &event_tx,
-                            &mut shutdown,
-                            &state,
-                            TerminalTeardown::starting(shutdown_timeout, Some(error.to_string())),
+                            event_tx,
+                            shutdown,
+                            state,
+                            TerminalTeardown::starting(shutdown_timeout, reason.clone()),
                         ).await;
+                        exit = classify_round_exit(shutdown, authenticated, reason);
                         break;
                     }
                     TransportIo::Received(None) => {
-                        let reason = close_reason(&transport);
+                        let authenticated = lock_core(state).is_authenticated();
+                        let reason = close_reason(transport);
                         emit_core_disconnected_or_shutdown(
-                            &mut transport,
+                            transport,
                             &mut pending_send,
-                            &event_tx,
-                            &mut shutdown,
-                            &state,
-                            TerminalTeardown::starting(shutdown_timeout, reason),
+                            event_tx,
+                            shutdown,
+                            state,
+                            TerminalTeardown::starting(shutdown_timeout, reason.clone()),
                         ).await;
+                        exit = classify_round_exit(shutdown, authenticated, reason);
                         break;
                     }
                 }
             }
         }
     }
-    debug!("transport loop exited");
+    exit
+}
+
+/// Convert one dequeued (or automatically staged) command into a pending
+/// outbound frame. Serialization failures release the operation's fence
+/// exactly like the dequeue path always has.
+#[cfg(feature = "tokio-runtime")]
+fn stage_command(
+    command: ClientCommand,
+    pending_send: &mut Option<PendingSend>,
+    state: &Arc<Mutex<ClientCore>>,
+) {
+    let (frame, is_game_data) = match command {
+        ClientCommand::Message(message) => match serialize_client_message(&message) {
+            Ok(json) => (
+                Some(TransportFrame::Text(json)),
+                matches!(message, ClientMessage::GameData { .. }),
+            ),
+            Err(error) => {
+                error!("failed to serialize ClientMessage: {error}");
+                lock_core(state).dequeue_serialization_failed(&message);
+                (None, false)
+            }
+        },
+        ClientCommand::Binary(payload) => (Some(TransportFrame::Binary(payload)), true),
+    };
+    if let Some(frame) = frame {
+        *pending_send = Some(PendingSend {
+            frame: Some(frame),
+            is_game_data,
+        });
+    }
+}
+
+/// After re-authentication on a policy-opened connection, consume the
+/// retained player-room reconnection context (if any) and stage the directed
+/// `reconnect` operation through the same admission/fence path as a caller
+/// command. A caller room operation that wins the race keeps the fence and
+/// the room-recovery decision.
+#[cfg(feature = "tokio-runtime")]
+fn maybe_queue_auto_reconnect(state: &Arc<Mutex<ClientCore>>, slot: &mut Option<ClientCommand>) {
+    if slot.is_some() {
+        return;
+    }
+    let mut core = lock_core(state);
+    let Some(operation) = core.take_auto_reconnect_operation() else {
+        return;
+    };
+    match core.prepare_with_admission(operation) {
+        Ok((command, admission)) => {
+            core.record_admission(admission);
+            *slot = Some(command);
+            debug!("staged automatic room reconnect after re-authentication");
+        }
+        Err(error) => {
+            debug!("automatic reconnect superseded by a caller room operation: {error}");
+        }
+    }
 }
 
 /// Result of racing an event delivery against the shutdown signal.
@@ -2668,6 +3275,13 @@ impl ShutdownSignal {
             self.observed,
             "ShutdownSignal state desynchronized"
         );
+        self.observed
+    }
+
+    /// Whether shutdown has already been observed. Never re-polls the
+    /// receiver; used after teardowns to distinguish a shutdown-driven exit
+    /// from a retryable transport death.
+    fn is_observed(&self) -> bool {
         self.observed
     }
 
@@ -7980,5 +8594,580 @@ mod tests {
             !closed.load(Ordering::Acquire),
             "dropping the shutdown future must not abort the transport"
         );
+    }
+
+    // ── ReconnectPolicy (issue #223 item 1) ────────────────────────────
+
+    fn room_joined_json_with_token(token: &str) -> String {
+        let player = crate::protocol::PlayerInfo {
+            id: uuid::Uuid::from_u128(42),
+            name: "local".into(),
+            is_authority: true,
+            is_ready: false,
+            connected_at: "2026-01-01T00:00:00Z".into(),
+            connection_info: None,
+            epoch: Some(1),
+            seq: Some(0),
+        };
+        let payload = RoomJoinedPayload {
+            room_id: uuid::Uuid::nil(),
+            room_code: "ABC123".into(),
+            player_id: uuid::Uuid::from_u128(42),
+            game_name: "test-game".into(),
+            max_players: 4,
+            supports_authority: true,
+            current_players: vec![player],
+            is_authority: true,
+            lobby_state: LobbyState::Waiting,
+            ready_players: vec![],
+            relay_type: "auto".into(),
+            current_spectators: vec![],
+            ice_servers: vec![],
+            reconnection_token: Some(token.into()),
+        };
+        serde_json::to_string(&ServerMessage::RoomJoined(Box::new(payload))).unwrap()
+    }
+
+    fn reconnected_json_rotated(token: &str) -> String {
+        use crate::protocol::ReconnectedPayload;
+        let payload = ReconnectedPayload {
+            room_id: uuid::Uuid::nil(),
+            room_code: "ABC123".into(),
+            player_id: uuid::Uuid::from_u128(42),
+            game_name: "test-game".into(),
+            max_players: 4,
+            supports_authority: true,
+            current_players: vec![crate::protocol::PlayerInfo {
+                id: uuid::Uuid::from_u128(42),
+                name: "local".into(),
+                is_authority: true,
+                is_ready: false,
+                connected_at: "2026-01-01T00:00:00Z".into(),
+                connection_info: None,
+                epoch: Some(1),
+                seq: Some(0),
+            }],
+            is_authority: true,
+            lobby_state: LobbyState::Waiting,
+            ready_players: vec![],
+            relay_type: "auto".into(),
+            current_spectators: vec![],
+            ice_servers: vec![],
+            missed_events: vec![],
+            replay: Some(crate::protocol::ReplayStatus::Complete),
+            sender_watermarks: vec![crate::protocol::SenderWatermark {
+                player_id: uuid::Uuid::from_u128(42),
+                epoch: 1,
+                seq: 0,
+            }],
+            reconnection_token: Some(token.into()),
+        };
+        serde_json::to_string(&ServerMessage::Reconnected(Box::new(payload))).unwrap()
+    }
+
+    fn reconnection_failed_json() -> String {
+        serde_json::to_string(&ServerMessage::ReconnectionFailed {
+            reason: "session expired".into(),
+            error_code: crate::error_codes::ErrorCode::ReconnectionExpired,
+        })
+        .unwrap()
+    }
+
+    /// Pre-built transports handed to the reconnect factory one per round.
+    type TransportPool = Arc<StdMutex<VecDeque<MockTransport>>>;
+
+    fn transport_pool(transports: Vec<MockTransport>) -> TransportPool {
+        Arc::new(StdMutex::new(VecDeque::from(transports)))
+    }
+
+    fn pool_factory(pool: &TransportPool) -> impl Fn() -> Box<dyn Transport + Send> + Send + Sync {
+        let pool = Arc::clone(pool);
+        move || {
+            pool.lock()
+                .unwrap()
+                .pop_front()
+                .map(|transport| Box::new(transport) as Box<dyn Transport + Send>)
+                .expect("transport pool exhausted")
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn reconnect_policy_rebuilds_connection_and_rejoins_room() {
+        // Round 1: authenticate, join a token-bearing player room, die.
+        let (transport1, _sent1, closed1) = MockTransport::new(vec![
+            Some(Ok(authenticated_json())),
+            Some(Ok(protocol_info_v3_json())),
+            Some(Ok(room_joined_json_with_token("tok-1"))),
+            None,
+        ]);
+        // Round 2: authenticate again; the automatic directed reconnect uses
+        // the retained context and the server rotates the token.
+        let (transport2, sent2, _closed2) = MockTransport::new(vec![
+            Some(Ok(authenticated_json())),
+            Some(Ok(protocol_info_v3_json())),
+            Some(Ok(reconnected_json_rotated("tok-2"))),
+        ]);
+        let pool = transport_pool(vec![transport2]);
+        let policy = ReconnectPolicy::new(pool_factory(&pool))
+            .with_max_attempts(3)
+            .with_initial_backoff(Duration::from_millis(50));
+        let config = SignalFishConfig::new("mb_reconnect")
+            .enable_v3()
+            .with_reconnect_policy(policy);
+        let (mut client, mut events) = SignalFishClient::start(transport1, config);
+
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Connected)
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Authenticated { .. })
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::ProtocolInfo(_))
+        ));
+        client
+            .join_room(JoinRoomParams::new("test-game", "local"))
+            .unwrap();
+        match events.recv().await {
+            Some(SignalFishEvent::RoomJoined {
+                reconnection_token, ..
+            }) => {
+                assert_eq!(reconnection_token.as_deref(), Some("tok-1"));
+            }
+            other => panic!("expected RoomJoined, got {other:?}"),
+        }
+        match events.recv().await {
+            Some(SignalFishEvent::Disconnected { .. }) => {}
+            other => panic!("expected Disconnected, got {other:?}"),
+        }
+        match events.recv().await {
+            Some(SignalFishEvent::Reconnecting {
+                attempt,
+                next_backoff,
+            }) => {
+                assert_eq!(attempt, 1);
+                assert_eq!(next_backoff, Duration::from_millis(50));
+            }
+            other => panic!("expected Reconnecting, got {other:?}"),
+        }
+        // The backoff sleep is tokio-timed, so paused time auto-advances it.
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Connected)
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Authenticated { .. })
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::ProtocolInfo(_))
+        ));
+        match events.recv().await {
+            Some(SignalFishEvent::Reconnected {
+                reconnection_token, ..
+            }) => {
+                assert_eq!(reconnection_token.as_deref(), Some("tok-2"));
+            }
+            other => panic!("expected automatic Reconnected, got {other:?}"),
+        }
+        assert!(closed1.load(Ordering::Acquire), "round-1 transport closed");
+        {
+            let sent2 = sent2.lock().unwrap();
+            assert_eq!(sent2.len(), 2, "round-2 wire: Authenticate then Reconnect");
+            let last = &sent2[1];
+            let message: serde_json::Value = serde_json::from_str(last).unwrap();
+            assert_eq!(message["type"], "Reconnect");
+            assert_eq!(message["data"]["auth_token"], "tok-1");
+        }
+        client.shutdown().await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn reconnect_policy_abandons_after_exhausted_attempts() {
+        let (transport1, _sent1, _closed1) =
+            MockTransport::new(vec![Some(Ok(authenticated_json())), None]);
+        // The single retry also dies immediately.
+        let (transport2, _sent2, _closed2) = MockTransport::new(vec![None]);
+        let pool = transport_pool(vec![transport2]);
+        let policy = ReconnectPolicy::new(pool_factory(&pool))
+            .with_max_attempts(1)
+            .with_initial_backoff(Duration::from_millis(10));
+        let config = SignalFishConfig::new("mb_reconnect").with_reconnect_policy(policy);
+        let (mut client, mut events) = SignalFishClient::start(transport1, config);
+
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Connected)
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Authenticated { .. })
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Disconnected { .. })
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Reconnecting { attempt: 1, .. })
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Connected)
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Disconnected { .. })
+        ));
+        match events.recv().await {
+            Some(SignalFishEvent::ReconnectAbandoned {
+                attempts,
+                last_reason,
+            }) => {
+                assert_eq!(attempts, 1);
+                assert_eq!(last_reason, None, "plain close without close metadata");
+            }
+            other => panic!("expected ReconnectAbandoned, got {other:?}"),
+        }
+        // The loop ended with the policy, so the event channel closes.
+        assert!(events.recv().await.is_none());
+        // A later shutdown reconciles and returns immediately.
+        client.shutdown().await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn reconnect_policy_with_zero_attempts_abandons_immediately() {
+        let (transport1, _sent1, _closed1) =
+            MockTransport::new(vec![Some(Ok(authenticated_json())), None]);
+        let pool = transport_pool(vec![]);
+        let policy = ReconnectPolicy::new(pool_factory(&pool)).with_max_attempts(0);
+        let config = SignalFishConfig::new("mb_reconnect").with_reconnect_policy(policy);
+        let (mut client, mut events) = SignalFishClient::start(transport1, config);
+
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Connected)
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Authenticated { .. })
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Disconnected { .. })
+        ));
+        match events.recv().await {
+            Some(SignalFishEvent::ReconnectAbandoned { attempts, .. }) => {
+                assert_eq!(attempts, 0);
+            }
+            other => panic!("expected ReconnectAbandoned, got {other:?}"),
+        }
+        assert!(events.recv().await.is_none());
+        client.shutdown().await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn violation_disconnect_teardown_is_never_retried() {
+        // A PlayerJoined outside any room is a lifecycle violation; under
+        // the Disconnect policy it tears the session down. (PlayerJoined is
+        // not one of the mock's command-gated directed responses, so the
+        // scripted frame actually reaches the core.)
+        let player_joined = serde_json::to_string(&ServerMessage::PlayerJoined {
+            player: crate::protocol::PlayerInfo {
+                id: uuid::Uuid::from_u128(7),
+                name: "peer-7".into(),
+                is_authority: false,
+                is_ready: false,
+                connected_at: "2026-01-01T00:00:00Z".into(),
+                connection_info: None,
+                epoch: None,
+                seq: None,
+            },
+        })
+        .unwrap();
+        let (transport1, _sent1, _closed1) = MockTransport::new(vec![
+            Some(Ok(authenticated_json())),
+            Some(Ok(protocol_info_v2_json())),
+            Some(Ok(player_joined)),
+        ]);
+        let pool = transport_pool(vec![]);
+        let policy = ReconnectPolicy::new(pool_factory(&pool)).with_max_attempts(5);
+        let config = SignalFishConfig::new("mb_reconnect")
+            .with_protocol_violation_policy(ProtocolViolationPolicy::Disconnect)
+            .with_reconnect_policy(policy);
+        let (mut client, mut events) = SignalFishClient::start(transport1, config);
+
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Connected)
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Authenticated { .. })
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::ProtocolInfo(_))
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::ProtocolViolation { .. })
+        ));
+        let ev = events.recv().await;
+        match ev {
+            Some(SignalFishEvent::Disconnected { reason, .. }) => {
+                assert_eq!(reason.as_deref(), Some("protocol violation"));
+            }
+            other => panic!("expected Disconnected, got {other:?}"),
+        }
+        // A protocol violation is a correctness signal: no retry is
+        // scheduled and the loop ends (the channel closes with no further
+        // event).
+        tokio::time::sleep(Duration::from_millis(5)).await;
+        assert!(
+            events.try_recv().is_err(),
+            "no event may follow the violation teardown"
+        );
+        client.shutdown().await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn shutdown_during_backoff_wait_ends_the_client() {
+        let (transport1, _sent1, closed1) =
+            MockTransport::new(vec![Some(Ok(authenticated_json())), None]);
+        let pool = transport_pool(vec![]);
+        let policy = ReconnectPolicy::new(pool_factory(&pool))
+            .with_max_attempts(5)
+            .with_initial_backoff(Duration::from_secs(3_600));
+        let config = SignalFishConfig::new("mb_reconnect").with_reconnect_policy(policy);
+        let (mut client, mut events) = SignalFishClient::start(transport1, config);
+
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Connected)
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Authenticated { .. })
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Disconnected { .. })
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Reconnecting { attempt: 1, .. })
+        ));
+        // Shutdown wins the race against the backoff sleep without waiting
+        // for the (virtual) hour to pass.
+        client.shutdown().await;
+        assert!(closed1.load(Ordering::Acquire));
+        // The channel closes without any further event.
+        assert!(events.recv().await.is_none());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn voluntary_room_leave_discards_the_reconnect_context() {
+        // Round 1: join a token-bearing room, leave voluntarily, then die.
+        let room_left = serde_json::to_string(&ServerMessage::RoomLeft).unwrap();
+        let (transport1, _sent1, _closed1) = MockTransport::new(vec![
+            Some(Ok(authenticated_json())),
+            Some(Ok(protocol_info_v3_json())),
+            Some(Ok(room_joined_json_with_token("tok-1"))),
+            Some(Ok(room_left)),
+            None,
+        ]);
+        // Round 2 re-authenticates but must NOT rejoin the left room.
+        let (transport2, sent2, _closed2) =
+            MockTransport::new(vec![Some(Ok(authenticated_json()))]);
+        let pool = transport_pool(vec![transport2]);
+        let policy = ReconnectPolicy::new(pool_factory(&pool))
+            .with_max_attempts(3)
+            .with_initial_backoff(Duration::from_millis(10));
+        let config = SignalFishConfig::new("mb_reconnect")
+            .enable_v3()
+            .with_reconnect_policy(policy);
+        let (mut client, mut events) = SignalFishClient::start(transport1, config);
+
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Connected)
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Authenticated { .. })
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::ProtocolInfo(_))
+        ));
+        client
+            .join_room(JoinRoomParams::new("test-game", "local"))
+            .unwrap();
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::RoomJoined { .. })
+        ));
+        client.leave_room().unwrap();
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::RoomLeft)
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Disconnected { .. })
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Reconnecting { .. })
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Connected)
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Authenticated { .. })
+        ));
+        // Give the loop a deterministic virtual beat to (not) send a
+        // reconnect; only the Authenticate ever goes out.
+        tokio::time::sleep(Duration::from_millis(5)).await;
+        assert_eq!(
+            sent2.lock().unwrap().len(),
+            1,
+            "a voluntarily left room must not be rejoined automatically"
+        );
+        client.shutdown().await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn reconnection_failed_stops_room_recovery_but_keeps_the_connection() {
+        let (transport1, _sent1, _closed1) = MockTransport::new(vec![
+            Some(Ok(authenticated_json())),
+            Some(Ok(protocol_info_v3_json())),
+            Some(Ok(room_joined_json_with_token("tok-1"))),
+            None,
+        ]);
+        let (transport2, sent2, _closed2) = MockTransport::new(vec![
+            Some(Ok(authenticated_json())),
+            Some(Ok(protocol_info_v3_json())),
+            Some(Ok(reconnection_failed_json())),
+        ]);
+        let pool = transport_pool(vec![transport2]);
+        let policy = ReconnectPolicy::new(pool_factory(&pool))
+            .with_max_attempts(3)
+            .with_initial_backoff(Duration::from_millis(10));
+        let config = SignalFishConfig::new("mb_reconnect")
+            .enable_v3()
+            .with_reconnect_policy(policy);
+        let (mut client, mut events) = SignalFishClient::start(transport1, config);
+
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Connected)
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Authenticated { .. })
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::ProtocolInfo(_))
+        ));
+        client
+            .join_room(JoinRoomParams::new("test-game", "local"))
+            .unwrap();
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::RoomJoined { .. })
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Disconnected { .. })
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Reconnecting { .. })
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Connected)
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Authenticated { .. })
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::ProtocolInfo(_))
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::ReconnectionFailed { .. })
+        ));
+        // Exactly one automatic reconnect was attempted; the connection
+        // stays up and the caller owns the fallback decision.
+        tokio::time::sleep(Duration::from_millis(5)).await;
+        {
+            let sent2 = sent2.lock().unwrap();
+            assert_eq!(sent2.len(), 2);
+            let message: serde_json::Value = serde_json::from_str(&sent2[1]).unwrap();
+            assert_eq!(message["type"], "Reconnect");
+        }
+        client.shutdown().await;
+    }
+
+    #[test]
+    fn backoff_schedule_is_exponential_and_capped() {
+        let policy = ReconnectPolicy::new(|| {
+            Box::new(MockTransport::new(vec![]).0) as Box<dyn Transport + Send>
+        })
+        .with_initial_backoff(Duration::from_millis(250))
+        .with_max_backoff(Duration::from_secs(10));
+        assert_eq!(policy.backoff_for_attempt(1), Duration::from_millis(250));
+        assert_eq!(policy.backoff_for_attempt(2), Duration::from_millis(500));
+        assert_eq!(policy.backoff_for_attempt(3), Duration::from_secs(1));
+        assert_eq!(policy.backoff_for_attempt(4), Duration::from_secs(2));
+        assert_eq!(policy.backoff_for_attempt(6), Duration::from_secs(8));
+        // The ceiling caps every later attempt; huge attempt numbers
+        // saturate instead of overflowing.
+        assert_eq!(policy.backoff_for_attempt(7), Duration::from_secs(10));
+        assert_eq!(
+            policy.backoff_for_attempt(u32::MAX),
+            Duration::from_secs(10)
+        );
+    }
+
+    #[test]
+    fn reconnect_policy_config_equality_and_debug_hide_the_factory() {
+        let make_config = |marker: u8| {
+            SignalFishConfig::new("mb_reconnect").with_reconnect_policy(
+                ReconnectPolicy::new(move || {
+                    let _ = marker;
+                    Box::new(MockTransport::new(vec![]).0) as Box<dyn Transport + Send>
+                })
+                .with_max_attempts(7)
+                .with_initial_backoff(Duration::from_millis(5))
+                .with_max_backoff(Duration::from_secs(60)),
+            )
+        };
+        // Distinct factories, identical observable tuning: equal.
+        assert_eq!(make_config(1), make_config(2));
+        // Tuning differences are visible.
+        let mut changed = make_config(1);
+        changed.reconnect_policy = changed
+            .reconnect_policy
+            .map(|policy| policy.with_max_attempts(9));
+        assert_ne!(make_config(1), changed);
+        let debug = format!("{:?}", make_config(1));
+        assert!(
+            debug.contains("ReconnectPolicy { .. }"),
+            "factory must stay opaque in Debug: {debug}"
+        );
+        assert!(!debug.contains("MockTransport"));
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -117,8 +117,9 @@ use crate::signal::PeerSignal;
 use crate::terminal_drain::{
     close_reason, peer_close_reason, ReadyFrameDrain, ReadyFrameDrainBudget, ReadyFrameDrainPoll,
 };
+use crate::transport::Transport;
 #[cfg(feature = "tokio-runtime")]
-use crate::transport::{close_transport, Transport, TransportDiagnostics, TransportFrame};
+use crate::transport::{close_transport, TransportDiagnostics, TransportFrame};
 
 /// Default capacity of the bounded event channel.
 const DEFAULT_EVENT_CHANNEL_CAPACITY: usize = 256;
@@ -195,6 +196,10 @@ pub(crate) fn decode_binary_server_message(
 ///
 /// Must be supplied to [`SignalFishClient::start`]. The only required field is
 /// `app_id`; all others have sensible defaults.
+///
+/// `PartialEq` compares a configured [`ReconnectPolicy`] by its observable
+/// tuning (attempts and backoff windows); the uncomparable transport factory
+/// is deliberately not part of the comparison.
 ///
 /// # Example
 ///
@@ -296,12 +301,11 @@ pub struct SignalFishConfig {
     ///
     /// `None` (the default) keeps recovery fully manual. See
     /// [`ReconnectPolicy`] for the automated behavior and
-    /// [`with_reconnect_policy`](Self::with_reconnect_policy) to opt in.
-    #[cfg(feature = "tokio-runtime")]
+    /// [`with_reconnect_policy`](Self::with_reconnect_policy) to opt in. The
+    /// polling client is caller-driven by design and ignores this option.
     pub reconnect_policy: Option<ReconnectPolicy>,
 }
 
-#[cfg(feature = "tokio-runtime")]
 impl std::fmt::Debug for SignalFishConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SignalFishConfig")
@@ -327,7 +331,6 @@ impl std::fmt::Debug for SignalFishConfig {
     }
 }
 
-#[cfg(feature = "tokio-runtime")]
 impl PartialEq for SignalFishConfig {
     fn eq(&self, other: &Self) -> bool {
         self.app_id == other.app_id
@@ -346,10 +349,8 @@ impl PartialEq for SignalFishConfig {
     }
 }
 
-#[cfg(feature = "tokio-runtime")]
 impl Eq for SignalFishConfig {}
 
-#[cfg(feature = "tokio-runtime")]
 impl SignalFishConfig {
     /// Comparable view of a configured policy: the observable tuning without
     /// the uncomparable transport factory.
@@ -387,7 +388,6 @@ impl SignalFishConfig {
             command_channel_capacity: DEFAULT_COMMAND_CHANNEL_CAPACITY,
             shutdown_timeout: DEFAULT_SHUTDOWN_TIMEOUT,
             protocol_violation_policy: ProtocolViolationPolicy::Quarantine,
-            #[cfg(feature = "tokio-runtime")]
             reconnect_policy: None,
         }
     }
@@ -440,11 +440,8 @@ impl SignalFishConfig {
     /// deterministic exponential backoff, per-attempt
     /// [`Reconnecting`](crate::SignalFishEvent::Reconnecting) events, and an
     /// automatic directed `reconnect` for the player room the client was in
-    /// when the connection ended.
-    ///
-    /// The [polling client](crate::SignalFishPollingClient) is caller-driven
-    /// by design and ignores this option.
-    #[cfg(feature = "tokio-runtime")]
+    /// when the connection ended. The polling client is caller-driven by
+    /// design and ignores this option.
     #[must_use]
     pub fn with_reconnect_policy(mut self, policy: ReconnectPolicy) -> Self {
         self.reconnect_policy = Some(policy);
@@ -672,7 +669,9 @@ const DEFAULT_RECONNECT_MAX_BACKOFF: Duration = Duration::from_secs(10);
 ///    automatic rejoin is **not** retried or replaced with an automatic
 ///    `join_room` — the caller decides the fallback. Voluntarily leaving a
 ///    room discards the context, so a policy never rejoins a room the caller
-///    chose to leave.
+///    chose to leave. One deliberate gap: a round that dies again before the
+///    automatic reconnect is answered loses that attempt with the round; the
+///    next round is connection-only.
 ///
 /// # Retryable terminal edges
 ///
@@ -717,7 +716,12 @@ const DEFAULT_RECONNECT_MAX_BACKOFF: Duration = Duration::from_secs(10);
 /// panicking factory kills the transport loop task exactly like a panicking
 /// [`Transport`](crate::Transport) method (the documented panic-boundary
 /// contract).
-#[cfg(feature = "tokio-runtime")]
+///
+/// The `Reconnecting` and `ReconnectAbandoned` deliveries are bounded by
+/// [`shutdown_timeout`](SignalFishConfig::shutdown_timeout) like the terminal
+/// farewell: a consumer that stops draining delays each round by at most one
+/// budget instead of parking the loop (or the reliable senders parked on the
+/// command queue) forever.
 pub struct ReconnectPolicy {
     factory: std::sync::Arc<dyn Fn() -> Box<dyn Transport + Send> + Send + Sync>,
     max_attempts: u32,
@@ -725,7 +729,6 @@ pub struct ReconnectPolicy {
     max_backoff: Duration,
 }
 
-#[cfg(feature = "tokio-runtime")]
 impl Clone for ReconnectPolicy {
     fn clone(&self) -> Self {
         Self {
@@ -737,7 +740,6 @@ impl Clone for ReconnectPolicy {
     }
 }
 
-#[cfg(feature = "tokio-runtime")]
 impl std::fmt::Debug for ReconnectPolicy {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ReconnectPolicy")
@@ -748,7 +750,6 @@ impl std::fmt::Debug for ReconnectPolicy {
     }
 }
 
-#[cfg(feature = "tokio-runtime")]
 impl ReconnectPolicy {
     /// Build a policy that rebuilds connections from `factory`.
     ///
@@ -837,6 +838,10 @@ impl ReconnectPolicy {
     }
 
     /// Open the next transport.
+    ///
+    /// Only the async transport loop invokes the factory; the polling client
+    /// never re-opens connections.
+    #[cfg(feature = "tokio-runtime")]
     fn create_transport(&self) -> Box<dyn Transport + Send> {
         (self.factory)()
     }
@@ -2735,6 +2740,25 @@ impl LoopState {
     }
 }
 
+/// Deliver one reconnection-scheduling event with the same bounded budget as
+/// a terminal farewell: a wedged consumer delays each round by at most one
+/// [`shutdown_timeout`](SignalFishConfig::shutdown_timeout) instead of
+/// parking the transport loop (and every parked reliable sender) forever. On
+/// budget expiry the event falls back to one nonblocking attempt, exactly
+/// like the terminal-disconnect deliveries.
+#[cfg(feature = "tokio-runtime")]
+async fn emit_reconnect_event_bounded(
+    event_tx: &mpsc::Sender<SignalFishEvent>,
+    shutdown: &mut ShutdownSignal,
+    timeout: Duration,
+    event: SignalFishEvent,
+) {
+    let deadline = tokio::time::Instant::now().checked_add(timeout);
+    if !emit_terminal_event(event_tx, shutdown, deadline, event.clone()).await {
+        let _ = event_tx.try_send(event);
+    }
+}
+
 /// Background transport loop that multiplexes send/receive via `tokio::select!`.
 ///
 /// Each connection lifetime is one *round* of [`connection_round`]. Exits
@@ -2786,29 +2810,28 @@ async fn transport_loop(
                 attempts,
                 last_reason: reason,
             };
-            if matches!(
-                emit_event_or_shutdown(&loop_state.event_tx, &mut loop_state.shutdown, abandoned)
-                    .await,
-                EmitOutcome::ShutdownRequested
-            ) {
-                debug!("shutdown preempted the ReconnectAbandoned delivery");
-            }
+            emit_reconnect_event_bounded(
+                &loop_state.event_tx,
+                &mut loop_state.shutdown,
+                loop_state.shutdown_timeout,
+                abandoned,
+            )
+            .await;
             break;
         }
         attempts = attempts.saturating_add(1);
         let backoff = policy.backoff_for_attempt(attempts);
-        if matches!(
-            emit_event_or_shutdown(
-                &loop_state.event_tx,
-                &mut loop_state.shutdown,
-                SignalFishEvent::Reconnecting {
-                    attempt: attempts,
-                    next_backoff: backoff,
-                },
-            )
-            .await,
-            EmitOutcome::ShutdownRequested
-        ) {
+        emit_reconnect_event_bounded(
+            &loop_state.event_tx,
+            &mut loop_state.shutdown,
+            loop_state.shutdown_timeout,
+            SignalFishEvent::Reconnecting {
+                attempt: attempts,
+                next_backoff: backoff,
+            },
+        )
+        .await;
+        if loop_state.shutdown.is_observed() {
             debug!("shutdown preempted the reconnection wait");
             break;
         }
@@ -2823,19 +2846,24 @@ async fn transport_loop(
         }
 
         let created = policy.create_transport();
+        // Commands still queued for the ended connection are discarded with
+        // it (`queued` is not `delivered`, surfaced by the `Disconnected`
+        // event). Draining happens while the core is still disconnected, so
+        // nothing validated against the fresh round can slip in between the
+        // re-arm below and the drain.
+        while loop_state.cmd_rx.try_recv().is_ok() {}
+        let Ok(json) = serialize_client_message(&loop_state.auth_message) else {
+            // Unreachable for the owned-string `Authenticate`, but never
+            // leave the snapshot claiming a live connection.
+            error!("failed to serialize Authenticate for a reconnection round");
+            lock_core(&loop_state.state).disconnect(Some("client shut down".into()));
+            break;
+        };
         {
             let mut core = lock_core(&loop_state.state);
             core.set_max_inbound_frame(created.max_frame_hint());
             core.begin_connection_round();
         }
-        // Commands still queued for the ended connection are discarded with
-        // it (`queued` is not `delivered`, surfaced by the `Disconnected`
-        // event); the fresh round starts from the re-seeded Authenticate.
-        while loop_state.cmd_rx.try_recv().is_ok() {}
-        let Ok(json) = serialize_client_message(&loop_state.auth_message) else {
-            error!("failed to serialize Authenticate for a reconnection round");
-            break;
-        };
         transport = AbortOnDropTransport::new(created);
         seed = Some(PendingSend {
             frame: Some(TransportFrame::Text(json)),
@@ -9118,6 +9146,148 @@ mod tests {
             let message: serde_json::Value = serde_json::from_str(&sent2[1]).unwrap();
             assert_eq!(message["type"], "Reconnect");
         }
+        client.shutdown().await;
+    }
+
+    /// A transport whose first outbound send fails terminally, then recovers
+    /// — pins the send-failure edge's retryable classification and the
+    /// policy path's open command receiver.
+    struct FirstSendFailsTransport {
+        incoming: std::sync::Mutex<std::collections::VecDeque<String>>,
+        first_send_attempted: std::sync::atomic::AtomicBool,
+    }
+
+    impl Transport for FirstSendFailsTransport {
+        fn abort(&mut self) {}
+        fn poll_close(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<std::result::Result<(), SignalFishError>> {
+            Poll::Ready(Ok(()))
+        }
+        fn poll_send(
+            &mut self,
+            _cx: &mut Context<'_>,
+            frame: &mut Option<TransportFrame>,
+        ) -> Poll<std::result::Result<(), SignalFishError>> {
+            if !self.first_send_attempted.swap(true, Ordering::Relaxed) {
+                return Poll::Ready(Err(SignalFishError::TransportSend(
+                    "scripted first-send failure".into(),
+                )));
+            }
+            let _ = frame.take();
+            Poll::Ready(Ok(()))
+        }
+        fn poll_recv(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Option<std::result::Result<TransportFrame, SignalFishError>>> {
+            match self.incoming.lock().unwrap().pop_front() {
+                Some(text) => Poll::Ready(Some(Ok(TransportFrame::Text(text)))),
+                None => Poll::Pending,
+            }
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn send_failure_edge_is_retryable_and_frees_the_command_queue() {
+        let transport1 = FirstSendFailsTransport {
+            incoming: std::sync::Mutex::new(std::collections::VecDeque::from(vec![
+                authenticated_json(),
+            ])),
+            first_send_attempted: std::sync::atomic::AtomicBool::new(false),
+        };
+        let (transport2, sent2, _closed2) =
+            MockTransport::new(vec![Some(Ok(authenticated_json()))]);
+        let pool = transport_pool(vec![transport2]);
+        let policy = ReconnectPolicy::new(pool_factory(&pool))
+            .with_max_attempts(2)
+            .with_initial_backoff(Duration::from_millis(10));
+        let config = SignalFishConfig::new("mb_reconnect").with_reconnect_policy(policy);
+        let (mut client, mut events) = SignalFishClient::start(transport1, config);
+
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Connected)
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Authenticated { .. })
+        ));
+        // The very first outbound frame (the channel-seeded Authenticate)
+        // fails terminally, classifying the round retryable.
+        match events.recv().await {
+            Some(SignalFishEvent::Disconnected { reason, .. }) => {
+                assert!(
+                    reason
+                        .as_deref()
+                        .unwrap_or("")
+                        .contains("scripted first-send failure"),
+                    "send-failure cause expected, got {reason:?}"
+                );
+            }
+            other => panic!("expected Disconnected, got {other:?}"),
+        }
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Reconnecting { attempt: 1, .. })
+        ));
+        // The fresh round re-seeds Authenticate and re-authenticates.
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Connected)
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Authenticated { .. })
+        ));
+        assert_eq!(
+            sent2.lock().unwrap().len(),
+            1,
+            "round 2 must re-seed Authenticate"
+        );
+        client.shutdown().await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn receive_error_edge_is_retryable() {
+        let (transport1, _sent1, _closed1) = MockTransport::new(vec![
+            Some(Ok(authenticated_json())),
+            Some(Err(SignalFishError::TransportClosed)),
+        ]);
+        let (transport2, _sent2, _closed2) =
+            MockTransport::new(vec![Some(Ok(authenticated_json()))]);
+        let pool = transport_pool(vec![transport2]);
+        let policy = ReconnectPolicy::new(pool_factory(&pool))
+            .with_max_attempts(2)
+            .with_initial_backoff(Duration::from_millis(10));
+        let config = SignalFishConfig::new("mb_reconnect").with_reconnect_policy(policy);
+        let (mut client, mut events) = SignalFishClient::start(transport1, config);
+
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Connected)
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Authenticated { .. })
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Disconnected { .. })
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Reconnecting { attempt: 1, .. })
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Connected)
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Authenticated { .. })
+        ));
         client.shutdown().await;
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -714,8 +714,7 @@ const DEFAULT_RECONNECT_MAX_BACKOFF: Duration = Duration::from_secs(10);
 ///
 /// The factory is called at most once per attempt and must not block; a
 /// panicking factory kills the transport loop task exactly like a panicking
-/// [`Transport`](crate::Transport) method (the documented panic-boundary
-/// contract).
+/// [`Transport`] method (the documented panic-boundary contract).
 ///
 /// The `Reconnecting` and `ReconnectAbandoned` deliveries are bounded by
 /// [`shutdown_timeout`](SignalFishConfig::shutdown_timeout) like the terminal

--- a/src/client_core.rs
+++ b/src/client_core.rs
@@ -237,6 +237,18 @@ pub(crate) struct ClientCore {
     pending_reconnects: VecDeque<PendingReconnect>,
     #[cfg(feature = "tokio-runtime")]
     admission_frozen: bool,
+    // Opt-in retention of the last player-room reconnection context across a
+    // terminal disconnect, enabled only when a `ReconnectPolicy` is
+    // configured. While a room is live the token already lives in the
+    // snapshot; retaining it past `clear_session` is the deliberate,
+    // documented exception that lets the async driver issue the automatic
+    // directed `reconnect` after re-authentication. Voluntary room exits
+    // (`clear_room`) discard it, so a policy never rejoins a room the caller
+    // chose to leave.
+    #[cfg(feature = "tokio-runtime")]
+    reconnect_retention: bool,
+    #[cfg(feature = "tokio-runtime")]
+    auto_reconnect: Option<AutoReconnectContext>,
     #[cfg(feature = "tokio-runtime")]
     session_plan_revision: u64,
     #[cfg(feature = "tokio-runtime")]
@@ -257,6 +269,19 @@ struct RoomBaseline {
 }
 
 pub(crate) struct PendingReconnect {
+    player_id: PlayerId,
+    room_id: RoomId,
+    token: String,
+}
+
+/// Player-room identity retained across a terminal disconnect for the
+/// opt-in automatic reconnection ([`ReconnectPolicy`]).
+///
+/// The token is exactly the value the server last issued on this room
+/// (freshened by every `RoomJoined`/`Reconnected` baseline). It must never
+/// reach `Debug`/tracing; the type deliberately derives nothing.
+#[cfg(feature = "tokio-runtime")]
+struct AutoReconnectContext {
     player_id: PlayerId,
     room_id: RoomId,
     token: String,
@@ -291,7 +316,14 @@ pub(crate) struct ClientOperationAdmission {
 
 impl ClientCore {
     pub(crate) fn authenticate(config: &SignalFishConfig) -> CoreCommand {
-        CoreCommand::Message(ClientMessage::Authenticate {
+        CoreCommand::Message(Self::authenticate_message(config))
+    }
+
+    /// The initial `Authenticate` wire message for `config`. Kept separate so
+    /// the async loop can re-seed authentication on reconnection-round
+    /// connections without routing through the command channel.
+    pub(crate) fn authenticate_message(config: &SignalFishConfig) -> ClientMessage {
+        ClientMessage::Authenticate {
             app_id: config.app_id.clone(),
             sdk_version: config.sdk_version.clone(),
             platform: config.platform.clone(),
@@ -302,7 +334,7 @@ impl ClientCore {
             requested_capabilities: config
                 .requests_room_operation_ids()
                 .then(|| vec![ROOM_OPERATION_IDS_CAPABILITY.to_string()]),
-        })
+        }
     }
 
     #[cfg(test)]
@@ -356,6 +388,10 @@ impl ClientCore {
             #[cfg(feature = "tokio-runtime")]
             admission_frozen: false,
             #[cfg(feature = "tokio-runtime")]
+            reconnect_retention: false,
+            #[cfg(feature = "tokio-runtime")]
+            auto_reconnect: None,
+            #[cfg(feature = "tokio-runtime")]
             session_plan_revision: 0,
             #[cfg(feature = "tokio-runtime")]
             room_revision: 0,
@@ -366,8 +402,10 @@ impl ClientCore {
         self.snapshot.clone()
     }
 
-    /// Record the transport's declared inbound frame bound once, at driver
-    /// construction, before any frame can be processed.
+    /// Record the transport's declared inbound frame bound before any frame
+    /// of the current connection can be processed. Called at driver
+    /// construction and again each time the reconnect policy opens a fresh
+    /// transport (the declared bound is a per-backend property).
     pub(crate) fn set_max_inbound_frame(&mut self, max_inbound_frame: Option<usize>) {
         self.max_inbound_frame = max_inbound_frame;
     }
@@ -610,6 +648,54 @@ impl ClientCore {
     #[cfg(feature = "tokio-runtime")]
     pub(crate) fn freeze_admission(&mut self) {
         self.admission_frozen = true;
+    }
+
+    /// Enable retention of the player-room reconnection context across a
+    /// terminal disconnect. Called once by the async driver when a
+    /// [`ReconnectPolicy`](crate::ReconnectPolicy) is configured; the
+    /// polling driver never enables it.
+    #[cfg(feature = "tokio-runtime")]
+    pub(crate) fn set_reconnect_retention(&mut self, enabled: bool) {
+        self.reconnect_retention = enabled;
+        if !enabled {
+            self.auto_reconnect = None;
+        }
+    }
+
+    /// Re-arm connection-level state for a fresh transport opened by the
+    /// reconnect policy's factory: the new handshake counts as a live
+    /// (pre-ready) connection again, and a send-failure teardown's admission
+    /// freeze ends with the old connection.
+    #[cfg(feature = "tokio-runtime")]
+    pub(crate) fn begin_connection_round(&mut self) {
+        self.snapshot.connected = true;
+        self.snapshot.transport_ready = false;
+        self.admission_frozen = false;
+    }
+
+    /// Consume the retained player-room reconnection context after
+    /// re-authentication on a policy-opened connection.
+    ///
+    /// Returns the directed [`ClientOperation::Reconnect`] the documented
+    /// manual procedure would issue, exactly once, only when the fresh
+    /// connection is authenticated, outside any room, and the context
+    /// survived from the previous connection. Any other state keeps the
+    /// context for a later qualifying moment (the caller retries per loop
+    /// cycle) — except that a *room exit* or a fresh join replaces it.
+    #[cfg(feature = "tokio-runtime")]
+    pub(crate) fn take_auto_reconnect_operation(&mut self) -> Option<ClientOperation> {
+        if !self.reconnect_retention
+            || !self.snapshot.authenticated
+            || self.snapshot.room_role.is_some()
+        {
+            return None;
+        }
+        let context = self.auto_reconnect.take()?;
+        Some(ClientOperation::Reconnect(
+            context.player_id,
+            context.room_id,
+            context.token,
+        ))
     }
 
     #[cfg(feature = "tokio-runtime")]
@@ -874,6 +960,10 @@ impl ClientCore {
         self.pending_room_operation = None;
         self.absorbed_spectator_leave = None;
         self.pending_reconnects.clear();
+        // Deliberately NOT clearing `auto_reconnect`: this is the disconnect
+        // path, and the retained player-room context is exactly what lets a
+        // configured reconnect policy issue the automatic directed
+        // `reconnect` after re-authentication on the next connection.
         #[cfg(feature = "tokio-runtime")]
         self.advance_session_plan_revision();
     }
@@ -2177,7 +2267,7 @@ impl ClientCore {
         self.snapshot.room_id = Some(baseline.room_id);
         self.snapshot.room_code = Some(baseline.room_code);
         self.snapshot.room_role = Some(baseline.room_role);
-        self.snapshot.reconnection_token = baseline.reconnection_token;
+        self.snapshot.reconnection_token = baseline.reconnection_token.clone();
         self.snapshot.session_generation = None;
         self.snapshot.session_topology = None;
         self.snapshot.session_transport = None;
@@ -2193,6 +2283,24 @@ impl ClientCore {
         self.pending_room_operation = None;
         self.absorbed_spectator_leave = None;
         self.pending_reconnects.clear();
+        // A fresh authoritative baseline replaces any retained reconnection
+        // context: player rooms store the identity + freshest token so a
+        // later disconnect can rejoin automatically (reconnect retention),
+        // while spectator baselines (no token) clear it — the protocol has
+        // no spectator reconnect.
+        #[cfg(feature = "tokio-runtime")]
+        {
+            self.auto_reconnect = match baseline.reconnection_token {
+                Some(token) if baseline.room_role == RoomRole::Player => {
+                    Some(AutoReconnectContext {
+                        player_id: baseline.player_id,
+                        room_id: baseline.room_id,
+                        token,
+                    })
+                }
+                _ => None,
+            };
+        }
         #[cfg(feature = "tokio-runtime")]
         self.advance_room_revision();
     }
@@ -2224,6 +2332,14 @@ impl ClientCore {
         // future exit kind reaches them.
         self.absorbed_spectator_leave = None;
         self.pending_reconnects.clear();
+        // A voluntary room exit ends automatic room recovery: the caller
+        // chose to leave, so a later disconnect must not rejoin this room.
+        // The retained context is also retired here (if any), while
+        // `clear_session` — the disconnect path — deliberately keeps it.
+        #[cfg(feature = "tokio-runtime")]
+        {
+            self.auto_reconnect = None;
+        }
         #[cfg(feature = "tokio-runtime")]
         self.advance_room_revision();
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -126,7 +126,19 @@ pub enum SignalFishError {
     #[error("transport connection closed")]
     TransportClosed,
 
-    /// Failed to serialize or deserialize a protocol message.
+    /// Failed to serialize an outbound protocol message.
+    ///
+    /// # Ambient-log safety invariant
+    ///
+    /// Every `SignalFishError` `Display` arm carrying free text must contain
+    /// only bounded, non-secret text (static strings, wire-code labels, or
+    /// the ≤512-byte bounded serde prefix) so callers can format any error
+    /// in logs. This variant currently has no production constructor: its
+    /// `#[from] serde_json::Error` impl must not be aimed at *inbound*
+    /// frames, because serde deserialization errors quote hostile wire
+    /// tokens verbatim — inbound text may flow only through the bounded
+    /// `DecodeFailed` path. `ServerError` carries the same invariant (no
+    /// production constructor today).
     #[error("serialization error: {0}")]
     Serialization(#[from] serde_json::Error),
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -130,15 +130,17 @@ pub enum SignalFishError {
     ///
     /// # Ambient-log safety invariant
     ///
-    /// Every `SignalFishError` `Display` arm carrying free text must contain
-    /// only bounded, non-secret text (static strings, wire-code labels, or
-    /// the ≤512-byte bounded serde prefix) so callers can format any error
-    /// in logs. This variant currently has no production constructor: its
-    /// `#[from] serde_json::Error` impl must not be aimed at *inbound*
+    /// SDK-authored `Display` text (static strings, wire-code labels,
+    /// identifiers, counts) is non-secret by construction. This variant
+    /// currently has no production constructor, and that is load-bearing:
+    /// its `#[from] serde_json::Error` impl must not be aimed at *inbound*
     /// frames, because serde deserialization errors quote hostile wire
     /// tokens verbatim — inbound text may flow only through the bounded
-    /// `DecodeFailed` path. `ServerError` carries the same invariant (no
-    /// production constructor today).
+    /// (≤512-byte) `DecodeFailed` path. `ServerError` carries the same
+    /// no-production-constructor invariant. The deliberate exception is the
+    /// `TransportSend`/`TransportReceive`/`Io` family, whose text is the
+    /// backend's own cause message — documented, but not bounded by the
+    /// SDK.
     #[error("serialization error: {0}")]
     Serialization(#[from] serde_json::Error),
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -106,9 +106,13 @@ pub enum SignalFishEvent {
     /// policy's factory. A successful attempt continues with a fresh
     /// [`Connected`](Self::Connected) →
     /// [`Authenticated`](Self::Authenticated) sequence (and, when the client
-    /// left a player room on the previous connection, an automatic
-    /// [`Reconnected`](Self::Reconnected) attempt); an exhausted policy ends
-    /// the client with [`ReconnectAbandoned`](Self::ReconnectAbandoned).
+    /// was a player in a room when the previous connection ended, an
+    /// automatic [`Reconnected`](Self::Reconnected) attempt); an exhausted
+    /// policy ends the client with
+    /// [`ReconnectAbandoned`](Self::ReconnectAbandoned). Like the terminal
+    /// farewell, this delivery is bounded by the configured shutdown
+    /// timeout: a wedged consumer delays the round instead of parking the
+    /// loop.
     Reconnecting {
         /// 1-based ordinal of this reconnection attempt within the current
         /// episode. The counter resets whenever a connection reaches the

--- a/src/event.rs
+++ b/src/event.rs
@@ -32,6 +32,8 @@ use crate::protocol::{
 /// |---|---|
 /// | [`Connected`](Self::Connected) | Transport layer opened successfully |
 /// | [`Disconnected`](Self::Disconnected) | Transport layer closed or errored |
+/// | [`Reconnecting`](Self::Reconnecting) | Configured [`ReconnectPolicy`](crate::ReconnectPolicy) scheduled a fresh connection |
+/// | [`ReconnectAbandoned`](Self::ReconnectAbandoned) | The configured reconnect policy exhausted its attempts |
 /// | [`DecodeFailed`](Self::DecodeFailed) | An inbound frame could not be decoded |
 /// | [`ProtocolViolation`](Self::ProtocolViolation) | A decoded frame contradicted negotiated protocol state |
 ///
@@ -88,6 +90,55 @@ pub enum SignalFishEvent {
         /// be attributed. The farewell may never arrive (the socket is
         /// congested by definition), in which case this is `None`.
         last_server_error: Option<ServerErrorInfo>,
+    },
+
+    /// The client is about to re-establish the signaling connection after a
+    /// terminal disconnect.
+    ///
+    /// This is a **synthetic event** — it is only emitted when a
+    /// [`ReconnectPolicy`](crate::ReconnectPolicy) is configured on
+    /// [`SignalFishConfig`](crate::SignalFishConfig). Without one, a terminal
+    /// disconnect ends the client and recovery stays fully manual.
+    ///
+    /// Emitted after the matching
+    /// [`Disconnected`](Self::Disconnected) event and before the client
+    /// waits `next_backoff` and then opens a fresh transport from the
+    /// policy's factory. A successful attempt continues with a fresh
+    /// [`Connected`](Self::Connected) →
+    /// [`Authenticated`](Self::Authenticated) sequence (and, when the client
+    /// left a player room on the previous connection, an automatic
+    /// [`Reconnected`](Self::Reconnected) attempt); an exhausted policy ends
+    /// the client with [`ReconnectAbandoned`](Self::ReconnectAbandoned).
+    Reconnecting {
+        /// 1-based ordinal of this reconnection attempt within the current
+        /// episode. The counter resets whenever a connection reaches the
+        /// authenticated state again.
+        attempt: u32,
+        /// How long the client waits before opening the new transport.
+        ///
+        /// `Duration::ZERO` retries immediately. The value follows the
+        /// policy's documented exponential schedule and never exceeds
+        /// [`max_backoff`](crate::ReconnectPolicy::max_backoff).
+        next_backoff: std::time::Duration,
+    },
+
+    /// Every configured reconnection attempt was exhausted; the client has
+    /// given up and the event stream ends after this event.
+    ///
+    /// This is a **synthetic event** — it is only emitted when a
+    /// [`ReconnectPolicy`](crate::ReconnectPolicy) is configured and its
+    /// attempt budget ran out without a successful reconnection. Shutdown,
+    /// a dropped client handle, and
+    /// [`ProtocolViolationPolicy::Disconnect`](crate::ProtocolViolationPolicy::Disconnect)
+    /// teardowns end the client without attempting reconnection and
+    /// therefore never produce this event.
+    ReconnectAbandoned {
+        /// How many reconnection attempts were made in this episode. `0`
+        /// means the policy allowed no attempts at all.
+        attempts: u32,
+        /// Reason text of the final disconnect, in the same ambient-log-safe
+        /// form as [`Disconnected`](Self::Disconnected)'s `reason`.
+        last_reason: Option<String>,
     },
 
     /// An inbound server frame could not be decoded into a
@@ -575,6 +626,8 @@ impl std::fmt::Debug for SignalFishEvent {
         f.write_str(match self {
             Self::Connected => "Connected",
             Self::Disconnected { .. } => "Disconnected",
+            Self::Reconnecting { .. } => "Reconnecting",
+            Self::ReconnectAbandoned { .. } => "ReconnectAbandoned",
             Self::DecodeFailed { .. } => "DecodeFailed",
             Self::ProtocolViolation { .. } => "ProtocolViolation",
             Self::Authenticated { .. } => "Authenticated",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,6 +173,9 @@ pub use client::{
     ClientSnapshot, ClientStats, GameDataDelivery, JoinRoomParams, ProtocolViolationPolicy,
     RoomRole, SignalFishClient, SignalFishConfig,
 };
+
+#[cfg(feature = "tokio-runtime")]
+pub use client::ReconnectPolicy;
 pub use client_api::SignalFishClientApi;
 pub use error::{SignalFishError, TokenBindingFailure};
 pub use error_codes::ErrorCode;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,11 +171,8 @@ pub const PROTOCOL_VERSION: u16 = 3;
 // Re-export primary types for ergonomic imports.
 pub use client::{
     ClientSnapshot, ClientStats, GameDataDelivery, JoinRoomParams, ProtocolViolationPolicy,
-    RoomRole, SignalFishClient, SignalFishConfig,
+    ReconnectPolicy, RoomRole, SignalFishClient, SignalFishConfig,
 };
-
-#[cfg(feature = "tokio-runtime")]
-pub use client::ReconnectPolicy;
 pub use client_api::SignalFishClientApi;
 pub use error::{SignalFishError, TokenBindingFailure};
 pub use error_codes::ErrorCode;

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -668,7 +668,7 @@ impl std::fmt::Debug for ReconnectedPayload {
 
 /// Payload for the `SpectatorJoined` server message.
 /// Boxed in `ServerMessage` to reduce enum size.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct SpectatorJoinedPayload {
     pub room_id: RoomId,
     pub room_code: String,
@@ -679,6 +679,15 @@ pub struct SpectatorJoinedPayload {
     pub lobby_state: LobbyState,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reason: Option<SpectatorStateChangeReason>,
+}
+
+impl std::fmt::Debug for SpectatorJoinedPayload {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // A room code is join-capability knowledge (a lobby-by-code
+        // credential), so the ambient `Debug` path redacts it exactly like
+        // the other room-baseline payloads.
+        f.write_str("SpectatorJoinedPayload { <credentials redacted> }")
+    }
 }
 
 /// Payload for the `SessionPlan` server message (protocol v3).

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -265,6 +265,55 @@ pub trait Transport {
     }
 }
 
+/// Forwarding impl so owned trait objects can flow through the same driver
+/// plumbing as concrete transports — in particular the reconnect policy's
+/// `Box<dyn Transport + Send>` factory products and the async loop's initial
+/// transport, which must share one type across reconnection rounds.
+impl Transport for Box<dyn Transport + Send> {
+    fn begin_poll_cycle(&mut self) {
+        (**self).begin_poll_cycle();
+    }
+
+    fn poll_send(
+        &mut self,
+        cx: &mut Context<'_>,
+        frame: &mut Option<TransportFrame>,
+    ) -> Poll<Result<(), SignalFishError>> {
+        (**self).poll_send(cx, frame)
+    }
+
+    fn poll_recv(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<TransportFrame, SignalFishError>>> {
+        (**self).poll_recv(cx)
+    }
+
+    fn poll_close(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), SignalFishError>> {
+        (**self).poll_close(cx)
+    }
+
+    fn abort(&mut self) {
+        (**self).abort();
+    }
+
+    fn is_ready(&self) -> bool {
+        (**self).is_ready()
+    }
+
+    fn close_info(&self) -> Option<TransportCloseInfo> {
+        (**self).close_info()
+    }
+
+    fn diagnostics(&self) -> TransportDiagnostics {
+        (**self).diagnostics()
+    }
+
+    fn max_frame_hint(&self) -> Option<usize> {
+        (**self).max_frame_hint()
+    }
+}
+
 /// Gate a synchronous backend send without transferring caller ownership until
 /// the backend accepts the borrowed frame.
 #[cfg(any(test, target_os = "emscripten"))]

--- a/src/webrtc.rs
+++ b/src/webrtc.rs
@@ -31,6 +31,21 @@ use crate::signal::PeerSignal;
 /// methods to drive connection setup, then repeatedly calls [`poll`](Self::poll)
 /// to drain outbound signals, connection-state changes, and received data. All
 /// methods are non-blocking; do real I/O inside [`poll`](Self::poll).
+///
+/// # Panic boundary
+///
+/// A panicking driver method unwinds through [`MeshController::recv`] into the
+/// consumer's task (the controller holds no panic guard), leaving the mesh view
+/// partially updated. This mirrors the `Transport` seam's contract-violation
+/// class; drivers must not panic on contract-compliant input.
+///
+/// # Duplicate output
+///
+/// Duplicate [`DriverEvent::Connected`] / [`DriverEvent::Disconnected`]
+/// outputs for an already-connected (or already-disconnected) peer surface as
+/// duplicate [`MeshEvent`]s to the consumer; only the wire's
+/// `TransportStatus` edge is deduplicated to one latest-state transition.
+/// Drivers should emit each edge once.
 pub trait WebRtcDriver {
     /// Apply the ICE (STUN/TURN) servers for subsequent connections. Called when
     /// a `SessionPlan` (or ICE pre-gather on join) provides them.
@@ -63,8 +78,14 @@ pub trait WebRtcDriver {
     /// Tear down the connection to `peer` (the peer left or was re-planned away).
     fn disconnect(&mut self, peer: PlayerId);
 
-    /// Drain the next driver output, or `None` when idle. The controller calls
-    /// this in a loop until it returns `None`.
+    /// Drain the next driver output, or `None` when idle.
+    ///
+    /// The controller drains opportunistically rather than to exhaustion: it
+    /// stops at the first surfacing event (a connection edge or data message)
+    /// or at a buffered signal, so controller-to-driver calls
+    /// ([`connect`](Self::connect), [`on_signal`](Self::on_signal), …) can
+    /// interleave between two `poll` calls. Do not assume the queue is empty
+    /// when the next driver method arrives.
     ///
     /// Implementations must guarantee forward progress toward `None`: every
     /// call must either return an event or retire it internally. Returning
@@ -75,10 +96,13 @@ pub trait WebRtcDriver {
     /// it has output ready to be polled — e.g. a trickled ICE candidate or
     /// inbound data became available *between* signaling events.
     ///
-    /// A driver that wakes on readiness is pumped on demand, so trickle ICE and
-    /// data surface immediately instead of waiting up to one pump interval. The
-    /// default implementation ignores the waker; such drivers are still pumped on
-    /// every signaling event and on the controller's periodic timer (see
+    /// Called exactly once, from [`MeshController::start`], before any other
+    /// driver method; the waker stays bound to that controller instance for
+    /// its lifetime. A driver that wakes on readiness is pumped on demand, so
+    /// trickle ICE and data surface immediately instead of waiting up to one
+    /// pump interval. The default implementation ignores the waker; such
+    /// drivers are still pumped on every signaling event and on the
+    /// controller's periodic timer (see
     /// [`MeshController::with_pump_interval`]), so this is purely a latency
     /// optimization and entirely optional to implement.
     #[cfg(feature = "tokio-runtime")]
@@ -357,7 +381,8 @@ mod controller {
         }
 
         /// Override the interval at which the driver is pumped for trickle ICE /
-        /// data between signaling events. Defaults to 20ms.
+        /// data between signaling events. Defaults to 20ms; values below 1ms
+        /// clamp to a 1ms floor.
         #[must_use]
         pub fn with_pump_interval(mut self, interval: Duration) -> Self {
             self.pump_interval = interval.max(Duration::from_millis(1));
@@ -385,6 +410,16 @@ mod controller {
         /// method returns a signaling [`SignalFishEvent::Disconnected`], that
         /// same teardown has already happened before the event reaches the
         /// caller, and the next call returns `None`.
+        ///
+        /// # Plan catch-up
+        ///
+        /// Until `recv` has observed the client's current session-plan
+        /// revision, it surfaces **only** signaling events: driver output is
+        /// not pumped during catch-up. Driver events earned before a room
+        /// teardown (for example a `Connected` edge queued just before the
+        /// signaling `Disconnected`) are therefore neither surfaced nor
+        /// relayed once the terminal boundary passes — the same deliberate
+        /// discard that applies to signals on a fused controller.
         ///
         /// # Cancel safety
         ///

--- a/src/webrtc.rs
+++ b/src/webrtc.rs
@@ -406,12 +406,22 @@ mod controller {
         }
 
         /// Receive the next high-level mesh event. Returns `None` once the
-        /// underlying transport closes. At that boundary the controller clears
-        /// its session, disconnects every known driver peer, and becomes fused:
-        /// later calls also return `None` without pumping the driver. When this
-        /// method returns a signaling [`SignalFishEvent::Disconnected`], that
-        /// same teardown has already happened before the event reaches the
-        /// caller, and the next call returns `None`.
+        /// underlying event stream ends (the transport loop exited — client
+        /// shutdown, dropped handle, or an exhausted reconnect policy). At
+        /// that boundary the controller clears its session, disconnects every
+        /// known driver peer, and becomes fused: later calls also return
+        /// `None` without pumping the driver. When this method returns a
+        /// signaling [`SignalFishEvent::Disconnected`], the data plane of
+        /// that connection has already been cleared (every known peer
+        /// disconnected, pending work dropped) before the event reaches the
+        /// caller.
+        ///
+        /// A configured
+        /// [`ReconnectPolicy`](crate::ReconnectPolicy) continues the same
+        /// client and event stream across a `Disconnected`: the controller
+        /// keeps draining and rebuilds its view when the fresh connection's
+        /// `Reconnected`/`SessionPlan` events arrive, so mesh consumers keep
+        /// calling `recv` instead of treating the disconnect as end-of-stream.
         ///
         /// # Plan catch-up
         ///
@@ -620,7 +630,7 @@ mod controller {
                         self.disconnect_peer(peer.id);
                     }
                 }
-                SignalFishEvent::Disconnected { .. } => self.terminate(),
+                SignalFishEvent::Disconnected { .. } => self.clear_data_plane(),
                 SignalFishEvent::RoomJoined { ice_servers, .. } if !ice_servers.is_empty() => {
                     self.driver.set_ice_servers(ice_servers);
                 }
@@ -656,13 +666,13 @@ mod controller {
             self.mark_disconnected(peer);
         }
 
-        /// End the controller's data plane exactly once without emitting a
-        /// room-scoped transport-status edge after signaling has terminated.
-        fn terminate(&mut self) {
-            if self.terminated {
-                return;
-            }
-            self.terminated = true;
+        /// Tear down the data plane of the current connection: clear the
+        /// mesh view, disconnect every known driver peer, and drop pending
+        /// fenced work. Unlike [`Self::terminate`], the controller keeps
+        /// draining: a configured reconnect policy continues the same client
+        /// and event stream, and the next connection's `Reconnected`/`Session
+        /// Plan` rebuilds the view.
+        fn clear_data_plane(&mut self) {
             self.pending_signal = None;
             self.pending_transport_status = None;
             self.connected_peers.clear();
@@ -670,6 +680,16 @@ mod controller {
             for peer in std::mem::take(&mut self.known_peers) {
                 self.driver.disconnect(peer.id);
             }
+        }
+
+        /// End the controller's data plane exactly once without emitting a
+        /// room-scoped transport-status edge after signaling has terminated.
+        fn terminate(&mut self) {
+            if self.terminated {
+                return;
+            }
+            self.terminated = true;
+            self.clear_data_plane();
         }
 
         /// Ensure the driver holds the server's current offerer role for `peer`.
@@ -2686,7 +2706,85 @@ mod tests {
         mesh.shutdown().await;
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
+    async fn mesh_controller_keeps_draining_across_reconnection_rounds() {
+        // A configured ReconnectPolicy continues the same client after a
+        // `Disconnected`; the controller must keep draining the shared event
+        // stream (clearing the data plane of the dead connection) instead of
+        // fusing and starving the transport loop on an undrained channel.
+        let driver = SharedDriver::default();
+        let (transport1, _sent1) = MockTransport::new(vec![
+            Some(Ok(authed())),
+            Some(Ok(protocol_info_v3())),
+            // Peer close ends round 1.
+            None,
+        ]);
+        let (transport2, _sent2) = MockTransport::new(vec![Some(Ok(authed()))]);
+        let pool: std::sync::Arc<std::sync::Mutex<std::collections::VecDeque<_>>> =
+            std::sync::Arc::new(std::sync::Mutex::new(std::collections::VecDeque::from([
+                (Box::new(transport2) as Box<dyn crate::transport::Transport + Send>),
+            ])));
+        let factory_pool = std::sync::Arc::clone(&pool);
+        let policy = crate::client::ReconnectPolicy::new(move || {
+            factory_pool
+                .lock()
+                .unwrap()
+                .pop_front()
+                .expect("round-2 transport scripted")
+        })
+        .with_max_attempts(2)
+        .with_initial_backoff(std::time::Duration::from_millis(10));
+        let config = SignalFishConfig::new("app").with_reconnect_policy(policy);
+        let mut mesh = MeshController::start(transport1, config, driver.clone());
+        wait_for_authenticated(&mut mesh).await;
+
+        let signaling_sequence = async {
+            let mut sequence = Vec::new();
+            while let Some(event) = mesh.recv().await {
+                if let MeshEvent::Signaling(signaling) = event {
+                    let name = match *signaling {
+                        SignalFishEvent::ProtocolInfo(_) => "ProtocolInfo",
+                        SignalFishEvent::Disconnected { .. } => "Disconnected",
+                        SignalFishEvent::Reconnecting { .. } => "Reconnecting",
+                        SignalFishEvent::Connected => "Connected",
+                        SignalFishEvent::Authenticated { .. } => "Authenticated",
+                        _ => "other",
+                    };
+                    if name != "other" {
+                        sequence.push(name);
+                    }
+                    if sequence.len() == 5 {
+                        break;
+                    }
+                }
+            }
+            sequence
+        };
+        let sequence = tokio::time::timeout(std::time::Duration::from_secs(5), signaling_sequence)
+            .await
+            .expect("controller must keep draining across the reconnection round");
+        assert_eq!(
+            sequence,
+            [
+                "ProtocolInfo",
+                "Disconnected",
+                "Reconnecting",
+                "Connected",
+                "Authenticated"
+            ],
+            "the controller must surface the full reconnect sequence, not fuse on Disconnected"
+        );
+        // The controller is still live: it parks on the idle stream instead
+        // of fusing (a fused controller would return `None` immediately).
+        let park = tokio::time::timeout(std::time::Duration::from_millis(50), mesh.recv()).await;
+        assert!(
+            park.is_err(),
+            "a live controller parks on the drained stream; a fused one returns None"
+        );
+        mesh.shutdown().await;
+    }
+
+    #[tokio::test(start_paused = true)]
     async fn plain_drop_aborts_signaling_but_never_disconnects_driver_peers() {
         // Plain `Drop` (no `shutdown()`) runs the signaling transport's abort
         // fallback exactly once and never calls driver `Disconnect` — graceful
@@ -3955,7 +4053,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn disconnected_event_is_immediately_terminal_before_the_next_recv() {
+    async fn disconnected_event_clears_the_data_plane_before_the_next_recv() {
         let peer = uuid(54);
         let driver = SharedDriver::default();
         let (transport, _sent) = MockTransport::new_in_room(vec![
@@ -3989,20 +4087,15 @@ mod tests {
                 if matches!(**event, SignalFishEvent::Disconnected { .. })
         ));
 
-        // Returning Disconnected is itself the terminal boundary: callers do
-        // not need another recv() to trigger cleanup or suppress data-plane I/O.
+        // Returning Disconnected already cleared the dead connection's data
+        // plane: callers do not need another recv() for the teardown. The
+        // controller itself only fuses at end-of-stream — a configured
+        // reconnect policy continues the same stream, so the controller keeps
+        // draining (pinned by
+        // `mesh_controller_keeps_draining_across_reconnection_rounds`).
         assert!(mesh.session().peers().is_empty());
         assert!(mesh.session().generation().is_none());
         assert!(mesh.session().transport().is_none());
-        mesh.send_to(peer, b"stale-after-disconnected");
-        let polls_at_terminal = count_calls(&driver, |call| matches!(call, DriverCall::Poll));
-
-        driver.emit_and_wake(DriverEvent::Data {
-            peer,
-            generation: Some(uuid(12)),
-            data: vec![7],
-        });
-        assert!(mesh.recv().await.is_none());
 
         let calls = driver.calls();
         assert_eq!(
@@ -4013,19 +4106,19 @@ mod tests {
             1,
             "Disconnected must tear down each known peer exactly once"
         );
-        assert_eq!(
-            count_calls(&driver, |call| matches!(call, DriverCall::Poll)),
-            polls_at_terminal,
-            "a fused controller must not poll its driver after Disconnected"
-        );
-        assert!(
-            !calls.iter().any(|call| matches!(
-                call,
-                DriverCall::Send(id, data)
-                    if *id == peer && data == b"stale-after-disconnected"
-            )),
-            "send_to must not forward data after Disconnected"
-        );
+        // Driver output for the dead connection's generation is fenced: the
+        // session view is cleared, so the stale Data never surfaces, and the
+        // next scripted event (or the stream end reached below) is what the
+        // consumer sees next.
+        driver.emit_and_wake(DriverEvent::Data {
+            peer,
+            generation: Some(uuid(12)),
+            data: vec![7],
+        });
+        // The scripted stream ended with the Disconnected, so the controller
+        // reaches end-of-stream here and fuses.
+        assert!(mesh.recv().await.is_none());
+        assert!(mesh.recv().await.is_none(), "fused recv stays None");
     }
 
     #[tokio::test]

--- a/src/webrtc.rs
+++ b/src/webrtc.rs
@@ -36,8 +36,9 @@ use crate::signal::PeerSignal;
 ///
 /// A panicking driver method unwinds through [`MeshController::recv`] into the
 /// consumer's task (the controller holds no panic guard), leaving the mesh view
-/// partially updated. This mirrors the `Transport` seam's contract-violation
-/// class; drivers must not panic on contract-compliant input.
+/// partially updated — the same contract-violation policy as the `Transport`
+/// seam, though mechanically the panic surfaces in the consumer's task rather
+/// than a spawned loop. Drivers must not panic on contract-compliant input.
 ///
 /// # Duplicate output
 ///
@@ -81,11 +82,12 @@ pub trait WebRtcDriver {
     /// Drain the next driver output, or `None` when idle.
     ///
     /// The controller drains opportunistically rather than to exhaustion: it
-    /// stops at the first surfacing event (a connection edge or data message)
-    /// or at a buffered signal, so controller-to-driver calls
-    /// ([`connect`](Self::connect), [`on_signal`](Self::on_signal), …) can
-    /// interleave between two `poll` calls. Do not assume the queue is empty
-    /// when the next driver method arrives.
+    /// stops at the first surfacing event (a connection edge or data
+    /// message), at a relay the transport refused (the signal stays buffered
+    /// as a fence), or when `poll` returns `None`, so controller-to-driver
+    /// calls ([`connect`](Self::connect), [`on_signal`](Self::on_signal), …)
+    /// can interleave between two `poll` calls. Do not assume the queue is
+    /// empty when the next driver method arrives.
     ///
     /// Implementations must guarantee forward progress toward `None`: every
     /// call must either return an event or retire it internally. Returning

--- a/tests/polling_parity_tests.rs
+++ b/tests/polling_parity_tests.rs
@@ -1945,6 +1945,16 @@ fn canonical_event(event: &SignalFishEvent) -> String {
         SignalFishEvent::RoomOperationFailed { reason, error_code } => {
             event_fields!("RoomOperationFailed", reason, error_code)
         }
+        SignalFishEvent::Reconnecting {
+            attempt,
+            next_backoff,
+        } => {
+            event_fields!("Reconnecting", attempt, next_backoff)
+        }
+        SignalFishEvent::ReconnectAbandoned {
+            attempts,
+            last_reason,
+        } => event_fields!("ReconnectAbandoned", attempts, last_reason),
     }
 }
 

--- a/tests/protocol_tests.rs
+++ b/tests/protocol_tests.rs
@@ -2688,6 +2688,7 @@ fn error_code_display_returns_description() {
 #[test]
 fn debug_redacts_credentials_signaling_and_application_payloads_transitively() {
     const SECRETS: &[&str] = &[
+        "room-secret",
         "reconnect-secret",
         "relay-secret",
         "unity-key-secret",
@@ -2788,12 +2789,26 @@ fn debug_redacts_credentials_signaling_and_application_payloads_transitively() {
         sender_watermarks: vec![],
         reconnection_token: Some("reconnect-secret".into()),
     };
+    let spectator_joined = SpectatorJoinedPayload {
+        room_id: test_uuid(4),
+        room_code: "room-secret".into(),
+        spectator_id: test_uuid(6),
+        game_name: "game".into(),
+        current_players: vec![],
+        current_spectators: vec![],
+        lobby_state: LobbyState::Waiting,
+        reason: None,
+    };
+    let join_params =
+        signal_fish_client::JoinRoomParams::new("game", "player").with_room_code("room-secret");
 
     for (debug, safe_marker) in [
         (format!("{relay:?}"), "ConnectionInfo::Relay"),
         (format!("{ice:?}"), "IceServer"),
         (format!("{joined:?}"), "RoomJoinedPayload"),
         (format!("{reconnected:?}"), "ReconnectedPayload"),
+        (format!("{spectator_joined:?}"), "SpectatorJoinedPayload"),
+        (format!("{join_params:?}"), "JoinRoomParams"),
         (format!("{:?}", ClientMessage::Ping), "Ping"),
         (format!("{:?}", ServerMessage::Pong), "Pong"),
     ] {
@@ -2812,6 +2827,8 @@ fn debug_redacts_credentials_signaling_and_application_payloads_transitively() {
         format!("{plan:?}"),
         format!("{joined:?}"),
         format!("{reconnected:?}"),
+        format!("{spectator_joined:?}"),
+        format!("{join_params:?}"),
         format!(
             "{:?}",
             ClientMessage::Reconnect {

--- a/tools/perf-lab/src/workloads.rs
+++ b/tools/perf-lab/src/workloads.rs
@@ -517,6 +517,11 @@ impl EventAccumulator {
             SignalFishEvent::SpectatorDisconnected { .. } => 33,
             SignalFishEvent::Error { .. } => 34,
             SignalFishEvent::RoomOperationFailed { .. } => 35,
+            // The perf-lab fixtures never configure a reconnect policy, so
+            // these never fire; appended (not inserted) to keep every pinned
+            // event index stable.
+            SignalFishEvent::Reconnecting { .. } => 36,
+            SignalFishEvent::ReconnectAbandoned { .. } => 37,
         };
         let count = self
             .counts

--- a/tools/stateful-campaign/src/run.rs
+++ b/tools/stateful-campaign/src/run.rs
@@ -154,6 +154,8 @@ pub fn event_name(ev: &SignalFishEvent) -> &'static str {
         SignalFishEvent::NewSpectatorJoined { .. } => "NewSpectatorJoined",
         SignalFishEvent::SpectatorDisconnected { .. } => "SpectatorDisconnected",
         SignalFishEvent::Error { .. } => "Error",
+        SignalFishEvent::Reconnecting { .. } => "Reconnecting",
+        SignalFishEvent::ReconnectAbandoned { .. } => "ReconnectAbandoned",
     }
 }
 
@@ -1364,6 +1366,14 @@ impl Oracle {
                 phase(self.authenticated)?;
             }
             SignalFishEvent::Pong | SignalFishEvent::Error { .. } => {}
+            // The campaign drives the polling client, which is caller-driven
+            // by design and can never configure a reconnect policy.
+            SignalFishEvent::Reconnecting { .. } | SignalFishEvent::ReconnectAbandoned { .. } => {
+                return Err(format!(
+                    "impossible reconnect-policy event `{}`",
+                    event_name(ev)
+                ));
+            }
         }
         // Game-data suppression under quarantine.
         if oracle_strict()


### PR DESCRIPTION
## Why

Recovering from a dropped connection today is fully manual: rebuild a transport, start a new client, re-authenticate, and re-issue the reconnect command yourself — right when a game is least able to handle the ceremony (issue #223, the top open usability item). This PR automates that recovery behind an opt-in policy, and lands paranoid-audit round 44 alongside it.

## What

**Automatic reconnection (opt-in).** Add a `ReconnectPolicy` to your config and, after a connection dies for a reason you didn't cause (not shutdown, not a protocol violation), the client itself:

1. delivers the usual `Disconnected` event,
2. waits a deterministic exponential backoff (`Reconnecting` event tells you the schedule),
3. opens a fresh transport from your factory and re-authenticates, and
4. if you were in a player room, re-issues the server-tokened `reconnect` for you.

Exhausted attempts end the client with a `ReconnectAbandoned` event. Voluntarily leaving a room is respected — the client never rejoins a room you chose to leave. No jitter by design (determinism is pinned); the polling client stays caller-driven.

Both new event variants are semver-breaking (exhaustive enum), as is the new config field — the changelog carries migration hints. The bounded-teardown guarantee is preserved: a consumer that stops draining delays each retry by at most `shutdown_timeout` instead of parking the client.

**Round-44 audits.**
- Ambient-log boundary re-sweep (first since round 10): no leaks; two room-code `Debug` redaction drifts fixed (`JoinRoomParams` now length-only, `SpectatorJoinedPayload` fully opaque — both breaking for Debug-text matching only; wire bytes unchanged).
- First out-of-tree `WebRtcDriver` implementor probe: the naive-driver handshake works end to end; six documentation fixes (drain contract, panic boundary, waker timing, catch-up behavior, duplicate edges, pump floor).

## Verification

- fmt / clippy (`-D warnings`) clean; **1137 tests pass, 0 failed** (all features) including 11 new paused-clock reconnect tests, red/green-proven via injected defects.
- Six sparse-feature clippy lanes warn-free; perf-lab ledger/allocation pins unbroken; all repository guard scripts and strict docs rendering pass.
- Review loop: two hostile reviewers + a convergence verifier; every finding (including two Majors) fixed and re-verified.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core async connection lifecycle, event enum, and mesh teardown semantics; mistakes could cause duplicate reconnects, stuck loops, or incorrect room recovery, though behavior is heavily tested and opt-in by default.
> 
> **Overview**
> Adds **opt-in automatic reconnection** for the async `SignalFishClient`: `ReconnectPolicy` on `SignalFishConfig` (via `.with_reconnect_policy`) rebuilds transports from a caller factory, uses deterministic exponential backoff, re-authenticates, and—when the prior connection ended in a **player** room—issues the directed `reconnect` automatically. New synthetic events **`Reconnecting`** and **`ReconnectAbandoned`** surface the schedule and terminal failure; shutdown, dropped handles, `ProtocolViolationPolicy::Disconnect`, and voluntary `leave_room` are never retried.
> 
> The transport loop is refactored into **reconnection rounds** (`connection_round`, shared `LoopState`); `ClientCore` can **retain** player-room token context across disconnect when a policy is configured. **`impl Transport for Box<dyn Transport + Send>`** lets factory-built transports share the same driver type.
> 
> **`MeshController`** now clears the data plane on `Disconnected` but keeps draining when a reconnect policy continues the same client (only true stream end fuses the controller).
> 
> **Breaking / hygiene:** exhaustive matches need the two new events; struct literals need `reconnect_policy: None`. **`JoinRoomParams`** and **`SpectatorJoinedPayload`** `Debug` no longer leak room codes (length-only or fully opaque). Docs/changelog cover manual vs automatic recovery, `WebRtcDriver` drain/panic contracts, and related mesh behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42e048bdfc2964c13f15314a0291eb732ab20721. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->