### PR TITLE
Round 54: semver gate reads the live PR title; kicked-client reconnect truth

### DIFF
--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -33,6 +33,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
@@ -79,8 +80,24 @@ jobs:
         id: pr-release-type
         if: github.event_name != 'push'
         env:
+          GH_TOKEN: ${{ github.token }}
           PR_TITLE: ${{ github.event.pull_request.title || inputs.pr_title }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
+          # A pull_request event payload freezes the PR title as it was when
+          # the event fired, so re-running this workflow after a retitle
+          # (typically adding the breaking `!:` marker) classified against a
+          # stale title and stayed red forever (issue #241). Classify from
+          # the live title instead, failing closed when it cannot be read.
+          # Explicitly dispatched candidates keep their `pr_title` input.
+          if [ -n "$PR_NUMBER" ]; then
+            if ! live_title="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq .title)" \
+              || [ -z "$live_title" ]; then
+              printf '::error::Could not read the live title of pull request %s.\n' "$PR_NUMBER"
+              exit 1
+            fi
+            PR_TITLE="$live_title"
+          fi
           if [[ "$PR_TITLE" == *"!:"* ]]; then
             echo "release-type=major" >> "$GITHUB_OUTPUT"
             echo "Conventional breaking-change marker found; checking with major compatibility policy."

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -91,8 +91,18 @@ jobs:
           # the live title instead, failing closed when it cannot be read.
           # Explicitly dispatched candidates keep their `pr_title` input.
           if [ -n "$PR_NUMBER" ]; then
-            if ! live_title="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq .title)" \
-              || [ -z "$live_title" ]; then
+            live_title=""
+            for attempt in 1 2 3; do
+              if live_title="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq .title)" \
+                && [ -n "$live_title" ]; then
+                break
+              fi
+              live_title=""
+              if [ "$attempt" -lt 3 ]; then
+                sleep 2
+              fi
+            done
+            if [ -z "$live_title" ]; then
               printf '::error::Could not read the live title of pull request %s.\n' "$PR_NUMBER"
               exit 1
             fi

--- a/.llm/skills/public-api-design/SKILL.md
+++ b/.llm/skills/public-api-design/SKILL.md
@@ -220,6 +220,18 @@ sealing analysis, and plain-struct field type changes have no lint at all.
 For those classes the `**Breaking:**` changelog marker is the only working
 gate — and it drives Prepare Release's bump policy, so it is mandatory.
 
+### The `!:` Title Marker and the Semver Gate
+
+A breaking PR title must carry `!:` (e.g. `feat!: …`). The Semver Checks
+workflow classifies from the **live** PR title via the API (issue #241), so
+retitling works: after the retitle, "Re-run failed jobs" picks up the new
+title. If a PR was opened before the fix or the gate still shows a stale
+classification, the clean retrigger is one empty commit (a fresh
+`synchronize` event regenerates every check run under the current title) —
+not a `workflow_dispatch`, whose check runs join a mixed history on the same
+head SHA and can leave the PR blocked for minutes. Prefer carrying the
+marker from PR-open time so the first run classifies correctly.
+
 ## Documenting Public API
 
 Every public item should have a doc comment:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   deterministic exponential backoff — re-authenticating and reissuing the
   directed `reconnect` after a player-room disconnect; shutdown, dropped
   handles, and `Disconnect`-policy teardowns are never retried, and the
-  polling client stays caller-driven.
+  polling client stays caller-driven. Close codes are not special-cased: an
+  authority kick (close 4007) is retried once, and the kicked seat's
+  automatic rejoin is refused in-band as `ReconnectionFailed` on a still
+  usable connection.
 - **Breaking:** the exhaustive `SignalFishEvent` enum gains `Reconnecting {
   attempt, next_backoff }` and `ReconnectAbandoned { attempts, last_reason }`
   (the reconnect policy's per-attempt and terminal events); add two arms to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   directed `reconnect` after a player-room disconnect; shutdown, dropped
   handles, and `Disconnect`-policy teardowns are never retried, and the
   polling client stays caller-driven. Close codes are not special-cased: an
-  authority kick (close 4007) is retried once, and the kicked seat's
-  automatic rejoin is refused in-band as `ReconnectionFailed` on a still
-  usable connection.
+  authority kick (close 4007) is retried like any peer close, and on a
+  spec-conformant server the kicked seat's automatic rejoin is refused
+  in-band as `ReconnectionFailed` on a still usable connection.
 - **Breaking:** the exhaustive `SignalFishEvent` enum gains `Reconnecting {
   attempt, next_backoff }` and `ReconnectAbandoned { attempts, last_reason }`
   (the reconnect policy's per-attempt and terminal events); add two arms to

--- a/docs/client.md
+++ b/docs/client.md
@@ -652,7 +652,11 @@ may miss a `Reconnecting` marker while reconnection itself continues).
 
 On `ReconnectionFailed` the connection stays up but room recovery stops —
 apply the same `error_code` decision tree as the manual flow (fall back to
-`join_room`, wait out `PlayerAlreadyConnected`, or give up). When the attempt
+`join_room`, wait out `PlayerAlreadyConnected`, or give up). Close codes are
+not inspected, so a server kick (private close code 4007, `kicked`) is
+retried like any peer close: one round that re-authenticates, sends the
+doomed automatic `reconnect` for the kicked seat, and ends in
+`ReconnectionFailed` on the still-usable fresh connection. When the attempt
 budget (`max_attempts`, reset whenever a connection reaches `Authenticated`)
 runs out, the client emits `ReconnectAbandoned { attempts, last_reason }` and
 the event stream ends.

--- a/docs/client.md
+++ b/docs/client.md
@@ -654,9 +654,10 @@ On `ReconnectionFailed` the connection stays up but room recovery stops —
 apply the same `error_code` decision tree as the manual flow (fall back to
 `join_room`, wait out `PlayerAlreadyConnected`, or give up). Close codes are
 not inspected, so a server kick (private close code 4007, `kicked`) is
-retried like any peer close: one round that re-authenticates, sends the
-doomed automatic `reconnect` for the kicked seat, and ends in
-`ReconnectionFailed` on the still-usable fresh connection. When the attempt
+retried like any peer close: the server never arms reconnection for a
+kicked seat, so on a spec-conformant server the episode ends with the
+doomed automatic `reconnect` refused in-band as `ReconnectionFailed` on a
+still-usable fresh connection. When the attempt
 budget (`max_attempts`, reset whenever a connection reaches `Authenticated`)
 runs out, the client emits `ReconnectAbandoned { attempts, last_reason }` and
 the event stream ends.

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -257,7 +257,7 @@ operations itself.
 |---------|-------------|
 | `NotRoomAuthority` | A moderation operation was sent by a connection that is not the room's designated authority player. |
 | `KickTargetNotFound` | The player named by `KickPlayer` is not a seated member of the room. |
-| `Kicked` | This connection was removed from its room by the room's authority player. The WebSocket closed with private close code 4007 (`kicked`); reconnection is not offered. |
+| `Kicked` | This connection was removed from its room by the room's authority player. The WebSocket closed with private close code 4007 (`kicked`); the server never arms reconnection for a kicked seat (a configured `ReconnectPolicy` still retries the close once, and the automatic rejoin is refused in-band). |
 
 !!! note "The v3-era *server* codes vs. `SignalFishError::ProtocolUnsupported`"
     The five v3 signaling codes plus `ConnectionIdleTimeout` are **server-sent**

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -257,7 +257,7 @@ operations itself.
 |---------|-------------|
 | `NotRoomAuthority` | A moderation operation was sent by a connection that is not the room's designated authority player. |
 | `KickTargetNotFound` | The player named by `KickPlayer` is not a seated member of the room. |
-| `Kicked` | This connection was removed from its room by the room's authority player. The WebSocket closed with private close code 4007 (`kicked`); the server never arms reconnection for a kicked seat (a configured `ReconnectPolicy` still retries the close once, and the automatic rejoin is refused in-band). |
+| `Kicked` | This connection was removed from its room by the room's authority player. The WebSocket closed with private close code 4007 (`kicked`); the server never arms reconnection for a kicked seat (a configured `ReconnectPolicy` still retries the close like any peer close, and on a spec-conformant server the automatic rejoin is refused in-band). |
 
 !!! note "The v3-era *server* codes vs. `SignalFishError::ProtocolUnsupported`"
     The five v3 signaling codes plus `ConnectionIdleTimeout` are **server-sent**

--- a/src/client.rs
+++ b/src/client.rs
@@ -692,9 +692,10 @@ const DEFAULT_RECONNECT_MAX_BACKOFF: Duration = Duration::from_secs(10);
 /// before transport readiness are all retried: every one of them can be
 /// caused by a dead or misbehaving *backend*, which is exactly what a fresh
 /// transport from the factory replaces. Close codes are not inspected: a
-/// server kick (private close code 4007, `kicked`) is retried like any peer
-/// close, and because the server never arms reconnection for a kicked seat,
-/// that one round ends with the automatic rejoin refused in-band as
+/// server kick (private close code 4007, `kicked`) is retried like any
+/// peer close. The server never arms reconnection for a kicked seat, so on
+/// a spec-conformant server the episode ends with the automatic rejoin
+/// refused in-band as
 /// [`ReconnectionFailed`](SignalFishEvent::ReconnectionFailed) while the
 /// fresh connection itself stays usable. Not retried — the client ends as
 /// today:
@@ -9753,12 +9754,17 @@ mod tests {
 
     #[tokio::test(start_paused = true)]
     async fn reconnection_failed_stops_room_recovery_but_keeps_the_connection() {
+        // Round 1 dies as an authority kick: private close code 4007
+        // ("kicked"). The close is an ordinary retryable peer close, so the
+        // policy runs the same doomed one-round journey as any in-band
+        // rejoin refusal.
         let (transport1, _sent1, _closed1) = MockTransport::new(vec![
             Some(Ok(authenticated_json())),
             Some(Ok(protocol_info_v3_json())),
             Some(Ok(room_joined_json_with_token("tok-1"))),
             None,
         ]);
+        let transport1 = transport1.with_peer_close(4007, "kicked");
         let (transport2, sent2, _closed2) = MockTransport::new(vec![
             Some(Ok(authenticated_json())),
             Some(Ok(protocol_info_v3_json())),
@@ -9768,93 +9774,6 @@ mod tests {
         let policy = ReconnectPolicy::new(pool_factory(&pool))
             .with_max_attempts(3)
             .with_initial_backoff(Duration::from_millis(10));
-        let config = SignalFishConfig::new("mb_reconnect")
-            .enable_v3()
-            .with_reconnect_policy(policy);
-        let (mut client, mut events) = SignalFishClient::start(transport1, config);
-
-        assert!(matches!(
-            events.recv().await,
-            Some(SignalFishEvent::Connected)
-        ));
-        assert!(matches!(
-            events.recv().await,
-            Some(SignalFishEvent::Authenticated { .. })
-        ));
-        assert!(matches!(
-            events.recv().await,
-            Some(SignalFishEvent::ProtocolInfo(_))
-        ));
-        client
-            .join_room(JoinRoomParams::new("test-game", "local"))
-            .unwrap();
-        assert!(matches!(
-            events.recv().await,
-            Some(SignalFishEvent::RoomJoined { .. })
-        ));
-        assert!(matches!(
-            events.recv().await,
-            Some(SignalFishEvent::Disconnected { .. })
-        ));
-        assert!(matches!(
-            events.recv().await,
-            Some(SignalFishEvent::Reconnecting { .. })
-        ));
-        assert!(matches!(
-            events.recv().await,
-            Some(SignalFishEvent::Connected)
-        ));
-        assert!(matches!(
-            events.recv().await,
-            Some(SignalFishEvent::Authenticated { .. })
-        ));
-        assert!(matches!(
-            events.recv().await,
-            Some(SignalFishEvent::ProtocolInfo(_))
-        ));
-        assert!(matches!(
-            events.recv().await,
-            Some(SignalFishEvent::ReconnectionFailed { .. })
-        ));
-        // Exactly one automatic reconnect was attempted; the connection
-        // stays up and the caller owns the fallback decision.
-        tokio::time::sleep(Duration::from_millis(5)).await;
-        {
-            let sent2 = sent2.lock().unwrap();
-            assert_eq!(sent2.len(), 2);
-            let message: serde_json::Value = serde_json::from_str(&sent2[1]).unwrap();
-            assert_eq!(message["type"], "Reconnect");
-        }
-        client.shutdown().await;
-    }
-
-    #[tokio::test(start_paused = true)]
-    async fn reconnect_policy_kick_close_4007_runs_one_doomed_rejoin_round() {
-        // An authority kick closes the kicked client's connection with
-        // private close code 4007 ("kicked"); the server never arms
-        // reconnection for that seat. The close is an ordinary retryable
-        // peer close, so the policy runs exactly one round: fresh transport,
-        // re-authentication, and the doomed automatic `Reconnect` answered
-        // in-band with `ReconnectionFailed` — no retry loop, and the
-        // connection stays usable for manual recovery.
-        let (transport1, _sent1, _closed1) = MockTransport::new(vec![
-            Some(Ok(authenticated_json())),
-            Some(Ok(protocol_info_v3_json())),
-            Some(Ok(room_joined_json_with_token("tok-1"))),
-            None,
-        ]);
-        let transport1 = transport1.with_peer_close(4007, "kicked");
-        // Round 2: authenticate again; the automatic reconnect for the kicked
-        // seat is refused in-band and the connection stays deliverable.
-        let (transport2, sent2, _closed2) = MockTransport::new(vec![
-            Some(Ok(authenticated_json())),
-            Some(Ok(protocol_info_v3_json())),
-            Some(Ok(reconnection_failed_json())),
-        ]);
-        let pool = transport_pool(vec![transport2]);
-        let policy = ReconnectPolicy::new(pool_factory(&pool))
-            .with_max_attempts(3)
-            .with_initial_backoff(Duration::from_millis(50));
         let config = SignalFishConfig::new("mb_reconnect")
             .enable_v3()
             .with_reconnect_policy(policy);
@@ -9918,10 +9837,9 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(5)).await;
         {
             let sent2 = sent2.lock().unwrap();
-            assert_eq!(sent2.len(), 2, "round-2 wire: Authenticate then Reconnect");
+            assert_eq!(sent2.len(), 2);
             let message: serde_json::Value = serde_json::from_str(&sent2[1]).unwrap();
             assert_eq!(message["type"], "Reconnect");
-            assert_eq!(message["data"]["auth_token"], "tok-1");
         }
         assert!(client.is_connected());
         client.shutdown().await;

--- a/src/client.rs
+++ b/src/client.rs
@@ -691,7 +691,12 @@ const DEFAULT_RECONNECT_MAX_BACKOFF: Duration = Duration::from_secs(10);
 /// [`max_frame_hint`](crate::Transport::max_frame_hint), and frames received
 /// before transport readiness are all retried: every one of them can be
 /// caused by a dead or misbehaving *backend*, which is exactly what a fresh
-/// transport from the factory replaces. Not retried — the client ends as
+/// transport from the factory replaces. Close codes are not inspected: a
+/// server kick (private close code 4007, `kicked`) is retried like any peer
+/// close, and because the server never arms reconnection for a kicked seat,
+/// that one round ends with the automatic rejoin refused in-band as
+/// [`ReconnectionFailed`](SignalFishEvent::ReconnectionFailed) while the
+/// fresh connection itself stays usable. Not retried — the client ends as
 /// today:
 ///
 /// - [`shutdown`](SignalFishClient::shutdown) (at any point, including
@@ -3596,6 +3601,8 @@ mod tests {
         diagnostics: crate::transport::TransportDiagnostics,
         /// Inbound bound declared through `Transport::max_frame_hint`.
         max_frame_hint: Option<usize>,
+        /// Close metadata reported once the scripted queue ends.
+        close_info: Option<crate::transport::TransportCloseInfo>,
     }
 
     impl MockTransport {
@@ -3649,6 +3656,7 @@ mod tests {
                 sent_binary: None,
                 diagnostics: crate::transport::TransportDiagnostics::default(),
                 max_frame_hint: None,
+                close_info: None,
             };
             (
                 transport,
@@ -3681,6 +3689,18 @@ mod tests {
             let frames_taken = Arc::clone(&transport.frames_taken);
             (transport, sent, closed, controls, gate, frames_taken)
         }
+
+        /// Report this close metadata from `Transport::close_info` once the
+        /// scripted queue ends (a peer-initiated close).
+        fn with_peer_close(mut self, code: u16, reason: &'static str) -> Self {
+            self.close_info = Some(crate::transport::TransportCloseInfo {
+                code: Some(code),
+                reason: Some(reason.into()),
+                clean: Some(true),
+                initiated_by_peer: true,
+            });
+            self
+        }
     }
 
     impl Transport for MockTransport {
@@ -3690,6 +3710,10 @@ mod tests {
 
         fn max_frame_hint(&self) -> Option<usize> {
             self.max_frame_hint
+        }
+
+        fn close_info(&self) -> Option<crate::transport::TransportCloseInfo> {
+            self.close_info.clone()
         }
 
         fn abort(&mut self) {
@@ -9801,6 +9825,105 @@ mod tests {
             let message: serde_json::Value = serde_json::from_str(&sent2[1]).unwrap();
             assert_eq!(message["type"], "Reconnect");
         }
+        client.shutdown().await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn reconnect_policy_kick_close_4007_runs_one_doomed_rejoin_round() {
+        // An authority kick closes the kicked client's connection with
+        // private close code 4007 ("kicked"); the server never arms
+        // reconnection for that seat. The close is an ordinary retryable
+        // peer close, so the policy runs exactly one round: fresh transport,
+        // re-authentication, and the doomed automatic `Reconnect` answered
+        // in-band with `ReconnectionFailed` — no retry loop, and the
+        // connection stays usable for manual recovery.
+        let (transport1, _sent1, _closed1) = MockTransport::new(vec![
+            Some(Ok(authenticated_json())),
+            Some(Ok(protocol_info_v3_json())),
+            Some(Ok(room_joined_json_with_token("tok-1"))),
+            None,
+        ]);
+        let transport1 = transport1.with_peer_close(4007, "kicked");
+        // Round 2: authenticate again; the automatic reconnect for the kicked
+        // seat is refused in-band and the connection stays deliverable.
+        let (transport2, sent2, _closed2) = MockTransport::new(vec![
+            Some(Ok(authenticated_json())),
+            Some(Ok(protocol_info_v3_json())),
+            Some(Ok(reconnection_failed_json())),
+        ]);
+        let pool = transport_pool(vec![transport2]);
+        let policy = ReconnectPolicy::new(pool_factory(&pool))
+            .with_max_attempts(3)
+            .with_initial_backoff(Duration::from_millis(50));
+        let config = SignalFishConfig::new("mb_reconnect")
+            .enable_v3()
+            .with_reconnect_policy(policy);
+        let (mut client, mut events) = SignalFishClient::start(transport1, config);
+
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Connected)
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Authenticated { .. })
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::ProtocolInfo(_))
+        ));
+        client
+            .join_room(JoinRoomParams::new("test-game", "local"))
+            .unwrap();
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::RoomJoined { .. })
+        ));
+        match events.recv().await {
+            Some(SignalFishEvent::Disconnected { reason, .. }) => {
+                assert_eq!(
+                    reason.as_deref(),
+                    Some("closed by server: code=Some(4007), reason=Some(\"kicked\")")
+                );
+            }
+            other => panic!("expected kicked Disconnected, got {other:?}"),
+        }
+        match events.recv().await {
+            Some(SignalFishEvent::Reconnecting { attempt, .. }) => assert_eq!(attempt, 1),
+            other => panic!("expected Reconnecting, got {other:?}"),
+        }
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Connected)
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Authenticated { .. })
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::ProtocolInfo(_))
+        ));
+        match events.recv().await {
+            Some(SignalFishEvent::ReconnectionFailed { error_code, .. }) => {
+                assert_eq!(
+                    error_code,
+                    crate::error_codes::ErrorCode::ReconnectionExpired
+                );
+            }
+            other => panic!("expected ReconnectionFailed, got {other:?}"),
+        }
+        // The budget is untouched by the in-band refusal: no further rounds,
+        // no ReconnectAbandoned, and the connection stays up.
+        tokio::time::sleep(Duration::from_millis(5)).await;
+        {
+            let sent2 = sent2.lock().unwrap();
+            assert_eq!(sent2.len(), 2, "round-2 wire: Authenticate then Reconnect");
+            let message: serde_json::Value = serde_json::from_str(&sent2[1]).unwrap();
+            assert_eq!(message["type"], "Reconnect");
+            assert_eq!(message["data"]["auth_token"], "tok-1");
+        }
+        assert!(client.is_connected());
         client.shutdown().await;
     }
 

--- a/src/error_codes.rs
+++ b/src/error_codes.rs
@@ -188,7 +188,9 @@ pub enum ErrorCode {
     KickTargetNotFound,
     /// This connection was removed from its room by the room's authority
     /// player. The WebSocket closed with private close code `4007`
-    /// (`kicked`); reconnection is not offered.
+    /// (`kicked`); the server never arms reconnection for a kicked seat (a
+    /// configured `ReconnectPolicy` still retries the close once, and the
+    /// automatic rejoin is refused in-band).
     Kicked,
 }
 

--- a/src/error_codes.rs
+++ b/src/error_codes.rs
@@ -189,8 +189,9 @@ pub enum ErrorCode {
     /// This connection was removed from its room by the room's authority
     /// player. The WebSocket closed with private close code `4007`
     /// (`kicked`); the server never arms reconnection for a kicked seat (a
-    /// configured `ReconnectPolicy` still retries the close once, and the
-    /// automatic rejoin is refused in-band).
+    /// configured `ReconnectPolicy` still retries the close like any peer
+    /// close, and on a spec-conformant server the automatic rejoin is
+    /// refused in-band).
     Kicked,
 }
 
@@ -406,7 +407,7 @@ impl ErrorCode {
                 "The player to kick is not a current member of this room."
             }
             Self::Kicked => {
-                "You were removed from the room by its authority player. Reconnection is not offered; join again with a valid room code."
+                "You were removed from the room by its authority player. The kicked seat cannot be reconnected; join again with a valid room code."
             }
         }
     }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -965,8 +965,8 @@ pub enum RoomOperationRequest {
     /// members, and closes the target's connection with private close code
     /// 4007 (`kicked`); the server never arms reconnection for a kicked seat
     /// (a client-side `ReconnectPolicy` still classifies that close as an
-    /// ordinary retryable peer close, and the automatic rejoin is refused
-    /// in-band).
+    /// ordinary retryable peer close; on a spec-conformant server the
+    /// automatic rejoin is refused in-band).
     KickPlayer {
         /// The seated player to remove.
         player_id: PlayerId,

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -963,7 +963,10 @@ pub enum RoomOperationRequest {
     /// current seated member and cannot be the sender. The server removes the
     /// seat, broadcasts the usual `PlayerLeft` roster delta to the remaining
     /// members, and closes the target's connection with private close code
-    /// 4007 (`kicked`); reconnection is never armed for a kicked seat.
+    /// 4007 (`kicked`); the server never arms reconnection for a kicked seat
+    /// (a client-side `ReconnectPolicy` still classifies that close as an
+    /// ordinary retryable peer close, and the automatic rejoin is refused
+    /// in-band).
     KickPlayer {
         /// The seated player to remove.
         player_id: PlayerId,

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -2235,12 +2235,20 @@ mod ci_workflow_policy {
         // The event payload freezes the PR title at event time, so
         // classification must read the live title through the API (issue
         // #241): a retitle to add `!:` must reach re-runs instead of
-        // replaying the stale title, and a failed read must fail closed.
+        // replaying the stale title. The fetch is retried against API
+        // flakiness, skipped for explicitly dispatched candidates (which
+        // carry their own title input), and fails closed when the title
+        // still cannot be read.
         assert!(
             contents.contains("pull-requests: read")
                 && contents.contains(r#"gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq .title"#)
-                && contents.contains("::error::Could not read the live title of pull request"),
-            "Semver CI must classify from the live PR title (fail-closed) instead of the frozen event payload"
+                && contents.contains("for attempt in 1 2 3")
+                && contents.contains(r#"if [ -n "$PR_NUMBER" ];"#)
+                && contents.contains(r#"if [ -z "$live_title" ];"#)
+                && contents
+                    .contains("::error::Could not read the live title of pull request")
+                && contents.contains("exit 1"),
+            "Semver CI must classify from the live PR title (retried, fail-closed) instead of the frozen event payload"
         );
     }
 

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -2232,6 +2232,16 @@ mod ci_workflow_policy {
                 && contents.contains("if [ \"$RELEASE_TYPE\" = major ]; then"),
             "Semver CI must use major policy only for explicitly marked breaking PRs and retain inferred checks otherwise"
         );
+        // The event payload freezes the PR title at event time, so
+        // classification must read the live title through the API (issue
+        // #241): a retitle to add `!:` must reach re-runs instead of
+        // replaying the stale title, and a failed read must fail closed.
+        assert!(
+            contents.contains("pull-requests: read")
+                && contents.contains(r#"gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq .title"#)
+                && contents.contains("::error::Could not read the live title of pull request"),
+            "Semver CI must classify from the live PR title (fail-closed) instead of the frozen event payload"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Why

Two user-facing problems, both found/fixed by audit round 54 (issue #126):

- **Issue #241 — the semver gate ignored retitles.** The gate classified a PR
  from the title frozen in the event payload. Adding the breaking `!:`
  marker after opening a PR changed nothing: re-runs replayed the stale
  title and stayed red. Session 113 had to re-derive the empty-commit
  workaround.
- **The docs lied about kicks.** `ErrorCode::Kicked` and four doc sites
  claimed "reconnection is not offered" for a kicked player. With the
  opt-in `ReconnectPolicy`, the kicked close (4007) *is* retried like any
  peer close; the audit proved the journey correct and bounded (one
  doomed automatic rejoin, refused in-band; no retry loop), but the docs
  said otherwise.

## What changed

- Semver Checks now classifies from the **live** PR title (read-only
  `pull-requests: read`, 3-attempt retry, fail-closed on read failure).
  Retitle, then "Re-run failed jobs" — no empty commit needed. A
  `ci_config` pin and the public-api-design skill document the convention.
- Kick docs reconciled across rustdoc, the client guide, the errors table,
  `ErrorCode`, `KickPlayer`, and the changelog; server-side behavior is
  now hedged to spec-conformant servers, and the `Kicked` Display string
  matches.
- The kicked journey is pinned by test: exact `code=Some(4007)` reason,
  one `Reconnecting` round, in-band `ReconnectionFailed`, connection stays
  usable. Red/green-proven via a `classify_round_exit` mutation.
- Upstream authority drift: none — upstream `main` is still our vendored
  pin `9534d0e6`; spec and wire samples are byte-identical.

The optional "treat a kick as terminal" policy classifier is filed as
#242 for a maintainer decision.

## Verification

- `cargo fmt` + `cargo clippy --workspace --all-targets --all-features -D warnings` clean; 1172 tests / 0 failed.
- Red/green probes: classification mutation and pin mutation both fail as
  designed and were reverted byte-clean.
- Step logic verified with a stubbed `gh`: classification, transient
  recovery, fail-closed, and dispatch-input fallback.
- Adversarial review (7 findings, all fixed) + convergence verifier:
  zero residual findings.

Closes #241.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are CI workflow permissions/scripting, documentation, test mocks, and CI policy tests—no altered production reconnect classification logic in the diff.
> 
> **Overview**
> Fixes **issue #241** by changing Semver Checks to classify breaking changes from the **live** pull request title (`gh api` with retries and fail-closed errors) instead of the title frozen in the `pull_request` event, plus `pull-requests: read`. Retitling with `!:` and re-running failed jobs should work without an empty commit; the public-api skill and `ci_config_tests` encode that contract.
> 
> Separately, documentation and changelog text for authority kicks (close **4007**) now match **`ReconnectPolicy`** behavior: kicks are not special-cased client-side—they trigger the same retry path as other peer closes, while a spec-conformant server still refuses the automatic rejoin in-band as **`ReconnectionFailed`** on a usable connection. **`ErrorCode::Kicked`** display copy and rustdoc across the client guide, errors table, and protocol types were updated accordingly.
> 
> Test support adds **`MockTransport::with_peer_close`** / **`close_info`** and tightens the reconnect-policy integration test for the kicked journey; no production reconnect classifier change in this diff (terminal kick handling remains filed as **#242**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efd70f4e8ab66d27c43b6f857a5a7ddfe7bee85a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->