### PR TITLE
Round 48: bound backoff computation; docs parity and copy fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Opt-in automatic reconnection for the async client: `ReconnectPolicy`
-  (via **Breaking:** new `SignalFishConfig` field
-  `reconnect_policy` — exhaustive struct literals must add the field,
-  usually `reconnect_policy: None`) rebuilds the transport from a caller
-  factory with deterministic exponential backoff, re-authenticates, and
-  issues the directed `reconnect` automatically when the dead connection
-  ended inside a player room; shutdown, dropped handles, and
-  `Disconnect`-policy teardowns are never retried, and the polling client
-  stays caller-driven.
+- **Breaking:** `SignalFishConfig` gains a `reconnect_policy` field;
+  exhaustive struct literals must add it, usually `reconnect_policy: None`.
+  The opt-in `ReconnectPolicy` auto-reconnects the async client with
+  deterministic exponential backoff — re-authenticating and reissuing the
+  directed `reconnect` after a room disconnect; shutdown, dropped handles,
+  and `Disconnect`-policy teardowns are never retried, and the polling
+  client stays caller-driven.
 - **Breaking:** the exhaustive `SignalFishEvent` enum gains `Reconnecting {
   attempt, next_backoff }` and `ReconnectAbandoned { attempts, last_reason }`
   (the reconnect policy's per-attempt and terminal events); add two arms to
@@ -29,11 +27,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `impl Transport for Box<dyn Transport + Send>` so owned trait objects
   (including the reconnect factory's products) flow through the same driver
   plumbing as concrete transports.
-- `Transport::max_frame_hint()`: backends that enforce an inbound frame bound
-  declare it, and both client drivers then refuse larger frames as a terminal
-  receive error before any decoding (the built-in WebSocket and Emscripten
-  transports report their bounds, as does the Godot adapter for SDK-created
-  peers; the default `None` preserves current behavior).
+- `Transport::max_frame_hint()`: a backend can declare its inbound frame
+  bound, and both drivers then reject larger frames as a terminal receive
+  error before decoding. The WebSocket, Emscripten, and Godot (SDK-created
+  peers) transports declare their bounds; the default `None` keeps current
+  behavior.
 - `SignalFishEvent::redacted_raw_prefix()`: a safe-path view of
   `DecodeFailed`'s raw frame prefix that masks every string literal's content
   while preserving the JSON skeleton.
@@ -45,13 +43,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `WebSocketTransport`, plus the same pattern in the reconnect rustdoc and
   guide.
 - `WebSocketTransport::connect_lazy(url)` and `connect_lazy_with_timeout`:
-  first-class lazy constructors for the `ReconnectPolicy` factory — the
-  handshake starts on the first driver poll instead of at construction.
-  They declare the default 8 MiB inbound frame bound immediately (so both
-  drivers enforce it from the first round), pin the disabled token-binding
-  profile, and fail a stalled handshake as a retryable `Timeout` after 10
-  seconds (configurable) instead of hanging forever; the example ships this
-  constructor instead of a hand-written lazy wrapper.
+  the handshake starts on the first driver poll, not at construction. They
+  declare the default 8 MiB frame bound up front, pin token binding off, and
+  turn a stalled handshake (10 s default, configurable) into a retryable
+  `Timeout`; the `auto_reconnect` example ships this constructor.
 
 ### Changed
 
@@ -60,11 +55,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reconnect barrier when legacy generationless plans leave no generation to
   fence with (issue #229).
 - **Breaking:** `JoinRoomParams`'s `Debug` output now reports its room code
-  as presence and byte length (the `ClientSnapshot` form), and
-  **Breaking:** `SpectatorJoinedPayload`'s `Debug` is now fully opaque
-  (matching the other room-baseline payloads): a room code is
-  join-capability knowledge, so ambient logs no longer leak it from a
-  payload or a builder. Public fields and wire serialization are unchanged.
+  as presence and byte length (the `ClientSnapshot` form). Public fields and
+  wire serialization are unchanged.
+- **Breaking:** `SpectatorJoinedPayload`'s `Debug` is now fully opaque,
+  matching the other room-baseline payloads: a room code is join-capability
+  knowledge, so ambient logs no longer leak it from a payload or a builder.
 - `SignalFishConfig::with_protocol_version` now logs a `tracing::warn!` for
   versions outside the known-supported `2..=3` range (the value is still sent
   unchanged; the server stays the negotiation authority).
@@ -93,15 +88,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   farewell frames exactly like the async driver.
 - Documentation accuracy: `docs/events.md` now counts the 38 (not 36)
   `SignalFishEvent` variants and documents the scripted-peer join-snapshot
-  contract (unique local player entry, v3 `epoch`/`seq` pairing, v2
-  baseline omission); `docs/client.md` now routes `start_game` rejections
-  through the `Error` event's error codes and documents the binary-send
-  error precedence (v3 `ProtocolUnsupported` gate before
-  `BinaryFormatNotNegotiated`); `docs/concepts.md` matches that precedence;
-  `docs/protocol.md` documents the `websocket`-only `MessageTransport`
-  value set and that `ProtocolInfo`'s optional fields must be omitted
-  rather than sent as `null`; the `redacted_raw_prefix()` contract now
-  states that non-JSON frames pass through effectively verbatim.
+  contract; `docs/client.md` routes `start_game` rejections through the
+  `Error` event's error codes and documents the binary-send error
+  precedence; `docs/concepts.md` matches that precedence; `docs/protocol.md`
+  documents the `websocket`-only `MessageTransport` value set and that
+  `ProtocolInfo`'s optional fields must be omitted rather than sent as
+  `null`; the `redacted_raw_prefix()` contract states that non-JSON frames
+  pass through effectively verbatim.
 - The mesh guide documents the complete manual driver-choreography contract
   for `tokio-runtime`-less (WASM) builds — fold/drive, signal relay with
   exact retry-versus-terminal semantics, the 0↔1 transport-status edge, and
@@ -118,13 +111,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   for `ReconnectionFailed`, the 4000 drain deadline, and others), gave the
   errors guide's `UnsupportedProtocolVersion` row its second trigger, and
   pointed the concepts guide's `Timeout` row at its single producer.
-- Fixed the fortress guide's stale guidance that still directed readers to a
-  git dependency for APIs published in 0.12.0.
+- The fortress, mesh, and token-binding guides now show versioned `0.12.0`
+  dependencies for APIs that 0.12.0 already published; their install
+  snippets no longer point at `main`.
 - Documented the `WebRtcDriver` seam's drain contract (the controller stops
   at the first surfacing event, refused relay, or idle poll — not at
   exhaustion), its panic boundary, the one-time `set_ready_waker` timing,
   the plan catch-up suppression of driver output, duplicate edge surfacing,
   and the `with_pump_interval` 1 ms floor.
+- `ReconnectPolicy::backoff_for_attempt` now returns every attempt's delay
+  in bounded time: a zero initial backoff no longer walks the whole doubling
+  schedule once per attempt on the driver loop.
+- Documented that `event_channel_capacity` is async-driver only; the polling
+  client delivers events synchronously and ignores it.
+- Documented the polling `send_capacity()` trap: after close or disconnect
+  the queue is cleared, so it reads full capacity while sends fail.
+- `Transport::is_ready`'s contract now documents the pre-ready fused
+  terminal-delivery carve-out.
 
 ## [0.12.0] - 2026-09-01
 

--- a/docs/client.md
+++ b/docs/client.md
@@ -41,7 +41,7 @@ let config = SignalFishConfig::new("mb_app_abc123");
 | `protocol_version` | `Option<u16>` | `None` | Highest signaling protocol version advertised. `None` preserves the v2 relay floor. Prefer `enable_v3()` or `enable_mesh()` over setting this alone. |
 | `supported_transports` | `Option<Vec<TransportKind>>` | `None` | Protocol-v3 data-path transports the application can actually fulfill. |
 | `supported_topologies` | `Option<Vec<Topology>>` | `None` | Protocol-v3 session topologies the application can participate in. |
-| `event_channel_capacity` | `usize` | `256` | Capacity of the bounded event channel. Events are never dropped on overflow — a full channel pauses the transport loop (backpressure), so this only controls buffering before backpressure kicks in. Values below 1 are clamped to 1; values above tokio's semaphore permit ceiling (`usize::MAX >> 3`) are clamped to that ceiling. |
+| `event_channel_capacity` | `usize` | `256` | Capacity of the bounded event channel. Events are never dropped on overflow — a full channel pauses the transport loop (backpressure), so this only controls buffering before backpressure kicks in. Values below 1 are clamped to 1; values above tokio's semaphore permit ceiling (`usize::MAX >> 3`) are clamped to that ceiling. Async driver only: the polling client ignores it (events come from `poll()`). |
 | `command_channel_capacity` | `usize` | `1024` | Capacity of the bounded outgoing command queue. When full, the synchronous send methods fail fast with [`SignalFishError::SendBufferFull`](errors.md#handling-sendbufferfull); the `*_reliable` variants wait for a slot instead. Values below 1 are clamped to 1; values above tokio's semaphore permit ceiling (`usize::MAX >> 3`) are clamped to that ceiling. |
 | `shutdown_timeout` | `Duration` | `1 second` | Deadline for async shutdown and polling-client close (including optional queued-work flush). A zero timeout aborts immediately. |
 | `protocol_violation_policy` | `ProtocolViolationPolicy` | `Quarantine` | Response to invalid v3 delivery-accountability state: quarantine room data, disconnect, or observe. |
@@ -993,7 +993,7 @@ All accessors are **synchronous** (no async, no mutex):
 | `current_player_id()` | `Option<PlayerId>` | Legacy name for the local player-or-spectator participant ID. |
 | `current_room_id()` | `Option<RoomId>` | Current room ID, if in a room. |
 | `current_room_code()` | `Option<&str>` | Current room code, if in a room. |
-| `send_capacity()` | `usize` | Messages that can still be queued before `SendBufferFull`. |
+| `send_capacity()` | `usize` | Messages that can still be queued before `SendBufferFull`. Queue-space only, not liveness: on a closed or disconnected client the queue is cleared, so this reads full capacity while sends fail with `NotConnected` — pair with `is_connected()`. |
 | `max_send_capacity()` | `usize` | Configured command-queue capacity. |
 | `stats()` | `ClientStats` | Cumulative `game_data_sent` / `game_data_received` / `messages_undecodable` counters (see [Send Queue and Traffic Stats](#send-queue-and-traffic-stats)). |
 | `snapshot()` | `ClientSnapshot` | Coherent connection readiness, room, reconnect-token, negotiation, selected-plan, and quarantine state. |

--- a/docs/fortress.md
+++ b/docs/fortress.md
@@ -10,8 +10,8 @@ Add the rollback library beside the SDK in the Godot GDExtension crate:
 fortress-rollback = "=0.13.0"
 godot = { version = "0.5.5", features = ["api-custom", "experimental-wasm", "experimental-wasm-nothreads", "lazy-function-tables"] }
 serde = { version = "1.0", features = ["derive"] }
-signal-fish-client = { git = "https://github.com/Ambiguous-Interactive/signal-fish-client-rust", default-features = false, features = ["polling-client"] }
-signal-fish-client-godot = { git = "https://github.com/Ambiguous-Interactive/signal-fish-client-rust" }
+signal-fish-client = { version = "0.12.0", default-features = false, features = ["polling-client"] }
+signal-fish-client-godot = "0.12.0"
 ```
 
 The adapter supports godot-rust 0.4.5 through 0.5.x and requires Rust 1.94;

--- a/docs/mesh-guide.md
+++ b/docs/mesh-guide.md
@@ -11,7 +11,7 @@ drive the whole handshake for you.
     `tokio-runtime` feature.
 
     ```toml
-    signal-fish-client = { git = "https://github.com/Ambiguous-Interactive/signal-fish-client-rust", features = ["mesh"] }
+    signal-fish-client = { version = "0.12.0", features = ["mesh"] }
     ```
 
     The generation-bearing protocol-v3 mesh APIs in this guide are all

--- a/docs/token-binding.md
+++ b/docs/token-binding.md
@@ -7,7 +7,7 @@ feature.
 
 ```toml
 [dependencies]
-signal-fish-client = { git = "https://github.com/Ambiguous-Interactive/signal-fish-client-rust", features = ["token-binding", "tls"] }
+signal-fish-client = { version = "0.12.0", features = ["token-binding", "tls"] }
 ```
 
 `token-binding` is not a default feature. Ordinary builds therefore keep the

--- a/src/client.rs
+++ b/src/client.rs
@@ -266,6 +266,10 @@ pub struct SignalFishConfig {
     /// Defaults to **256**. Values below 1 are clamped to 1; values above
     /// tokio's semaphore permit ceiling (`usize::MAX >> 3`) are clamped to
     /// that ceiling.
+    ///
+    /// Async driver only. The polling client (and the Godot adapter built on
+    /// it) deliver events synchronously from [`SignalFishPollingClient::poll`]
+    /// and ignore this value.
     pub event_channel_capacity: usize,
     /// Capacity of the bounded outgoing command queue.
     ///
@@ -838,12 +842,17 @@ impl ReconnectPolicy {
     /// the driver uses the same computation.
     #[must_use]
     pub fn backoff_for_attempt(&self, attempt: u32) -> Duration {
-        // Doubling saturates instead of overflowing: attempt counts beyond
-        // the schedule's doubling horizon all produce the same capped delay.
+        // Doubling saturates instead of overflowing, and a saturated or zero
+        // delay never grows: both end the loop, so the work per call is
+        // bounded no matter how large `attempt` is.
         let mut delay = self.initial_backoff;
         let mut doublings = attempt.saturating_sub(1);
         while doublings > 0 {
-            delay = delay.saturating_mul(2);
+            let doubled = delay.saturating_mul(2);
+            if doubled <= delay {
+                break;
+            }
+            delay = doubled;
             if delay >= self.max_backoff {
                 return self.max_backoff;
             }
@@ -9457,6 +9466,29 @@ mod tests {
             policy.backoff_for_attempt(u32::MAX),
             Duration::from_secs(10)
         );
+    }
+
+    #[test]
+    fn backoff_schedule_zero_initial_and_saturation_stay_constant_work() {
+        // A zero initial backoff never grows: every attempt waits zero,
+        // and huge attempt numbers must not walk the whole doubling loop.
+        let zero = ReconnectPolicy::new(|| {
+            Box::new(MockTransport::new(vec![]).0) as Box<dyn Transport + Send>
+        })
+        .with_initial_backoff(Duration::ZERO)
+        .with_max_backoff(Duration::from_secs(10));
+        assert_eq!(zero.backoff_for_attempt(1), Duration::ZERO);
+        assert_eq!(zero.backoff_for_attempt(1_000), Duration::ZERO);
+        assert_eq!(zero.backoff_for_attempt(u32::MAX), Duration::ZERO);
+
+        // A saturated initial backoff stops growing in one doubling step.
+        let saturated = ReconnectPolicy::new(|| {
+            Box::new(MockTransport::new(vec![]).0) as Box<dyn Transport + Send>
+        })
+        .with_initial_backoff(Duration::MAX)
+        .with_max_backoff(Duration::MAX);
+        assert_eq!(saturated.backoff_for_attempt(1), Duration::MAX);
+        assert_eq!(saturated.backoff_for_attempt(u32::MAX), Duration::MAX);
     }
 
     #[test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -268,7 +268,8 @@ pub struct SignalFishConfig {
     /// that ceiling.
     ///
     /// Async driver only. The polling client (and the Godot adapter built on
-    /// it) deliver events synchronously from [`SignalFishPollingClient::poll`]
+    /// it) deliver events synchronously from
+    /// [`SignalFishPollingClient::poll`](crate::polling_client::SignalFishPollingClient::poll)
     /// and ignore this value.
     pub event_channel_capacity: usize,
     /// Capacity of the bounded outgoing command queue.

--- a/src/polling_client.rs
+++ b/src/polling_client.rs
@@ -956,6 +956,13 @@ impl<T: Transport> SignalFishPollingClient<T> {
     ///
     /// The queue drains on every [`poll()`](Self::poll) while the transport
     /// accepts writes, so a shrinking value means the transport is congested.
+    ///
+    /// This is a *queue-space* diagnostic, not a liveness signal: on a closed
+    /// or disconnected client the queue is abandoned and cleared, so this
+    /// reports full capacity while every send fails with
+    /// [`SignalFishError::NotConnected`]. Pair it with
+    /// [`is_connected`](Self::is_connected) or [`is_closing`](Self::is_closing)
+    /// to observe connection health.
     #[must_use = "this diagnostic view is discarded if not used"]
     pub fn send_capacity(&self) -> usize {
         self.command_capacity.saturating_sub(self.cmd_queue.len())


### PR DESCRIPTION
## Why

Paranoid-audit round 48 (issue #126) ran three fresh surfaces. It found one real code defect and a few doc-drift items. All are fixed here.

## What

- **Backoff fix:** `ReconnectPolicy::backoff_for_attempt` walked its doubling loop once per attempt. With the documented `initial_backoff = Duration::ZERO`, the driver loop spun before every `Reconnecting` event — ~109 s at `u32::MAX` in debug. A saturation break now ends the loop at once. Results are identical (24-case equivalence sweep); red/green probe included.
- **Docs parity:** `event_channel_capacity` is async-driver only — the polling client and Godot adapter deliver synchronously and ignore it. Polling `send_capacity()` now warns that a dead client reads full capacity while sends fail.
- **Install snippets:** the fortress, mesh, and token-binding guides pointed at git `main` while their own prose said 0.12.0 published those APIs. They now show versioned `0.12.0` deps. Guides that hedge ("to evaluate unreleased changes") keep git snippets.
- **Changelog:** `[Unreleased]` entries condensed to short, simple sentences; `**Breaking:**` markers moved to the front; the Debug entry split in two; missing `Transport::is_ready` carve-out entry added.

## Verification

- `cargo fmt` + `cargo clippy -D warnings` + `cargo test --workspace --all-features` all green.
- Two review rounds (hostile reviewer + convergence verifier) ended with zero findings.
- All 17 pre-commit checks pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving performance fix to reconnect backoff math plus documentation and changelog edits; no auth, wire, or API surface changes beyond comments.
> 
> **Overview**
> Fixes **`ReconnectPolicy::backoff_for_attempt`** so doubling stops when delay can no longer grow (zero or saturated `Duration`). That keeps each call **O(1)** instead of walking `attempt - 1` iterations—important when `initial_backoff` is zero and the async reconnect driver calls this on every attempt.
> 
> Documentation and release notes catch up: **`event_channel_capacity`** is documented as **async-driver only** (polling/Godot ignore it); polling **`send_capacity()`** is clarified as queue space, not liveness (dead clients can show full capacity while sends fail). Fortress, mesh, and token-binding guides switch install snippets from **git `main`** to **`signal-fish-client` 0.12.0** where the prose already claimed those APIs shipped. **`CHANGELOG.md` `[Unreleased]`** is tightened (breaking markers, split Debug entries, added `Transport::is_ready` carve-out note).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a01ce143984853b9d7e4ca0021a818fb268fc85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->