### PR TITLE
feat!: decode the upstream moderation surface (round 53)

### DIFF
--- a/.llm/context.md
+++ b/.llm/context.md
@@ -96,7 +96,7 @@ Dependabot uses one root-workspace updater; minimum/latest Godot fixtures stay s
 | `src/protocol/binary.rs` | Strict physical MessagePack envelope decoders for v2/v3 binary game data |
 | `src/accountability.rs` | Server-0.4.0-derived delivery-accountability state machine |
 | `src/signal.rs` | `PeerSignal` — typed, matchbox-compatible WebRTC signal (protocol v3) |
-| `src/error_codes.rs` | `ErrorCode` enum — 54 variants from server (48 in the post-0.7 authority, 6 compatibility-only) |
+| `src/error_codes.rs` | `ErrorCode` enum — 57 variants from server (51 in the post-0.7 authority, 6 compatibility-only) |
 | `src/error.rs` | `SignalFishError` error type |
 | `src/event.rs` | `SignalFishEvent` high-level event stream |
 | `src/client_core.rs` | Shared command construction, decoding, accountability, state, events, and statistics |

--- a/.llm/skills/error-handling/SKILL.md
+++ b/.llm/skills/error-handling/SKILL.md
@@ -192,13 +192,14 @@ fn do_thing(&mut self) -> Result<(), SignalFishError> {
 
 ## ErrorCode Enum
 
-The post-0.7 protocol authority declares 48 emitted tokens. The public client
-enum has 54 variants: `RoomSessionIncompatible` is current, while the six
+The post-0.7 protocol authority declares 51 emitted tokens. The public client
+enum has 57 variants: `RoomSessionIncompatible` and the three moderation codes
+are current, while the six
 values in `ErrorCode::NON_EMITTED` are retained for older-server decoding.
 Conformance must use that explicit compatibility set rather than removing
 public variants.
 
-Defined in `src/error_codes.rs`. This enum is exhaustive. 54 variants:
+Defined in `src/error_codes.rs`. This enum is exhaustive. 57 variants:
 
 ```rust
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -246,6 +247,9 @@ pub enum ErrorCode {
     // Delivery & liveness (5)
     SlowConsumer, ActivityTimeout, ServerDraining, InvalidDeliveryClass,
     UnsupportedProtocolVersion,
+
+    // Moderation, authority-only operations (3)
+    NotRoomAuthority, KickTargetNotFound, Kicked,
 }
 ```
 

--- a/.llm/skills/protocol-wire-conformance/SKILL.md
+++ b/.llm/skills/protocol-wire-conformance/SKILL.md
@@ -34,11 +34,15 @@ the blind spot where a server-side error-code addition passes the wire-sample
 golden tests (they pin message *shapes*, not the error-code value space).
 
 The canonical corpus pins protocol-authority commit
-`ceb47cbc86c88d321b778596f195b68a7bd03aea`, advanced from the Server 0.8.0
+`9534d0e61e0217b768048274deb9a79ede3b47a5`, advanced from the Server 0.8.0
 release pin `d79dcdc7549777c8c2bd9fcb2d132641532d8c86` by descriptive prose
-plus one deliberate v3 schema change (the v3 room-member snapshot excludes the
-legacy `connection_info` echo — server issue #529; the v2 snapshot shape is
-frozen and the wire samples are byte-identical across all three commits).
+plus two deliberate additive changes (the v3 room-member snapshot excludes the
+legacy `connection_info` echo — server issue #529; and the authority-only
+moderation surface — server issue #525 — added the NOT_ROOM_AUTHORITY /
+KICK_TARGET_NOT_FOUND / KICKED error codes, the KickPlayer / RegenerateRoomCode
+operations, and the PlayerKicked / RoomCodeRegenerated results; the v2 shapes
+are frozen and the v3 sample additions are append-only, so pre-existing sample
+lines stay byte-identical to the release pin).
 Released runtime compatibility stays bound to the Server 0.8.0 release in
 `tests/compatibility.toml`, while the vendored AsyncAPI spec re-syncs to
 upstream `main` at every refresh — descriptive prose drift is absorbed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Breaking:** the wire types gained the upstream authority-moderation
+  surface — exhaustive `ErrorCode` adds `NotRoomAuthority`, `KickTargetNotFound`,
+  and `Kicked`; `RoomOperationRequest` adds `KickPlayer { player_id }` and
+  `RegenerateRoomCode`; `RoomOperationResult` adds `PlayerKicked { player_id }`
+  and `RoomCodeRegenerated { room_code }` — so every moderation frame a newer
+  server sends decodes (add arms to exhaustive matches; the SDK still issues
+  no moderation operations, and its pending-operation fences never match
+  these results).
 - **Breaking:** `SignalFishConfig` gains a `reconnect_policy` field;
   exhaustive struct literals must add it, usually `reconnect_policy: None`.
   The opt-in `ReconnectPolicy` auto-reconnects the async client with

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -500,8 +500,8 @@ migration](migration-0.11.md#structured-transport-error-causes).
 
 ### Server-Side: `ErrorCode`
 
-`ErrorCode` is a 54-variant enum that arrives inside events. The post-0.7
-protocol authority declares 48 variants; six compatibility variants remain
+`ErrorCode` is a 57-variant enum that arrives inside events. The post-0.7
+protocol authority declares 51 variants; six compatibility variants remain
 decodable for older servers. The wire uses `SCREAMING_SNAKE_CASE` strings
 (e.g., `"ROOM_NOT_FOUND"`).
 
@@ -534,6 +534,7 @@ Error codes are grouped by category:
 | **Connection Lifecycle (v3)** | `ConnectionIdleTimeout` |
 | **Delivery & Liveness** | `SlowConsumer`, `ActivityTimeout`, `ServerDraining`, `InvalidDeliveryClass` |
 | **Protocol Negotiation** | `UnsupportedProtocolVersion` |
+| **Moderation** | `NotRoomAuthority`, `KickTargetNotFound`, `Kicked` |
 
 See [Errors](errors.md) for the full table with descriptions.
 

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -95,9 +95,9 @@ fn try_join(client: &mut SignalFishClient) {
 
 ## `ErrorCode`
 
-`ErrorCode` is a protocol-level enum with **54 variants** representing
+`ErrorCode` is a protocol-level enum with **57 variants** representing
 structured error codes returned by compatible Signal Fish servers. The
-post-0.7 protocol authority declares 48 of them; six variants remain decodable
+post-0.7 protocol authority declares 51 of them; six variants remain decodable
 for older servers and are listed by `ErrorCode::NON_EMITTED`. It derives `Debug`,
 `Clone`, `PartialEq`, `Eq`, `Serialize`, and `Deserialize`.
 
@@ -247,7 +247,19 @@ that the server could not honor. See the [Mesh Guide](mesh-guide.md).
 |---------|-------------|
 | `UnsupportedProtocolVersion` | The client's highest supported protocol version is below the server's configured minimum, or a pre-v3 connection sent a frame class that requires a newer protocol surface. |
 
-!!! note "The six new v3 *server* codes vs. `SignalFishError::ProtocolUnsupported`"
+### Moderation (3)
+
+Authority-only room operations (`KickPlayer`, `RegenerateRoomCode`) reject with
+these codes. The SDK exposes their wire types but issues no moderation
+operations itself.
+
+| Variant | Description |
+|---------|-------------|
+| `NotRoomAuthority` | A moderation operation was sent by a connection that is not the room's designated authority player. |
+| `KickTargetNotFound` | The player named by `KickPlayer` is not a seated member of the room. |
+| `Kicked` | This connection was removed from its room by the room's authority player. The WebSocket closed with private close code 4007 (`kicked`); reconnection is not offered. |
+
+!!! note "The v3-era *server* codes vs. `SignalFishError::ProtocolUnsupported`"
     The five v3 signaling codes plus `ConnectionIdleTimeout` are **server-sent**
     `ErrorCode`s that arrive inside `SignalFishEvent::Error`. They are distinct
     from the client-side `SignalFishError::ProtocolUnsupported`, which fails a

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -598,7 +598,7 @@ pub enum ClientMessage { /* ... */ }
 | `Reconnect` | Reconnect to a room after a disconnection. |
 | `JoinAsSpectator` | Join a room as a read-only spectator. |
 | `LeaveSpectator` | Leave spectator mode. |
-| `RoomOperation` | **(negotiated v3)** Wrap one of the five directed room commands with a fresh canonical UUID after `room_operation_ids` is echoed. |
+| `RoomOperation` | **(negotiated v3)** Wrap one of the five directed room commands with a fresh canonical UUID after `room_operation_ids` is echoed. The wire envelope also carries the upstream authority-only `KickPlayer`/`RegenerateRoomCode` operations, which this SDK types but never issues. |
 | `StartGame` | **(v2)** Explicitly start the game, finalizing the lobby (via `client.start_game()`). |
 | `Signal` | **(v3)** Relay an opaque WebRTC signal to a single peer (via `client.send_signal(...)`). |
 | `TransportStatus` | **(v3)** Report whether a data-path transport is established (via `client.report_transport_status(...)`). |
@@ -685,7 +685,11 @@ safely ignores any of these it doesn't recognize.
 form. After `room_operation_ids` is requested and echoed on v3, `JoinRoom`,
 `LeaveRoom`, `Reconnect`, `JoinAsSpectator`, and `LeaveSpectator` are carried in
 `RoomOperation`; their terminal response arrives in `RoomOperationResult` with
-the identical ID. IDs are correlation fences, not idempotency keys: the server
+the identical ID. (The wire envelope also carries the upstream authority-only
+`KickPlayer`/`RegenerateRoomCode` operations and their `PlayerKicked`/
+`RoomCodeRegenerated` results; the SDK types them for decoding but issues no
+moderation operations, and its operation fences never match those results.)
+IDs are correlation fences, not idempotency keys: the server
 echoes them but does not deduplicate operations. A fresh physical connection
 negotiates a new scope. Autonomous spectator removal, disconnection, and room
 closure remain top-level `SpectatorLeft` messages.

--- a/src/client.rs
+++ b/src/client.rs
@@ -3820,6 +3820,9 @@ mod tests {
                                 RoomOperationRequest::Reconnect { .. } => Some(2),
                                 RoomOperationRequest::JoinAsSpectator { .. } => Some(3),
                                 RoomOperationRequest::LeaveSpectator => Some(4),
+                                // The SDK sends no moderation operations.
+                                RoomOperationRequest::KickPlayer { .. }
+                                | RoomOperationRequest::RegenerateRoomCode => None,
                             }
                         }
                         _ => None,

--- a/src/client_core.rs
+++ b/src/client_core.rs
@@ -1355,6 +1355,12 @@ impl ClientCore {
                 RoomOperationRequest::Reconnect { .. } => PendingRoomOperation::ReconnectPlayer,
                 RoomOperationRequest::JoinAsSpectator { .. } => PendingRoomOperation::JoinSpectator,
                 RoomOperationRequest::LeaveSpectator => PendingRoomOperation::LeaveSpectator,
+                // The SDK issues no moderation operations, so no fence can
+                // ever be keyed to their request kinds.
+                RoomOperationRequest::KickPlayer { .. }
+                | RoomOperationRequest::RegenerateRoomCode => {
+                    return;
+                }
             },
             _ => return,
         };
@@ -2602,6 +2608,8 @@ fn room_operation_result_name(result: &RoomOperationResult) -> &'static str {
         RoomOperationResult::SpectatorJoinFailed { .. } => "SpectatorJoinFailed",
         RoomOperationResult::SpectatorLeft { .. } => "SpectatorLeft",
         RoomOperationResult::OperationFailed { .. } => "OperationFailed",
+        RoomOperationResult::PlayerKicked { .. } => "PlayerKicked",
+        RoomOperationResult::RoomCodeRegenerated { .. } => "RoomCodeRegenerated",
     }
 }
 

--- a/src/error_codes.rs
+++ b/src/error_codes.rs
@@ -179,6 +179,17 @@ pub enum ErrorCode {
     /// requires a newer protocol surface (such as the v3 `RoomOperation`
     /// envelope).
     UnsupportedProtocolVersion,
+
+    // Moderation errors (authority-only room operations)
+    /// A moderation operation (`KickPlayer` / `RegenerateRoomCode`) was sent
+    /// by a connection that is not the room's designated authority player.
+    NotRoomAuthority,
+    /// The player named by `KickPlayer` is not a seated member of the room.
+    KickTargetNotFound,
+    /// This connection was removed from its room by the room's authority
+    /// player. The WebSocket closed with private close code `4007`
+    /// (`kicked`); reconnection is not offered.
+    Kicked,
 }
 
 impl ErrorCode {
@@ -383,6 +394,17 @@ impl ErrorCode {
             }
             Self::UnsupportedProtocolVersion => {
                 "The client's highest supported protocol version is below this server's configured minimum, or a pre-v3 connection sent a frame class that requires a newer protocol surface. Upgrade the client or connect to a compatible deployment."
+            }
+
+            // Moderation errors (authority-only room operations)
+            Self::NotRoomAuthority => {
+                "Only the room's authority player may perform this moderation operation."
+            }
+            Self::KickTargetNotFound => {
+                "The player to kick is not a current member of this room."
+            }
+            Self::Kicked => {
+                "You were removed from the room by its authority player. Reconnection is not offered; join again with a valid room code."
             }
         }
     }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -957,6 +957,25 @@ pub enum RoomOperationRequest {
         spectator_name: String,
     },
     LeaveSpectator,
+    /// Authority-only: remove a seated player from the room.
+    ///
+    /// Only the room's designated authority is accepted; the target must be a
+    /// current seated member and cannot be the sender. The server removes the
+    /// seat, broadcasts the usual `PlayerLeft` roster delta to the remaining
+    /// members, and closes the target's connection with private close code
+    /// 4007 (`kicked`); reconnection is never armed for a kicked seat.
+    KickPlayer {
+        /// The seated player to remove.
+        player_id: PlayerId,
+    },
+    /// Authority-only: replace the room code with a freshly generated one.
+    ///
+    /// The old code stops resolving to this room immediately; joins naming it
+    /// behave like any unknown code. Existing members stay connected and
+    /// reconnection tokens are unaffected. The
+    /// [`RoomOperationResult::RoomCodeRegenerated`] response carries the new
+    /// code for the authority to distribute to future invitees.
+    RegenerateRoomCode,
 }
 
 impl std::fmt::Debug for RoomOperationRequest {
@@ -967,6 +986,8 @@ impl std::fmt::Debug for RoomOperationRequest {
             Self::Reconnect { .. } => "Reconnect",
             Self::JoinAsSpectator { .. } => "JoinAsSpectator",
             Self::LeaveSpectator => "LeaveSpectator",
+            Self::KickPlayer { .. } => "KickPlayer",
+            Self::RegenerateRoomCode => "RegenerateRoomCode",
         })
     }
 }
@@ -1012,6 +1033,21 @@ pub enum RoomOperationResult {
         #[serde(skip_serializing_if = "Option::is_none")]
         error_code: Option<ErrorCode>,
     },
+    /// The requested `KickPlayer` moderation operation succeeded: the target
+    /// seat was removed and its connection is being closed with close code
+    /// 4007 (`kicked`). The remaining members receive the usual `PlayerLeft`
+    /// roster delta.
+    PlayerKicked {
+        /// The seated player that was removed.
+        player_id: PlayerId,
+    },
+    /// The requested `RegenerateRoomCode` moderation operation succeeded:
+    /// distribute the new code to future invitees, as the old code no longer
+    /// resolves to this room.
+    RoomCodeRegenerated {
+        /// The room's freshly generated code.
+        room_code: String,
+    },
 }
 
 impl std::fmt::Debug for RoomOperationResult {
@@ -1026,6 +1062,8 @@ impl std::fmt::Debug for RoomOperationResult {
             Self::SpectatorJoinFailed { .. } => "SpectatorJoinFailed",
             Self::SpectatorLeft { .. } => "SpectatorLeft",
             Self::OperationFailed { .. } => "OperationFailed",
+            Self::PlayerKicked { .. } => "PlayerKicked",
+            Self::RoomCodeRegenerated { .. } => "RoomCodeRegenerated",
         })
     }
 }
@@ -1059,6 +1097,26 @@ impl RoomOperationResult {
             },
             Self::OperationFailed { reason, error_code } => {
                 return Err((reason, error_code));
+            }
+            // The moderation results have no legacy top-level face and can
+            // never match a pending operation of this SDK (it issues no
+            // moderation operations); the public message→event conversion
+            // renders them as no-effect operation failures.
+            Self::PlayerKicked { .. } => {
+                return Err((
+                    "the room authority removed a player (PlayerKicked); this SDK does not \
+                     issue moderation operations"
+                        .to_string(),
+                    None,
+                ));
+            }
+            Self::RoomCodeRegenerated { .. } => {
+                return Err((
+                    "the room authority regenerated the room code (RoomCodeRegenerated); this \
+                     SDK does not issue moderation operations"
+                        .to_string(),
+                    None,
+                ));
             }
         })
     }

--- a/tests/compatibility.toml
+++ b/tests/compatibility.toml
@@ -10,7 +10,7 @@ synced = "2026-09-01"
 # files) without touching the released runtime binding above; any schema,
 # message, or error-code change triggers full type reconciliation.
 [protocol_authority]
-commit = "ceb47cbc86c88d321b778596f195b68a7bd03aea"
+commit = "9534d0e61e0217b768048274deb9a79ede3b47a5"
 synced = "2026-09-07"
 
 [legacy_server]
@@ -26,8 +26,8 @@ generation = "omitted"
 [wire_samples]
 "v2-client-messages.jsonl" = "929f25d702d3e21f2cca640cd14f9ce044945a6ef9c2c258de56f3f112164227"
 "v2-server-messages.jsonl" = "b5aee60d2cbd410c1088da1bbd1142d88d89600bc600f00b2d1849586f1654cd"
-"v3-client-messages.jsonl" = "0e41d5696f06f9c1edfd4e09dc94b9cdc4d8cf91b9fb8bd1a347f3e8a9452204"
-"v3-server-messages.jsonl" = "21ed576f61cc042eee9c463363bde5a4b38a9285d0560666423afd6c930588b2"
+"v3-client-messages.jsonl" = "5f6e92f550e7bb0b2ea4be02dea30f5b09677ecf4e01b5451d41d824f405b4cb"
+"v3-server-messages.jsonl" = "5d210777ffe3db0ba36b10be6f40f2354acbbe9c5f4b6b83544eafa95daedbd6"
 
 [server_spec]
-"signal-fish-protocol.asyncapi.yaml" = "ff00245e15d61826a0bf93aa94856ff249952f6f04f3d86c58a438651b51328f"
+"signal-fish-protocol.asyncapi.yaml" = "e57fd4cd233312ea07a005653febb61f8c0f0f16d8d87cc4e0b494d8961eb060"

--- a/tests/compatibility_manifest_tests.rs
+++ b/tests/compatibility_manifest_tests.rs
@@ -87,7 +87,7 @@ fn compatibility_manifest_binds_exact_server_artifacts() {
     // descriptive drift plus reviewed deliberate schema changes; the released
     // runtime binding above stays at the 0.8.0 release commit. Keep this
     // literal review-forced.
-    assert_eq!(protocol_commit, "ceb47cbc86c88d321b778596f195b68a7bd03aea");
+    assert_eq!(protocol_commit, "9534d0e61e0217b768048274deb9a79ede3b47a5");
     assert_eq!(
         wire_provenance["upstream"]["commit"].as_str(),
         Some(protocol_commit)

--- a/tests/error_code_conformance_tests.rs
+++ b/tests/error_code_conformance_tests.rs
@@ -144,6 +144,9 @@ fn all_client_error_codes() -> Vec<ErrorCode> {
         ErrorCode::ServerDraining,
         ErrorCode::InvalidDeliveryClass,
         ErrorCode::UnsupportedProtocolVersion,
+        ErrorCode::NotRoomAuthority,
+        ErrorCode::KickTargetNotFound,
+        ErrorCode::Kicked,
     ]
 }
 
@@ -206,7 +209,10 @@ fn exhaustiveness_guard(code: &ErrorCode) {
         | ErrorCode::ActivityTimeout
         | ErrorCode::ServerDraining
         | ErrorCode::InvalidDeliveryClass
-        | ErrorCode::UnsupportedProtocolVersion => {}
+        | ErrorCode::UnsupportedProtocolVersion
+        | ErrorCode::NotRoomAuthority
+        | ErrorCode::KickTargetNotFound
+        | ErrorCode::Kicked => {}
     }
 }
 

--- a/tests/polling_parity_tests.rs
+++ b/tests/polling_parity_tests.rs
@@ -192,7 +192,9 @@ fn advance_room_command_requirements(json: &str, gate: &mut RoomCommandRequireme
             RoomOperationResult::RoomJoinFailed { .. }
             | RoomOperationResult::ReconnectionFailed { .. }
             | RoomOperationResult::SpectatorJoinFailed { .. }
-            | RoomOperationResult::OperationFailed { .. } => return,
+            | RoomOperationResult::OperationFailed { .. }
+            | RoomOperationResult::PlayerKicked { .. }
+            | RoomOperationResult::RoomCodeRegenerated { .. } => return,
         },
         message => message,
     };

--- a/tests/server-spec/PROVENANCE.toml
+++ b/tests/server-spec/PROVENANCE.toml
@@ -7,21 +7,21 @@
 repo = "https://github.com/Ambiguous-Interactive/signal-fish-server"
 path = "spec"
 # Exact server commit the spec bytes were copied from.
-# 2026-09-07 refresh: the protocol-v3 room-member snapshot (V3PlayerInfo)
-# deliberately excludes the legacy `connection_info` echo (server issue #529),
-# and the ConnectionInfo/SpectatorInfo/V2PlayerInfo descriptions were updated
-# to record that visibility contract; the v2 snapshot shape is frozen and the
-# wire samples remain byte-identical to the Server 0.8.0 release pin
-# (d79dcdc7549777c8c2bd9fcb2d132641532d8c86). This evidence authority advances
-# together with tests/compatibility.toml's [protocol_authority] and the
-# wire-samples PROVENANCE, while the released runtime compatibility binding
-# (server_commit + release artifacts in tests/compatibility.toml) stays at the
-# 0.8.0 release.
-commit = "ceb47cbc86c88d321b778596f195b68a7bd03aea"
+# 2026-09-07 refresh: upstream added the authority-only moderation surface
+# (server issue #525) — the NOT_ROOM_AUTHORITY / KICK_TARGET_NOT_FOUND /
+# KICKED error codes, the KickPlayer / RegenerateRoomCode operations, and the
+# PlayerKicked / RoomCodeRegenerated results (additive only; existing
+# schema lines untouched). The Server 0.8.0 release pin
+# (d79dcdc7549777c8c2bd9fcb2d132641532d8c86) does not declare the moderation
+# surface, so the released runtime compatibility binding stays at that
+# release. This evidence authority advances together with
+# tests/compatibility.toml's [protocol_authority] and the wire-samples
+# PROVENANCE.
+commit = "9534d0e61e0217b768048274deb9a79ede3b47a5"
 # ISO 8601 date of the last refresh.
 synced = "2026-09-07"
 
 # SHA-256 of each vendored file. A policy test recomputes these, so the spec
 # cannot be edited without also updating this marker (keeps provenance honest).
 [files]
-"signal-fish-protocol.asyncapi.yaml" = "ff00245e15d61826a0bf93aa94856ff249952f6f04f3d86c58a438651b51328f"
+"signal-fish-protocol.asyncapi.yaml" = "e57fd4cd233312ea07a005653febb61f8c0f0f16d8d87cc4e0b494d8961eb060"

--- a/tests/server-spec/signal-fish-protocol.asyncapi.yaml
+++ b/tests/server-spec/signal-fish-protocol.asyncapi.yaml
@@ -600,6 +600,9 @@ components:
         - INVALID_DELIVERY_CLASS
         - UNSUPPORTED_PROTOCOL_VERSION
         - ROOM_SESSION_INCOMPATIBLE
+        - NOT_ROOM_AUTHORITY
+        - KICK_TARGET_NOT_FOUND
+        - KICKED
 
     ReliableDeliveryCounters:
       type: object
@@ -1084,6 +1087,37 @@ components:
       properties:
         type: { const: LeaveSpectator }
       required: [type]
+    KickPlayer:
+      type: object
+      description: >-
+        Authority-only: remove a seated player from the room. Only the room's
+        designated authority is accepted; the target must be a current seated
+        member and cannot be the sender. The server removes the seat,
+        broadcasts the usual PlayerLeft roster delta to the remaining members,
+        closes the target's connection with private close code 4007
+        (`kicked`), and never arms reconnection for a kicked seat. Success
+        responses use the PlayerKicked result.
+      properties:
+        type: { const: KickPlayer }
+        data:
+          type: object
+          required: [player_id]
+          properties:
+            player_id: { type: string, format: uuid }
+      required: [type, data]
+    RegenerateRoomCode:
+      type: object
+      description: >-
+        Authority-only: replace the room code with a freshly generated one.
+        The old code stops resolving to this room immediately; joins that name
+        it behave like any unknown code (join-creates-room may open a fresh,
+        unrelated room under it). Existing members stay connected and
+        reconnection tokens are unaffected. Success responses use the
+        RoomCodeRegenerated result, which carries the new code for the
+        authority to distribute to future invitees.
+      properties:
+        type: { const: RegenerateRoomCode }
+      required: [type]
     RoomOperation:
       type: object
       description: >-
@@ -1111,6 +1145,8 @@ components:
                 - { $ref: '#/components/schemas/Reconnect' }
                 - { $ref: '#/components/schemas/JoinAsSpectator' }
                 - { $ref: '#/components/schemas/LeaveSpectator' }
+                - { $ref: '#/components/schemas/KickPlayer' }
+                - { $ref: '#/components/schemas/RegenerateRoomCode' }
       required: [type, data]
     TransportStatus:
       type: object
@@ -2120,6 +2156,35 @@ components:
             reason: { type: string }
             error_code: { $ref: '#/components/schemas/ErrorCode' }
       required: [type, data]
+    PlayerKicked:
+      type: object
+      description: >-
+        The requested KickPlayer operation succeeded: the target seat was
+        removed and its connection is being closed with close code 4007
+        (`kicked`). The remaining members receive the usual PlayerLeft roster
+        delta.
+      properties:
+        type: { const: PlayerKicked }
+        data:
+          type: object
+          required: [player_id]
+          properties:
+            player_id: { type: string, format: uuid }
+      required: [type, data]
+    RoomCodeRegenerated:
+      type: object
+      description: >-
+        The requested RegenerateRoomCode operation succeeded. Distribute the
+        new code to future invitees; the old code no longer resolves to this
+        room.
+      properties:
+        type: { const: RoomCodeRegenerated }
+        data:
+          type: object
+          required: [room_code]
+          properties:
+            room_code: { type: string }
+      required: [type, data]
     RoomOperationResult:
       type: object
       description: >-
@@ -2148,6 +2213,8 @@ components:
                 - { $ref: '#/components/schemas/SpectatorJoinFailed' }
                 - { $ref: '#/components/schemas/SpectatorLeft' }
                 - { $ref: '#/components/schemas/OperationFailed' }
+                - { $ref: '#/components/schemas/PlayerKicked' }
+                - { $ref: '#/components/schemas/RoomCodeRegenerated' }
       required: [type, data]
     NewSpectatorJoined:
       type: object

--- a/tests/wire-samples/PROVENANCE.toml
+++ b/tests/wire-samples/PROVENANCE.toml
@@ -8,11 +8,14 @@ repo = "https://github.com/Ambiguous-Interactive/signal-fish-server"
 path = ".llm/code-samples/protocol"
 # Exact server commit the .jsonl bytes were copied from. The bytes are
 # byte-identical from the Server 0.8.0 release pin (d79dcdc7549777c8c2bd9fcb2d132641532d8c86)
-# through this commit (the v3 `connection_info` snapshot echo removal landed
-# only in the AsyncAPI spec and server code; these published samples never
-# carried it); the evidence authority advances together across
+# through the 2026-09-07 refresh, which appended the authority-only moderation
+# samples (KickPlayer / RegenerateRoomCode operations, PlayerKicked /
+# RoomCodeRegenerated results — server issue #525) at upstream's positions;
+# pre-existing lines are unchanged. The 0.8.0 release never declared the
+# moderation surface, so the released runtime compatibility binding stays at
+# that release; the evidence authority advances together across
 # compatibility.toml and both PROVENANCE files.
-commit = "ceb47cbc86c88d321b778596f195b68a7bd03aea"
+commit = "9534d0e61e0217b768048274deb9a79ede3b47a5"
 # Protocol version range these samples exercise.
 protocol_version_min = 2
 protocol_version_max = 3
@@ -24,5 +27,5 @@ synced = "2026-09-07"
 [files]
 "v2-client-messages.jsonl" = "929f25d702d3e21f2cca640cd14f9ce044945a6ef9c2c258de56f3f112164227"
 "v2-server-messages.jsonl" = "b5aee60d2cbd410c1088da1bbd1142d88d89600bc600f00b2d1849586f1654cd"
-"v3-client-messages.jsonl" = "0e41d5696f06f9c1edfd4e09dc94b9cdc4d8cf91b9fb8bd1a347f3e8a9452204"
-"v3-server-messages.jsonl" = "21ed576f61cc042eee9c463363bde5a4b38a9285d0560666423afd6c930588b2"
+"v3-client-messages.jsonl" = "5f6e92f550e7bb0b2ea4be02dea30f5b09677ecf4e01b5451d41d824f405b4cb"
+"v3-server-messages.jsonl" = "5d210777ffe3db0ba36b10be6f40f2354acbbe9c5f4b6b83544eafa95daedbd6"

--- a/tests/wire-samples/v3-client-messages.jsonl
+++ b/tests/wire-samples/v3-client-messages.jsonl
@@ -1,5 +1,7 @@
 {"type": "Authenticate", "data": {"app_id": "mb_app_abc123", "sdk_version": "1.2.3", "platform": "unity", "protocol_version": 3, "supported_transports": ["relay", "direct", "webrtc"], "supported_topologies": ["relay", "host", "mesh"], "requested_capabilities": ["room_operation_ids"]}}
 {"type": "RoomOperation", "data": {"operation_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "operation": {"type": "LeaveRoom"}}}
+{"type": "RoomOperation", "data": {"operation_id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", "operation": {"type": "KickPlayer", "data": {"player_id": "cccccccc-cccc-cccc-cccc-cccccccccccc"}}}}
+{"type": "RoomOperation", "data": {"operation_id": "dddddddd-dddd-dddd-dddd-dddddddddddd", "operation": {"type": "RegenerateRoomCode"}}}
 {"type": "GameData", "data": {"data": {"position": {"x": 12, "y": 34}}, "class": "latest", "key": 7}}
 {"type": "GameData", "data": {"data": {"effect": "footstep"}, "class": "volatile"}}
 {"type": "Signal", "data": {"to": "00000000-0000-0000-0000-00000000000b", "generation": "00000000-0000-0000-0000-00000000000c", "signal": {"Offer": "v=0\r\no=- 0 0 IN IP4 0.0.0.0\r\n..."}}}

--- a/tests/wire-samples/v3-server-messages.jsonl
+++ b/tests/wire-samples/v3-server-messages.jsonl
@@ -1,5 +1,7 @@
 {"type": "ProtocolInfo", "data": {"capabilities": ["reconnection", "spectators", "authority", "room_operation_ids"], "game_data_formats": ["json", "message_pack"], "protocol_version": 3, "min_protocol_version": 2, "max_protocol_version": 3, "transports": ["websocket"], "max_outbound_message_size": 8388608}}
 {"type": "RoomOperationResult", "data": {"operation_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "result": {"type": "RoomLeft"}}}
+{"type": "RoomOperationResult", "data": {"operation_id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", "result": {"type": "PlayerKicked", "data": {"player_id": "cccccccc-cccc-cccc-cccc-cccccccccccc"}}}}
+{"type": "RoomOperationResult", "data": {"operation_id": "dddddddd-dddd-dddd-dddd-dddddddddddd", "result": {"type": "RoomCodeRegenerated", "data": {"room_code": "USE4XP"}}}}
 {"type": "DeliveryReport", "data": {"per_class": {"reliable": {"delivered": 8, "abandoned": 0, "unsupported_format": 0}, "latest": {"delivered": 12, "superseded": 1, "dropped_full": 0, "abandoned": 0, "unsupported_format": 0}, "volatile": {"delivered": 4, "dropped": 0, "abandoned": 0, "unsupported_format": 0}}, "gaps": [{"from_player": "00000000-0000-0000-0000-00000000000b", "epoch": 1, "from_seq": 42, "to_seq": 42, "reason": "latest_superseded"}]}}
 {"type": "GameData", "data": {"from_player": "00000000-0000-0000-0000-00000000000b", "data": {"position": {"x": 12, "y": 34}}, "seq": 43, "epoch": 1, "class": "latest", "key": 7}}
 {"type": "NewPeer", "data": {"peer_id": "00000000-0000-0000-0000-00000000000b", "you_initiate": true}}


### PR DESCRIPTION
## Why

The weekly protocol re-sync found one wire-touching upstream server commit since the vendored evidence pin: the new authority-moderation surface (server issue #525). Without this, a newer server's kick/regenerate frames would fail to decode, and the vendored authority would drift from upstream `main`.

## What

- **Re-vendor the protocol authority** at upstream `9534d0e6`: the AsyncAPI spec plus all four wire-sample files are byte-identical to upstream, with both PROVENANCE pins, `compatibility.toml`, and the review-forced manifest literal advanced together. The released 0.8.0 runtime binding is untouched.
- **Decode the new surface** (breaking — 7 new exhaustive-enum variants): `ErrorCode` gains `NotRoomAuthority`, `KickTargetNotFound`, and `Kicked`; `RoomOperationRequest` gains `KickPlayer`/`RegenerateRoomCode`; `RoomOperationResult` gains `PlayerKicked`/`RoomCodeRegenerated`. The SDK still issues no moderation operations, and unsolicited moderation results stay lifecycle violations — no fence can ever match them.
- **Docs & changelog truth**: error-code counts 54→57 everywhere (errors/concepts guides, context, skills), a Moderation section in the errors guide, protocol-guide notes on the typed-but-never-issued operations, and one Breaking changelog entry.

Also from this session's audit round: dependency/lock health re-verified clean after the recent Dependabot bumps, and a never-audited reconnect-round coherence audit found zero defects.

## Verification

- Vendored bytes diff-verified against upstream `9534d0e6` (spec + 4 jsonl).
- Red/green: the wire goldens panic on the new samples without the typed variants; conformance nets enforce 57 = 51 authority + 6 compatibility.
- `cargo fmt` + `cargo clippy --workspace --all-targets --all-features -- -D warnings` + `cargo test --workspace --all-features`: all green.
- Two-round adversarial review (hostile reviewer + convergence verifier) converged to zero findings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking exhaustive enum growth affects every downstream `match`, but the SDK does not issue moderation operations; main risk is compile-time migration and correct decoding/handling of `Kicked` on newer servers.
> 
> **Overview**
> **Breaking wire-type sync** with upstream protocol authority (`9534d0e6`): vendored AsyncAPI, v3 wire samples, and conformance pins advance while the released Server 0.8.0 runtime binding stays unchanged.
> 
> The client now **decodes** the authority-only moderation surface from server issue #525: three new `ErrorCode` variants (`NotRoomAuthority`, `KickTargetNotFound`, `Kicked`), `RoomOperationRequest::KickPlayer` / `RegenerateRoomCode`, and matching `RoomOperationResult` variants. Exhaustive `match`es on those enums need new arms; docs and changelog reflect **57** error codes (51 authority + 6 compatibility).
> 
> **Runtime behavior is unchanged for SDK callers:** the library still never sends moderation operations, pending room-operation fences ignore kick/regenerate requests, and unsolicited `PlayerKicked` / `RoomCodeRegenerated` results are treated as non-matching operation failures rather than first-class events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a17c6f8d89d7f13563404dfe205893ed37824d61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->