### PR TITLE
Round 52: post-0.8.0 protocol re-sync; wedged-consumer mesh freeze fix; #235 portability lanes

### DIFF
--- a/.github/workflows/portability.yml
+++ b/.github/workflows/portability.yml
@@ -1,0 +1,79 @@
+# Cross-platform compile portability gate (issue #235).
+#
+# Weekly scheduled `cargo check` lanes for the desktop targets that round 51
+# verified by hand (Windows MSVC and macOS ARM64), so a Windows-only or
+# macOS-only compile break surfaces within seven days instead of at the next
+# cross-platform session audit. Scheduled only, by design: per-PR Windows or
+# macOS runners would contradict the measured CI-cost policy (issue #225) for
+# a regression class that has never failed. Promotion to a required check
+# additionally needs the ruleset plumbing in `.github/required-checks.json`.
+#
+# The opt-in `tls` feature's `ring` needs the target C toolchain, so lanes
+# run the max NON-crypto feature set and leave `tls` to upstream ring
+# coverage (ring 0.17 officially supports all three targets).
+#
+# The concurrency group includes the event name so scheduled and manual runs
+# on the same ref do not cancel each other.
+
+name: Portability
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/portability.yml
+      - Cargo.toml
+      - Cargo.lock
+      - crates/*/Cargo.toml
+      - tools/*/Cargo.toml
+  schedule:
+    # Mondays at 06:30 UTC — after protocol-sync (05:30) and off the
+    # security-supply-chain slot (06:00) so scheduled runs never start
+    # simultaneously.
+    - cron: "30 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  # ──────────────────────────────────────────────────────────────
+  # check — cargo check per desktop target × feature cell
+  # ──────────────────────────────────────────────────────────────
+  check:
+    name: cargo check (${{ matrix.target }}, ${{ matrix.cell }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - x86_64-pc-windows-msvc
+          - aarch64-apple-darwin
+        cell:
+          - name: workspace default
+            flags: --workspace
+          - name: max non-crypto
+            flags: --workspace --no-default-features --features transport-websocket,polling-client,mesh,token-binding,tokio-runtime
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain with cross target
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Check workspace compiles for target
+        run: cargo check ${{ matrix.cell.flags }} --all-targets --locked --target ${{ matrix.target }}

--- a/.github/workflows/portability.yml
+++ b/.github/workflows/portability.yml
@@ -50,7 +50,7 @@ jobs:
   # check — cargo check per desktop target × feature cell
   # ──────────────────────────────────────────────────────────────
   check:
-    name: cargo check (${{ matrix.target }}, ${{ matrix.cell }})
+    name: cargo check (${{ matrix.target }}, ${{ matrix.cell.name }})
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:

--- a/.llm/skills/protocol-wire-conformance/SKILL.md
+++ b/.llm/skills/protocol-wire-conformance/SKILL.md
@@ -34,9 +34,11 @@ the blind spot where a server-side error-code addition passes the wire-sample
 golden tests (they pin message *shapes*, not the error-code value space).
 
 The canonical corpus pins protocol-authority commit
-`11e165cecb9179378f53d65971bd39a2f4e3baab`, advanced from the Server 0.8.0
-release pin `d79dcdc7549777c8c2bd9fcb2d132641532d8c86` by descriptive-only
-prose drift (the wire samples are byte-identical across both commits).
+`ceb47cbc86c88d321b778596f195b68a7bd03aea`, advanced from the Server 0.8.0
+release pin `d79dcdc7549777c8c2bd9fcb2d132641532d8c86` by descriptive prose
+plus one deliberate v3 schema change (the v3 room-member snapshot excludes the
+legacy `connection_info` echo — server issue #529; the v2 snapshot shape is
+frozen and the wire samples are byte-identical across all three commits).
 Released runtime compatibility stays bound to the Server 0.8.0 release in
 `tests/compatibility.toml`, while the vendored AsyncAPI spec re-syncs to
 upstream `main` at every refresh — descriptive prose drift is absorbed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Disconnected` event clears the data plane (peers disconnected, view
   cleared) but only true end-of-stream fuses the controller, so mesh
   consumers survive automatic reconnection.
+- A reconnect round whose farewell cannot be delivered — the consumer wedged
+  past `shutdown_timeout` on a full event channel — now ends the client
+  instead of retrying, so a missed barrier event can no longer desynchronize
+  mesh catch-up accounting.
 - `impl Transport for Box<dyn Transport + Send>` so owned trait objects
   (including the reconnect factory's products) flow through the same driver
   plumbing as concrete transports.
@@ -53,6 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Protocol v3 room snapshots on upstream Server `main` (post-0.8.0) no longer echo `connection_info`; the client decodes both shapes unchanged, and the protocol guide's `PlayerInfo` fields (`epoch`/`seq`, visibility contract) now document the omission.
 - The `WebRtcDriver::disconnect` contract now requires drivers to retire the
   torn-down peer's queued, unpollled output, so stale events cannot cross a
   reconnect barrier when legacy generationless plans leave no generation to

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -281,6 +281,8 @@ pub struct PlayerInfo {
     pub is_ready: bool,
     pub connected_at: String,
     pub connection_info: Option<ConnectionInfo>,
+    pub epoch: Option<u32>,
+    pub seq: Option<u64>,
 }
 ```
 
@@ -291,7 +293,9 @@ pub struct PlayerInfo {
 | `is_authority` | `bool` | Whether this player is the room authority. |
 | `is_ready` | `bool` | Whether the player has signaled readiness. |
 | `connected_at` | `String` | ISO 8601 timestamp of when the player connected. |
-| `connection_info` | `Option<ConnectionInfo>` | P2P connection info (present when the player is ready). |
+| `connection_info` | `Option<ConnectionInfo>` | Legacy self-declared P2P metadata. Protocol-v2 room snapshots may include it; protocol-v3 room snapshots omit it (the authoritative copy reaches peers via `GameStarting`'s `PeerConnectionInfo`). |
+| `epoch` | `Option<u32>` | Protocol v3 only: the player's current incarnation epoch. |
+| `seq` | `Option<u64>` | Protocol v3 only: the player's exact relay baseline; delivery obligations start at `seq + 1`. |
 
 ---
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -699,7 +699,12 @@ const DEFAULT_RECONNECT_MAX_BACKOFF: Duration = Duration::from_secs(10);
 /// - a dropped client handle,
 /// - a [`ProtocolViolationPolicy::Disconnect`] teardown (a protocol
 ///   violation is a correctness signal; automatic reconnection would mask
-///   it), and
+///   it),
+/// - a teardown whose terminal farewell could not be delivered because the
+///   consumer wedged past [`shutdown_timeout`](SignalFishConfig::shutdown_timeout):
+///   the consumer missed a barrier event, and a mesh controller's
+///   catch-up accounting can never resynchronize a lost edge, so the loop
+///   ends instead of retrying into a wedged consumer, and
 /// - an exhausted attempt budget, reported via
 ///   [`ReconnectAbandoned`](SignalFishEvent::ReconnectAbandoned).
 ///
@@ -2375,12 +2380,15 @@ async fn emit_core_disconnected_or_shutdown(
     shutdown: &mut ShutdownSignal,
     state: &Arc<Mutex<ClientCore>>,
     teardown: TerminalTeardown,
-) {
+) -> bool {
     // Peer-close delivery is bounded by the same budget as graceful
     // termination: a wedged consumer must not leak the task holding the
     // command receiver, which would park every waiting reliable sender
     // forever. On expiry the terminal event falls back to a nonblocking
-    // attempt before the loop terminates.
+    // attempt before the loop terminates. The fallback's outcome decides
+    // whether the loop may retry: a farewell abandoned on a full channel
+    // means the consumer missed a barrier event, so returning `false` ends
+    // the loop instead of opening a round that can never resynchronize it.
     let TerminalTeardown {
         reason,
         deadline,
@@ -2389,7 +2397,18 @@ async fn emit_core_disconnected_or_shutdown(
     let event = lock_core(state).disconnect(reason);
     let deliver_event = async {
         if !emit_terminal_event(event_tx, shutdown, deadline, event.clone()).await {
-            let _ = event_tx.try_send(event);
+            match event_tx.try_send(event) {
+                Ok(()) => true,
+                // The consumer still lives but wedged past the budget: the
+                // farewell barrier event is lost, so the loop must not
+                // retry.
+                Err(mpsc::error::TrySendError::Full(_)) => false,
+                // The consumer is gone; nothing can resynchronize and
+                // retrying is harmless.
+                Err(mpsc::error::TrySendError::Closed(_)) => true,
+            }
+        } else {
+            true
         }
     };
     let close = finish_send_and_close_bounded(
@@ -2398,7 +2417,8 @@ async fn emit_core_disconnected_or_shutdown(
         state,
         remaining_shutdown_budget(timeout, deadline),
     );
-    let ((), ()) = tokio::join!(deliver_event, close);
+    let (farewell_delivered, ()) = tokio::join!(deliver_event, close);
+    farewell_delivered
 }
 
 /// One terminal disconnect's attribution and shared shutdown budget: every
@@ -2645,7 +2665,7 @@ async fn finish_send_failure(
     state: &Arc<Mutex<ClientCore>>,
     error: SignalFishError,
     timeout: Duration,
-) {
+) -> bool {
     let deadline = tokio::time::Instant::now().checked_add(timeout);
     let mut drain = ReadyFrameDrain::new(None, ReadyFrameDrainBudget::standard());
     loop {
@@ -2696,10 +2716,19 @@ async fn finish_send_failure(
     let disconnected = lock_core(state).disconnect(reason);
     // A preempted batch means the sticky signal was observed or the shared
     // deadline has passed, so this bounded wait always collapses within one
-    // poll instead of parking beside the already-spent budget.
+    // poll instead of parking beside the already-spent budget. A farewell
+    // abandoned on a full channel returns `false` so the loop ends instead
+    // of retrying a round whose barrier event the consumer never saw (the
+    // same lost-barrier class as `emit_core_disconnected_or_shutdown`).
     let deliver_disconnected = async {
         if !emit_terminal_event(event_tx, shutdown, deadline, disconnected.clone()).await {
-            let _ = event_tx.try_send(disconnected);
+            match event_tx.try_send(disconnected) {
+                Ok(()) => true,
+                Err(mpsc::error::TrySendError::Full(_)) => false,
+                Err(mpsc::error::TrySendError::Closed(_)) => true,
+            }
+        } else {
+            true
         }
     };
     let close = finish_send_and_close_bounded(
@@ -2708,7 +2737,8 @@ async fn finish_send_failure(
         state,
         remaining_shutdown_budget(timeout, deadline),
     );
-    let ((), ()) = tokio::join!(deliver_disconnected, close);
+    let (farewell_delivered, ()) = tokio::join!(deliver_disconnected, close);
+    farewell_delivered
 }
 
 /// How one connection lifetime (one transport) ended inside the transport
@@ -2732,14 +2762,21 @@ enum ConnectionRoundExit {
 }
 
 /// Classify a teardown the loop just completed: an observed (sticky) shutdown
-/// signal always wins over retrying, because the client was asked to end.
+/// signal always wins over retrying, because the client was asked to end. A
+/// blocked farewell (`farewell_unblocked == false`: a living consumer wedged
+/// past the budget on a full channel) also terminates: the consumer missed a
+/// barrier event, and a retried round can never resynchronize a
+/// mesh controller whose catch-up accounting counts one delivered event
+/// per authoritative edge. `true` covers delivery and a gone consumer alike —
+/// in neither case does a retry face a blocked barrier.
 #[cfg(feature = "tokio-runtime")]
 fn classify_round_exit(
     shutdown: &ShutdownSignal,
+    farewell_unblocked: bool,
     authenticated: bool,
     reason: Option<String>,
 ) -> ConnectionRoundExit {
-    if shutdown.is_observed() {
+    if shutdown.is_observed() || !farewell_unblocked {
         ConnectionRoundExit::Terminal
     } else {
         ConnectionRoundExit::Retryable {
@@ -3056,15 +3093,21 @@ async fn connection_round(
                     let authenticated = lock_core(state).is_authenticated();
                     let reason: Option<String> =
                         Some("transport received a protocol frame before readiness".into());
-                    emit_core_disconnected_or_shutdown(
+                    let farewell_unblocked = emit_core_disconnected_or_shutdown(
                         transport,
                         &mut pending_send,
                         event_tx,
                         shutdown,
                         state,
                         TerminalTeardown::starting(shutdown_timeout, reason.clone()),
-                    ).await;
-                    exit = classify_round_exit(shutdown, authenticated, reason);
+                    )
+                    .await;
+                    exit = classify_round_exit(
+                        shutdown,
+                        farewell_unblocked,
+                        authenticated,
+                        reason,
+                    );
                     break;
                 }
                 match io {
@@ -3086,7 +3129,7 @@ async fn connection_round(
                             cmd_rx.close();
                         }
                         let error_text = error.to_string();
-                        finish_send_failure(
+                        let farewell_unblocked = finish_send_failure(
                             transport,
                             &mut pending_send,
                             event_tx,
@@ -3094,9 +3137,15 @@ async fn connection_round(
                             state,
                             error,
                             shutdown_timeout,
-                        ).await;
+                        )
+                        .await;
                         let reason = peer_close_reason(transport).or(Some(error_text));
-                        exit = classify_round_exit(shutdown, authenticated, reason);
+                        exit = classify_round_exit(
+                            shutdown,
+                            farewell_unblocked,
+                            authenticated,
+                            reason,
+                        );
                         break;
                     }
                     TransportIo::Received(Some(Ok(frame))) => {
@@ -3109,15 +3158,21 @@ async fn connection_round(
                         if let Some(reason) = outcome.input_error {
                             let authenticated = lock_core(state).is_authenticated();
                             let reason_text = Some(reason.clone());
-                            emit_core_disconnected_or_shutdown(
+                            let farewell_unblocked = emit_core_disconnected_or_shutdown(
                                 transport,
                                 &mut pending_send,
                                 event_tx,
                                 shutdown,
                                 state,
                                 TerminalTeardown::starting(shutdown_timeout, Some(reason)),
-                            ).await;
-                            exit = classify_round_exit(shutdown, authenticated, reason_text);
+                            )
+                            .await;
+                            exit = classify_round_exit(
+                                shutdown,
+                                farewell_unblocked,
+                                authenticated,
+                                reason_text,
+                            );
                             break;
                         }
                         let disconnect = outcome.disconnect;
@@ -3195,29 +3250,41 @@ async fn connection_round(
                     TransportIo::Received(Some(Err(error))) => {
                         let authenticated = lock_core(state).is_authenticated();
                         let reason = Some(error.to_string());
-                        emit_core_disconnected_or_shutdown(
+                        let farewell_unblocked = emit_core_disconnected_or_shutdown(
                             transport,
                             &mut pending_send,
                             event_tx,
                             shutdown,
                             state,
                             TerminalTeardown::starting(shutdown_timeout, reason.clone()),
-                        ).await;
-                        exit = classify_round_exit(shutdown, authenticated, reason);
+                        )
+                        .await;
+                        exit = classify_round_exit(
+                            shutdown,
+                            farewell_unblocked,
+                            authenticated,
+                            reason,
+                        );
                         break;
                     }
                     TransportIo::Received(None) => {
                         let authenticated = lock_core(state).is_authenticated();
                         let reason = close_reason(transport);
-                        emit_core_disconnected_or_shutdown(
+                        let farewell_unblocked = emit_core_disconnected_or_shutdown(
                             transport,
                             &mut pending_send,
                             event_tx,
                             shutdown,
                             state,
                             TerminalTeardown::starting(shutdown_timeout, reason.clone()),
-                        ).await;
-                        exit = classify_round_exit(shutdown, authenticated, reason);
+                        )
+                        .await;
+                        exit = classify_round_exit(
+                            shutdown,
+                            farewell_unblocked,
+                            authenticated,
+                            reason,
+                        );
                         break;
                     }
                 }
@@ -9424,6 +9491,82 @@ mod tests {
             factory_calls.load(Ordering::SeqCst),
             0,
             "the factory must not be consulted after the handle drop"
+        );
+    }
+
+    /// A reconnect round whose terminal farewell could not be delivered —
+    /// the consumer wedged past `shutdown_timeout` on a full event channel —
+    /// ends the loop instead of opening a replacement round. The consumer
+    /// missed the `Disconnected` barrier event, and a mesh controller's
+    /// catch-up accounting counts exactly one delivered event per
+    /// authoritative edge, so a lost farewell would permanently desynchronize
+    /// it while the data plane silently stopped being polled (round-52
+    /// audit).
+    #[tokio::test(start_paused = true)]
+    async fn abandoned_farewell_ends_the_loop_instead_of_retrying() {
+        // Capacity 1: the consumer drains only `Connected`, so the buffered
+        // `Authenticated` event keeps the channel full while the transport
+        // dies (peer close) and the farewell delivery races its deadline.
+        let (transport1, _sent1, closed1) =
+            MockTransport::new(vec![Some(Ok(authenticated_json())), None]);
+        let pool = transport_pool(vec![]);
+        let factory_calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let inner = pool_factory(&pool);
+        let calls = Arc::clone(&factory_calls);
+        let policy = ReconnectPolicy::new(move || {
+            calls.fetch_add(1, Ordering::SeqCst);
+            inner()
+        })
+        .with_max_attempts(5)
+        .with_initial_backoff(Duration::from_millis(50));
+        let config = SignalFishConfig::new("mb_reconnect")
+            .with_event_channel_capacity(1)
+            .with_reconnect_policy(policy);
+        let (mut client, mut events) = SignalFishClient::start(transport1, config);
+
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Connected)
+        ));
+        // Keep the test task from draining while virtual time advances: the
+        // buffered `Authenticated` stays in the channel, so the transport
+        // death's farewell delivery (1 s shared budget, virtual) expires
+        // against a still-full channel, the nonblocking fallback fails, and
+        // the loop must terminate instead of opening a replacement round.
+        tokio::time::sleep(Duration::from_secs(60)).await;
+        // The wedge lifted: the buffered `Authenticated` is the last readable
+        // event — no `Reconnecting` round, and the abandoned farewell never
+        // surfaces.
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Authenticated { .. })
+        ));
+        let observed = tokio::time::timeout(Duration::from_secs(30), events.recv())
+            .await
+            .expect("channel close must be prompt");
+        assert!(
+            observed.is_none(),
+            "the loop must end without further events, got {observed:?}"
+        );
+        assert_eq!(
+            factory_calls.load(Ordering::SeqCst),
+            0,
+            "the factory must never be consulted after an abandoned farewell"
+        );
+        assert!(
+            matches!(
+                client.send_game_data(serde_json::json!({ "n": 1 })),
+                Err(SignalFishError::NotConnected)
+            ),
+            "the ended loop must fail commands fast"
+        );
+        tokio::time::timeout(Duration::from_secs(2), client.shutdown())
+            .await
+            .expect("shutdown after an abandoned farewell must complete promptly");
+        assert!(!client.is_connected());
+        assert!(
+            closed1.load(Ordering::Acquire),
+            "the dead round's transport must have been closed during teardown"
         );
     }
 

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -387,7 +387,10 @@ pub struct PlayerInfo {
     pub is_authority: bool,
     pub is_ready: bool,
     pub connected_at: String,
-    /// Connection info for P2P establishment (provided when player is ready).
+    /// Legacy self-declared connection info for P2P establishment. Protocol
+    /// v2 room snapshots may include it (when the player provided it);
+    /// protocol v3 room snapshots omit it — the authoritative copy reaches
+    /// peers via `GameStarting`'s `PeerConnectionInfo`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub connection_info: Option<ConnectionInfo>,
     /// Current server-tracked incarnation epoch (protocol v3 only).

--- a/src/webrtc.rs
+++ b/src/webrtc.rs
@@ -2518,6 +2518,136 @@ mod tests {
         mesh.shutdown().await;
     }
 
+    /// A terminal `Disconnected` edge runs the same authoritative teardown as
+    /// a room exit, so a refused room-scoped status retained across it must
+    /// also be discarded (round-52 audit): releasing queue capacity afterward
+    /// must never leak the stale snapshot of a dead connection.
+    ///
+    /// Runs on paused virtual time for the same reasons as
+    /// [`congestion_buffers_driver_signal_and_relays_exactly_once`]: the
+    /// permit/counter/channel seams carry all progress, and the bounded
+    /// waits resolve deterministically via auto-advance instead of racing
+    /// CI scheduling.
+    #[tokio::test(start_paused = true)]
+    async fn disconnect_discards_congested_transport_status() {
+        let peer = uuid(12);
+        let GatedAnswerer {
+            mut mesh,
+            driver,
+            permits,
+            entered,
+            sent,
+            generation,
+        } = start_gated_answerer(peer, 2, protocol_info_v3(), false).await;
+
+        mesh.client_mut()
+            .send_game_data(serde_json::json!({ "filler": 1 }))
+            .expect("first filler should enter the transport");
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            spin_until(|| entered.load(std::sync::atomic::Ordering::Acquire) >= 3).await;
+        })
+        .await
+        .expect("transport loop never parked in the congested send");
+        mesh.client_mut()
+            .send_game_data(serde_json::json!({ "filler": 2 }))
+            .expect("second filler should occupy the command queue");
+        driver.emit_and_wake(DriverEvent::Connected { peer, generation });
+        assert!(matches!(
+            tokio::time::timeout(std::time::Duration::from_secs(1), mesh.recv()).await,
+            Ok(Some(MeshEvent::PeerConnected(id))) if id == peer
+        ));
+
+        mesh.handle_event(&SignalFishEvent::Disconnected {
+            reason: Some("closed by transport".into()),
+            last_server_error: None,
+        });
+        assert!(driver.calls().contains(&DriverCall::Disconnect(peer)));
+
+        permits.add_permits(3);
+        for _ in 0..8 {
+            let _ = tokio::time::timeout(std::time::Duration::from_millis(25), mesh.recv()).await;
+        }
+        assert_eq!(
+            sent_count(&sent, &["TransportStatus", "webrtc", "true"]),
+            0,
+            "a status refused before Disconnected must not reach the wire afterward"
+        );
+
+        permits.add_permits(8);
+        mesh.shutdown().await;
+    }
+
+    /// While the command queue refuses every report, a connect/disconnect
+    /// flap must coalesce in the single latest-state slot instead of queueing
+    /// edges: releasing capacity afterward sends exactly the final aggregate
+    /// state, never the superseded intermediate snapshots (round-52 audit).
+    ///
+    /// Runs on paused virtual time for the same reasons as
+    /// [`congestion_buffers_driver_signal_and_relays_exactly_once`].
+    #[tokio::test(start_paused = true)]
+    async fn congested_status_flap_coalesces_to_latest_state() {
+        let peer = uuid(13);
+        let GatedAnswerer {
+            mut mesh,
+            driver,
+            permits,
+            entered,
+            sent,
+            generation,
+        } = start_gated_answerer(peer, 2, protocol_info_v3(), false).await;
+
+        mesh.client_mut()
+            .send_game_data(serde_json::json!({ "filler": 1 }))
+            .expect("first filler should enter the transport");
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            spin_until(|| entered.load(std::sync::atomic::Ordering::Acquire) >= 3).await;
+        })
+        .await
+        .expect("transport loop never parked in the congested send");
+        mesh.client_mut()
+            .send_game_data(serde_json::json!({ "filler": 2 }))
+            .expect("second filler should occupy the command queue");
+
+        // The flap happens entirely inside the congestion window: every edge
+        // is refused and overwrites the slot; none reaches the wire.
+        driver.emit_and_wake(DriverEvent::Connected { peer, generation });
+        assert!(matches!(
+            tokio::time::timeout(std::time::Duration::from_secs(1), mesh.recv()).await,
+            Ok(Some(MeshEvent::PeerConnected(id))) if id == peer
+        ));
+        driver.emit_and_wake(DriverEvent::Disconnected { peer, generation });
+        assert!(matches!(
+            tokio::time::timeout(std::time::Duration::from_secs(1), mesh.recv()).await,
+            Ok(Some(MeshEvent::PeerDisconnected(id))) if id == peer
+        ));
+        driver.emit_and_wake(DriverEvent::Connected { peer, generation });
+        assert!(matches!(
+            tokio::time::timeout(std::time::Duration::from_secs(1), mesh.recv()).await,
+            Ok(Some(MeshEvent::PeerConnected(id))) if id == peer
+        ));
+
+        permits.add_permits(3);
+        for _ in 0..8 {
+            let _ = tokio::time::timeout(std::time::Duration::from_millis(25), mesh.recv()).await;
+            if sent_count(&sent, &["TransportStatus", "webrtc", "true"]) == 1 {
+                break;
+            }
+        }
+        assert_eq!(
+            sent_count(&sent, &["TransportStatus", "webrtc", "true"]),
+            1,
+            "only the final aggregate state must reach the wire"
+        );
+        assert_eq!(
+            sent_count(&sent, &["TransportStatus", "webrtc", "false"]),
+            0,
+            "intermediate flap edges must never surface after congestion clears"
+        );
+
+        permits.add_permits(8);
+        mesh.shutdown().await;
+    }
+
     /// A leave fence is also transient when the correlated operation later
     /// fails. The last-channel down edge must survive `RoomOperationPending`
     /// and be reported after the failure leaves this client in the room.

--- a/src/webrtc.rs
+++ b/src/webrtc.rs
@@ -2578,7 +2578,7 @@ mod tests {
     }
 
     /// While the command queue refuses every report, a connect/disconnect
-    /// flap must coalesce in the single latest-state slot instead of queueing
+    /// flap must coalesce in the single latest-state slot instead of queuing
     /// edges: releasing capacity afterward sends exactly the final aggregate
     /// state, never the superseded intermediate snapshots (round-52 audit).
     ///

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -1088,6 +1088,55 @@ mod workflow_existence {
             }
         }
     }
+
+    /// The scheduled Portability lanes (issue #235) must keep pinning the
+    /// exact round-51 evidence shape: both desktop targets, the workspace
+    /// default and max NON-crypto feature cells, a `--locked` check
+    /// invocation on its staggered weekly slot, and no `tls` (its `ring`
+    /// needs the target C toolchain and stays upstream-covered). Drift in
+    /// any of these silently turns the lane into something the audited
+    /// evidence no longer describes.
+    #[test]
+    fn portability_workflow_pins_cross_target_check_lanes() {
+        let workflow = read_project_file(".github/workflows/portability.yml");
+        for target in ["x86_64-pc-windows-msvc", "aarch64-apple-darwin"] {
+            assert!(
+                workflow.contains(&format!("- {target}")),
+                "portability.yml must check the {target} desktop target"
+            );
+        }
+        assert!(
+            workflow.contains(
+                "flags: --workspace --no-default-features --features transport-websocket,polling-client,mesh,token-binding,tokio-runtime",
+            ),
+            "portability.yml must run the max non-crypto feature cell"
+        );
+        assert!(
+            workflow.contains("flags: --workspace\n"),
+            "portability.yml must run the workspace-default feature cell"
+        );
+        assert!(
+            !workflow.contains("--features tls") && !workflow.contains(",tls"),
+            "portability.yml must stay on the non-crypto set (ring needs the target C toolchain)"
+        );
+        assert!(
+            workflow.contains("--all-targets --locked --target"),
+            "portability.yml must run the check with --locked against the matrix target"
+        );
+        assert!(
+            workflow.contains("cron: \"30 6 * * 1\""),
+            "portability.yml must keep its Monday 06:30 UTC slot (staggered after \
+             protocol-sync 05:30 and off security-supply-chain 06:00)"
+        );
+        assert!(
+            workflow.contains("  workflow_dispatch:"),
+            "portability.yml must support app-free explicit dispatch"
+        );
+        assert!(
+            workflow.contains("persist-credentials: false"),
+            "portability.yml checkouts must not persist credentials"
+        );
+    }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/tests/compatibility.toml
+++ b/tests/compatibility.toml
@@ -10,7 +10,7 @@ synced = "2026-09-01"
 # files) without touching the released runtime binding above; any schema,
 # message, or error-code change triggers full type reconciliation.
 [protocol_authority]
-commit = "11e165cecb9179378f53d65971bd39a2f4e3baab"
+commit = "ceb47cbc86c88d321b778596f195b68a7bd03aea"
 synced = "2026-09-07"
 
 [legacy_server]
@@ -30,4 +30,4 @@ generation = "omitted"
 "v3-server-messages.jsonl" = "21ed576f61cc042eee9c463363bde5a4b38a9285d0560666423afd6c930588b2"
 
 [server_spec]
-"signal-fish-protocol.asyncapi.yaml" = "26542caf25adcf0638e87faca8def19a02da6e4ce2c73165092dd2228c7f312d"
+"signal-fish-protocol.asyncapi.yaml" = "ff00245e15d61826a0bf93aa94856ff249952f6f04f3d86c58a438651b51328f"

--- a/tests/compatibility_manifest_tests.rs
+++ b/tests/compatibility_manifest_tests.rs
@@ -84,9 +84,10 @@ fn compatibility_manifest_binds_exact_server_artifacts() {
         .as_str()
         .unwrap_or_else(|| panic!("protocol authority commit must be a string"));
     // The evidence authority (all vendored protocol artifacts) advances with
-    // descriptive-only upstream drift; the released runtime binding above
-    // stays at the 0.8.0 release commit. Keep this literal review-forced.
-    assert_eq!(protocol_commit, "11e165cecb9179378f53d65971bd39a2f4e3baab");
+    // descriptive drift plus reviewed deliberate schema changes; the released
+    // runtime binding above stays at the 0.8.0 release commit. Keep this
+    // literal review-forced.
+    assert_eq!(protocol_commit, "ceb47cbc86c88d321b778596f195b68a7bd03aea");
     assert_eq!(
         wire_provenance["upstream"]["commit"].as_str(),
         Some(protocol_commit)

--- a/tests/server-spec/PROVENANCE.toml
+++ b/tests/server-spec/PROVENANCE.toml
@@ -7,18 +7,21 @@
 repo = "https://github.com/Ambiguous-Interactive/signal-fish-server"
 path = "spec"
 # Exact server commit the spec bytes were copied from.
-# 2026-09-07 refresh: descriptive-only drift from the Server 0.8.0 release pin
-# (d79dcdc7549777c8c2bd9fcb2d132641532d8c86) — summary/description prose and
-# one cosmetic reformat; zero schema, message, or error-code changes. This
-# evidence authority advances together with tests/compatibility.toml's
-# [protocol_authority] and the wire-samples PROVENANCE, while the released
-# runtime compatibility binding (server_commit + release artifacts in
-# tests/compatibility.toml) stays at the 0.8.0 release.
-commit = "11e165cecb9179378f53d65971bd39a2f4e3baab"
+# 2026-09-07 refresh: the protocol-v3 room-member snapshot (V3PlayerInfo)
+# deliberately excludes the legacy `connection_info` echo (server issue #529),
+# and the ConnectionInfo/SpectatorInfo/V2PlayerInfo descriptions were updated
+# to record that visibility contract; the v2 snapshot shape is frozen and the
+# wire samples remain byte-identical to the Server 0.8.0 release pin
+# (d79dcdc7549777c8c2bd9fcb2d132641532d8c86). This evidence authority advances
+# together with tests/compatibility.toml's [protocol_authority] and the
+# wire-samples PROVENANCE, while the released runtime compatibility binding
+# (server_commit + release artifacts in tests/compatibility.toml) stays at the
+# 0.8.0 release.
+commit = "ceb47cbc86c88d321b778596f195b68a7bd03aea"
 # ISO 8601 date of the last refresh.
 synced = "2026-09-07"
 
 # SHA-256 of each vendored file. A policy test recomputes these, so the spec
 # cannot be edited without also updating this marker (keeps provenance honest).
 [files]
-"signal-fish-protocol.asyncapi.yaml" = "26542caf25adcf0638e87faca8def19a02da6e4ce2c73165092dd2228c7f312d"
+"signal-fish-protocol.asyncapi.yaml" = "ff00245e15d61826a0bf93aa94856ff249952f6f04f3d86c58a438651b51328f"

--- a/tests/server-spec/signal-fish-protocol.asyncapi.yaml
+++ b/tests/server-spec/signal-fish-protocol.asyncapi.yaml
@@ -691,6 +691,9 @@ components:
       type: object
       required: [id, name, is_authority, is_ready, connected_at]
       additionalProperties: false
+      description: >-
+        Frozen legacy v2 room-member snapshot shape (unchanged by issue
+        #529).
       properties:
         id: { $ref: '#/components/schemas/PlayerId' }
         name: { type: string }
@@ -702,13 +705,22 @@ components:
       type: object
       required: [id, name, is_authority, is_ready, connected_at, epoch, seq]
       additionalProperties: false
+      description: >-
+        Protocol v3 room-member snapshot. Deliberately excludes the legacy
+        `connection_info` echo: it is self-declared handoff metadata whose
+        consumer is `GameStarting` (PeerConnectionInfo) — v3 connectivity is
+        negotiated via SessionPlan — and its snapshot echo broadcast
+        arbitrary `Custom` JSON and unauthenticated credential-looking
+        `relay.token` values to every member (issue #529). `connected_at`
+        stays on the v3 wire: every released client SDK deserializes it as a
+        required field, so trimming it needs a coordinated SDK change
+        (issue #529 follow-up).
       properties:
         id: { $ref: '#/components/schemas/PlayerId' }
         name: { type: string }
         is_authority: { type: boolean }
         is_ready: { type: boolean }
         connected_at: { type: string, format: date-time }
-        connection_info: { $ref: '#/components/schemas/ConnectionInfo' }
         epoch:
           type: integer
           minimum: 1
@@ -751,6 +763,10 @@ components:
       type: object
       additionalProperties: false
       required: [id, name, connected_at]
+      description: >-
+        Shared v2/v3 spectator snapshot shape. `connected_at` stays on the
+        wire for both versions (released SDKs require it; issue #529
+        follow-up).
       properties:
         id: { $ref: '#/components/schemas/PlayerId' }
         name: { type: string }
@@ -779,8 +795,14 @@ components:
     ConnectionInfo:
       description: >-
         Legacy self-declared peer metadata (tagged by an inner `type` field:
-        direct | unity_relay | relay | webrtc | custom). Visible in room member
-        snapshots and GameStarting; not v3 capability negotiation. Values are
+        direct | unity_relay | relay | webrtc | custom). Visible at the legacy
+        handoff surface (`GameStarting` PeerConnectionInfo, both versions)
+        and in protocol-v2 room snapshots. Protocol-v3 room snapshots omit it
+        (issue #529): the echo broadcast arbitrary `Custom` JSON and
+        unauthenticated credential-looking `relay.token` values to every
+        member with no snapshot protocol purpose, and v3 connectivity is
+        negotiated via SessionPlan instead. Not v3 capability negotiation.
+        Values are
         stored and forwarded rather than authenticated. A syntactically
         validated direct value is also used to elect an executable Direct host,
         but remains self-declared and is not reachability proof. The serialized

--- a/tests/wire-samples/PROVENANCE.toml
+++ b/tests/wire-samples/PROVENANCE.toml
@@ -8,9 +8,11 @@ repo = "https://github.com/Ambiguous-Interactive/signal-fish-server"
 path = ".llm/code-samples/protocol"
 # Exact server commit the .jsonl bytes were copied from. The bytes are
 # byte-identical from the Server 0.8.0 release pin (d79dcdc7549777c8c2bd9fcb2d132641532d8c86)
-# through this commit; the evidence authority advances together across
+# through this commit (the v3 `connection_info` snapshot echo removal landed
+# only in the AsyncAPI spec and server code; these published samples never
+# carried it); the evidence authority advances together across
 # compatibility.toml and both PROVENANCE files.
-commit = "11e165cecb9179378f53d65971bd39a2f4e3baab"
+commit = "ceb47cbc86c88d321b778596f195b68a7bd03aea"
 # Protocol version range these samples exercise.
 protocol_version_min = 2
 protocol_version_max = 3


### PR DESCRIPTION
## Why

Issue #126's recurring paranoid-audit rounds protect correctness by auditing never-previously-audited surfaces. Round 52 also incorporates the one wire-touching upstream server change since the last re-sync and delivers issue #235.

## What

**1. Stay wire-compatible with the newest server (upstream issue #529)**

Protocol-v3 room snapshots no longer echo the legacy `connection_info` (it broadcast arbitrary `Custom` JSON and credential-looking relay tokens to every room member); v2 is frozen. The client already decodes both shapes — `PlayerInfo.connection_info` is optional and nothing assumes it. The vendored AsyncAPI spec re-synced byte-exact at upstream HEAD `ceb47cbc`; all four wire-sample files are byte-identical; provenance, the compatibility manifest, and the review-forced test literal advanced together while the released Server 0.8.0 runtime binding stays untouched. The protocol guide's `PlayerInfo` gained its missing v3 `epoch`/`seq` fields and the corrected visibility contract.

**2. Fix: a wedged consumer no longer freezes the mesh across reconnects**

If the event consumer stopped draining past `shutdown_timeout`, a reconnect round's farewell could be silently abandoned while the round still retried — the consumer missed a barrier event, and `MeshController` catch-up accounting can never resynchronize a lost edge, so the mesh data plane silently stopped being polled. A blocked farewell now ends the client, matching the documented contract. Red/green pinned; changelogged.

**3. Round-52 audit pins (mesh transport-status retry slot)**

Nine of ten hostile candidates mechanism-refuted. Two new pins: a terminal `Disconnected` discards a congested retained status exactly like a room exit, and a congested connect/disconnect flap coalesces to the final aggregate state with exactly-once delivery. Both red-probed and reverted.

**4. Sparse-feature sweep — zero defects**

Nine feature combinations no CI cell compiles (e.g. `tls,polling-client`, `mesh,tokio-runtime`) clippy-clean with `-D warnings`: no cfg-vs-consumer regressions after reconnect policy, `connect_lazy`, and `max_frame_hint`.

**5. Issue #235: weekly scheduled portability lanes**

New **Portability** workflow: `cargo check --workspace --all-targets --locked` for Windows MSVC and macOS ARM64 in the default and max non-crypto feature sets (`tls`/ring stays upstream-covered), Mondays 06:30 UTC staggered off the other crons, scheduled-only per the #225 cost policy. All four cells verified green locally; ci_config pin added.

Closes #235.

## Verification

- Mandatory workflow green: fmt, clippy `-D warnings`, full test suite (27 suites, 0 failures).
- Docs gate green locally (`RUSTDOCFLAGS=-D warnings cargo doc --workspace --all-features --no-deps --locked`).
- Workflow guard, test-quality, FFI-safety, admonition checks green.
- Five red/green probes verified and reverted.
- Two-round hostile review + convergence-verifier loop converged to zero known findings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes reconnect teardown semantics (can end the client where retry used to occur) and advances protocol authority/spec documentation; core decoding was already optional-field compatible.
> 
> **Overview**
> **Reconnect policy** now treats a **blocked terminal farewell** (consumer wedged past `shutdown_timeout` on a full event channel) as **non-retryable**: `emit_core_disconnected_or_shutdown` and `finish_send_failure` return whether the `Disconnected` barrier was delivered, and `classify_round_exit` ends the loop when it was not—so automatic reconnect cannot continue after a missed barrier that would desync mesh catch-up. Docs, changelog, and a paused-time test (`abandoned_farewell_ends_the_loop_instead_of_retrying`) pin the behavior.
> 
> **Protocol evidence** re-syncs to upstream commit `ceb47cbc`: vendored AsyncAPI documents that **protocol-v3 room snapshots omit legacy `connection_info`** (server #529) while v2 stays frozen; wire-sample hashes are unchanged. `PlayerInfo` comments and `docs/protocol.md` document the visibility contract and v3 `epoch`/`seq`.
> 
> **Mesh/WebRTC tests** add two round-52 pins: terminal `Disconnected` drops a congested retained transport status like room exit, and a congested connect/disconnect flap coalesces to the latest aggregate state.
> 
> **CI (#235)** adds scheduled **Portability** workflow: `cargo check --workspace --all-targets --locked` for `x86_64-pc-windows-msvc` and `aarch64-apple-darwin` (default + max non-crypto features, no `tls`), plus `ci_config_tests` guardrails on the workflow shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c634261ff7a1a6741ab8686b266deddeccb5d6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->