### PR TITLE
Round 50: re-sync vendored protocol spec; de-flake real-clock test pins

### DIFF
--- a/.llm/context.md
+++ b/.llm/context.md
@@ -379,7 +379,7 @@ Receive polls bound skipped controls, flush Pong/Close, and fuse terminal errors
 `ClientMessage` and `ServerMessage` use adjacently-tagged serde encoding
 (`#[serde(tag = "type", content = "data")]`) to match the Signal Fish server
 v2 JSON protocol. Server 0.8.0 commit `d79dcdc7549777c8c2bd9fcb2d132641532d8c86` is the released runtime compatibility binding.
-The samples and AsyncAPI authority (room-correlation extension, advertised outbound limit, room-session incompatibility error) are byte-identical to the earlier post-0.7 preview at commit `5de9105e4c269a29919ae29880f5b67fc8d630c3`.
+The samples are byte-identical to the earlier post-0.7 preview at commit `5de9105e4c269a29919ae29880f5b67fc8d630c3` (room-correlation extension, advertised outbound limit, room-session incompatibility error); the vendored AsyncAPI authority re-syncs to upstream `main` prose only.
 Never change serde attributes without verifying both bindings. See `skills/serde-patterns/SKILL.md` and `skills/protocol-wire-conformance/SKILL.md` for details.
 
 ### Exhaustive Public Types

--- a/.llm/skills/protocol-wire-conformance/SKILL.md
+++ b/.llm/skills/protocol-wire-conformance/SKILL.md
@@ -33,11 +33,15 @@ enum covers the spec's error-code token space in both directions. This closes
 the blind spot where a server-side error-code addition passes the wire-sample
 golden tests (they pin message *shapes*, not the error-code value space).
 
-The canonical corpus currently pins released protocol-authority commit
-`d79dcdc7549777c8c2bd9fcb2d132641532d8c86` (Server 0.8.0; the wire samples and
-AsyncAPI spec are byte-identical to the earlier post-0.7 preview this corpus
-previously pinned). Released runtime compatibility is bound to that same
-Server 0.8.0 release in `tests/compatibility.toml`; the older Server 0.7.0
+The canonical corpus pins protocol-authority commit
+`11e165cecb9179378f53d65971bd39a2f4e3baab`, advanced from the Server 0.8.0
+release pin `d79dcdc7549777c8c2bd9fcb2d132641532d8c86` by descriptive-only
+prose drift (the wire samples are byte-identical across both commits).
+Released runtime compatibility stays bound to the Server 0.8.0 release in
+`tests/compatibility.toml`, while the vendored AsyncAPI spec re-syncs to
+upstream `main` at every refresh — descriptive prose drift is absorbed
+without wire impact, and any schema/message/error-code change triggers the
+full reconciliation below. The older Server 0.7.0
 commit `3f7f43d4cd4b3cc7f8fb893220dc35c9b1fad333` remains the prior released
 binding in history. The client retains six legacy
 `ErrorCode::NON_EMITTED` variants outside the 0.7 emitted-token set; conformance
@@ -79,6 +83,14 @@ In `tests/ci_config_tests.rs` (`protocol_wire_conformance_policy`):
 - `server_spec_files_exist_and_are_non_empty`, `server_spec_provenance_marker_is_valid`,
   `server_spec_provenance_checksum_matches_vendored_file` — the same discipline
   for the vendored AsyncAPI spec in `tests/server-spec/`.
+
+`tests/compatibility_manifest_tests.rs`
+(`compatibility_manifest_binds_exact_server_artifacts`) additionally enforces
+corpus coherence: both PROVENANCE `commit`/`synced` values must equal
+`compatibility.toml`'s `[protocol_authority]`, and every vendored file hash
+must equal the manifest's. A refresh advances all of them together (the
+authority commit literal there is review-forced); the released runtime
+binding (`server_commit`, tags, release-artifact hashes) stays at the release.
 
 ## Drift Detection
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -7792,7 +7792,7 @@ mod tests {
         // Reach membership without draining events: Connected..RoomJoined
         // then exactly fill the capacity-4 channel, so the terminal
         // Disconnected delivery wedges against a permanently full channel.
-        let give_up = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
+        let give_up = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
         while !client.is_authenticated() {
             assert!(
                 tokio::time::Instant::now() < give_up,
@@ -7912,7 +7912,7 @@ mod tests {
             .with_shutdown_timeout(std::time::Duration::from_millis(500));
         let (mut client, _events) = SignalFishClient::start(transport, config);
 
-        let give_up = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
+        let give_up = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
         while !client.is_authenticated() {
             assert!(
                 tokio::time::Instant::now() < give_up,
@@ -8017,10 +8017,10 @@ mod tests {
             .with_shutdown_timeout(std::time::Duration::from_millis(500));
         let (mut client, events) = SignalFishClient::start(transport, config);
 
-        let give_up = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        let give_up = std::time::Instant::now() + std::time::Duration::from_secs(10);
         while !client.is_authenticated() {
             assert!(
-                give_up.elapsed() < std::time::Duration::from_secs(2),
+                give_up.elapsed() < std::time::Duration::from_secs(10),
                 "the scripted handshake never authenticated"
             );
             tokio::time::sleep(std::time::Duration::from_millis(1)).await;
@@ -8032,7 +8032,7 @@ mod tests {
             .expect("join must be admitted once authenticated");
         while client.current_room_id().await.is_none() {
             assert!(
-                give_up.elapsed() < std::time::Duration::from_secs(2),
+                give_up.elapsed() < std::time::Duration::from_secs(10),
                 "the loop stopped servicing inbound frames after the receiver was dropped"
             );
             tokio::time::sleep(std::time::Duration::from_millis(1)).await;

--- a/src/webrtc.rs
+++ b/src/webrtc.rs
@@ -4422,10 +4422,11 @@ mod tests {
             matches!(got, Some(MeshEvent::Data { .. })),
             "should surface the driver data, got {got:?}"
         );
-        assert!(
-            elapsed < std::time::Duration::from_secs(2),
-            "waker must surface output promptly (well under one 30s pump), took {elapsed:?}"
-        );
+        // Timing stays diagnostic: the 5 s recv bound is the mechanism oracle
+        // (a 30 s pump can never deliver inside it, so success proves the
+        // waker path), and the elapsed time is reported for trend inspection
+        // instead of gated (round-50 audit; timings are pinned-diagnostic).
+        println!("waker surfaced driver data after {elapsed:?}");
         mesh.shutdown().await;
     }
 }

--- a/tests/compatibility.toml
+++ b/tests/compatibility.toml
@@ -5,9 +5,13 @@ server_tag = "v0.8.0"
 server_commit = "d79dcdc7549777c8c2bd9fcb2d132641532d8c86"
 synced = "2026-09-01"
 
+# The evidence authority all vendored protocol artifacts are synced to.
+# Descriptive-only upstream spec drift advances this (and both PROVENANCE
+# files) without touching the released runtime binding above; any schema,
+# message, or error-code change triggers full type reconciliation.
 [protocol_authority]
-commit = "d79dcdc7549777c8c2bd9fcb2d132641532d8c86"
-synced = "2026-09-01"
+commit = "11e165cecb9179378f53d65971bd39a2f4e3baab"
+synced = "2026-09-07"
 
 [legacy_server]
 version = "0.4.0"
@@ -26,4 +30,4 @@ generation = "omitted"
 "v3-server-messages.jsonl" = "21ed576f61cc042eee9c463363bde5a4b38a9285d0560666423afd6c930588b2"
 
 [server_spec]
-"signal-fish-protocol.asyncapi.yaml" = "77a9556079899cc291082ae9570a5186b645ec821a033edd7a0bfee8772489a3"
+"signal-fish-protocol.asyncapi.yaml" = "26542caf25adcf0638e87faca8def19a02da6e4ce2c73165092dd2228c7f312d"

--- a/tests/compatibility_manifest_tests.rs
+++ b/tests/compatibility_manifest_tests.rs
@@ -83,7 +83,10 @@ fn compatibility_manifest_binds_exact_server_artifacts() {
     let protocol_commit = manifest["protocol_authority"]["commit"]
         .as_str()
         .unwrap_or_else(|| panic!("protocol authority commit must be a string"));
-    assert_eq!(protocol_commit, "d79dcdc7549777c8c2bd9fcb2d132641532d8c86");
+    // The evidence authority (all vendored protocol artifacts) advances with
+    // descriptive-only upstream drift; the released runtime binding above
+    // stays at the 0.8.0 release commit. Keep this literal review-forced.
+    assert_eq!(protocol_commit, "11e165cecb9179378f53d65971bd39a2f4e3baab");
     assert_eq!(
         wire_provenance["upstream"]["commit"].as_str(),
         Some(protocol_commit)

--- a/tests/real_server_e2e.rs
+++ b/tests/real_server_e2e.rs
@@ -1699,8 +1699,8 @@ async fn e2e_server_040_generationless_mesh_signal() {
 }
 
 /// Smoke check that a flooding sender's own control plane stays healthy:
-/// Pings sent during a sustained GameData flood still get Pongs promptly
-/// (the sender's outbound queue is not the congested one).
+/// Pings sent during a sustained GameData flood still get Pongs within the
+/// bounded wait (the sender's outbound queue is not the congested one).
 #[tokio::test]
 #[ignore = "requires a live signal-fish server; set SIGNAL_FISH_SERVER_BIN or SIGNAL_FISH_E2E_URL"]
 async fn e2e_sender_ping_survives_own_game_data_flood() {
@@ -1761,10 +1761,10 @@ async fn e2e_sender_ping_survives_own_game_data_flood() {
         "every substantial pre-ping flood batch must be accepted"
     );
     assert_eq!(pongs, PING_ROUNDS);
-    assert!(
-        worst_rtt < Duration::from_secs(2),
-        "sender-side Pong RTT should stay low during its own flood; got {worst_rtt:?}"
-    );
+    // Timing stays diagnostic by policy: the 3 s `wait_for_event` bound is the
+    // survival oracle, and the SMOKE DATA line above reports the worst RTT for
+    // trend inspection instead of gating on it (round-50 audit; throughput
+    // gating is deliberately rejected in blocking CI).
     a.shutdown().await;
 }
 

--- a/tests/server-spec/PROVENANCE.toml
+++ b/tests/server-spec/PROVENANCE.toml
@@ -7,11 +7,18 @@
 repo = "https://github.com/Ambiguous-Interactive/signal-fish-server"
 path = "spec"
 # Exact server commit the spec bytes were copied from.
-commit = "d79dcdc7549777c8c2bd9fcb2d132641532d8c86"
+# 2026-09-07 refresh: descriptive-only drift from the Server 0.8.0 release pin
+# (d79dcdc7549777c8c2bd9fcb2d132641532d8c86) — summary/description prose and
+# one cosmetic reformat; zero schema, message, or error-code changes. This
+# evidence authority advances together with tests/compatibility.toml's
+# [protocol_authority] and the wire-samples PROVENANCE, while the released
+# runtime compatibility binding (server_commit + release artifacts in
+# tests/compatibility.toml) stays at the 0.8.0 release.
+commit = "11e165cecb9179378f53d65971bd39a2f4e3baab"
 # ISO 8601 date of the last refresh.
-synced = "2026-09-01"
+synced = "2026-09-07"
 
 # SHA-256 of each vendored file. A policy test recomputes these, so the spec
 # cannot be edited without also updating this marker (keeps provenance honest).
 [files]
-"signal-fish-protocol.asyncapi.yaml" = "77a9556079899cc291082ae9570a5186b645ec821a033edd7a0bfee8772489a3"
+"signal-fish-protocol.asyncapi.yaml" = "26542caf25adcf0638e87faca8def19a02da6e4ce2c73165092dd2228c7f312d"

--- a/tests/server-spec/signal-fish-protocol.asyncapi.yaml
+++ b/tests/server-spec/signal-fish-protocol.asyncapi.yaml
@@ -232,6 +232,13 @@ components:
     ClientGameData:
       title: GameData
       summary: Send opaque game data to other players in the room (relay floor).
+      description: >-
+        Each relayed frame consumes the sender's per-window relay byte budget
+        (`rate_limit.max_relay_bytes`, or the sending application's
+        `max_relay_bytes` allowlist override), measured on the sender-controlled
+        payload, and the relaying room's aggregate per-window ceiling
+        (`rate_limit.max_room_relay_bytes`). An over-budget frame is answered
+        with RATE_LIMIT_EXCEEDED and is not relayed.
       payload: { $ref: '#/components/schemas/ClientGameData' }
     ClientSignal:
       title: Signal
@@ -255,6 +262,11 @@ components:
     ProvideConnectionInfo:
       title: ProvideConnectionInfo
       summary: Legacy self-declared v2 connection metadata for GameStarting.
+      description: >-
+        The serialized `connection_info` entry must fit
+        `security.max_connection_info_bytes` (default 8192 canonical JSON
+        bytes); oversize submissions are rejected with MESSAGE_TOO_LARGE and
+        not stored.
       payload: { $ref: '#/components/schemas/ProvideConnectionInfo' }
     Ping:
       title: Ping
@@ -262,7 +274,18 @@ components:
       payload: { $ref: '#/components/schemas/Ping' }
     Reconnect:
       title: Reconnect
-      summary: Reconnect to a room after disconnection using the join auth_token.
+      summary: >-
+        Reconnect to a room after disconnection using the join auth_token.
+        The token is a bearer seat credential: anyone who possesses it can
+        take over the seat within the reconnection window. Never log, store,
+        or expose it like a public identifier.
+      description: >-
+        Protocol-version support: reconnect tokens are pre-issued on the wire
+        only to v3+ recipients (`RoomJoined.reconnection_token`). The v2
+        envelope carries no token field, so a v2 client cannot honestly
+        present `Reconnect`; the message remains in the v2 floor for envelope
+        compatibility only. See the protocol version lifecycle policy in
+        docs/protocol.md.
       payload: { $ref: '#/components/schemas/Reconnect' }
     JoinAsSpectator:
       title: JoinAsSpectator
@@ -760,7 +783,13 @@ components:
         snapshots and GameStarting; not v3 capability negotiation. Values are
         stored and forwarded rather than authenticated. A syntactically
         validated direct value is also used to elect an executable Direct host,
-        but remains self-declared and is not reachability proof.
+        but remains self-declared and is not reachability proof. The serialized
+        entry is size-capped: `ProvideConnectionInfo` submissions whose
+        canonical JSON exceeds `security.max_connection_info_bytes` (default
+        8192 bytes) are rejected with MESSAGE_TOO_LARGE and not stored. Its
+        product with the roster ceiling is validated to stay under the
+        outbound message limit (entry payloads alone), so one member's
+        metadata cannot push a roster broadcast past the outbound cap.
       oneOf:
         - type: object
           additionalProperties: false
@@ -1008,7 +1037,12 @@ components:
           properties:
             player_id: { $ref: '#/components/schemas/PlayerId' }
             room_id: { $ref: '#/components/schemas/RoomId' }
-            auth_token: { type: string, description: Token issued at initial join. }
+            auth_token:
+              type: string
+              description: >-
+                Token issued at initial join. Bearer credential: possession
+                authorizes seat takeover within the reconnection window;
+                protect it like a password (never log, never screenshare).
       required: [type, data]
     JoinAsSpectator:
       type: object
@@ -1035,7 +1069,12 @@ components:
         room_operation_ids and ProtocolInfo.capabilities echoes that token.
         operation_id is an opaque client-generated UUID unique among live or
         recently completed operations on this physical connection. The server
-        echoes it but does not deduplicate or make operations idempotent.
+        echoes it but does not deduplicate or make operations idempotent:
+        duplicate operations MAY re-execute and re-apply their effects.
+        Senders SHOULD correlate operation_id values and deduplicate on their
+        side, and every new operation added to this surface MUST establish
+        its own server-side replay guard (today: `ALREADY_IN_ROOM` and the
+        seat-fill gate).
       properties:
         type: { const: RoomOperation }
         data:
@@ -2208,7 +2247,13 @@ components:
             retry_after_secs:
               type: integer
               nullable: true
-              description: Optional operator retry hint.
+              description: >-
+                Optional operator retry hint: the earliest safe attempt
+                against the DEPLOYMENT, not this instance. Server state
+                (rooms, reconnection tokens) does not survive a restart, so
+                clients should reconnect to another instance of the
+                deployment and build a fresh room rather than retrying this
+                instance.
       required: [type, data]
     DeliveryReport:
       type: object

--- a/tests/wire-samples/PROVENANCE.toml
+++ b/tests/wire-samples/PROVENANCE.toml
@@ -6,13 +6,16 @@
 [upstream]
 repo = "https://github.com/Ambiguous-Interactive/signal-fish-server"
 path = ".llm/code-samples/protocol"
-# Exact server commit the .jsonl bytes were copied from.
-commit = "d79dcdc7549777c8c2bd9fcb2d132641532d8c86"
+# Exact server commit the .jsonl bytes were copied from. The bytes are
+# byte-identical from the Server 0.8.0 release pin (d79dcdc7549777c8c2bd9fcb2d132641532d8c86)
+# through this commit; the evidence authority advances together across
+# compatibility.toml and both PROVENANCE files.
+commit = "11e165cecb9179378f53d65971bd39a2f4e3baab"
 # Protocol version range these samples exercise.
 protocol_version_min = 2
 protocol_version_max = 3
 # ISO 8601 date of the last refresh.
-synced = "2026-09-01"
+synced = "2026-09-07"
 
 # SHA-256 of each vendored file. A policy test recomputes these, so a sample
 # cannot be edited without also updating this marker (keeps provenance honest).


### PR DESCRIPTION
## Why

Two quiet risks surfaced in this round's audit:

1. **The weekly protocol drift gate was about to go red.** Upstream Signal Fish Server `main` advanced four descriptive commits since the Server 0.8.0 pin. The vendored AsyncAPI spec (which the Monday cron diffs against upstream) is now stale — and the repo's own coherence test requires any spec refresh to advance the whole evidence corpus together.
2. **One blocking-CI test pinned a performance number tighter than its own pass condition.** The flood-ping e2e cell asserted a 2 s RTT ceiling under a 3 s wait bound: a loaded runner could fail the test even though the thing it protects (pings survive a flood) held. A mesh waker test carried the same pattern.

## What

- **Spec re-sync:** re-vendor the AsyncAPI spec from upstream `main` (`11e165ce`). The drift is descriptive prose only — six prose hunks plus one cosmetic reformat; zero schema, message, or error-code changes, so no client type changes are needed. The evidence authority (`[protocol_authority]` + both PROVENANCE files + the review-forced test literal) advances together to keep the enforced coherence invariant, while the released runtime binding (0.8.0, `d79dcdc75`, artifact hashes) is untouched.
- **Timing de-flaking:** the 3 s bounded wait remains the flood-ping survival oracle; the RTT becomes a printed diagnostic (repo policy: timings are pinned-diagnostic). Same treatment for the mesh waker test, whose 5 s bound already proves the waker path mechanically. Three script-mock handshake guards widen 2 s → 10 s so a loaded runner only slows failures, never successes.
- **Docs:** the wire-conformance skill and canonical context doc now describe the two-layer model (runtime binding pinned at the release; vendored evidence re-syncs to upstream prose).

## Verification

- Drift personally re-diffed and independently re-verified by two audit agents (hashes recomputed against real upstream; wire samples byte-identical across both commits).
- Conformance + policy suites green: `error_code_conformance_tests` 8/8, `ci_config_tests` 236/236, `compatibility_manifest_tests` 1/1.
- Full mandatory workflow on the final tree: fmt clean, clippy clean (`--all-features` and `--no-default-features`), 1163 tests passed / 0 failed.
- Data-backed drift re-check: all four perf-lab CI cells green (zero ledger/allocation drift); stateful hostility campaign 800 seeds / 96,000 sequences / 0 failures with full wire coverage; selftest canaries intact (13/13).
- Adversarial review loop: hostile reviewer (5 findings, all fixed) + convergence verifier → **CONVERGED, zero findings**.

No changelog entry: evidence, test, and docs-only changes (per the changelog policy).

Part of the recurring audit series on #126 (round 50).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Evidence, documentation, and test-only timing changes; no public API or wire-format behavior changes.
> 
> **Overview**
> **Re-syncs vendored protocol evidence** so the weekly upstream drift check stays green: the AsyncAPI spec is refreshed from upstream `main` at commit `11e165ce` (descriptive prose only—no schema, message, or error-code changes). Wire sample hashes are unchanged; **Server 0.8.0 runtime binding** (`server_commit`, release artifacts) stays on `d79dcdc`.
> 
> Introduces an explicit **`[protocol_authority]`** in `tests/compatibility.toml` that advances with the vendored corpus (both `PROVENANCE.toml` files, spec checksum, review-forced manifest test literal) while the released pin does not. Docs in `.llm/context.md` and the wire-conformance skill describe this two-layer model.
> 
> **Test stability:** removes hard RTT/elapsed ceilings in the mesh waker and flood-ping e2e tests (bounded waits remain the pass/fail oracle; timings are logged for trends). Mock-client handshake polls widen from 2s to 10s to reduce flaky failures on loaded CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12e48a93c5ecab0bf42291e3346a11a17e942bb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->