### PR TITLE
Round 49: pin reconnect-policy lifecycle, gap-reason buckets, public docs hygiene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   exhaustive struct literals must add it, usually `reconnect_policy: None`.
   The opt-in `ReconnectPolicy` auto-reconnects the async client with
   deterministic exponential backoff — re-authenticating and reissuing the
-  directed `reconnect` after a room disconnect; shutdown, dropped handles,
-  and `Disconnect`-policy teardowns are never retried, and the polling
-  client stays caller-driven.
+  directed `reconnect` after a player-room disconnect; shutdown, dropped
+  handles, and `Disconnect`-policy teardowns are never retried, and the
+  polling client stays caller-driven.
 - **Breaking:** the exhaustive `SignalFishEvent` enum gains `Reconnecting {
   attempt, next_backoff }` and `ReconnectAbandoned { attempts, last_reason }`
   (the reconnect policy's per-attempt and terminal events); add two arms to
@@ -70,6 +70,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   presence and byte length instead of printing the value: a room code is
   join-capability knowledge, so ambient logs no longer leak it. The public
   `room_code` field is unchanged.
+- Rustdoc now documents every `ErrorCode` variant plus the previously bare
+  `ClientSnapshot`, `DeliveryGapReason`, `DeliveryGap`, `ReplayStatus`,
+  `ProtocolViolationKind`, and `GameDataDelivery::Latest::key` members, with
+  intra-doc links for `TransportFrame`, `ServerMessage`, `WebSocketTransport`,
+  and `SignalFishEvent`.
 
 ### Fixed
 
@@ -128,6 +133,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the queue is cleared, so it reads full capacity while sends fail.
 - `Transport::is_ready`'s contract now documents the pre-ready fused
   terminal-delivery carve-out.
+- Corrected the `auto_reconnect` example's header: the default v2 endpoint
+  re-authenticates but never auto-rejoins (auto-rejoin needs a v3
+  token-bearing player room), and a duplicate `join_room` there is refused
+  with `RoomOperationPending` or displaces the automatic rejoin — it is not
+  "requested twice per round".
 
 ## [0.12.0] - 2026-09-01
 

--- a/examples/auto_reconnect.rs
+++ b/examples/auto_reconnect.rs
@@ -21,12 +21,14 @@
 //!
 //! Try killing and restarting the server while the example runs: every
 //! retryable disconnect prints a `Reconnecting` event and the client
-//! re-authenticates and re-joins its room automatically.
+//! re-authenticates on the fresh connection automatically.
 //!
-//! On protocol v3 (`.enable_v3()`) the driver additionally auto-rejoins a
-//! player room after reconnecting; drop this template's
-//! `join_room`-on-`Authenticated` call in that configuration, or the seat is
-//! requested twice per round.
+//! On protocol v3 (`.enable_v3()`), a disconnect inside a *player* room also
+//! reissues the directed `reconnect` automatically — spectator rooms never
+//! auto-rejoin, because the protocol issues no spectator token. In that
+//! configuration drop this template's `join_room`-on-`Authenticated` call:
+//! one room operation may be admitted per round, so the manual join is
+//! refused with `RoomOperationPending` or displaces the automatic rejoin.
 
 use signal_fish_client::{
     JoinRoomParams, ReconnectPolicy, SignalFishClient, SignalFishConfig, SignalFishEvent,

--- a/src/accountability.rs
+++ b/src/accountability.rs
@@ -1350,6 +1350,80 @@ mod tests {
     }
 
     #[test]
+    fn dropped_full_and_volatile_gap_reasons_align_with_their_counter_buckets() {
+        // Every gap reason must sum into its own counter bucket: a bucket
+        // swap (or a dropped mapping arm) would mis-validate server loss
+        // accounting, so both `LatestDroppedFull` and `VolatileDropped` are
+        // pinned in the accepted pairing and against a mis-bucketed pairing.
+        for (reason, fill_bucket) in [
+            (
+                DeliveryGapReason::LatestDroppedFull,
+                (|c: &mut DeliveryCountersByClass, n: u64| c.latest.dropped_full = n)
+                    as fn(&mut DeliveryCountersByClass, u64),
+            ),
+            (
+                DeliveryGapReason::VolatileDropped,
+                (|c: &mut DeliveryCountersByClass, n: u64| c.volatile.dropped = n)
+                    as fn(&mut DeliveryCountersByClass, u64),
+            ),
+        ] {
+            let sender = id(1);
+
+            // Accepted pairing: the causal gap count lands in its own bucket.
+            let mut state = DeliveryAccountability::default();
+            state.note_player_joined(&player(sender, 1)).unwrap();
+            state
+                .record_game_data(sender, Some(1), Some(1), None, None)
+                .unwrap();
+            let mut bucket_counters = counters(0);
+            fill_bucket(&mut bucket_counters, 2);
+            state
+                .record_report(&DeliveryReportPayload {
+                    per_class: bucket_counters,
+                    gaps: vec![DeliveryGap {
+                        from_player: sender,
+                        epoch: 1,
+                        from_seq: 2,
+                        to_seq: 3,
+                        reason,
+                    }],
+                })
+                .unwrap_or_else(|error| panic!("{reason:?} pairing must be accepted: {error}"));
+            // The covered range authorizes the next sequence.
+            state
+                .record_game_data(sender, Some(4), Some(1), None, None)
+                .unwrap_or_else(|error| {
+                    panic!("{reason:?} coverage must authorize seq 4: {error}")
+                });
+
+            // Mis-bucketed pairing: the same gap units reported against a
+            // different bucket must violate.
+            let mut state = DeliveryAccountability::default();
+            state.note_player_joined(&player(sender, 1)).unwrap();
+            state
+                .record_game_data(sender, Some(1), Some(1), None, None)
+                .unwrap();
+            let mut bucket_counters = counters(0);
+            bucket_counters.latest.superseded = 2;
+            assert!(
+                state
+                    .record_report(&DeliveryReportPayload {
+                        per_class: bucket_counters,
+                        gaps: vec![DeliveryGap {
+                            from_player: sender,
+                            epoch: 1,
+                            from_seq: 2,
+                            to_seq: 3,
+                            reason,
+                        }],
+                    })
+                    .is_err(),
+                "{reason:?} gaps must not validate against another bucket's counters"
+            );
+        }
+    }
+
+    #[test]
     fn same_socket_frontiers_survive_reconnect_watermark_rebaseline() {
         let sender = id(2);
         let mut state = DeliveryAccountability::default();

--- a/src/accountability.rs
+++ b/src/accountability.rs
@@ -1352,9 +1352,10 @@ mod tests {
     #[test]
     fn dropped_full_and_volatile_gap_reasons_align_with_their_counter_buckets() {
         // Every gap reason must sum into its own counter bucket: a bucket
-        // swap (or a dropped mapping arm) would mis-validate server loss
-        // accounting, so both `LatestDroppedFull` and `VolatileDropped` are
-        // pinned in the accepted pairing and against a mis-bucketed pairing.
+        // swap (or a dropped mapping arm) would corrupt server loss
+        // accounting validation, so both `LatestDroppedFull` and
+        // `VolatileDropped` are pinned in the accepted pairing and against
+        // a wrong-bucket pairing.
         for (reason, fill_bucket) in [
             (
                 DeliveryGapReason::LatestDroppedFull,
@@ -1396,7 +1397,7 @@ mod tests {
                     panic!("{reason:?} coverage must authorize seq 4: {error}")
                 });
 
-            // Mis-bucketed pairing: the same gap units reported against a
+            // Wrong-bucket pairing: the same gap units reported against a
             // different bucket must violate.
             let mut state = DeliveryAccountability::default();
             state.note_player_joined(&player(sender, 1)).unwrap();

--- a/src/client.rs
+++ b/src/client.rs
@@ -611,7 +611,13 @@ pub enum GameDataDelivery {
     #[default]
     Reliable,
     /// Retain only the newest undelivered value for this sender-defined key.
-    Latest { key: u32 },
+    ///
+    /// The key is caller-chosen; the server coalesces per (sender, key), so
+    /// a newer value on the same key supersedes an undelivered older one.
+    Latest {
+        /// The caller-chosen coalescing key.
+        key: u32,
+    },
     /// Deliver opportunistically without sender backpressure.
     Volatile,
 }
@@ -1061,6 +1067,10 @@ pub struct ClientSnapshot {
     pub transport_ready: bool,
     /// Whether the server has confirmed authentication for this connection.
     pub authenticated: bool,
+    /// Protocol version negotiated with the server: `Some(v)` with `v >= 3`
+    /// once the server's [`ProtocolInfo`](SignalFishEvent::ProtocolInfo)
+    /// reports its version. `None` while un-negotiated, for frozen-v2
+    /// servers, and after the connection ends.
     pub negotiated_protocol_version: Option<u16>,
     /// Exact game-data preference supplied in [`SignalFishConfig`].
     ///
@@ -1099,7 +1109,16 @@ pub struct ClientSnapshot {
     /// Cleared together with [`room_role`](Self::room_role) on every confirmed
     /// room or spectator exit.
     pub player_id: Option<PlayerId>,
+    /// Authoritative room ID of the joined room.
+    ///
+    /// Cleared together with [`room_role`](Self::room_role) on every
+    /// confirmed room or spectator exit.
     pub room_id: Option<RoomId>,
+    /// Room code of the joined room, as join-capability knowledge.
+    ///
+    /// Cleared together with [`room_role`](Self::room_role) on every
+    /// confirmed room or spectator exit, and [`Debug`]-redacted to presence
+    /// and byte length like every other ambient-log surface.
     pub room_code: Option<String>,
     /// Generation from the latest authoritative session plan.
     ///
@@ -8835,6 +8854,237 @@ mod tests {
             let message: serde_json::Value = serde_json::from_str(last).unwrap();
             assert_eq!(message["type"], "Reconnect");
             assert_eq!(message["data"]["auth_token"], "tok-1");
+        }
+        client.shutdown().await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn reconnect_policy_spectator_rooms_never_auto_rejoin() {
+        // Round 1: authenticate, join as a spectator (no reconnection token
+        // exists for spectators), die.
+        let (transport1, _sent1, closed1, controls1) = MockTransport::new_shared(vec![
+            Some(Ok(authenticated_json())),
+            Some(Ok(protocol_info_v3_json())),
+            Some(Ok(spectator_joined_json())),
+        ]);
+        // Round 2: authenticate again; nothing else may be sent — the
+        // protocol has no spectator reconnect, so the retained context must
+        // not exist.
+        let (transport2, sent2, _closed2) = MockTransport::new(vec![
+            Some(Ok(authenticated_json())),
+            Some(Ok(protocol_info_v3_json())),
+        ]);
+        let pool = transport_pool(vec![transport2]);
+        let policy = ReconnectPolicy::new(pool_factory(&pool))
+            .with_max_attempts(3)
+            .with_initial_backoff(Duration::from_millis(50));
+        let config = SignalFishConfig::new("mb_reconnect")
+            .enable_v3()
+            .with_reconnect_policy(policy);
+        let (mut client, mut events) = SignalFishClient::start(transport1, config);
+
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Connected)
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Authenticated { .. })
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::ProtocolInfo(_))
+        ));
+        client
+            .join_as_spectator("spec-game".into(), "SPEC1".into(), "viewer".into())
+            .unwrap();
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::SpectatorJoined { .. })
+        ));
+        // The loop is parked here (nothing scripted), so the snapshot is
+        // race-free.
+        let snapshot = client.snapshot();
+        assert_eq!(snapshot.room_role, Some(RoomRole::Spectator));
+        assert_eq!(
+            snapshot.reconnection_token, None,
+            "spectator baselines carry no reconnection token"
+        );
+
+        controls1.close_peer();
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Disconnected { .. })
+        ));
+        match events.recv().await {
+            Some(SignalFishEvent::Reconnecting { attempt, .. }) => {
+                assert_eq!(attempt, 1);
+            }
+            other => panic!("expected Reconnecting, got {other:?}"),
+        }
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Connected)
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Authenticated { .. })
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::ProtocolInfo(_))
+        ));
+        {
+            let sent2 = sent2.lock().unwrap();
+            assert_eq!(
+                sent2.len(),
+                1,
+                "round-2 wire must carry only the reseeded Authenticate"
+            );
+            let message: serde_json::Value = serde_json::from_str(&sent2[0]).unwrap();
+            assert_eq!(message["type"], "Authenticate");
+        }
+        // A virtual beat later the wire is unchanged: no automatic room
+        // operation ever fires for a spectator baseline.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(sent2.lock().unwrap().len(), 1);
+        assert!(closed1.load(Ordering::Acquire), "round-1 transport closed");
+        client.shutdown().await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn reconnect_budget_resets_after_reauth_and_retained_context_is_single_use() {
+        // Round 1: authenticate, join a token-bearing player room, die.
+        let (transport1, _sent1, _closed1) = MockTransport::new(vec![
+            Some(Ok(authenticated_json())),
+            Some(Ok(protocol_info_v3_json())),
+            Some(Ok(room_joined_json_with_token("tok-1"))),
+            None,
+        ]);
+        // Round 2: re-authenticates (resetting the attempt budget), stages
+        // the automatic reconnect — consuming the retained context — and
+        // dies before any reply.
+        let (transport2, sent2, _closed2) = MockTransport::new(vec![
+            Some(Ok(authenticated_json())),
+            Some(Ok(protocol_info_v3_json())),
+            None,
+        ]);
+        // Round 3 exists only because the budget reset after round 2's
+        // re-authentication: max_attempts is 1.
+        let (transport3, sent3, _closed3) = MockTransport::new(vec![
+            Some(Ok(authenticated_json())),
+            Some(Ok(protocol_info_v3_json())),
+        ]);
+        let pool = transport_pool(vec![transport2, transport3]);
+        let policy = ReconnectPolicy::new(pool_factory(&pool))
+            .with_max_attempts(1)
+            .with_initial_backoff(Duration::from_millis(50));
+        let config = SignalFishConfig::new("mb_reconnect")
+            .enable_v3()
+            .with_reconnect_policy(policy);
+        let (mut client, mut events) = SignalFishClient::start(transport1, config);
+
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Connected)
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Authenticated { .. })
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::ProtocolInfo(_))
+        ));
+        client
+            .join_room(JoinRoomParams::new("test-game", "local"))
+            .unwrap();
+        match events.recv().await {
+            Some(SignalFishEvent::RoomJoined {
+                reconnection_token, ..
+            }) => {
+                assert_eq!(reconnection_token.as_deref(), Some("tok-1"));
+            }
+            other => panic!("expected RoomJoined, got {other:?}"),
+        }
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Disconnected { .. })
+        ));
+        match events.recv().await {
+            Some(SignalFishEvent::Reconnecting {
+                attempt,
+                next_backoff,
+            }) => {
+                assert_eq!(attempt, 1);
+                assert_eq!(next_backoff, Duration::from_millis(50));
+            }
+            other => panic!("expected Reconnecting, got {other:?}"),
+        }
+        // Round 2: the automatic reconnect is staged the moment the fresh
+        // connection authenticates.
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Connected)
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Authenticated { .. })
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::ProtocolInfo(_))
+        ));
+        // The staged automatic reconnect reached the wire before the round
+        // died (`poll_transport_io` flushes pending sends before polling
+        // receives), with the retained token.
+        {
+            let sent2 = sent2.lock().unwrap();
+            assert_eq!(sent2.len(), 2, "round-2 wire: Authenticate then Reconnect");
+            let message: serde_json::Value = serde_json::from_str(&sent2[1]).unwrap();
+            assert_eq!(message["type"], "Reconnect");
+            assert_eq!(message["data"]["auth_token"], "tok-1");
+        }
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Disconnected { .. })
+        ));
+        // The documented deliberate gap: the context was consumed when the
+        // round-2 reconnect was staged, so this round is connection-only.
+        // The attempt ordinal reset to 1 because round 2 reached the
+        // authenticated state — with `max_attempts(1)` this round proves
+        // the budget was refreshed instead of abandoned.
+        match events.recv().await {
+            Some(SignalFishEvent::Reconnecting {
+                attempt,
+                next_backoff,
+            }) => {
+                assert_eq!(attempt, 1);
+                assert_eq!(next_backoff, Duration::from_millis(50));
+            }
+            other => panic!("expected Reconnecting after the budget reset, got {other:?}"),
+        }
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Connected)
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Authenticated { .. })
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::ProtocolInfo(_))
+        ));
+        {
+            let sent3 = sent3.lock().unwrap();
+            assert_eq!(
+                sent3.len(),
+                1,
+                "round-3 wire must be connection-only: the retained context was consumed at staging"
+            );
+            let message: serde_json::Value = serde_json::from_str(&sent3[0]).unwrap();
+            assert_eq!(message["type"], "Authenticate");
         }
         client.shutdown().await;
     }

--- a/src/client_core.rs
+++ b/src/client_core.rs
@@ -3157,6 +3157,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "tokio-runtime")]
     fn auto_reconnect_operation_requires_authenticated_roomless_state_and_is_single_use() {
         let mut core = ClientCore::new(
             Some(GameDataEncoding::Json),

--- a/src/client_core.rs
+++ b/src/client_core.rs
@@ -3157,6 +3157,52 @@ mod tests {
     }
 
     #[test]
+    fn auto_reconnect_operation_requires_authenticated_roomless_state_and_is_single_use() {
+        let mut core = ClientCore::new(
+            Some(GameDataEncoding::Json),
+            ProtocolViolationPolicy::Observe,
+            true,
+        );
+        core.set_reconnect_retention(true);
+        let _ = process(&mut core, authenticated());
+        let _ = process(&mut core, protocol_info(Some(3)));
+
+        // Authenticated and roomless, but nothing retained yet.
+        assert!(core.take_auto_reconnect_operation().is_none());
+
+        // A token-bearing player room retains the reconnect context.
+        core.record_admission(ClientCore::admission_for(&ClientOperation::JoinRoom(
+            JoinRoomParams::new("game", "local"),
+        )));
+        let _ = process(&mut core, room_joined());
+
+        // Still inside the room: the guard keeps the context for a later
+        // qualifying moment.
+        assert!(core.take_auto_reconnect_operation().is_none());
+
+        // A transport death clears the session (including authentication)
+        // but deliberately keeps the retained context.
+        core.clear_session();
+        assert!(core.take_auto_reconnect_operation().is_none());
+
+        // A fresh policy round re-authenticates; the qualifying moment
+        // consumes the retained context exactly once.
+        let _ = process(&mut core, authenticated());
+        let Some(ClientOperation::Reconnect(player_id, room_id, token)) =
+            core.take_auto_reconnect_operation()
+        else {
+            panic!("expected the retained reconnect context to be consumed");
+        };
+        assert_eq!(player_id, PlayerId::from_u128(LOCAL));
+        assert_eq!(room_id, RoomId::from_u128(10));
+        assert_eq!(token, "token");
+        assert!(
+            core.take_auto_reconnect_operation().is_none(),
+            "the retained context is single use"
+        );
+    }
+
+    #[test]
     fn room_operation_capability_requires_request_and_echo_with_legacy_fallback() {
         let join = || ClientOperation::JoinRoom(JoinRoomParams::new("game", "local"));
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -486,4 +486,23 @@ mod tests {
              flatten the payload"
         );
     }
+
+    #[test]
+    fn serialization_display_prefixes_the_cause_and_source_reaches_it() {
+        use std::error::Error as _;
+
+        // Constructed through the `#[from]` conversion; production code has
+        // deliberately no constructor for this variant (see the variant's
+        // ambient-log invariant), so this pin exercises the conversion and
+        // display contract only.
+        let error = SignalFishError::from(serde_json::from_str::<String>("123").unwrap_err());
+        assert!(
+            error.to_string().starts_with("serialization error: "),
+            "{error:?} must keep the serialization display prefix: {error}"
+        );
+        assert!(
+            error.source().is_some(),
+            "the boxed serde_json cause must stay reachable through source()"
+        );
+    }
 }

--- a/src/error_codes.rs
+++ b/src/error_codes.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum ErrorCode {
     // Authentication errors
+    /// Authentication credentials were missing or invalid.
     Unauthorized,
     /// Compatibility only (see [`NON_EMITTED`](ErrorCode::NON_EMITTED)): no
     /// longer emitted by Server 0.7+; retained so older deployments stay
@@ -25,6 +26,7 @@ pub enum ErrorCode {
     /// longer emitted by Server 0.7+; retained so older deployments stay
     /// decodable.
     AuthenticationRequired,
+    /// The provided application ID is unrecognized or unacceptable.
     InvalidAppId,
     /// Compatibility only (see [`NON_EMITTED`](ErrorCode::NON_EMITTED)): no
     /// longer emitted by Server 0.7+; retained so older deployments stay
@@ -38,51 +40,88 @@ pub enum ErrorCode {
     /// longer emitted by Server 0.7+; retained so older deployments stay
     /// decodable.
     AppIdSuspended,
+    /// No application ID was provided; the server requires one.
     MissingAppId,
+    /// Authentication did not complete within the server's time limit.
     AuthenticationTimeout,
+    /// This SDK version is no longer supported by the server.
     SdkVersionUnsupported,
+    /// The requested game-data format is unsupported; the server falls back
+    /// to JSON.
     UnsupportedGameDataFormat,
 
     // Validation errors
+    /// A request parameter was invalid or malformed.
     InvalidInput,
+    /// The game name violates the server's naming requirements.
     InvalidGameName,
+    /// The room code is invalid or malformed.
     InvalidRoomCode,
+    /// The player name violates the server's naming requirements.
     InvalidPlayerName,
+    /// The requested maximum player count is invalid or out of range.
     InvalidMaxPlayers,
+    /// The message exceeds the server's size limit.
     MessageTooLarge,
 
     // Room errors
+    /// The requested room does not exist (closed, or wrong code).
     RoomNotFound,
+    /// The room has reached its advertised player capacity.
     RoomFull,
+    /// The connection is already a participant of a room.
     AlreadyInRoom,
+    /// The operation requires room membership the connection does not have.
     NotInRoom,
+    /// The server failed to create the requested room.
     RoomCreationFailed,
+    /// The game already has the maximum number of rooms the server allows.
     MaxRoomsPerGameExceeded,
+    /// The room's state does not permit this operation.
     InvalidRoomState,
 
     // Authority errors
+    /// The server does not support authority handoff at all.
     AuthorityNotSupported,
+    /// Another participant already holds the room's authority.
     AuthorityConflict,
+    /// The connection may not claim the room's authority.
     AuthorityDenied,
 
     // Rate limiting
+    /// Too many requests in the current window; retry later. Room/spectator
+    /// admission refusals leave the connection open; a refused handshake
+    /// closes it.
     RateLimitExceeded,
+    /// The deployment's connection limit for this client was reached.
     TooManyConnections,
 
     // Reconnection errors
+    /// The directed reconnect failed; the token is not consumed by such a
+    /// refusal, so retry from a fresh connection while the window is open.
     ReconnectionFailed,
+    /// The reconnection token is invalid or malformed; join the room again.
     ReconnectionTokenInvalid,
+    /// The reconnection window has expired; join the room again as a new
+    /// player.
     ReconnectionExpired,
+    /// The player is already connected to the room from another session.
     PlayerAlreadyConnected,
 
     // Spectator errors
+    /// The room does not permit spectators.
     SpectatorNotAllowed,
+    /// The room has reached its spectator capacity.
     TooManySpectators,
+    /// The connection is not a spectator in this room.
     NotASpectator,
+    /// The spectator join failed (room full or spectating disabled).
     SpectatorJoinFailed,
 
     // Server errors
+    /// An internal server error occurred; retry or contact the operator.
     InternalError,
+    /// A server-side storage error occurred while handling the request.
     StorageError,
     /// Compatibility only (see [`NON_EMITTED`](ErrorCode::NON_EMITTED)): no
     /// longer emitted by Server 0.7+; retained so older deployments stay
@@ -90,20 +129,30 @@ pub enum ErrorCode {
     ServiceUnavailable,
 
     // Game-start errors (protocol v2)
+    /// Not every player in the room is ready yet.
     GameStartNotReady,
+    /// Only the room's authority may start the game.
     GameStartForbidden,
     /// The room already finalized a peer-to-peer session whose sticky
     /// topology and transport were not negotiated by this connection.
     RoomSessionIncompatible,
 
     // Signaling errors (protocol v3)
+    /// The signal's target is not a participant of this room.
     CrossRoomSignal,
+    /// The requested data-path transport is unsupported or was not
+    /// negotiated for this connection.
     UnsupportedTransport,
+    /// The signal's target peer could not be found in the room.
     SignalTargetNotFound,
+    /// Too many signaling messages were sent in the current window.
     SignalRateLimited,
+    /// The signal payload exceeds the server's size limit.
     SignalTooLarge,
 
     // Connection lifecycle (protocol v3)
+    /// The server closed the connection after it stayed idle for too long.
+    /// See also [`ActivityTimeout`](ErrorCode::ActivityTimeout).
     ConnectionIdleTimeout,
 
     // Delivery & liveness

--- a/src/event.rs
+++ b/src/event.rs
@@ -673,12 +673,30 @@ impl std::fmt::Debug for SignalFishEvent {
 /// Category of a decoded protocol-state violation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ProtocolViolationKind {
+    /// A delivery-accountability snapshot contradicted the client's tracked
+    /// state (baseline, watermark, or incarnation view).
     Snapshot,
+    /// A message arrived outside its valid lifecycle window or was otherwise
+    /// inconsistent with the connection's lifecycle state (unknown or
+    /// departed player, out-of-transition reply, roster or authority
+    /// mismatch).
     Lifecycle,
+    /// An exact gap range was invalid: out of order, beyond a terminal
+    /// watermark, oversized, overlapping, unexplained, or inconsistent with
+    /// prior reports.
     DeliveryGap,
+    /// Cumulative delivery counters moved backward or disagreed with the
+    /// reported outcomes.
     Counters,
+    /// A causal report (unsupported-format ranges and their supplemental
+    /// advisory) violated ordering or authorization rules.
     Causality,
+    /// A sender epoch/sequence stamp was malformed or moved backward (the
+    /// classifier's fallback category).
     Stamp,
+    /// A frame carried metadata inconsistent with the negotiated protocol
+    /// surface, delivery class, or encoding (for example v3-only fields on a
+    /// v2 message).
     UnexpectedMetadata,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,8 +15,8 @@
 //! - **Wire-compatible** — all protocol types match the server's v2 format exactly
 //! - **Protocol v2 relay + v3 mesh** — v3 is additive and opt-in; a default client
 //!   stays byte-identical to v2 (see [Protocol versions](#protocol-versions))
-//! - **WebSocket built-in** — default `transport-websocket` feature provides `WebSocketTransport`
-//! - **Event-driven** — receive typed `SignalFishEvent`s via a channel
+//! - **WebSocket built-in** — default `transport-websocket` feature provides [`WebSocketTransport`]
+//! - **Event-driven** — receive typed [`SignalFishEvent`]s via a channel
 //! - **No silent loss** — events are delivered with backpressure and sends are
 //!   bounded with explicit congestion signals (see
 //!   [Delivery guarantees](client#delivery-guarantees))

--- a/src/mesh.rs
+++ b/src/mesh.rs
@@ -24,7 +24,7 @@ use crate::protocol::{
 pub struct MeshPeer {
     /// The peer's identifier.
     pub player_id: PlayerId,
-    /// The peer's display name (empty until a `SessionPlan` names it).
+    /// The peer's display name (empty until a [`SessionPlan`](crate::protocol::SessionPlanPayload) names it).
     pub player_name: String,
     /// Whether the peer is the session's authoritative host.
     pub is_authority: bool,
@@ -222,9 +222,11 @@ impl MeshSession {
         }
     }
 
-    /// Fold an ICE pre-gather set (from `RoomJoined`/`Reconnected`). An empty set
-    /// preserves the existing one and an identical set is a no-op; either way it
-    /// reports `false` so `apply` only signals a real change.
+    /// Fold an ICE pre-gather set (from
+    /// [`RoomJoined`](crate::SignalFishEvent::RoomJoined) and
+    /// [`Reconnected`](crate::SignalFishEvent::Reconnected)). An empty set
+    /// preserves the existing one and an identical set is a no-op; either way
+    /// it reports `false` so `apply` only signals a real change.
     fn apply_pre_gather(&mut self, ice_servers: &[IceServer]) -> bool {
         if ice_servers.is_empty() || self.ice_servers.as_slice() == ice_servers {
             false

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -93,7 +93,8 @@ mod canonical_room_operation_id {
 /// and in self-declared [`ConnectionInfo::Relay`] metadata. It does not select
 /// the [`Transport`](crate::Transport) used by this crate, open a socket, or add
 /// datagram framing. The core client continues to exchange complete
-/// text/binary signaling frames with its configured `Transport`.
+/// text/binary signaling frames with its configured
+/// [`Transport`](crate::Transport).
 ///
 /// Signal Fish Server 0.8 accepts but ignores the `JoinRoom` field and carries
 /// all signaling and relayed game data over the current WebSocket connection.
@@ -150,19 +151,32 @@ pub enum DeliveryClass {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum DeliveryGapReason {
+    /// A keyed-latest value was superseded by a newer value for the same key
+    /// before delivery.
     LatestSuperseded,
+    /// A keyed-latest value was dropped because the key's retention slot was
+    /// full.
     LatestDroppedFull,
+    /// A volatile (best-effort) value was dropped without delivery.
     VolatileDropped,
+    /// The value was undeliverable because its game-data format is
+    /// unsupported for the recipient. Servers may coalesce consecutive
+    /// unsupported-format omissions into one range.
     UnsupportedFormat,
 }
 
 /// Exact inclusive sequence range omitted for one recipient.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DeliveryGap {
+    /// The player whose stream was omitted.
     pub from_player: PlayerId,
+    /// Sender epoch the omitted range belongs to.
     pub epoch: u32,
+    /// Inclusive first sequence of the omitted range.
     pub from_seq: u64,
+    /// Inclusive last sequence of the omitted range.
     pub to_seq: u64,
+    /// Why the range was omitted.
     pub reason: DeliveryGapReason,
 }
 
@@ -216,8 +230,14 @@ pub const DELIVERY_REPORT_MAX_GAPS: usize = 256;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ReplayStatus {
+    /// Every replayable control event missed during the disconnect was
+    /// replayed.
     Complete,
+    /// The bounded replay ring evicted some missed events, so
+    /// `missed_events` is a suffix — resync from the snapshot.
     Truncated,
+    /// Event replay is not active on this deployment; treat the reconnection
+    /// as a full resync from the snapshot.
     Unavailable,
 }
 
@@ -583,7 +603,7 @@ pub struct DirectEndpoint {
 // ── Payload structs ─────────────────────────────────────────────────
 
 /// Payload for the `RoomJoined` server message.
-/// Boxed in `ServerMessage` to reduce enum size.
+/// Boxed in [`ServerMessage`] to reduce enum size.
 #[derive(Clone, Serialize, Deserialize)]
 pub struct RoomJoinedPayload {
     pub room_id: RoomId,
@@ -622,7 +642,7 @@ impl std::fmt::Debug for RoomJoinedPayload {
 }
 
 /// Payload for the `Reconnected` server message.
-/// Boxed in `ServerMessage` to reduce enum size.
+/// Boxed in [`ServerMessage`] to reduce enum size.
 #[derive(Clone, Serialize, Deserialize)]
 pub struct ReconnectedPayload {
     pub room_id: RoomId,
@@ -667,7 +687,7 @@ impl std::fmt::Debug for ReconnectedPayload {
 }
 
 /// Payload for the `SpectatorJoined` server message.
-/// Boxed in `ServerMessage` to reduce enum size.
+/// Boxed in [`ServerMessage`] to reduce enum size.
 #[derive(Clone, Serialize, Deserialize)]
 pub struct SpectatorJoinedPayload {
     pub room_id: RoomId,
@@ -691,7 +711,7 @@ impl std::fmt::Debug for SpectatorJoinedPayload {
 }
 
 /// Payload for the `SessionPlan` server message (protocol v3).
-/// Boxed in `ServerMessage` to reduce enum size.
+/// Boxed in [`ServerMessage`] to reduce enum size.
 ///
 /// Sent per-recipient when a room finalizes and again for relay resets, late
 /// joins, host re-election, or reconnect replay. Each recipient receives a plan

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -110,7 +110,7 @@ pub struct TransportDiagnostics {
 /// Bidirectional framed transport for the Signal Fish signaling protocol.
 ///
 /// Each successful receive yields exactly one complete text or binary frame in
-/// protocol order from the one intended server connection. `TransportFrame`
+/// protocol order from the one intended server connection. [`TransportFrame`]
 /// carries no source address or peer identity, so the client attributes every
 /// yielded frame to that server. This trait does not authenticate the server or
 /// turn arbitrary stream/datagram bytes into frames; the backend must apply an


### PR DESCRIPTION
## Why

Paranoid-audit round 49 (issue #126) ran three never-audited surfaces and found zero production defects — but several documented contracts had no test, two protocol gap-reasons had zero coverage, and some public rustdoc rendered bare.

## What

- **Reconnect-policy lifecycle pins** (red/green verified): spectator baselines never retain a reconnect context, the attempt budget resets after re-authentication, the retained context is single-use at staging, and the `take_auto_reconnect_operation` guard matrix. The shipped `auto_reconnect` example no longer claims a v2 run auto-rejoins, or that a duplicate join is "requested twice per round".
- **Public-variant reachability** (33 enums, ~200 variants): `DeliveryGapReason::LatestDroppedFull`/`VolatileDropped` were never tested — now pinned in both the accepted counter pairing and a mis-bucketed rejection; `SignalFishError::Serialization`'s display/source contract pinned.
- **Docs.rs rendering**: all 42 bare `ErrorCode` variants documented, plus the bare `ClientSnapshot` fields, `DeliveryGapReason`/`DeliveryGap`/`ReplayStatus`/`ProtocolViolationKind` members, `GameDataDelivery::Latest::key`, and 8 intra-doc links. `missing_docs` drops 245 → 180; the remainder is the deliberately member-undocumented protocol wire structs.

All findings survived a hostile review (10 findings fixed) and a convergence verifier pass (zero findings). Tests: 1163 passed / 0 failed; fmt, clippy (all-features and no-default-features), and rustdoc `-D warnings` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and documentation-only changes; no production reconnect or accountability logic modified in the diff.
> 
> **Overview**
> Paranoid-audit round 49 adds **contract tests** and **public rustdoc** without changing reconnect or accountability production behavior.
> 
> **Reconnect policy** is pinned with new async tests: spectator sessions never emit a round-2 `Reconnect` (re-auth only), player rooms still auto-stage `Reconnect` with the retained token, the attempt budget resets after re-authentication, and retained context is **single-use** at staging. `ClientCore` gets a unit test for the `take_auto_reconnect_operation` guard matrix. The `auto_reconnect` example and **CHANGELOG** now state that default v2 only re-authenticates, v3 **player** rooms auto-rejoin via directed reconnect, spectators never auto-rejoin, and a manual `join_room` on v3 conflicts with the automatic rejoin (`RoomOperationPending` / displacement)—not a duplicate join “twice per round.”
> 
> **Delivery accountability** gains a test that `LatestDroppedFull` and `VolatileDropped` gaps must pair with their own counter buckets and reject mis-bucketed reports. **`SignalFishError::Serialization`** display/`source()` contract is pinned in `error.rs`.
> 
> **Docs**: all `ErrorCode` variants plus previously bare members on `ClientSnapshot`, `DeliveryGapReason`, `DeliveryGap`, `ReplayStatus`, `ProtocolViolationKind`, and `GameDataDelivery::Latest::key`; intra-doc links in crate root, mesh, protocol, and transport modules. CHANGELOG records the doc pass and reconnect wording tweak (“player-room disconnect”).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c9c0d6ce4ff6789044e6cef93d12c11cd9cc16c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->