### PR TITLE
First-class lazy WebSocket constructors; round-46 audit fixes

### DIFF
--- a/.llm/skills/transport-abstraction/SKILL.md
+++ b/.llm/skills/transport-abstraction/SKILL.md
@@ -194,7 +194,9 @@ logical detach; a later `abort` or `Drop` may retry the failed cleanup.
 `is_ready()` is cheap and non-blocking. The default `true` fits transports
 whose constructor completes the handshake. Async-handshake transports return
 `false` until ready; both clients defer their synthetic `Connected` event.
-Once true, readiness remains true for that physical connection. If readiness
+Once true, readiness remains true for that physical connection. A transport
+that fused terminally before readiness (a failed deferred handshake) stays
+`false` while its polls deliver the terminal error or EOF. If readiness
 changes while the async driver is blocked, wake a waker registered by
 `poll_send` or `poll_recv`, because `is_ready()` cannot register one itself.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,11 +41,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   policy, secret reconnection tokens, rotation guidance, and log-hygiene
   rules.
 - Added an `auto_reconnect` example: a complete, compiling auto-reconnection
-  client including the lazy WebSocket transport wrapper the
-  `ReconnectPolicy` factory needs (the built-in `WebSocketTransport`
-  connects asynchronously and cannot be constructed inside the synchronous
-  factory), plus the same corrected pattern in the reconnect rustdoc and
+  client showing the `ReconnectPolicy` factory pattern for the built-in
+  `WebSocketTransport`, plus the same pattern in the reconnect rustdoc and
   guide.
+- `WebSocketTransport::connect_lazy(url)` and `connect_lazy_with_timeout`:
+  first-class lazy constructors for the `ReconnectPolicy` factory — the
+  handshake starts on the first driver poll instead of at construction.
+  They declare the default 8 MiB inbound frame bound immediately (so both
+  drivers enforce it from the first round), pin the disabled token-binding
+  profile, and fail a stalled handshake as a retryable `Timeout` after 10
+  seconds (configurable) instead of hanging forever; the example ships this
+  constructor instead of a hand-written lazy wrapper.
 
 ### Changed
 
@@ -68,6 +74,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The send-failure teardown drain no longer applies frames served by a
+  transport that never reported readiness: such frames are a backend
+  contract violation (the main connection loops already tear the round down
+  on them), so both drivers now discard them instead of emitting protocol
+  events and mutating state from a hostile backend during teardown. The
+  polling driver also re-samples transport readiness after a send failure,
+  so a round whose deferred (`connect_lazy`) handshake completed inside the
+  failing `poll_send` still emits `Connected` and delivers the backend's
+  farewell frames exactly like the async driver.
 - Documentation accuracy: `docs/events.md` now counts the 38 (not 36)
   `SignalFishEvent` variants and documents the scripted-peer join-snapshot
   contract (unique local player entry, v3 `epoch`/`seq` pairing, v2

--- a/docs/client.md
+++ b/docs/client.md
@@ -608,11 +608,12 @@ the transport-and-authentication core of it with a
 
 ```rust,ignore
 // The factory returns a fresh, *unconnected* transport per attempt and must
-// not block. WebSocketTransport::connect is asynchronous, so wrap it in a
-// lazy transport that connects on first poll — see
-// examples/auto_reconnect.rs for a complete, compiling implementation.
+// not block. WebSocketTransport::connect_lazy exists exactly for this: it
+// returns immediately and starts the handshake on the first driver poll,
+// with a built-in 10-second handshake deadline so a server that never
+// completes the upgrade is a retryable failure instead of a hang.
 let config = SignalFishConfig::new("mb_app_abc123").with_reconnect_policy(
-    ReconnectPolicy::new(move || Box::new(LazyWebSocketTransport::new(url.clone()))),
+    ReconnectPolicy::new(move || Box::new(WebSocketTransport::connect_lazy(url.clone()))),
 );
 
 let (mut client, events) = SignalFishClient::start(transport, config);

--- a/examples/auto_reconnect.rs
+++ b/examples/auto_reconnect.rs
@@ -3,15 +3,11 @@
 //! Opt-in reconnection ([`SignalFishConfig::with_reconnect_policy`]) rebuilds
 //! the connection from a caller-supplied **factory**: a synchronous function
 //! that returns a fresh, *unconnected* transport per attempt. The built-in
-//! [`WebSocketTransport`] connects asynchronously, so it cannot be constructed
-//! inside the factory directly — this example ships the small lazy wrapper
-//! that bridges the two: it defers `WebSocketTransport::connect` until the
-//! driver first polls the transport.
-//!
-//! Use this example as a template whenever you want
-//!
-//! - **automatic reconnect with backoff** after retryable disconnects, and
-//! - the built-in WebSocket transport (no hand-written framing).
+//! [`WebSocketTransport::connect_lazy`] constructor exists exactly for this:
+//! it returns the transport immediately and starts the WebSocket handshake on
+//! the first driver poll, with a built-in 10-second handshake deadline so a
+//! server that never completes the upgrade is observed as a retryable
+//! failure instead of a hang.
 //!
 //! ## Running
 //!
@@ -32,198 +28,13 @@
 //! `join_room`-on-`Authenticated` call in that configuration, or the seat is
 //! requested twice per round.
 
-use std::future::Future;
-use std::pin::Pin;
-use std::task::{Context, Poll};
-
-use signal_fish_client::transport::TransportFrame;
 use signal_fish_client::{
-    JoinRoomParams, ReconnectPolicy, SignalFishClient, SignalFishConfig, SignalFishError,
-    SignalFishEvent, Transport, WebSocketTransport,
+    JoinRoomParams, ReconnectPolicy, SignalFishClient, SignalFishConfig, SignalFishEvent,
+    WebSocketTransport,
 };
 
 /// Default server URL when `SIGNAL_FISH_URL` is not set.
 const DEFAULT_URL: &str = "ws://localhost:3536/v2/ws";
-
-/// Handshake deadline for the lazy connect. Without it, a peer that accepts
-/// TCP but never completes the upgrade parks the attempt in `Pending`
-/// forever, and a reconnect policy never observes a failure to retry.
-const HANDSHAKE_DEADLINE: std::time::Duration = std::time::Duration::from_secs(10);
-
-// ─────────────────────────────────────────────────────────────────────
-// Step 1: A lazy WebSocket transport for the reconnect factory
-// ─────────────────────────────────────────────────────────────────────
-
-/// A [`WebSocketTransport`] that connects on first use.
-///
-/// The reconnect factory must return a transport *immediately* and must not
-/// block, but a WebSocket handshake is asynchronous. This wrapper stores the
-/// URL and starts the handshake the first time the client polls for I/O.
-/// Until the handshake completes the wrapper reports `is_ready() == false`
-/// and defers every send (`Pending` keeps the caller's frame intact), which
-/// is exactly the pre-ready contract the drivers already implement.
-enum LazyWebSocketTransport {
-    /// No handshake started yet; the URL is connected on first poll.
-    Idle { url: String },
-    /// The handshake future is being polled to completion.
-    Connecting(Pin<Box<dyn Future<Output = Result<WebSocketTransport, SignalFishError>> + Send>>),
-    /// The handshake finished; all operations forward to the real transport.
-    Ready(Box<WebSocketTransport>),
-    /// The handshake failed. The stored error is delivered once, then the
-    /// wrapper stays terminal: the driver tears the round down on the first
-    /// error, and a configured reconnect policy starts the next attempt from
-    /// a fresh value.
-    Failed(Option<SignalFishError>),
-    /// [`Transport::abort`] ran; no further work is possible.
-    Aborted,
-}
-
-impl LazyWebSocketTransport {
-    fn new(url: String) -> Self {
-        Self::Idle { url }
-    }
-
-    /// Start the handshake if it has not started yet.
-    fn ensure_connecting(&mut self) {
-        if let Self::Idle { url } = self {
-            // The future must own the URL: the stored future outlives this
-            // `&mut self` call. The deadline turns a black-holed route or a
-            // TCP peer that never finishes the upgrade into a terminal
-            // error, so a reconnect policy can count the attempt and apply
-            // backoff instead of waiting forever.
-            let url = url.clone();
-            *self = Self::Connecting(Box::pin(async move {
-                WebSocketTransport::connect_with_timeout(&url, HANDSHAKE_DEADLINE).await
-            }));
-        }
-    }
-
-    /// Drive a pending handshake to completion, if one is running.
-    ///
-    /// `Ready(Ok(()))` always leaves the wrapper in the `Ready` state.
-    fn poll_connect(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), SignalFishError>> {
-        if let Self::Connecting(future) = self {
-            match future.as_mut().poll(cx) {
-                Poll::Ready(Ok(transport)) => {
-                    *self = Self::Ready(Box::new(transport));
-                }
-                Poll::Ready(Err(error)) => {
-                    *self = Self::Failed(Some(error));
-                }
-                Poll::Pending => return Poll::Pending,
-            }
-        }
-        match self {
-            Self::Ready(_) => Poll::Ready(Ok(())),
-            // Deliver the handshake error once; later polls observe the
-            // already-terminated connection.
-            Self::Failed(error) => Poll::Ready(Err(error
-                .take()
-                .unwrap_or(SignalFishError::TransportClosed))),
-            _ => Poll::Pending,
-        }
-    }
-}
-
-impl Transport for LazyWebSocketTransport {
-    fn poll_send(
-        &mut self,
-        cx: &mut Context<'_>,
-        frame: &mut Option<TransportFrame>,
-    ) -> Poll<Result<(), SignalFishError>> {
-        self.ensure_connecting();
-        match self.poll_connect(cx) {
-            // The frame stays in the caller's slot: the ownership-transfer
-            // point is backend acceptance, which has not happened yet.
-            Poll::Pending => Poll::Pending,
-            Poll::Ready(Err(error)) => Poll::Ready(Err(error)),
-            Poll::Ready(Ok(())) => match self {
-                Self::Ready(transport) => transport.poll_send(cx, frame),
-                // Unreachable: poll_connect only reports Ok once the wrapper
-                // reached (or already sat in) the Ready state.
-                _ => Poll::Pending,
-            },
-        }
-    }
-
-    fn poll_recv(
-        &mut self,
-        cx: &mut Context<'_>,
-    ) -> Poll<Option<Result<TransportFrame, SignalFishError>>> {
-        self.ensure_connecting();
-        match self.poll_connect(cx) {
-            Poll::Pending => Poll::Pending,
-            Poll::Ready(Err(error)) => Poll::Ready(Some(Err(error))),
-            Poll::Ready(Ok(())) => match self {
-                Self::Ready(transport) => transport.poll_recv(cx),
-                _ => Poll::Ready(None),
-            },
-        }
-    }
-
-    fn poll_close(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), SignalFishError>> {
-        match self {
-            // Nothing was ever connected; a close is trivially complete.
-            Self::Idle { .. } => Poll::Ready(Ok(())),
-            Self::Connecting(_) => {
-                // Cancel the handshake and report the close as complete; the
-                // socket, if it races to completion underneath us, is dropped
-                // with the cancelled future.
-                *self = Self::Aborted;
-                Poll::Ready(Ok(()))
-            }
-            Self::Ready(transport) => transport.poll_close(cx),
-            Self::Failed(_) | Self::Aborted => Poll::Ready(Ok(())),
-        }
-    }
-
-    fn abort(&mut self) {
-        // Required to be prompt, non-blocking, non-panicking, and idempotent.
-        // Delegate to the connected inner transport's own abort (equally
-        // prompt and idempotent) so it releases its socket AND retains its
-        // close metadata: the driver may still call `close_info()` after
-        // `abort` to attribute the disconnect. A pending handshake is
-        // cancelled by dropping the future; there is no connection whose
-        // close could be attributed, so the wrapper becomes terminal.
-        if let Self::Ready(transport) = self {
-            transport.abort();
-        } else {
-            *self = Self::Aborted;
-        }
-    }
-
-    fn is_ready(&self) -> bool {
-        match self {
-            Self::Ready(transport) => transport.is_ready(),
-            _ => false,
-        }
-    }
-
-    fn close_info(&self) -> Option<signal_fish_client::transport::TransportCloseInfo> {
-        match self {
-            Self::Ready(transport) => transport.close_info(),
-            _ => None,
-        }
-    }
-
-    fn max_frame_hint(&self) -> Option<usize> {
-        match self {
-            // Declared per connection: the drivers sample this hint once per
-            // round, before the handshake runs, so a pre-ready `Some` would
-            // have to hard-code the delegate's bound. Returning `None` until
-            // connected simply leaves the driver's second enforcement layer
-            // inactive; the delegate's own in-transport bound still applies.
-            // A first-class lazy constructor in the SDK could declare the
-            // bound up front.
-            Self::Ready(transport) => transport.max_frame_hint(),
-            _ => None,
-        }
-    }
-}
-
-// ─────────────────────────────────────────────────────────────────────
-// Step 2: Run a lobby client that reconnects automatically
-// ─────────────────────────────────────────────────────────────────────
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -237,15 +48,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let url = std::env::var("SIGNAL_FISH_URL").unwrap_or_else(|_| DEFAULT_URL.to_string());
 
     // The factory is called at most once per reconnect attempt and must not
-    // block. It produces a fresh *unconnected* transport each time.
+    // block. `connect_lazy` returns a fresh, *unconnected* transport
+    // immediately; the driver starts its handshake on the first poll.
     let factory_url = url.clone();
     let config = SignalFishConfig::new("mb_app_reconnect_example").with_reconnect_policy(
-        ReconnectPolicy::new(move || Box::new(LazyWebSocketTransport::new(factory_url.clone()))),
+        ReconnectPolicy::new(move || {
+            Box::new(WebSocketTransport::connect_lazy(factory_url.clone()))
+        }),
     );
 
-    // The initial transport is the same lazy type; the driver connects it on
+    // The initial transport is lazy the same way; the driver connects it on
     // its first loop iteration.
-    let initial = LazyWebSocketTransport::new(url);
+    let initial = WebSocketTransport::connect_lazy(url);
     let (mut client, mut events) = SignalFishClient::start(initial, config);
 
     let mut joined = false;

--- a/src/client.rs
+++ b/src/client.rs
@@ -707,16 +707,19 @@ const DEFAULT_RECONNECT_MAX_BACKOFF: Duration = Duration::from_secs(10);
 /// # Example
 ///
 /// The factory returns a fresh, *unconnected* transport per attempt and must
-/// not block. Because [`WebSocketTransport::connect`](crate::WebSocketTransport::connect)
-/// is asynchronous, wrap it in a lazy transport that starts the handshake on
-/// first poll — the complete, compiling pattern lives in
-/// `examples/auto_reconnect.rs`:
+/// not block. [`WebSocketTransport::connect_lazy`](crate::WebSocketTransport::connect_lazy)
+/// exists exactly for this: it returns the built-in WebSocket transport
+/// immediately and starts the handshake on the first driver poll:
 ///
 /// ```rust,ignore
 /// let config = SignalFishConfig::new("mb_app_abc123").with_reconnect_policy(
-///     ReconnectPolicy::new(move || Box::new(LazyWebSocketTransport::new(url.clone()))),
+///     ReconnectPolicy::new(move || Box::new(WebSocketTransport::connect_lazy(url.clone()))),
 /// );
 /// ```
+///
+/// Custom transports implement [`Transport`] directly, eagerly or lazily; the
+/// reconnect flow with the built-in transport — including its built-in
+/// handshake deadline — is shown in `examples/auto_reconnect.rs`.
 ///
 /// The factory is called at most once per attempt and must not block; a
 /// panicking factory kills the transport loop task exactly like a panicking
@@ -2649,7 +2652,7 @@ async fn finish_send_failure(
             break;
         };
 
-        let outcome = lock_core(state).process_frame(frame);
+        let outcome = lock_core(state).process_drained_frame(frame);
         let protocol_stop = outcome.disconnect || outcome.input_error.is_some();
         if !emit_event_batch(event_tx, shutdown, deadline, outcome.events).await {
             debug!("terminal event delivery was preempted mid-batch after send failure");
@@ -9158,6 +9161,138 @@ mod tests {
             let message: serde_json::Value = serde_json::from_str(&sent2[1]).unwrap();
             assert_eq!(message["type"], "Reconnect");
         }
+        client.shutdown().await;
+    }
+
+    /// A hostile backend that never reports readiness yet fails the first
+    /// send (after taking the frame) and serves complete protocol frames from
+    /// the teardown drain: the exact double violation the pre-ready frame
+    /// guards exist for. The drain must discard, not apply, those frames.
+    struct NeverReadyHostileTransport {
+        incoming: std::sync::Mutex<std::collections::VecDeque<String>>,
+        first_send_attempted: std::sync::atomic::AtomicBool,
+        ready_on_send: bool,
+        ready: std::sync::atomic::AtomicBool,
+    }
+
+    impl Transport for NeverReadyHostileTransport {
+        fn abort(&mut self) {}
+        fn is_ready(&self) -> bool {
+            self.ready.load(Ordering::Relaxed)
+        }
+        fn poll_close(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<std::result::Result<(), SignalFishError>> {
+            Poll::Ready(Ok(()))
+        }
+        fn poll_send(
+            &mut self,
+            _cx: &mut Context<'_>,
+            frame: &mut Option<TransportFrame>,
+        ) -> Poll<std::result::Result<(), SignalFishError>> {
+            self.first_send_attempted.store(true, Ordering::Relaxed);
+            if self.ready_on_send {
+                self.ready.store(true, Ordering::Relaxed);
+            }
+            let _ = frame.take();
+            Poll::Ready(Err(SignalFishError::TransportSend(
+                "hostile send failure".into(),
+            )))
+        }
+        fn poll_recv(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Option<std::result::Result<TransportFrame, SignalFishError>>> {
+            // Surface the frames only after the send failed, so they reach
+            // the core through the teardown drain and not the main loop's
+            // own pre-ready guard.
+            if !self.first_send_attempted.load(Ordering::Relaxed) {
+                return Poll::Pending;
+            }
+            match self.incoming.lock().unwrap().pop_front() {
+                Some(text) => Poll::Ready(Some(Ok(TransportFrame::Text(text)))),
+                None => Poll::Pending,
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn teardown_drain_discards_frames_from_a_transport_that_never_became_ready() {
+        let transport = NeverReadyHostileTransport {
+            incoming: std::sync::Mutex::new(std::collections::VecDeque::from(vec![
+                authenticated_json(),
+                authenticated_json(),
+            ])),
+            first_send_attempted: std::sync::atomic::AtomicBool::new(false),
+            ready_on_send: false,
+            ready: std::sync::atomic::AtomicBool::new(false),
+        };
+        let config = SignalFishConfig::new("mb_hostile_pre_ready");
+        let (mut client, mut events) = SignalFishClient::start(transport, config);
+
+        // No `Connected` (never ready) and no `Authenticated` (drained frames
+        // from a never-ready transport are contract violations, not session
+        // progress): the send failure is the round's whole story.
+        match events.recv().await {
+            Some(SignalFishEvent::Disconnected { reason, .. }) => {
+                assert!(
+                    reason
+                        .as_deref()
+                        .unwrap_or("")
+                        .contains("hostile send failure"),
+                    "send-failure cause expected, got {reason:?}"
+                );
+            }
+            other => panic!("expected Disconnected, got {other:?}"),
+        }
+        assert!(
+            events.recv().await.is_none(),
+            "no further events may follow"
+        );
+        client.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn send_failure_after_a_handshake_completed_inside_poll_send_still_emits_connected() {
+        let transport = NeverReadyHostileTransport {
+            incoming: std::sync::Mutex::new(std::collections::VecDeque::from(vec![
+                authenticated_json(),
+            ])),
+            first_send_attempted: std::sync::atomic::AtomicBool::new(false),
+            ready_on_send: true,
+            ready: std::sync::atomic::AtomicBool::new(false),
+        };
+        let config = SignalFishConfig::new("mb_lazy_ready_on_send");
+        let (mut client, mut events) = SignalFishClient::start(transport, config);
+
+        // The handshake completed inside the failing `poll_send`: the round
+        // emits `Connected`, and the drain applies the ready backend's
+        // farewell frame before the `Disconnected` farewell.
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Connected)
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Authenticated { .. })
+        ));
+        match events.recv().await {
+            Some(SignalFishEvent::Disconnected { reason, .. }) => {
+                assert!(
+                    reason
+                        .as_deref()
+                        .unwrap_or("")
+                        .contains("hostile send failure"),
+                    "send-failure cause expected, got {reason:?}"
+                );
+            }
+            other => panic!("expected Disconnected, got {other:?}"),
+        }
+        assert!(
+            events.recv().await.is_none(),
+            "no further events may follow"
+        );
         client.shutdown().await;
     }
 

--- a/src/client_core.rs
+++ b/src/client_core.rs
@@ -1009,6 +1009,28 @@ impl ClientCore {
         }
     }
 
+    /// Process one frame surfaced by a terminal teardown drain.
+    ///
+    /// The send-failure teardown drains already-ready inbound frames so a
+    /// backend's farewell is not lost, but a transport that never reported
+    /// [`is_ready`](crate::Transport::is_ready) must not serve complete
+    /// frames at all — the main loops tear the round down on exactly that
+    /// contract violation. This drain runs while the round is already
+    /// tearing down, so the same violation only discards the frame: no state
+    /// is applied and no event is emitted, and the original send failure
+    /// remains the disconnect cause.
+    pub(crate) fn process_drained_frame(&mut self, frame: TransportFrame) -> FrameOutcome {
+        if self.is_transport_ready() {
+            self.process_frame(frame)
+        } else {
+            FrameOutcome {
+                events: Vec::new(),
+                disconnect: false,
+                input_error: None,
+            }
+        }
+    }
+
     fn process_text(&mut self, text: String) -> FrameOutcome {
         let mut outcome = FrameOutcome::new();
         let server_msg = match serde_json::from_str::<ServerMessage>(&text) {

--- a/src/polling_client.rs
+++ b/src/polling_client.rs
@@ -384,6 +384,15 @@ impl<T: Transport> SignalFishPollingClient<T> {
         if let Err(error) = self.drive_outbound(&mut cx, now) {
             error!(%error, "transport send failed");
             self.abandon_client_owned(false, now);
+            // A lazy handshake may complete inside the failing `poll_send`
+            // (the contract lets a pre-ready transport deliver its terminal
+            // error from the very poll that completes the handshake):
+            // re-sample readiness so the round still emits `Connected` and
+            // the drain can apply the backend's farewell frames, matching
+            // the async driver's re-sample before its teardown drain.
+            if self.transport.is_ready() && self.core.mark_transport_ready() {
+                events.push(SignalFishEvent::Connected);
+            }
             self.drain_ready_after_send_failure(&mut events, &mut cx, now, &mut terminal_now);
             let reason = peer_close_reason(&self.transport).or_else(|| Some(error.to_string()));
             let close_now = terminal_now().max(now);
@@ -1243,7 +1252,7 @@ impl<T: Transport> SignalFishPollingClient<T> {
                     frame,
                     budget_reached,
                 } => {
-                    let outcome = core.process_frame(frame);
+                    let outcome = core.process_drained_frame(frame);
                     events.extend(outcome.events);
                     if budget_reached {
                         self.polling_stats.receive_budget_exhaustions = self
@@ -3692,6 +3701,102 @@ mod tests {
             self.close_calls = self.close_calls.saturating_add(1);
             std::task::Poll::Pending
         }
+    }
+
+    /// A hostile backend that never reports readiness yet fails every send
+    /// (after taking the frame) and serves complete protocol frames from the
+    /// teardown drain: the drain must discard, not apply, those frames.
+    struct NeverReadySendFailsTransport {
+        incoming: VecDeque<String>,
+        ready_on_send: bool,
+        ready: std::cell::Cell<bool>,
+    }
+
+    impl NeverReadySendFailsTransport {
+        fn never_ready(incoming: VecDeque<String>) -> Self {
+            Self {
+                incoming,
+                ready_on_send: false,
+                ready: std::cell::Cell::new(false),
+            }
+        }
+    }
+
+    impl Transport for NeverReadySendFailsTransport {
+        fn abort(&mut self) {}
+        fn is_ready(&self) -> bool {
+            self.ready.get()
+        }
+        fn poll_send(
+            &mut self,
+            _cx: &mut std::task::Context<'_>,
+            frame: &mut Option<TransportFrame>,
+        ) -> std::task::Poll<std::result::Result<(), SignalFishError>> {
+            if self.ready_on_send {
+                self.ready.set(true);
+            }
+            let _ = frame.take();
+            std::task::Poll::Ready(Err(SignalFishError::TransportSend(
+                "hostile send failure".into(),
+            )))
+        }
+        fn poll_recv(
+            &mut self,
+            _cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<Option<std::result::Result<TransportFrame, SignalFishError>>> {
+            match self.incoming.pop_front() {
+                Some(text) => std::task::Poll::Ready(Some(Ok(TransportFrame::Text(text)))),
+                None => std::task::Poll::Pending,
+            }
+        }
+        fn poll_close(
+            &mut self,
+            _cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<std::result::Result<(), SignalFishError>> {
+            std::task::Poll::Ready(Ok(()))
+        }
+    }
+
+    #[test]
+    fn teardown_drain_discards_frames_from_a_transport_that_never_became_ready() {
+        let transport =
+            NeverReadySendFailsTransport::never_ready(std::collections::VecDeque::from(vec![
+                authenticated_json_str().to_string(),
+                authenticated_json_str().to_string(),
+            ]));
+        let mut client = SignalFishPollingClient::new(transport, default_config());
+        let events = client.poll();
+
+        // No `Connected` (never ready) and no `Authenticated` (drained frames
+        // from a never-ready transport are contract violations, not session
+        // progress): the send failure is the round's whole story.
+        assert!(matches!(
+            events.as_slice(),
+            [SignalFishEvent::Disconnected { .. }]
+        ));
+    }
+
+    #[test]
+    fn send_failure_after_a_handshake_completed_inside_poll_send_still_emits_connected() {
+        let transport = NeverReadySendFailsTransport {
+            incoming: std::collections::VecDeque::from(vec![r#"{"type":"Pong"}"#.to_string()]),
+            ready_on_send: true,
+            ready: std::cell::Cell::new(false),
+        };
+        let mut client = SignalFishPollingClient::new(transport, default_config());
+        let events = client.poll();
+
+        // The handshake completed inside the failing `poll_send`: the round
+        // emits `Connected`, and the drain applies the ready backend's
+        // farewell frame before the `Disconnected` farewell.
+        assert!(matches!(
+            events.as_slice(),
+            [
+                SignalFishEvent::Connected,
+                SignalFishEvent::Pong,
+                SignalFishEvent::Disconnected { .. }
+            ]
+        ));
     }
 
     /// A transport whose `poll_send` always returns `Pending`.

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -220,7 +220,11 @@ pub trait Transport {
     /// blocked must wake a waker previously registered by `poll_send` or
     /// `poll_recv`, because this accessor does not receive a waker itself.
     /// While this returns `false`, `poll_send` must return `Pending` without
-    /// taking a caller-owned frame.
+    /// taking a caller-owned frame. The one exception is a transport that
+    /// fused terminally before readiness (for example a failed deferred
+    /// handshake): it stays not-ready while its polls deliver the terminal
+    /// error or EOF, so the drivers observe an ordinary teardown instead of
+    /// parking forever.
     /// Complete protocol frames must not be returned by `poll_recv` before
     /// readiness.
     fn is_ready(&self) -> bool {

--- a/src/transports/websocket.rs
+++ b/src/transports/websocket.rs
@@ -689,14 +689,19 @@ struct LazyHandshake {
     phase: LazyPhase,
 }
 
+/// The boxed deferred-handshake future.
+type LazyHandshakeFuture =
+    Pin<Box<dyn std::future::Future<Output = Result<WsStream, SignalFishError>> + Send>>;
+
 /// Lifecycle of one deferred handshake.
 enum LazyPhase {
     /// No handshake started yet; the first send/receive poll starts it.
     Idle,
-    /// The handshake future is being polled to completion.
-    Connecting(
-        Pin<Box<dyn std::future::Future<Output = Result<WsStream, SignalFishError>> + Send>>,
-    ),
+    /// The handshake future is being polled to completion. The mutex exists
+    /// only to keep `WebSocketTransport` `Sync` (a boxed future is `Send`
+    /// but never `Sync`); every access runs behind `&mut self`, so it is
+    /// always taken with `get_mut` and never actually locks.
+    Connecting(std::sync::Mutex<LazyHandshakeFuture>),
     /// The handshake failed or was abandoned (close/abort). Terminal: any
     /// handshake error was delivered exactly once before fusing, and every
     /// later poll is inert. `is_ready()` stays `false` — no connection ever
@@ -1305,7 +1310,7 @@ impl WebSocketTransport {
             }
             let url = lazy.url.clone();
             let timeout = lazy.timeout;
-            lazy.phase = LazyPhase::Connecting(Box::pin(async move {
+            lazy.phase = LazyPhase::Connecting(std::sync::Mutex::new(Box::pin(async move {
                 let connected = Self::connect_with_timeout(&url, timeout).await?;
                 // Success pins the disabled token-binding profile (default
                 // options), so moving the raw stream into a fresh state is
@@ -1321,7 +1326,7 @@ impl WebSocketTransport {
                     // transport or an error.
                     WebSocketInner::Lazy(_) => Err(SignalFishError::TransportClosed),
                 }
-            }));
+            })));
         }
         let WebSocketInner::Lazy(lazy) = &mut self.inner else {
             return LazyAdvance::Connected;
@@ -1331,7 +1336,17 @@ impl WebSocketTransport {
             // nothing left to drive.
             return LazyAdvance::FusedTerminal;
         };
-        match future.as_mut().poll(cx) {
+        // Take the future through the exclusive `&mut` reference: the mutex
+        // exists for `Sync` (a boxed future is `Send` but never `Sync`), not
+        // for locking; `get_mut` proves exclusivity without a lock, and the
+        // `LockResult` wrapper is unwrapped without panicking for signature
+        // compatibility (it can never actually be poisoned here).
+        let poll_result = future
+            .get_mut()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .as_mut()
+            .poll(cx);
+        match poll_result {
             Poll::Pending => LazyAdvance::Pending,
             Poll::Ready(Ok(stream)) => {
                 self.inner = WebSocketInner::Connected(Box::new(WebSocketState::new(stream)));
@@ -1812,6 +1827,17 @@ mod tests {
     fn websocket_transport_is_send() {
         fn assert_send<T: Send>() {}
         assert_send::<WebSocketTransport>();
+    }
+
+    #[test]
+    fn websocket_transport_is_send_and_sync() {
+        // The lazy constructors hold a boxed handshake future (`Send` but
+        // never `Sync`), so `Sync` now depends on that future staying behind
+        // a mutex. Losing the auto trait is a semver-major change (the
+        // `API compatibility` gate would fail); this pin catches it in the
+        // ordinary suite first.
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<WebSocketTransport>();
     }
 
     #[test]

--- a/src/transports/websocket.rs
+++ b/src/transports/websocket.rs
@@ -633,6 +633,12 @@ impl WebSocketConnectOptions {
 /// an already-completed handshake, it cannot enable token binding and retains
 /// the caller's WebSocket codec limits.
 ///
+/// For the synchronous [`ReconnectPolicy`](crate::ReconnectPolicy) factory —
+/// which must return a fresh, unconnected transport without blocking — use
+/// [`WebSocketTransport::connect_lazy`]: the handshake starts on the first
+/// poll and the transport reports `is_ready() == false` until it completes.
+/// Like `from_stream`, the lazy constructors cannot enable token binding.
+///
 /// # Polling Safety
 ///
 /// [`poll_recv`](Transport::poll_recv) preserves the WebSocket stream's partial
@@ -648,12 +654,67 @@ impl WebSocketConnectOptions {
 /// including a restored `WriteBufferFull`, to a terminal disconnect that drops
 /// the connection and its retained frame.
 pub struct WebSocketTransport {
-    state: WebSocketState<WsStream>,
+    inner: WebSocketInner,
     /// The connect-time inbound frame/message bound the backend enforces via
     /// tungstenite, reported through [`Transport::max_frame_hint`] so the
     /// drivers enforce it too. `from_stream` callers own their codec limits,
-    /// so the transport cannot know one and reports `None`.
+    /// so the transport cannot know one and reports `None`. The lazy
+    /// constructors pin the default bound so it is declared before the
+    /// deferred handshake runs.
     max_inbound_frame: Option<usize>,
+}
+
+/// Internal state of one [`WebSocketTransport`].
+enum WebSocketInner {
+    /// The handshake completed (or the physical connection reached a terminal
+    /// state); all transport behavior lives in the shared [`WebSocketState`].
+    /// Boxed so the lazy variant stays small (the stream is large and the
+    /// allocation happens once, at connect time).
+    Connected(Box<WebSocketState<WsStream>>),
+    /// The handshake is deferred to the first send/receive poll.
+    Lazy(LazyHandshake),
+}
+
+/// Default handshake deadline for [`WebSocketTransport::connect_lazy`].
+///
+/// Without it, a peer that accepts TCP but never completes the upgrade parks
+/// the attempt in `Pending` forever and a reconnect policy never observes a
+/// failure to retry.
+const DEFAULT_LAZY_HANDSHAKE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// Deferred WebSocket handshake behind the lazy constructors.
+struct LazyHandshake {
+    url: String,
+    timeout: std::time::Duration,
+    phase: LazyPhase,
+}
+
+/// Lifecycle of one deferred handshake.
+enum LazyPhase {
+    /// No handshake started yet; the first send/receive poll starts it.
+    Idle,
+    /// The handshake future is being polled to completion.
+    Connecting(
+        Pin<Box<dyn std::future::Future<Output = Result<WsStream, SignalFishError>> + Send>>,
+    ),
+    /// The handshake failed or was abandoned (close/abort). Terminal: any
+    /// handshake error was delivered exactly once before fusing, and every
+    /// later poll is inert. `is_ready()` stays `false` — no connection ever
+    /// existed, so no synthetic `Connected` edge may fire.
+    Fused,
+}
+
+/// Outcome of advancing a deferred handshake.
+enum LazyAdvance {
+    /// The handshake is still running; the caller returns `Pending`.
+    Pending,
+    /// The handshake completed; the transport is now connected.
+    Connected,
+    /// The handshake failed; the transport fused and the caller must deliver
+    /// this terminal error exactly once.
+    Failed(SignalFishError),
+    /// The transport fused without an error to deliver (close/abort race).
+    FusedTerminal,
 }
 
 struct WebSocketState<S> {
@@ -730,17 +791,33 @@ impl WebSocketTokenBinding {
 impl std::fmt::Debug for WebSocketTransport {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // The stream codec can retain raw inbound/outbound protocol frames,
-        // and close reasons are peer-controlled. Expose state only.
-        f.debug_struct("WebSocketTransport")
-            .field("has_stream", &self.state.stream.is_some())
-            .field("closed", &self.state.closed)
-            .field("has_close_info", &self.state.close_info.is_some())
-            .field("send_started", &self.state.send_started)
-            .field("send_failed", &self.state.send_failed)
-            .field("control_flush_pending", &self.state.control_flush_pending)
-            .field("peer_close_pending", &self.state.peer_close_pending)
-            .field("token_binding", &self.state.token_binding.status())
-            .finish()
+        // and close reasons are peer-controlled. Expose state only; the lazy
+        // URL is connection information and is never formatted.
+        match &self.inner {
+            WebSocketInner::Connected(state) => f
+                .debug_struct("WebSocketTransport")
+                .field("has_stream", &state.stream.is_some())
+                .field("closed", &state.closed)
+                .field("has_close_info", &state.close_info.is_some())
+                .field("send_started", &state.send_started)
+                .field("send_failed", &state.send_failed)
+                .field("control_flush_pending", &state.control_flush_pending)
+                .field("peer_close_pending", &state.peer_close_pending)
+                .field("token_binding", &state.token_binding.status())
+                .finish(),
+            WebSocketInner::Lazy(lazy) => f
+                .debug_struct("WebSocketTransport")
+                .field("has_stream", &false)
+                .field(
+                    "lazy_handshake",
+                    &match lazy.phase {
+                        LazyPhase::Idle => "idle",
+                        LazyPhase::Connecting(_) => "connecting",
+                        LazyPhase::Fused => "fused",
+                    },
+                )
+                .finish(),
+        }
     }
 }
 
@@ -927,7 +1004,10 @@ impl WebSocketTransport {
         );
 
         Ok(Self {
-            state: WebSocketState::new_with_token_binding(stream, token_binding),
+            inner: WebSocketInner::Connected(Box::new(WebSocketState::new_with_token_binding(
+                stream,
+                token_binding,
+            ))),
             max_inbound_frame: options.max_inbound_message_size,
         })
     }
@@ -1049,7 +1129,10 @@ impl WebSocketTransport {
             "WebSocket connection established"
         );
         Ok(Self {
-            state: WebSocketState::new_with_token_binding(stream, token_binding),
+            inner: WebSocketInner::Connected(Box::new(WebSocketState::new_with_token_binding(
+                stream,
+                token_binding,
+            ))),
             max_inbound_frame: options.max_inbound_message_size,
         })
     }
@@ -1070,15 +1153,22 @@ impl WebSocketTransport {
     /// extension must own the full handshake/proof wrapper or use a connect API.
     pub fn from_stream(stream: WsStream) -> Self {
         Self {
-            state: WebSocketState::new(stream),
+            inner: WebSocketInner::Connected(Box::new(WebSocketState::new(stream))),
             max_inbound_frame: None,
         }
     }
 
     /// Return the negotiated token-binding state for this physical connection.
+    ///
+    /// A lazy transport reports [`TokenBindingStatus::Disabled`] until the
+    /// deferred handshake completes; the lazy constructors pin the disabled
+    /// profile.
     #[must_use]
     pub fn token_binding_status(&self) -> TokenBindingStatus {
-        self.state.token_binding.status()
+        match self.connected_state() {
+            Some(state) => state.token_binding.status(),
+            None => TokenBindingStatus::Disabled,
+        }
     }
 
     /// Return the validated server challenge when token binding is active.
@@ -1087,7 +1177,8 @@ impl WebSocketTransport {
     /// application frame. Callers normally need only [`token_binding_status`](Self::token_binding_status).
     #[must_use]
     pub fn token_binding_challenge(&self) -> Option<&TokenBindingChallenge> {
-        self.state.token_binding.challenge()
+        self.connected_state()
+            .and_then(|state| state.token_binding.challenge())
     }
 
     /// Establish a new WebSocket connection with a timeout.
@@ -1111,6 +1202,158 @@ impl WebSocketTransport {
         tokio::time::timeout(timeout, Self::connect(url))
             .await
             .map_err(|_| SignalFishError::Timeout)?
+    }
+
+    /// Create a transport that starts the WebSocket handshake on first use.
+    ///
+    /// Unlike [`connect`](Self::connect), this never blocks and never performs
+    /// network I/O at construction time, so it can run inside the synchronous
+    /// [`ReconnectPolicy`](crate::ReconnectPolicy) factory, which must return
+    /// a fresh, unconnected transport immediately. The handshake starts on the
+    /// first [`poll_send`](Transport::poll_send) or
+    /// [`poll_recv`](Transport::poll_recv) call; until it completes, the
+    /// transport reports `is_ready() == false` and defers every send
+    /// (`Pending` keeps the caller's frame intact).
+    ///
+    /// The deferred handshake uses the default connect profile: disabled token
+    /// binding, `TCP_NODELAY`, and the default 8 MiB inbound frame/message
+    /// bound. Token binding cannot be offered here by design — the handshake
+    /// (and with it the exact `Sec-WebSocket-Key` a proof binds to) has not
+    /// started when the constructor returns, matching the
+    /// [`from_stream`](Self::from_stream) precedent.
+    ///
+    /// A handshake deadline of **10 seconds** applies so a peer that accepts
+    /// TCP but never completes the upgrade becomes a terminal
+    /// [`Timeout`](SignalFishError::Timeout) instead of parking the attempt in
+    /// `Pending` forever — a reconnect policy can only count attempts it can
+    /// observe failing. Use
+    /// [`connect_lazy_with_timeout`](Self::connect_lazy_with_timeout) to tune
+    /// it.
+    ///
+    /// The declared [`max_frame_hint`](Transport::max_frame_hint) is stable
+    /// for the transport's whole life: the drivers sample it once per
+    /// connection round, before the handshake runs, and this constructor
+    /// declares the default 8 MiB bound immediately.
+    ///
+    /// An invalid URL is not rejected at construction time; it surfaces as a
+    /// terminal [`InvalidConfig`](SignalFishError::InvalidConfig) on the first
+    /// poll, exactly like any other handshake failure. The same poll also
+    /// requires a live tokio runtime on the polling thread (as every WebSocket
+    /// connect does): without one, the handshake fails with a classified
+    /// `InvalidConfig` instead of panicking inside the reactor.
+    #[must_use]
+    pub fn connect_lazy(url: String) -> Self {
+        Self::connect_lazy_with_timeout(url, DEFAULT_LAZY_HANDSHAKE_TIMEOUT)
+    }
+
+    /// Create a lazy transport with an explicit handshake deadline.
+    ///
+    /// Behaves like [`connect_lazy`](Self::connect_lazy) but fails the
+    /// deferred handshake with [`SignalFishError::Timeout`] if it has not
+    /// completed within the given duration.
+    #[must_use]
+    pub fn connect_lazy_with_timeout(url: String, timeout: std::time::Duration) -> Self {
+        Self {
+            inner: WebSocketInner::Lazy(LazyHandshake {
+                url,
+                timeout,
+                phase: LazyPhase::Idle,
+            }),
+            max_inbound_frame: Some(DEFAULT_MAX_INBOUND_MESSAGE_SIZE),
+        }
+    }
+
+    /// The connected backend state, when the handshake has completed.
+    fn connected_state(&self) -> Option<&WebSocketState<WsStream>> {
+        match &self.inner {
+            WebSocketInner::Connected(state) => Some(state),
+            WebSocketInner::Lazy(_) => None,
+        }
+    }
+
+    fn connected_state_mut(&mut self) -> Option<&mut WebSocketState<WsStream>> {
+        match &mut self.inner {
+            WebSocketInner::Connected(state) => Some(state.as_mut()),
+            WebSocketInner::Lazy(_) => None,
+        }
+    }
+
+    /// Start the handshake if it has not started yet, then drive it.
+    ///
+    /// The future owns the URL: it outlives the `&mut self` borrow that
+    /// created it. Fusing on failure keeps later polls inert while
+    /// `is_ready()` stays `false` — a handshake that never completed must not
+    /// produce the synthetic `Connected` edge.
+    fn advance_lazy(&mut self, cx: &mut Context<'_>) -> LazyAdvance {
+        let WebSocketInner::Lazy(lazy) = &mut self.inner else {
+            return LazyAdvance::Connected;
+        };
+        if matches!(lazy.phase, LazyPhase::Idle) {
+            // The deferred handshake needs the tokio reactor (timer and TCP
+            // connect), which must be entered on the polling thread. Without
+            // it the tokio primitives would panic mid-poll; classify the
+            // environment problem as a terminal configuration error instead
+            // so the drivers observe an ordinary handshake failure.
+            if tokio::runtime::Handle::try_current().is_err() {
+                self.fuse_lazy();
+                return LazyAdvance::Failed(SignalFishError::InvalidConfig {
+                    field: "runtime",
+                    problem: "the deferred WebSocket handshake requires a \
+                              live tokio runtime on the polling thread"
+                        .into(),
+                });
+            }
+            let url = lazy.url.clone();
+            let timeout = lazy.timeout;
+            lazy.phase = LazyPhase::Connecting(Box::pin(async move {
+                let connected = Self::connect_with_timeout(&url, timeout).await?;
+                // Success pins the disabled token-binding profile (default
+                // options), so moving the raw stream into a fresh state is
+                // equivalent. The transport wrapper itself is not needed.
+                match connected.inner {
+                    WebSocketInner::Connected(mut state) => match state.stream.take() {
+                        Some(stream) => Ok(stream),
+                        // Unreachable on a successful connect; still fused
+                        // terminal rather than panicking.
+                        None => Err(SignalFishError::TransportClosed),
+                    },
+                    // Unreachable: `connect_with_timeout` returns a connected
+                    // transport or an error.
+                    WebSocketInner::Lazy(_) => Err(SignalFishError::TransportClosed),
+                }
+            }));
+        }
+        let WebSocketInner::Lazy(lazy) = &mut self.inner else {
+            return LazyAdvance::Connected;
+        };
+        let LazyPhase::Connecting(future) = &mut lazy.phase else {
+            // Fused between polls (close/abort raced the observing poll);
+            // nothing left to drive.
+            return LazyAdvance::FusedTerminal;
+        };
+        match future.as_mut().poll(cx) {
+            Poll::Pending => LazyAdvance::Pending,
+            Poll::Ready(Ok(stream)) => {
+                self.inner = WebSocketInner::Connected(Box::new(WebSocketState::new(stream)));
+                LazyAdvance::Connected
+            }
+            Poll::Ready(Err(error)) => {
+                self.fuse_lazy();
+                LazyAdvance::Failed(error)
+            }
+        }
+    }
+
+    /// Fuse the lazy transport without delivering a handshake error.
+    ///
+    /// Used by `poll_close` and `abort` before or while the handshake runs:
+    /// there is no connection to close gracefully, so dropping the handshake
+    /// future cancels it (a socket that races to completion underneath is
+    /// dropped with the future) and the transport becomes inert.
+    fn fuse_lazy(&mut self) {
+        if let WebSocketInner::Lazy(lazy) = &mut self.inner {
+            lazy.phase = LazyPhase::Fused;
+        }
     }
 }
 
@@ -1462,26 +1705,80 @@ impl Transport for WebSocketTransport {
         cx: &mut Context<'_>,
         frame: &mut Option<TransportFrame>,
     ) -> Poll<Result<(), SignalFishError>> {
-        self.state.poll_send(cx, frame)
+        if matches!(self.inner, WebSocketInner::Lazy(_)) {
+            match self.advance_lazy(cx) {
+                LazyAdvance::Pending => return Poll::Pending,
+                LazyAdvance::Failed(error) => return Poll::Ready(Err(error)),
+                LazyAdvance::FusedTerminal => {
+                    return Poll::Ready(Err(SignalFishError::TransportClosed));
+                }
+                LazyAdvance::Connected => {}
+            }
+        }
+        match self.connected_state_mut() {
+            Some(state) => state.poll_send(cx, frame),
+            // Unreachable: `advance_lazy` leaves the transport connected or
+            // returned above.
+            None => Poll::Ready(Err(SignalFishError::TransportClosed)),
+        }
     }
 
     fn poll_recv(
         &mut self,
         cx: &mut Context<'_>,
     ) -> Poll<Option<Result<TransportFrame, SignalFishError>>> {
-        self.state.poll_recv(cx)
+        if matches!(self.inner, WebSocketInner::Lazy(_)) {
+            match self.advance_lazy(cx) {
+                LazyAdvance::Pending => return Poll::Pending,
+                LazyAdvance::Failed(error) => return Poll::Ready(Some(Err(error))),
+                LazyAdvance::FusedTerminal => return Poll::Ready(None),
+                LazyAdvance::Connected => {}
+            }
+        }
+        match self.connected_state_mut() {
+            Some(state) => state.poll_recv(cx),
+            // Unreachable: `advance_lazy` leaves the transport connected or
+            // returned above.
+            None => Poll::Ready(None),
+        }
     }
 
     fn poll_close(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), SignalFishError>> {
-        self.state.poll_close(cx)
+        if matches!(self.inner, WebSocketInner::Lazy(_)) {
+            // Nothing was ever connected: there is no socket to close
+            // gracefully. Cancel the pending handshake and report the close
+            // as complete; later polls observe the fused terminal state.
+            self.fuse_lazy();
+            return Poll::Ready(Ok(()));
+        }
+        match self.connected_state_mut() {
+            Some(state) => state.poll_close(cx),
+            // Unreachable: non-lazy transports always carry connected state.
+            None => Poll::Ready(Ok(())),
+        }
     }
 
     fn close_info(&self) -> Option<TransportCloseInfo> {
-        self.state.close_info()
+        self.connected_state().and_then(|state| state.close_info())
     }
 
     fn abort(&mut self) {
-        self.state.abort();
+        match &mut self.inner {
+            WebSocketInner::Connected(state) => state.abort(),
+            WebSocketInner::Lazy(_) => {
+                // No connection exists whose close could be attributed; drop
+                // the handshake future and become inert. Idempotent: repeated
+                // calls re-fuse the same terminal phase.
+                self.fuse_lazy();
+            }
+        }
+    }
+
+    /// Ready once the deferred handshake has completed. Stays `false` when a
+    /// handshake failed or was abandoned: no connection ever existed, so the
+    /// drivers must not emit the synthetic `Connected` edge.
+    fn is_ready(&self) -> bool {
+        self.connected_state().is_some()
     }
 
     fn max_frame_hint(&self) -> Option<usize> {
@@ -3056,10 +3353,11 @@ mod tests {
 
     fn plain_tcp_stream(transport: &WebSocketTransport) -> &tokio::net::TcpStream {
         match transport
-            .state
+            .connected_state()
+            .expect("transport must hold a live stream after connect")
             .stream
             .as_ref()
-            .expect("transport must hold a live stream after connect")
+            .expect("connected state must hold the WebSocket stream")
             .get_ref()
         {
             tokio_tungstenite::MaybeTlsStream::Plain(tcp) => tcp,
@@ -3081,7 +3379,7 @@ mod tests {
         let secret = "websocket-debug-secret";
         let transport = WebSocketTransport {
             max_inbound_frame: None,
-            state: WebSocketState {
+            inner: WebSocketInner::Connected(Box::new(WebSocketState {
                 stream: None,
                 closed: true,
                 close_info: Some(TransportCloseInfo {
@@ -3093,7 +3391,7 @@ mod tests {
                 control_flush_pending: false,
                 peer_close_pending: false,
                 token_binding: WebSocketTokenBinding::Disabled,
-            },
+            })),
         };
 
         let output = format!("{transport:?}");
@@ -3688,8 +3986,8 @@ mod tests {
                 .expect("server task must report whether it received the response"),
             "client must flush a matching close response before recv returns None"
         );
-        assert!(transport.state.closed);
-        assert!(!transport.state.peer_close_pending);
+        assert!(transport.connected_state().unwrap().closed);
+        assert!(!transport.connected_state().unwrap().peer_close_pending);
         finish_mock_server(server_task).await;
     }
 
@@ -3739,10 +4037,11 @@ mod tests {
                 .expect("custom inbound policy must connect");
 
             let live_config = transport
-                .state
+                .connected_state()
+                .expect("connected transport must retain its WebSocket stream")
                 .stream
                 .as_ref()
-                .expect("connected transport must retain its WebSocket stream")
+                .expect("connected state must hold the WebSocket stream")
                 .get_config();
             assert_eq!(live_config.max_frame_size, limit);
             assert_eq!(live_config.max_message_size, limit);
@@ -3780,10 +4079,11 @@ mod tests {
             .expect("explicit rustls connect path must support a plain ws endpoint");
 
         let live_config = transport
-            .state
+            .connected_state()
+            .expect("connected transport must retain its WebSocket stream")
             .stream
             .as_ref()
-            .expect("connected transport must retain its WebSocket stream")
+            .expect("connected state must hold the WebSocket stream")
             .get_config();
         assert_eq!(live_config.max_frame_size, Some(256));
         assert_eq!(live_config.max_message_size, Some(256));
@@ -3811,8 +4111,8 @@ mod tests {
             crate::transport::recv_frame(&mut transport).await,
             Some(Err(SignalFishError::TransportReceive(_)))
         ));
-        assert!(transport.state.closed);
-        assert!(transport.state.stream.is_none());
+        assert!(transport.connected_state().unwrap().closed);
+        assert!(transport.connected_state().unwrap().stream.is_none());
         assert!(crate::transport::recv_frame(&mut transport).await.is_none());
 
         let expected = TransportFrame::Text("caller-retains-oversize-retry".into());
@@ -3890,11 +4190,11 @@ mod tests {
             first,
             Some(Err(SignalFishError::TransportReceive(_)))
         ));
-        assert!(transport.state.closed);
-        assert!(transport.state.stream.is_none());
-        assert!(!transport.state.send_started);
-        assert!(!transport.state.control_flush_pending);
-        assert!(!transport.state.peer_close_pending);
+        assert!(transport.connected_state().unwrap().closed);
+        assert!(transport.connected_state().unwrap().stream.is_none());
+        assert!(!transport.connected_state().unwrap().send_started);
+        assert!(!transport.connected_state().unwrap().control_flush_pending);
+        assert!(!transport.connected_state().unwrap().peer_close_pending);
 
         assert!(crate::transport::recv_frame(&mut transport).await.is_none());
         let expected = TransportFrame::Text("must-remain-caller-owned".into());
@@ -3928,9 +4228,10 @@ mod tests {
         .await
         .expect("reset socket must wake the send poll");
         assert!(matches!(first, Err(SignalFishError::TransportSend(_))));
-        assert!(transport.state.send_failed);
-        assert!(!transport.state.closed);
-        assert!(transport.state.stream.is_some());
+        let state = transport.connected_state().unwrap();
+        assert!(state.send_failed);
+        assert!(!state.closed);
+        assert!(state.stream.is_some());
 
         let expected = TransportFrame::Text("second".into());
         let mut offered = Some(expected.clone());
@@ -3938,8 +4239,8 @@ mod tests {
         assert!(matches!(second, Err(SignalFishError::TransportClosed)));
         assert_eq!(offered, Some(expected));
         let _ = crate::transport::recv_frame(&mut transport).await;
-        assert!(transport.state.closed);
-        assert!(transport.state.stream.is_none());
+        assert!(transport.connected_state().unwrap().closed);
+        assert!(transport.connected_state().unwrap().stream.is_none());
         crate::transport::close_transport(&mut transport)
             .await
             .expect("close after send failure must be idempotent");
@@ -4004,8 +4305,8 @@ mod tests {
         transport.abort();
         transport.abort();
 
-        assert!(transport.state.closed);
-        assert!(transport.state.stream.is_none());
+        assert!(transport.connected_state().unwrap().closed);
+        assert!(transport.connected_state().unwrap().stream.is_none());
         let expected = TransportFrame::Text("caller still owns this".into());
         let mut offered = Some(expected.clone());
         let waker = std::task::Waker::noop();
@@ -4166,5 +4467,289 @@ mod tests {
 
         assert!(crate::transport::recv_frame(&mut transport).await.is_none());
         finish_mock_server(server_task).await;
+    }
+
+    // ── Lazy constructors (issue #227) ────────────────────────────────
+
+    /// A listener that never accepts: the TCP connect completes through the
+    /// backlog while the upgrade can never finish, parking the handshake in
+    /// `Pending` deterministically.
+    fn stalled_listener() -> (String, std::net::TcpListener) {
+        let listener =
+            std::net::TcpListener::bind("127.0.0.1:0").expect("stalled listener must bind");
+        let addr = listener
+            .local_addr()
+            .expect("stalled listener must have a local address");
+        (format!("ws://{addr}"), listener)
+    }
+
+    #[tokio::test]
+    async fn lazy_transport_reports_pending_and_retains_the_caller_frame_before_connect() {
+        let (url, _listener) = stalled_listener();
+        let mut transport = WebSocketTransport::connect_lazy(url);
+        assert!(!Transport::is_ready(&transport));
+
+        let waker = std::task::Waker::noop();
+        let mut cx = Context::from_waker(waker);
+        let mut frame = Some(TransportFrame::Text("queued".into()));
+        assert!(matches!(
+            Transport::poll_send(&mut transport, &mut cx, &mut frame),
+            Poll::Pending
+        ));
+        assert_eq!(
+            frame.as_ref(),
+            Some(&TransportFrame::Text("queued".into())),
+            "pre-ready poll_send must leave the frame in the caller slot"
+        );
+        assert!(!Transport::is_ready(&transport));
+        assert!(Transport::close_info(&transport).is_none());
+    }
+
+    #[tokio::test]
+    async fn lazy_transport_poll_send_drives_the_handshake_to_completion() {
+        let (url, server_task) = start_mock_server(|mut ws| async move {
+            ws.send(Message::Text("server-hello".into()))
+                .await
+                .expect("server must send the probe frame");
+            while let Some(Ok(_)) = ws.next().await {}
+        })
+        .await;
+
+        // The async driver's first I/O on every round is the seeded
+        // Authenticate send, so `poll_send` is the production path that must
+        // start the deferred handshake and complete once connected.
+        let mut transport = WebSocketTransport::connect_lazy(url);
+        assert!(!Transport::is_ready(&transport));
+        crate::transport::send_frame(&mut transport, TransportFrame::Text("seed".into()))
+            .await
+            .expect("poll_send must drive the deferred handshake to completion");
+        assert!(Transport::is_ready(&transport));
+
+        let received = crate::transport::recv_frame(&mut transport).await;
+        assert_eq!(
+            expect_received_frame(received),
+            TransportFrame::Text("server-hello".into())
+        );
+        crate::transport::close_transport(&mut transport)
+            .await
+            .expect("lazy transport close must succeed after connecting");
+        finish_mock_server(server_task).await;
+    }
+
+    #[tokio::test]
+    async fn lazy_transport_connects_on_first_poll_and_carries_traffic() {
+        let (url, server_task) = start_mock_server(|mut ws| async move {
+            ws.send(Message::Binary(vec![1, 2, 3].into()))
+                .await
+                .expect("server must send the probe frame");
+            while let Some(Ok(_)) = ws.next().await {}
+        })
+        .await;
+
+        let mut transport = WebSocketTransport::connect_lazy(url.clone());
+        assert_eq!(
+            Transport::max_frame_hint(&transport),
+            Some(DEFAULT_MAX_INBOUND_MESSAGE_SIZE),
+            "the lazy constructor declares the default inbound bound up front"
+        );
+        assert_eq!(
+            transport.token_binding_status(),
+            TokenBindingStatus::Disabled,
+            "the lazy constructors pin the disabled token-binding profile"
+        );
+
+        // `recv_frame` drives the deferred handshake through the real tokio
+        // waker: the first poll starts it, later polls run only when the
+        // handshake future wakes us, proving waker delivery. The timeout
+        // bounds a lost-waker regression as a test failure instead of a
+        // hung CI job.
+        let received = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            crate::transport::recv_frame(&mut transport),
+        )
+        .await
+        .expect("the handshake waker must be delivered promptly");
+        assert_eq!(
+            expect_received_frame(received),
+            TransportFrame::Binary(vec![1, 2, 3])
+        );
+        assert!(Transport::is_ready(&transport));
+
+        crate::transport::send_frame(&mut transport, TransportFrame::Text("hi".into()))
+            .await
+            .expect("post-handshake send must succeed");
+        assert_eq!(
+            Transport::max_frame_hint(&transport),
+            Some(DEFAULT_MAX_INBOUND_MESSAGE_SIZE),
+            "the declared hint must stay stable across the handshake"
+        );
+        crate::transport::close_transport(&mut transport)
+            .await
+            .expect("lazy transport close must succeed after connecting");
+        finish_mock_server(server_task).await;
+    }
+
+    #[tokio::test]
+    async fn lazy_transport_handshake_failure_is_delivered_once_then_fuses() {
+        // Port 1 is not listening (house precedent for a guaranteed refusal
+        // without a droppable-listener port-reuse race).
+        let mut transport = WebSocketTransport::connect_lazy("ws://127.0.0.1:1".into());
+        let error = crate::transport::recv_frame(&mut transport)
+            .await
+            .expect("handshake failure must surface as a terminal receive error")
+            .expect_err("the handshake must fail against a closed port");
+        assert!(
+            matches!(error, SignalFishError::Io(_)),
+            "unexpected: {error:?}"
+        );
+
+        // The transport is now fused: inert forever, still not ready.
+        assert!(!Transport::is_ready(&transport));
+        assert!(crate::transport::recv_frame(&mut transport).await.is_none());
+        assert!(matches!(
+            crate::transport::send_frame(&mut transport, TransportFrame::Text("x".into())).await,
+            Err(SignalFishError::TransportClosed)
+        ));
+        crate::transport::close_transport(&mut transport)
+            .await
+            .expect("close on a fused transport must succeed");
+        Transport::abort(&mut transport);
+        assert!(!Transport::is_ready(&transport));
+    }
+
+    #[tokio::test]
+    async fn lazy_transport_invalid_url_fails_on_first_poll_not_at_construction() {
+        let mut transport = WebSocketTransport::connect_lazy("not-a-valid-url".into());
+        assert!(!Transport::is_ready(&transport));
+        let error = crate::transport::recv_frame(&mut transport)
+            .await
+            .expect("handshake failure must surface as a terminal receive error")
+            .expect_err("an invalid URL must fail the deferred handshake");
+        assert!(
+            matches!(error, SignalFishError::InvalidConfig { .. }),
+            "unexpected: {error:?}"
+        );
+        assert!(!Transport::is_ready(&transport));
+        assert!(crate::transport::recv_frame(&mut transport).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn lazy_transport_zero_timeout_fails_the_handshake_with_timeout() {
+        let (url, _listener) = stalled_listener();
+        let mut transport =
+            WebSocketTransport::connect_lazy_with_timeout(url, std::time::Duration::ZERO);
+        let error = crate::transport::recv_frame(&mut transport)
+            .await
+            .expect("handshake failure must surface as a terminal receive error")
+            .expect_err("a zero deadline must fail the handshake immediately");
+        assert!(
+            matches!(error, SignalFishError::Timeout),
+            "unexpected: {error:?}"
+        );
+        assert!(!Transport::is_ready(&transport));
+        assert!(crate::transport::recv_frame(&mut transport).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn lazy_transport_close_during_handshake_completes_and_fuses() {
+        let (url, _listener) = stalled_listener();
+        let mut transport = WebSocketTransport::connect_lazy(url);
+
+        // Close before the handshake ever starts.
+        crate::transport::close_transport(&mut transport)
+            .await
+            .expect("close on an untouched lazy transport must complete");
+        assert!(!Transport::is_ready(&transport));
+        assert!(Transport::close_info(&transport).is_none());
+        assert!(crate::transport::recv_frame(&mut transport).await.is_none());
+        assert!(matches!(
+            crate::transport::send_frame(&mut transport, TransportFrame::Text("x".into())).await,
+            Err(SignalFishError::TransportClosed)
+        ));
+
+        // Close while a handshake is running: the future is cancelled and the
+        // close reports complete.
+        let (url, _listener) = stalled_listener();
+        let mut transport = WebSocketTransport::connect_lazy(url);
+        let waker = std::task::Waker::noop();
+        let mut cx = Context::from_waker(waker);
+        let mut frame = Some(TransportFrame::Text("queued".into()));
+        assert!(matches!(
+            Transport::poll_send(&mut transport, &mut cx, &mut frame),
+            Poll::Pending
+        ));
+        crate::transport::close_transport(&mut transport)
+            .await
+            .expect("close during the handshake must complete");
+        assert!(!Transport::is_ready(&transport));
+        assert!(crate::transport::recv_frame(&mut transport).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn lazy_transport_abort_during_handshake_is_prompt_idempotent_and_inert() {
+        let (url, _listener) = stalled_listener();
+        let mut transport = WebSocketTransport::connect_lazy(url);
+        let waker = std::task::Waker::noop();
+        let mut cx = Context::from_waker(waker);
+        let mut frame = Some(TransportFrame::Text("queued".into()));
+        assert!(matches!(
+            Transport::poll_send(&mut transport, &mut cx, &mut frame),
+            Poll::Pending
+        ));
+
+        Transport::abort(&mut transport);
+        Transport::abort(&mut transport);
+        assert!(!Transport::is_ready(&transport));
+        assert!(Transport::close_info(&transport).is_none());
+        assert_eq!(
+            frame.as_ref(),
+            Some(&TransportFrame::Text("queued".into())),
+            "abort must not fabricate acceptance of a frame the backend never took"
+        );
+        assert!(crate::transport::recv_frame(&mut transport).await.is_none());
+        crate::transport::close_transport(&mut transport)
+            .await
+            .expect("close after abort must succeed");
+    }
+
+    #[test]
+    fn lazy_transport_debug_never_formats_the_url() {
+        let transport =
+            WebSocketTransport::connect_lazy("ws://secret-host:3536/v2/ws?token=secret".into());
+        let rendered = format!("{transport:?}");
+        assert!(rendered.contains("lazy_handshake"));
+        assert!(
+            !rendered.contains("secret"),
+            "the lazy URL is connection information: {rendered}"
+        );
+    }
+
+    #[test]
+    fn lazy_transport_without_a_tokio_runtime_fails_classified_not_panicking() {
+        // No `#[tokio::test]`: this thread deliberately has no runtime.
+        let mut transport = WebSocketTransport::connect_lazy("ws://127.0.0.1:1".into());
+        let waker = std::task::Waker::noop();
+        let mut cx = Context::from_waker(waker);
+        let error = match Transport::poll_recv(&mut transport, &mut cx) {
+            Poll::Ready(Some(Err(error))) => error,
+            other => panic!("expected a classified handshake failure, got {other:?}"),
+        };
+        assert!(
+            matches!(error, SignalFishError::InvalidConfig { .. }),
+            "unexpected: {error:?}"
+        );
+        assert!(!Transport::is_ready(&transport));
+        assert!(matches!(
+            Transport::poll_recv(&mut transport, &mut cx),
+            Poll::Ready(None)
+        ));
+    }
+
+    #[test]
+    fn reconnect_factory_accepts_the_lazy_constructor() {
+        let url = "ws://localhost:3536/v2/ws".to_string();
+        let _policy = crate::ReconnectPolicy::new(move || {
+            Box::new(WebSocketTransport::connect_lazy(url.clone())) as Box<dyn Transport + Send>
+        });
     }
 }


### PR DESCRIPTION
## Why

Two open items, one PR:

1. **Issue #227 — automatic reconnection was harder than it should be.** The `ReconnectPolicy` factory must return an unconnected transport synchronously, but the built-in `WebSocketTransport` only had async constructors — so every consumer hand-wrote a ~170-line lazy wrapper (and the wrapper silently disabled the drivers' second inbound-frame-bound enforcement layer, because `max_frame_hint` could not be declared before readiness).
2. **Round 46 of the #126 correctness audit** (three fresh surfaces, parallel adversarial agents, hostile diff review, two convergence passes) found two real defects in the send-failure teardown path.

## What changed

**`WebSocketTransport::connect_lazy(url)` / `connect_lazy_with_timeout(url, timeout)`** — closes #227.
- Handshake starts on the first driver poll; `is_ready()` stays `false` until it completes, and a failed/abandoned handshake delivers its error exactly once, then fuses (no phantom `Connected`).
- Declares the default 8 MiB inbound frame bound immediately, so both drivers enforce it from the first round (the wrapper's foot-gun, gone).
- Built-in 10 s handshake stall deadline (configurable): a black-holed peer is a retryable `Timeout` a reconnect policy can count, not a forever-`Pending` hang.
- Polling without a tokio runtime fails with a classified `InvalidConfig` instead of panicking inside the reactor.
- `examples/auto_reconnect.rs`, the `ReconnectPolicy` rustdoc, and the client guide now use the constructor; the hand-written wrapper is deleted.

**Send-failure teardown hardening** (round-46 findings, both red/green pinned).
- Drained frames from a transport that never reported readiness are contract-violating input — the main loops already tear down on them; the teardown drains now discard them too, on both drivers, instead of applying a hostile backend's state.
- The polling driver re-samples readiness after a send failure (async parity): a deferred handshake completing inside the failing `poll_send` still emits `Connected` and delivers the backend's farewell frames.

Also: `Transport::is_ready`'s contract doc (and the transport-abstraction skill) gains the pre-ready-fused terminal-delivery carve-out the lazy constructors exercise.

## Verification

- Mandatory workflow clean: `cargo fmt`, `clippy --workspace --all-targets --all-features -D warnings` (zero warnings), full test suite green.
- 13 new tests (11 lazy-constructor + 2×2 red/green teardown pins); the red states were verified by reverting the fix.
- One audit finding needs a seam design decision rather than a patch — filed as #229 with candidate directions.

CHANGELOG updated under `[Unreleased]` (Added ×2, Fixed ×1).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes public WebSocket construction and both drivers' disconnect/teardown paths; incorrect readiness or drain behavior would affect reconnect loops and event ordering, though auth and wire formats are untouched.
> 
> **Overview**
> Adds **`WebSocketTransport::connect_lazy`** / **`connect_lazy_with_timeout`** so `ReconnectPolicy` factories can return an unconnected transport synchronously: the handshake runs on the first poll, **`is_ready()`** stays false until success, failed handshakes fuse with a one-shot error (no synthetic **`Connected`**), the default **8 MiB** inbound bound is declared up front, and a **10s** stall becomes a retryable **`Timeout`**. The auto-reconnect example, client guide, and rustdoc drop the hand-written lazy wrapper in favor of these constructors.
> 
> **Send-failure teardown** is tightened on both drivers: frames drained after a send error are applied only if the transport had reported readiness; otherwise they are discarded so a never-ready hostile backend cannot drive protocol state during teardown. The polling driver **re-samples readiness** after send failure so a handshake that completes inside the failing **`poll_send`** still emits **`Connected`** and can apply farewell frames, matching async behavior.
> 
> **`Transport::is_ready`** documentation (and the transport-abstraction skill) now covers transports that fuse before readiness while still delivering terminal errors/EOF on poll.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6dd9cfe5d3e7b7836fa38663b1e81ed1f075e295. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->