### PR TITLE
Round 51: cross-platform portability evidence; reconnect and polling scheduler audit pins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   declare the default 8 MiB frame bound up front, pin token binding off, and
   turn a stalled handshake (10 s default, configurable) into a retryable
   `Timeout`; the `auto_reconnect` example ships this constructor.
+- Documented desktop platform support in the README: `cargo check` passes
+  for every target (including tests) on Windows (MSVC and GNU) and macOS
+  ARM64, with browser and Emscripten builds covered by dedicated CI lanes.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,13 @@ from the onboarding path.
 The core crate supports Rust 1.87.0 and newer. The Godot adapter requires Rust
 1.94.0 because of its godot-rust dependency.
 
+Desktop targets are first-class: `cargo check` passes for every target
+(including tests) on Windows (MSVC and GNU) and macOS ARM64, and the full
+build-and-test matrix runs on Linux CI. The opt-in `tls` feature uses
+`ring`, which supports those targets when its target C toolchain is
+available. Browser (wasm32-unknown-unknown) and Emscripten builds are
+covered by dedicated CI lanes.
+
 <details>
 <summary>AI disclosure</summary>
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -8763,6 +8763,29 @@ mod tests {
         }
     }
 
+    /// Pre-built boxed transports (mixed concrete types) handed to the
+    /// reconnect factory one per round.
+    #[cfg(feature = "transport-websocket")]
+    type BoxedTransportPool = Arc<StdMutex<VecDeque<Box<dyn Transport + Send>>>>;
+
+    #[cfg(feature = "transport-websocket")]
+    fn boxed_transport_pool(transports: Vec<Box<dyn Transport + Send>>) -> BoxedTransportPool {
+        Arc::new(StdMutex::new(VecDeque::from(transports)))
+    }
+
+    #[cfg(feature = "transport-websocket")]
+    fn boxed_pool_factory(
+        pool: &BoxedTransportPool,
+    ) -> impl Fn() -> Box<dyn Transport + Send> + Send + Sync {
+        let pool = Arc::clone(pool);
+        move || {
+            pool.lock()
+                .unwrap()
+                .pop_front()
+                .expect("transport pool exhausted")
+        }
+    }
+
     #[tokio::test(start_paused = true)]
     async fn reconnect_policy_rebuilds_connection_and_rejoins_room() {
         // Round 1: authenticate, join a token-bearing player room, die.
@@ -9271,6 +9294,217 @@ mod tests {
         assert!(closed1.load(Ordering::Acquire));
         // The channel closes without any further event.
         assert!(events.recv().await.is_none());
+    }
+
+    /// A panicking reconnect factory is the same contract-violation class as
+    /// a panicking `Transport` method (documented on [`ReconnectPolicy`]):
+    /// the loop task dies on the factory call, the event channel closes
+    /// without further events, parked reliable senders resolve
+    /// `NotConnected`, the previous round transport's `abort` still runs
+    /// from the loop's drop guard, and a later `shutdown()` reconciles the
+    /// snapshot.
+    #[tokio::test(start_paused = true)]
+    async fn panicking_reconnect_factory_kills_the_loop_like_a_panicking_transport() {
+        let (transport1, _sent1, closed1) =
+            MockTransport::new(vec![Some(Ok(authenticated_json())), None]);
+        let policy = ReconnectPolicy::new(|| -> Box<dyn Transport + Send> {
+            panic!("factory exploded");
+        })
+        .with_max_attempts(3)
+        .with_initial_backoff(Duration::from_millis(50));
+        let config = SignalFishConfig::new("mb_reconnect").with_reconnect_policy(policy);
+        let (mut client, mut events) = SignalFishClient::start(transport1, config);
+
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Connected)
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Authenticated { .. })
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Disconnected { .. })
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Reconnecting { attempt: 1, .. })
+        ));
+        // Paused time advances the 50 ms backoff, the loop calls the
+        // factory, and the panic unwinds the task: the channel closes with
+        // no further event (no `ReconnectAbandoned`, no second
+        // `Disconnected`).
+        let observed = tokio::time::timeout(Duration::from_secs(2), events.recv())
+            .await
+            .expect("channel close must be prompt");
+        assert!(
+            observed.is_none(),
+            "the loop must die without further events, got {observed:?}"
+        );
+
+        // Same boundary as the panicking-Transport contract: commands fail
+        // fast and parked reliable senders resolve. Unlike the mid-round
+        // Transport-panic face, the core is already disconnected here: the
+        // round ended (peer close) before the factory was consulted, and
+        // its `Disconnected` event was the last event delivered.
+        assert!(matches!(
+            client.send_game_data(serde_json::json!({ "n": 1 })),
+            Err(SignalFishError::NotConnected)
+        ));
+        let result = tokio::time::timeout(
+            Duration::from_secs(2),
+            client.send_game_data_reliable(serde_json::json!({ "n": 2 })),
+        )
+        .await
+        .expect("parked reliable send must resolve promptly");
+        assert!(matches!(result, Err(SignalFishError::NotConnected)));
+        assert!(
+            !client.is_connected(),
+            "the round ended before the factory ran, so the core is already disconnected"
+        );
+        assert!(
+            closed1.load(Ordering::Acquire),
+            "abort must run on the previous round's transport during unwind"
+        );
+        tokio::time::timeout(Duration::from_secs(2), client.shutdown())
+            .await
+            .expect("shutdown after factory panic must complete promptly");
+        assert!(!client.is_connected());
+    }
+
+    /// Dropping the handle during a reconnection backoff wait tears down the
+    /// parked loop promptly: the factory is never consulted, and the event
+    /// channel closes without further events. (The mid-round drop-guard
+    /// `abort` face is pinned separately by the panicking-Transport test;
+    /// during backoff the previous round's *connection* has already ended in
+    /// a peer close, and the idle transport sits inside the loop's
+    /// drop-guard.)
+    #[tokio::test(start_paused = true)]
+    async fn handle_drop_during_backoff_aborts_the_parked_loop() {
+        let (transport1, _sent1, _closed1) =
+            MockTransport::new(vec![Some(Ok(authenticated_json())), None]);
+        let pool = transport_pool(vec![]);
+        let factory_calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let calls = Arc::clone(&factory_calls);
+        let inner = pool_factory(&pool);
+        let policy = ReconnectPolicy::new(move || {
+            calls.fetch_add(1, Ordering::SeqCst);
+            inner()
+        })
+        .with_max_attempts(5)
+        .with_initial_backoff(Duration::from_secs(3_600));
+        let config = SignalFishConfig::new("mb_reconnect").with_reconnect_policy(policy);
+        let (client, mut events) = SignalFishClient::start(transport1, config);
+
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Connected)
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Authenticated { .. })
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Disconnected { .. })
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Reconnecting { attempt: 1, .. })
+        ));
+        // Drop while the loop is parked on the (virtual) hour-long backoff:
+        // no await in between, so time cannot advance and the factory can
+        // never be reached.
+        drop(client);
+        // The channel closes once the aborted task's future drops, and the
+        // factory was never consulted.
+        assert!(events.recv().await.is_none());
+        assert_eq!(
+            factory_calls.load(Ordering::SeqCst),
+            0,
+            "the factory must not be consulted after the handle drop"
+        );
+    }
+
+    /// The built-in lazy constructor's stalled-handshake `Timeout` is an
+    /// ordinary retryable round death at the driver level: the never-ready
+    /// round emits `Disconnected` without a `Connected`, the attempt budget
+    /// is consumed (no reset — the round never authenticated), and the next
+    /// factory product reconnects normally.
+    #[cfg(feature = "transport-websocket")]
+    #[tokio::test(start_paused = true)]
+    async fn lazy_handshake_timeout_is_an_ordinary_retryable_round() {
+        // Round 1: authenticate, then die.
+        let (transport1, _sent1, _closed1) =
+            MockTransport::new(vec![Some(Ok(authenticated_json())), None]);
+        // Round 2: a lazy transport whose handshake fails at a zero
+        // deadline. The zero deadline elapses on the handshake future's
+        // first poll — before any dial outcome is observable — so the
+        // failure is the deadline regardless; the bound listener merely
+        // models the stalled peer.
+        let stalled = std::net::TcpListener::bind("127.0.0.1:0").expect("bind stalled listener");
+        let stalled_port = stalled.local_addr().expect("local addr").port();
+        let lazy = Box::new(
+            crate::transports::WebSocketTransport::connect_lazy_with_timeout(
+                format!("ws://127.0.0.1:{stalled_port}/ws"),
+                Duration::ZERO,
+            ),
+        ) as Box<dyn Transport + Send>;
+        // Round 3: a normal round re-authenticates.
+        let (transport3, _sent3, _closed3) =
+            MockTransport::new(vec![Some(Ok(authenticated_json()))]);
+        let pool = boxed_transport_pool(vec![lazy, Box::new(transport3)]);
+        let policy = ReconnectPolicy::new(boxed_pool_factory(&pool))
+            .with_max_attempts(5)
+            .with_initial_backoff(Duration::from_millis(50));
+        let config = SignalFishConfig::new("mb_reconnect").with_reconnect_policy(policy);
+        let (mut client, mut events) = SignalFishClient::start(transport1, config);
+
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Connected)
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Authenticated { .. })
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Disconnected { .. })
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Reconnecting { attempt: 1, .. })
+        ));
+        // The lazy round never becomes ready, so no `Connected` is emitted
+        // for it; its terminal `Timeout` surfaces as a plain retryable
+        // `Disconnected`.
+        match events.recv().await {
+            Some(SignalFishEvent::Disconnected { reason, .. }) => {
+                assert_eq!(
+                    reason.as_deref(),
+                    Some(SignalFishError::Timeout.to_string().as_str()),
+                    "the stalled handshake must surface the Timeout face"
+                );
+            }
+            other => panic!("expected Timeout Disconnected, got {other:?}"),
+        }
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Reconnecting { attempt: 2, .. })
+        ));
+        // Round 3 reconnects normally.
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Connected)
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Authenticated { .. })
+        ));
+        client.shutdown().await;
+        drop(stalled);
     }
 
     #[tokio::test(start_paused = true)]

--- a/src/polling_client.rs
+++ b/src/polling_client.rs
@@ -4036,9 +4036,13 @@ mod tests {
         abort_calls: usize,
         send_pending: bool,
         close_pending: bool,
+        poll_cycles: usize,
     }
 
     impl Transport for RecordingFrameTransport {
+        fn begin_poll_cycle(&mut self) {
+            self.poll_cycles += 1;
+        }
         fn poll_send(
             &mut self,
             _cx: &mut std::task::Context<'_>,
@@ -5599,6 +5603,41 @@ mod tests {
     }
 
     #[test]
+    fn begin_poll_cycle_runs_exactly_once_per_poll_even_when_budget_skips() {
+        let options = PollingClientOptions {
+            work_budget: PollingWorkBudget {
+                send_frames: 1,
+                send_bytes: usize::MAX,
+                receive_frames: 64,
+                receive_bytes: 64 * 1024,
+            },
+            close_policy: PollingClosePolicy::Abandon,
+        };
+        let transport = RecordingFrameTransport::default();
+        let mut client =
+            SignalFishPollingClient::new_with_options(transport, default_config(), options);
+        let _ = client.poll(); // flush the automatic Authenticate
+        for _ in 0..2 {
+            enqueue_direct(&mut client, PollingCommand::Message(ClientMessage::Ping));
+        }
+
+        // Every poll runs exactly one backend cycle (plus the Authenticate
+        // flush poll above): the poll that parks the second ping behind the
+        // frame budget, the poll that drains it, and the idle poll with no
+        // work at all.
+        let _ = client.poll();
+        assert_eq!(client.transport.sent.len(), 2);
+        assert_eq!(client.polling_stats().current_queue_depth, 1);
+        let _ = client.poll();
+        let _ = client.poll();
+        assert_eq!(client.transport.sent.len(), 3);
+        assert_eq!(
+            client.transport.poll_cycles, 4,
+            "exactly one begin_poll_cycle per poll, even when the budget skips work"
+        );
+    }
+
+    #[test]
     fn send_byte_budget_retains_fifo_work_for_later_polls() {
         let options = PollingClientOptions {
             work_budget: PollingWorkBudget {
@@ -5756,6 +5795,71 @@ mod tests {
 
         assert_eq!(ids, vec![1, 2]);
         assert!(client.polling_stats().receive_budget_exhaustions >= 1);
+        assert!(client.pending_inbound.is_none());
+    }
+
+    #[test]
+    fn oversized_inbound_frame_gets_single_frame_escape() {
+        // A complete inbound frame strictly larger than the entire receive
+        // byte budget is still admitted on its own poll (first-frame
+        // escape); the next frame parks and leads the following poll.
+        let from = uuid::Uuid::from_u128(78);
+        let frame = |id| {
+            TransportFrame::Text(
+                serde_json::to_string(&ServerMessage::GameData {
+                    from_player: from,
+                    data: serde_json::json!({ "id": id, "padding": "x".repeat(64) }),
+                    seq: None,
+                    epoch: None,
+                    class: None,
+                    key: None,
+                })
+                .expect("GameData should serialize"),
+            )
+        };
+        let first = frame(1);
+        let second = frame(2);
+        assert!(
+            frame_payload_len(&first) > 8,
+            "test frame must strictly exceed the 8-byte budget"
+        );
+        let transport = RecordingFrameTransport {
+            incoming: [first, second].into_iter().collect(),
+            ..RecordingFrameTransport::default()
+        };
+        let options = PollingClientOptions {
+            work_budget: PollingWorkBudget {
+                send_frames: 8,
+                send_bytes: usize::MAX,
+                receive_frames: 8,
+                receive_bytes: 8,
+            },
+            close_policy: PollingClosePolicy::Abandon,
+        };
+        let mut client =
+            SignalFishPollingClient::new_with_options(transport, default_config(), options);
+        prime_room(&mut client);
+
+        let first_events = client.poll();
+        assert_eq!(
+            first_events
+                .iter()
+                .filter(|event| matches!(event, SignalFishEvent::GameData { data, .. } if data["id"] == 1))
+                .count(),
+            1,
+            "the strictly oversized first frame is admitted on its own poll"
+        );
+        assert_eq!(client.polling_stats().receive_budget_exhaustions, 1);
+
+        let second_events = client.poll();
+        assert_eq!(
+            second_events
+                .iter()
+                .filter(|event| matches!(event, SignalFishEvent::GameData { data, .. } if data["id"] == 2))
+                .count(),
+            1,
+            "the parked follower leads the next poll without loss or reordering"
+        );
         assert!(client.pending_inbound.is_none());
     }
 


### PR DESCRIPTION
## Why

Issue #126's recurring paranoid-audit rounds protect correctness by auditing never-previously-audited surfaces. Round 51 covers three fresh surfaces; all findings were pinning/documentation gaps — **zero production defects**.

## What

**1. Cross-platform portability (first evidence in 51 rounds)**
The workspace (all targets, including tests) passes `cargo check` for **Windows (MSVC and GNU)** and **macOS ARM64**, in both the default and max non-crypto feature sets. The only cross-target build requirement is the opt-in `tls` feature's `ring` needing the target C toolchain (upstream-supported). Documented in the README project notes; a scheduled CI lane is proposed separately in #235 (kept out of per-PR CI per the #225 cost policy).

**2. Reconnect-policy × transport-construction failures (async driver)**
The infallible factory design converts every construction failure into an ordinary retryable edge — proven at mechanism level. Three documented-but-unpinned faces landed as red/green-verified pins:
- a panicking factory kills the loop exactly like a panicking `Transport` method (channel closes, parked reliable senders resolve `NotConnected`);
- the lazy constructor's stalled-handshake `Timeout` is an ordinary retryable round — the never-ready round emits `Disconnected` without `Connected` and consumes attempt 2 without a budget reset (surfaces through the send-failure arm; verified by failed mutation probes on the receive arms);
- dropping the handle during a backoff wait never consults the factory and closes the channel promptly.

**3. Polling-scheduler progress guarantees under oversized single frames**
Every starvation candidate mechanism-refuted (first-frame escape in both directions, parked frames lead the next poll, total FIFO, exact accounting, honest zero-clamp). Two documented-but-unpinned cells landed as red/green-verified pins:
- a complete inbound frame strictly larger than the entire `receive_bytes` budget is admitted on its own poll (mirror of the send-side escape pin);
- `begin_poll_cycle` runs exactly once per `poll()`, including budget-skipped and idle polls.

All four behavioral pins were mutation-probed red (catch-and-continue factory, terminal-ized send-failure classification, removed first-frame escape, doubled `begin_poll_cycle`); one initially vacuous assertion found by probing was removed rather than kept.

## Verification

- Mandatory workflow green locally: `cargo fmt`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo test --workspace --all-features` (0 failures).
- Sparse-cell clippy re-verified: tokio-runtime-only, polling-client-only.
- Hostile reviewer + convergence-verifier loop converged to zero findings (7 review findings fixed, including two causally wrong comments, an `unused_mut`/dead-code CI break, and a README over-claim softened to the `cargo check` evidence).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are documentation and test-only pins; no production driver or transport logic is modified in this diff.
> 
> **Overview**
> Documents **first-class desktop targets** in the README and changelog: `cargo check` (including tests) on Windows MSVC/GNU and macOS ARM64, Linux CI for the full matrix, and separate wasm/Emscripten lanes; notes the opt-in `tls`/`ring` C-toolchain requirement.
> 
> Adds **async reconnect-policy regression tests** in `client.rs`: helpers for mixed `Box<dyn Transport>` pools, plus pins that a **panicking reconnect factory** ends the loop like a panicking `Transport` (channel closes, `NotConnected` on sends), **handle drop during backoff** never calls the factory, and a **lazy WebSocket handshake `Timeout`** is a normal retryable round (`Disconnected` without `Connected`, attempt budget not reset).
> 
> Adds **polling-scheduler pins** in `polling_client.rs`: `RecordingFrameTransport` tracks `begin_poll_cycle` so tests assert **one cycle per `poll()`** even when send budgets skip work, and that an inbound frame **larger than `receive_bytes`** still gets the documented **first-frame escape** with FIFO on the next poll.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4626282aa77edacd8f5bca5146ce0c06249ef63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->