### PR TITLE
ReconnectPolicy: optional terminal close codes (#242)

### DIFF
--- a/.llm/skills/transport-abstraction/SKILL.md
+++ b/.llm/skills/transport-abstraction/SKILL.md
@@ -302,7 +302,10 @@ dropping it each call.
 
 - maps WebSocket text and binary messages without discarding either;
 - retains an accepted outbound message until `poll_flush` completes;
-- records close code/reason in `TransportCloseInfo`;
+- records close code/reason in `TransportCloseInfo` before returning `None`
+  (async-driver callers consult it after the farewell to honor
+  `ReconnectPolicy::with_terminal_close_codes`; a late or missing record
+  degrades a terminal verdict into an ordinary retry);
 - drives `poll_close` idempotently;
 - flushes tungstenite's automatically queued Pong before reading again;
 - bounds skipped control frames per receive poll and self-wakes to resume;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,10 +23,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   deterministic exponential backoff — re-authenticating and reissuing the
   directed `reconnect` after a player-room disconnect; shutdown, dropped
   handles, and `Disconnect`-policy teardowns are never retried, and the
-  polling client stays caller-driven. Close codes are not special-cased: an
-  authority kick (close 4007) is retried like any peer close, and on a
-  spec-conformant server the kicked seat's automatic rejoin is refused
-  in-band as `ReconnectionFailed` on a still usable connection.
+  polling client stays caller-driven. Close codes are not special-cased by
+  default: an authority kick (close 4007) is retried like any peer close,
+  and on a spec-conformant server the kicked seat's automatic rejoin is
+  refused in-band as `ReconnectionFailed` on a still usable connection;
+  `ReconnectPolicy::with_terminal_close_codes` can instead list
+  known-permanent codes (peer-initiated only) that end the client right
+  after the `Disconnected` farewell.
 - **Breaking:** the exhaustive `SignalFishEvent` enum gains `Reconnecting {
   attempt, next_backoff }` and `ReconnectAbandoned { attempts, last_reason }`
   (the reconnect policy's per-attempt and terminal events); add two arms to

--- a/docs/client.md
+++ b/docs/client.md
@@ -620,9 +620,10 @@ let (mut client, events) = SignalFishClient::start(transport, config);
 ```
 
 With a policy configured, a terminal disconnect **other than** shutdown, a
-dropped handle, or a `ProtocolViolationPolicy::Disconnect` teardown (a
-protocol violation is a correctness signal, never masked) becomes a
-retryable edge:
+dropped handle, a `ProtocolViolationPolicy::Disconnect` teardown (a
+protocol violation is a correctness signal, never masked), or a peer close
+whose code the policy classifies terminal (`with_terminal_close_codes`,
+below) becomes a retryable edge:
 
 1. The usual bounded teardown delivers `Disconnected`, exactly as without a
    policy.
@@ -662,10 +663,9 @@ would rather skip that doomed round can classify known-permanent closes as
 terminal with `ReconnectPolicy::with_terminal_close_codes` — a peer-initiated
 close whose code is listed ends the client right after the `Disconnected`
 farewell, while every unlisted code (notably `4000`, a server going away)
-keeps reconnecting. When the attempt
-budget (`max_attempts`, reset whenever a connection reaches `Authenticated`)
-runs out, the client emits `ReconnectAbandoned { attempts, last_reason }` and
-the event stream ends.
+keeps reconnecting. When the attempt budget (`max_attempts`, reset whenever
+a connection reaches `Authenticated`) runs out, the client emits
+`ReconnectAbandoned { attempts, last_reason }` and the event stream ends.
 
 The polling client is caller-driven by design and ignores this option —
 recover it by constructing a new client inside your game loop. There is

--- a/docs/client.md
+++ b/docs/client.md
@@ -653,11 +653,16 @@ may miss a `Reconnecting` marker while reconnection itself continues).
 On `ReconnectionFailed` the connection stays up but room recovery stops —
 apply the same `error_code` decision tree as the manual flow (fall back to
 `join_room`, wait out `PlayerAlreadyConnected`, or give up). Close codes are
-not inspected, so a server kick (private close code 4007, `kicked`) is
-retried like any peer close: the server never arms reconnection for a
-kicked seat, so on a spec-conformant server the episode ends with the
-doomed automatic `reconnect` refused in-band as `ReconnectionFailed` on a
-still-usable fresh connection. When the attempt
+not inspected by default, so a server kick (private close code 4007,
+`kicked`) is retried like any peer close: the server never arms
+reconnection for a kicked seat, so on a spec-conformant server the episode
+ends with the doomed automatic `reconnect` refused in-band as
+`ReconnectionFailed` on a still-usable fresh connection. Deployments that
+would rather skip that doomed round can classify known-permanent closes as
+terminal with `ReconnectPolicy::with_terminal_close_codes` — a peer-initiated
+close whose code is listed ends the client right after the `Disconnected`
+farewell, while every unlisted code (notably `4000`, a server going away)
+keeps reconnecting. When the attempt
 budget (`max_attempts`, reset whenever a connection reaches `Authenticated`)
 runs out, the client emits `ReconnectAbandoned { attempts, last_reason }` and
 the event stream ends.

--- a/docs/client.md
+++ b/docs/client.md
@@ -621,9 +621,10 @@ let (mut client, events) = SignalFishClient::start(transport, config);
 
 With a policy configured, a terminal disconnect **other than** shutdown, a
 dropped handle, a `ProtocolViolationPolicy::Disconnect` teardown (a
-protocol violation is a correctness signal, never masked), or a peer close
-whose code the policy classifies terminal (`with_terminal_close_codes`,
-below) becomes a retryable edge:
+protocol violation is a correctness signal, never masked), a teardown whose
+farewell could not be delivered (the consumer wedged past the shutdown
+budget), or a peer close whose code the policy classifies terminal
+(`with_terminal_close_codes`, below) becomes a retryable edge:
 
 1. The usual bounded teardown delivers `Disconnected`, exactly as without a
    policy.

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -257,7 +257,7 @@ operations itself.
 |---------|-------------|
 | `NotRoomAuthority` | A moderation operation was sent by a connection that is not the room's designated authority player. |
 | `KickTargetNotFound` | The player named by `KickPlayer` is not a seated member of the room. |
-| `Kicked` | This connection was removed from its room by the room's authority player. The WebSocket closed with private close code 4007 (`kicked`); the server never arms reconnection for a kicked seat (a configured `ReconnectPolicy` still retries the close like any peer close, and on a spec-conformant server the automatic rejoin is refused in-band). |
+| `Kicked` | This connection was removed from its room by the room's authority player. The WebSocket closed with private close code 4007 (`kicked`); the server never arms reconnection for a kicked seat (a configured `ReconnectPolicy` retries the close like any peer close unless the deployment listed 4007 in `with_terminal_close_codes`, and on a spec-conformant server the automatic rejoin is refused in-band). |
 
 !!! note "The v3-era *server* codes vs. `SignalFishError::ProtocolUnsupported`"
     The five v3 signaling codes plus `ConnectionIdleTimeout` are **server-sent**

--- a/docs/events.md
+++ b/docs/events.md
@@ -84,10 +84,13 @@ the async client. `Reconnecting { attempt, next_backoff }` precedes each
 fresh-transport attempt (1-based `attempt`, deterministic exponential
 `next_backoff`); a successful attempt continues with a fresh `Connected` →
 `Authenticated` sequence and, when the client was a player in a room when
-the previous connection ended, an automatic directed reconnect. `ReconnectAbandoned {
+the previous connection ended, an automatic directed reconnect.
+`ReconnectAbandoned {
 attempts, last_reason }` is the terminal event when the budget runs out;
-shutdown, a dropped handle, and `ProtocolViolationPolicy::Disconnect`
-teardowns end the client without attempting reconnection and never produce
+shutdown, a dropped handle, a `ProtocolViolationPolicy::Disconnect`
+teardown, a peer close whose code the policy classifies terminal
+(`with_terminal_close_codes`), and a farewell the consumer never drained
+end the client without attempting reconnection and never produce
 these events.
 
 ### `DecodeFailed`

--- a/docs/transport.md
+++ b/docs/transport.md
@@ -484,6 +484,9 @@ the [WebAssembly guide](wasm.md) for target and linker requirements.
 - Make close multi-poll and idempotent.
 - Implement prompt, non-blocking, non-panicking, idempotent `abort` cleanup;
   clear retained work and make failed backend cleanup safe to retry.
-- Record close code/reason/initiator before returning `None`.
+- Record close code/reason/initiator before returning `None`; async-driver
+  callers consult this metadata after the farewell to honor
+  `ReconnectPolicy::with_terminal_close_codes`, so a late or missing record
+  degrades a terminal verdict into an ordinary retry.
 - Keep `is_ready` cheap and monotonic for one physical connection.
 - Put connection-specific construction outside the trait.

--- a/examples/auto_reconnect.rs
+++ b/examples/auto_reconnect.rs
@@ -29,6 +29,11 @@
 //! configuration drop this template's `join_room`-on-`Authenticated` call:
 //! one room operation may be admitted per round, so the manual join is
 //! refused with `RoomOperationPending` or displaces the automatic rejoin.
+//!
+//! A kick (private close code 4007) is retried like any peer close by
+//! default; add `.with_terminal_close_codes([4007])` to the policy to end
+//! the client right after the farewell instead of spending the doomed
+//! round.
 
 use signal_fish_client::{
     JoinRoomParams, ReconnectPolicy, SignalFishClient, SignalFishConfig, SignalFishEvent,

--- a/src/client.rs
+++ b/src/client.rs
@@ -723,7 +723,10 @@ const DEFAULT_RECONNECT_MAX_BACKOFF: Duration = Duration::from_secs(10);
 ///   consumer wedged past [`shutdown_timeout`](SignalFishConfig::shutdown_timeout):
 ///   the consumer missed a barrier event, and a mesh controller's
 ///   catch-up accounting can never resynchronize a lost edge, so the loop
-///   ends instead of retrying into a wedged consumer, and
+///   ends instead of retrying into a wedged consumer,
+/// - a peer close classified terminal by
+///   [`with_terminal_close_codes`](Self::with_terminal_close_codes) (no
+///   attempt is spent, so the budget machinery never runs), and
 /// - an exhausted attempt budget, reported via
 ///   [`ReconnectAbandoned`](SignalFishEvent::ReconnectAbandoned).
 ///
@@ -869,12 +872,17 @@ impl ReconnectPolicy {
     /// Matching is deliberately narrow: the close must report
     /// `initiated_by_peer` (a local transport failure is never a server
     /// verdict) *and* carry a code, and only exact configured codes match.
-    /// A terminal close skips the attempt budget entirely — the loop ends
-    /// with no [`Reconnecting`](SignalFishEvent::Reconnecting) and no
-    /// [`ReconnectAbandoned`](SignalFishEvent::ReconnectAbandoned) event.
+    /// The list is normalized (sorted, deduplicated), so equality and
+    /// [`Debug`](std::fmt::Debug) reflect the configured set, not its
+    /// spelling. A terminal close skips the attempt budget entirely — the
+    /// loop ends with no [`Reconnecting`](SignalFishEvent::Reconnecting) and
+    /// no [`ReconnectAbandoned`](SignalFishEvent::ReconnectAbandoned) event.
     #[must_use]
     pub fn with_terminal_close_codes(mut self, codes: impl IntoIterator<Item = u16>) -> Self {
-        self.terminal_close_codes = codes.into_iter().collect();
+        let mut normalized: Vec<u16> = codes.into_iter().collect();
+        normalized.sort_unstable();
+        normalized.dedup();
+        self.terminal_close_codes = normalized;
         self
     }
 
@@ -2838,8 +2846,8 @@ enum ConnectionRoundExit {
 
 /// Whether the configured policy (if any) classifies the transport's current
 /// close metadata as a terminal peer close (issue #242). Evaluated at every
-/// round-exit edge: a peer close can surface through whichever I/O arm
-/// observed the dead socket first.
+/// edge that can classify the round retryable: a peer close can surface
+/// through whichever I/O arm observed the dead socket first.
 #[cfg(feature = "tokio-runtime")]
 fn peer_close_is_terminal(
     reconnect: &Option<ReconnectPolicy>,
@@ -10230,6 +10238,25 @@ mod tests {
         assert_eq!(base, same);
         assert_ne!(base, different);
         assert_ne!(base, default_codes);
+        // The list is normalized: order and duplicates are not observable
+        // tuning, so they never affect equality or the accessor.
+        let reordered = SignalFishConfig::new("mb_reconnect").with_reconnect_policy(
+            ReconnectPolicy::new(factory).with_terminal_close_codes([4999, 4007]),
+        );
+        let duplicated = SignalFishConfig::new("mb_reconnect").with_reconnect_policy(
+            ReconnectPolicy::new(factory).with_terminal_close_codes([4007, 4007, 4999]),
+        );
+        let normalized = SignalFishConfig::new("mb_reconnect").with_reconnect_policy(
+            ReconnectPolicy::new(factory).with_terminal_close_codes([4007, 4999]),
+        );
+        assert_eq!(reordered, normalized);
+        assert_eq!(duplicated, normalized);
+        assert_eq!(
+            ReconnectPolicy::new(factory)
+                .with_terminal_close_codes([4999, 4007, 4007])
+                .terminal_close_codes(),
+            [4007, 4999]
+        );
         // The codes are visible diagnostics, not secrets.
         let debug = format!(
             "{:?}",

--- a/src/client.rs
+++ b/src/client.rs
@@ -198,8 +198,8 @@ pub(crate) fn decode_binary_server_message(
 /// `app_id`; all others have sensible defaults.
 ///
 /// `PartialEq` compares a configured [`ReconnectPolicy`] by its observable
-/// tuning (attempts and backoff windows); the uncomparable transport factory
-/// is deliberately not part of the comparison.
+/// tuning (attempts, backoff windows, and terminal close codes); the
+/// uncomparable transport factory is deliberately not part of the comparison.
 ///
 /// # Example
 ///
@@ -359,12 +359,15 @@ impl Eq for SignalFishConfig {}
 impl SignalFishConfig {
     /// Comparable view of a configured policy: the observable tuning without
     /// the uncomparable transport factory.
-    fn reconnect_tuning(policy: Option<&ReconnectPolicy>) -> Option<(u32, Duration, Duration)> {
+    fn reconnect_tuning(
+        policy: Option<&ReconnectPolicy>,
+    ) -> Option<(u32, Duration, Duration, Vec<u16>)> {
         policy.map(|policy| {
             (
                 policy.max_attempts,
                 policy.initial_backoff,
                 policy.max_backoff,
+                policy.terminal_close_codes.clone(),
             )
         })
     }
@@ -691,14 +694,24 @@ const DEFAULT_RECONNECT_MAX_BACKOFF: Duration = Duration::from_secs(10);
 /// [`max_frame_hint`](crate::Transport::max_frame_hint), and frames received
 /// before transport readiness are all retried: every one of them can be
 /// caused by a dead or misbehaving *backend*, which is exactly what a fresh
-/// transport from the factory replaces. Close codes are not inspected: a
-/// server kick (private close code 4007, `kicked`) is retried like any
-/// peer close. The server never arms reconnection for a kicked seat, so on
-/// a spec-conformant server the episode ends with the automatic rejoin
-/// refused in-band as
+/// transport from the factory replaces. Close codes are not inspected by
+/// default: a server kick (private close code 4007, `kicked`) is retried
+/// like any peer close. The server never arms reconnection for a kicked
+/// seat, so on a spec-conformant server the episode ends with the automatic
+/// rejoin refused in-band as
 /// [`ReconnectionFailed`](SignalFishEvent::ReconnectionFailed) while the
-/// fresh connection itself stays usable. Not retried — the client ends as
-/// today:
+/// fresh connection itself stays usable.
+///
+/// Deployments that would rather treat *known-permanent* close codes as
+/// terminal can opt in with
+/// [`with_terminal_close_codes`](Self::with_terminal_close_codes): a
+/// peer-initiated close whose code is configured ends the client after the
+/// ordinary [`Disconnected`](SignalFishEvent::Disconnected) farewell,
+/// skipping the doomed round (and its
+/// [`Reconnecting`](SignalFishEvent::Reconnecting) event) entirely. Codes
+/// not configured stay retryable, so a plain list such as `[4007]` keeps
+/// `4000` (server going away) and other transient closes reconnecting.
+/// Not retried — the client ends as today:
 ///
 /// - [`shutdown`](SignalFishClient::shutdown) (at any point, including
 ///   during a backoff wait),
@@ -764,6 +777,7 @@ pub struct ReconnectPolicy {
     max_attempts: u32,
     initial_backoff: Duration,
     max_backoff: Duration,
+    terminal_close_codes: Vec<u16>,
 }
 
 impl Clone for ReconnectPolicy {
@@ -773,6 +787,7 @@ impl Clone for ReconnectPolicy {
             max_attempts: self.max_attempts,
             initial_backoff: self.initial_backoff,
             max_backoff: self.max_backoff,
+            terminal_close_codes: self.terminal_close_codes.clone(),
         }
     }
 }
@@ -783,6 +798,7 @@ impl std::fmt::Debug for ReconnectPolicy {
             .field("max_attempts", &self.max_attempts)
             .field("initial_backoff", &self.initial_backoff)
             .field("max_backoff", &self.max_backoff)
+            .field("terminal_close_codes", &self.terminal_close_codes)
             .finish_non_exhaustive()
     }
 }
@@ -799,6 +815,7 @@ impl ReconnectPolicy {
             max_attempts: DEFAULT_RECONNECT_MAX_ATTEMPTS,
             initial_backoff: DEFAULT_RECONNECT_INITIAL_BACKOFF,
             max_backoff: DEFAULT_RECONNECT_MAX_BACKOFF,
+            terminal_close_codes: Vec::new(),
         }
     }
 
@@ -835,6 +852,32 @@ impl ReconnectPolicy {
         self
     }
 
+    /// Treat the listed WebSocket close codes as **terminal** when the peer
+    /// initiated the close: the client ends after the ordinary
+    /// [`Disconnected`](SignalFishEvent::Disconnected) farewell instead of
+    /// spending a reconnection round on a close the deployment knows is
+    /// permanent.
+    ///
+    /// The canonical member is the authority kick, private code **4007**
+    /// (`kicked`): the server will never arm reconnection for a kicked seat,
+    /// so the default retry only produces one doomed round that the server
+    /// refuses in-band. Keep transient codes out of the list — `4000`
+    /// (`going away`) is how a server announces a restart and must stay
+    /// retryable — and the SDK never hard-codes server policy: an empty list
+    /// (the default) retries every peer close as today.
+    ///
+    /// Matching is deliberately narrow: the close must report
+    /// `initiated_by_peer` (a local transport failure is never a server
+    /// verdict) *and* carry a code, and only exact configured codes match.
+    /// A terminal close skips the attempt budget entirely — the loop ends
+    /// with no [`Reconnecting`](SignalFishEvent::Reconnecting) and no
+    /// [`ReconnectAbandoned`](SignalFishEvent::ReconnectAbandoned) event.
+    #[must_use]
+    pub fn with_terminal_close_codes(mut self, codes: impl IntoIterator<Item = u16>) -> Self {
+        self.terminal_close_codes = codes.into_iter().collect();
+        self
+    }
+
     /// The configured attempt budget per episode.
     #[must_use]
     pub fn max_attempts(&self) -> u32 {
@@ -851,6 +894,13 @@ impl ReconnectPolicy {
     #[must_use]
     pub fn max_backoff(&self) -> Duration {
         self.max_backoff
+    }
+
+    /// The close codes configured as terminal via
+    /// [`with_terminal_close_codes`](Self::with_terminal_close_codes).
+    #[must_use]
+    pub fn terminal_close_codes(&self) -> &[u16] {
+        &self.terminal_close_codes
     }
 
     /// The deterministic delay before the 1-based `attempt`-th
@@ -886,6 +936,25 @@ impl ReconnectPolicy {
     #[cfg(feature = "tokio-runtime")]
     fn create_transport(&self) -> Box<dyn Transport + Send> {
         (self.factory)()
+    }
+
+    /// Whether this close metadata names a configured terminal code. Only a
+    /// *peer-initiated* close with a code can be a server verdict the
+    /// deployment asked to honor; local transport failures and code-less
+    /// closes stay retryable.
+    #[cfg(feature = "tokio-runtime")]
+    fn classifies_peer_close_terminal(
+        &self,
+        close: Option<&crate::transport::TransportCloseInfo>,
+    ) -> bool {
+        let Some(info) = close else {
+            return false;
+        };
+        if !info.initiated_by_peer {
+            return false;
+        }
+        info.code
+            .is_some_and(|code| self.terminal_close_codes.contains(&code))
     }
 }
 
@@ -2767,6 +2836,20 @@ enum ConnectionRoundExit {
     },
 }
 
+/// Whether the configured policy (if any) classifies the transport's current
+/// close metadata as a terminal peer close (issue #242). Evaluated at every
+/// round-exit edge: a peer close can surface through whichever I/O arm
+/// observed the dead socket first.
+#[cfg(feature = "tokio-runtime")]
+fn peer_close_is_terminal(
+    reconnect: &Option<ReconnectPolicy>,
+    transport: &AbortOnDropTransport<Box<dyn Transport + Send>>,
+) -> bool {
+    reconnect.as_ref().is_some_and(|policy| {
+        policy.classifies_peer_close_terminal(transport.close_info().as_ref())
+    })
+}
+
 /// Classify a teardown the loop just completed: an observed (sticky) shutdown
 /// signal always wins over retrying, because the client was asked to end. A
 /// blocked farewell (`farewell_unblocked == false`: a living consumer wedged
@@ -2774,15 +2857,19 @@ enum ConnectionRoundExit {
 /// barrier event, and a retried round can never resynchronize a
 /// mesh controller whose catch-up accounting counts one delivered event
 /// per authoritative edge. `true` covers delivery and a gone consumer alike —
-/// in neither case does a retry face a blocked barrier.
+/// in neither case does a retry face a blocked barrier. A peer-initiated
+/// close whose code the policy classifies as terminal ends the client after
+/// the delivered farewell instead of spending a round the deployment knows
+/// is doomed (issue #242).
 #[cfg(feature = "tokio-runtime")]
 fn classify_round_exit(
     shutdown: &ShutdownSignal,
     farewell_unblocked: bool,
     authenticated: bool,
     reason: Option<String>,
+    peer_close_terminal: bool,
 ) -> ConnectionRoundExit {
-    if shutdown.is_observed() || !farewell_unblocked {
+    if shutdown.is_observed() || !farewell_unblocked || peer_close_terminal {
         ConnectionRoundExit::Terminal
     } else {
         ConnectionRoundExit::Retryable {
@@ -3108,11 +3195,13 @@ async fn connection_round(
                         TerminalTeardown::starting(shutdown_timeout, reason.clone()),
                     )
                     .await;
+                    let peer_close_terminal = peer_close_is_terminal(reconnect, transport);
                     exit = classify_round_exit(
                         shutdown,
                         farewell_unblocked,
                         authenticated,
                         reason,
+                        peer_close_terminal,
                     );
                     break;
                 }
@@ -3146,11 +3235,13 @@ async fn connection_round(
                         )
                         .await;
                         let reason = peer_close_reason(transport).or(Some(error_text));
+                        let peer_close_terminal = peer_close_is_terminal(reconnect, transport);
                         exit = classify_round_exit(
                             shutdown,
                             farewell_unblocked,
                             authenticated,
                             reason,
+                            peer_close_terminal,
                         );
                         break;
                     }
@@ -3173,11 +3264,14 @@ async fn connection_round(
                                 TerminalTeardown::starting(shutdown_timeout, Some(reason)),
                             )
                             .await;
+                            let peer_close_terminal =
+                                peer_close_is_terminal(reconnect, transport);
                             exit = classify_round_exit(
                                 shutdown,
                                 farewell_unblocked,
                                 authenticated,
                                 reason_text,
+                                peer_close_terminal,
                             );
                             break;
                         }
@@ -3265,11 +3359,13 @@ async fn connection_round(
                             TerminalTeardown::starting(shutdown_timeout, reason.clone()),
                         )
                         .await;
+                        let peer_close_terminal = peer_close_is_terminal(reconnect, transport);
                         exit = classify_round_exit(
                             shutdown,
                             farewell_unblocked,
                             authenticated,
                             reason,
+                            peer_close_terminal,
                         );
                         break;
                     }
@@ -3285,11 +3381,13 @@ async fn connection_round(
                             TerminalTeardown::starting(shutdown_timeout, reason.clone()),
                         )
                         .await;
+                        let peer_close_terminal = peer_close_is_terminal(reconnect, transport);
                         exit = classify_round_exit(
                             shutdown,
                             farewell_unblocked,
                             authenticated,
                             reason,
+                            peer_close_terminal,
                         );
                         break;
                     }
@@ -3700,6 +3798,13 @@ mod tests {
                 clean: Some(true),
                 initiated_by_peer: true,
             });
+            self
+        }
+
+        /// Report arbitrary close metadata from `Transport::close_info` once
+        /// the scripted queue ends.
+        fn with_close_info(mut self, close: crate::transport::TransportCloseInfo) -> Self {
+            self.close_info = Some(close);
             self
         }
     }
@@ -9843,6 +9948,297 @@ mod tests {
         }
         assert!(client.is_connected());
         client.shutdown().await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn terminal_close_code_ends_the_client_without_retrying() {
+        // Issue #242: a policy that classifies the authority kick (private
+        // close code 4007) as terminal ends the client after the ordinary
+        // `Disconnected` farewell — no doomed rejoin round, no `Reconnecting`,
+        // no `ReconnectAbandoned`.
+        let (transport1, _sent1, _closed1) = MockTransport::new(vec![
+            Some(Ok(authenticated_json())),
+            Some(Ok(protocol_info_v3_json())),
+            Some(Ok(room_joined_json_with_token("tok-1"))),
+            None,
+        ]);
+        let transport1 = transport1.with_peer_close(4007, "kicked");
+        // The pool stays empty: a retried round would panic the factory, so
+        // a regression cannot pass by silently retrying into nothing.
+        let pool = transport_pool(Vec::new());
+        let policy = ReconnectPolicy::new(pool_factory(&pool))
+            .with_max_attempts(3)
+            .with_terminal_close_codes([4007]);
+        assert_eq!(policy.terminal_close_codes(), [4007]);
+        let config = SignalFishConfig::new("mb_reconnect")
+            .enable_v3()
+            .with_reconnect_policy(policy);
+        let (mut client, mut events) = SignalFishClient::start(transport1, config);
+
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Connected)
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Authenticated { .. })
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::ProtocolInfo(_))
+        ));
+        client
+            .join_room(JoinRoomParams::new("test-game", "local"))
+            .unwrap();
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::RoomJoined { .. })
+        ));
+        match events.recv().await {
+            Some(SignalFishEvent::Disconnected { reason, .. }) => {
+                assert_eq!(
+                    reason.as_deref(),
+                    Some("closed by server: code=Some(4007), reason=Some(\"kicked\")")
+                );
+            }
+            other => panic!("expected kicked Disconnected, got {other:?}"),
+        }
+        // The loop ended without scheduling anything: the very next item is
+        // channel closure, not a `Reconnecting` event.
+        assert!(events.recv().await.is_none());
+        client.shutdown().await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn terminal_close_codes_leave_unlisted_codes_retryable() {
+        // 4000 (server going away) is a transient close: it must keep
+        // reconnecting even while 4007 and 4999 are configured terminal.
+        let (transport1, _sent1, _closed1) = MockTransport::new(vec![
+            Some(Ok(authenticated_json())),
+            Some(Ok(protocol_info_v3_json())),
+            Some(Ok(room_joined_json_with_token("tok-1"))),
+            None,
+        ]);
+        let transport1 = transport1.with_peer_close(4000, "draining");
+        let (transport2, sent2, _closed2) = MockTransport::new(vec![
+            Some(Ok(authenticated_json())),
+            Some(Ok(protocol_info_v3_json())),
+        ]);
+        let pool = transport_pool(vec![transport2]);
+        let policy = ReconnectPolicy::new(pool_factory(&pool))
+            .with_max_attempts(3)
+            .with_initial_backoff(Duration::from_millis(10))
+            .with_terminal_close_codes([4007, 4999]);
+        let config = SignalFishConfig::new("mb_reconnect")
+            .enable_v3()
+            .with_reconnect_policy(policy);
+        let (mut client, mut events) = SignalFishClient::start(transport1, config);
+
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Connected)
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Authenticated { .. })
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::ProtocolInfo(_))
+        ));
+        client
+            .join_room(JoinRoomParams::new("test-game", "local"))
+            .unwrap();
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::RoomJoined { .. })
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Disconnected { .. })
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Reconnecting { attempt: 1, .. })
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Connected)
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Authenticated { .. })
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::ProtocolInfo(_))
+        ));
+        // Everything else about the round is unchanged: the retained
+        // player-room context still arms the automatic rejoin.
+        tokio::time::sleep(Duration::from_millis(5)).await;
+        {
+            let sent2 = sent2.lock().unwrap();
+            assert_eq!(sent2.len(), 2);
+            let message: serde_json::Value = serde_json::from_str(&sent2[1]).unwrap();
+            assert_eq!(message["type"], "Reconnect");
+        }
+        client.shutdown().await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn terminal_close_codes_match_only_peer_initiated_coded_closes() {
+        // Matching is deliberately narrow: a transport-initiated close
+        // carrying a configured code is a local backend failure, and a
+        // peer-initiated close without a code names no verdict — both stay
+        // retryable, and the budget machinery still runs (one remaining
+        // attempt is consumed, then `ReconnectAbandoned`).
+        let (transport1, _sent1, _closed1) = MockTransport::new(vec![
+            Some(Ok(authenticated_json())),
+            Some(Ok(protocol_info_v3_json())),
+            None,
+        ]);
+        let transport1 = transport1.with_close_info(crate::transport::TransportCloseInfo {
+            code: Some(4007),
+            reason: Some("backend reset".into()),
+            clean: Some(false),
+            initiated_by_peer: false,
+        });
+        // The scripted `None` ends the round through the ordinary stream-end
+        // edge so the close metadata is consulted.
+        let (transport2, _sent2, _closed2) = MockTransport::new(vec![None]);
+        let transport2 = transport2.with_close_info(crate::transport::TransportCloseInfo {
+            code: None,
+            reason: None,
+            clean: Some(false),
+            initiated_by_peer: true,
+        });
+        let pool = transport_pool(vec![transport2]);
+        let policy = ReconnectPolicy::new(pool_factory(&pool))
+            .with_max_attempts(1)
+            .with_initial_backoff(Duration::from_millis(10))
+            .with_terminal_close_codes([4007]);
+        let config = SignalFishConfig::new("mb_reconnect")
+            .enable_v3()
+            .with_reconnect_policy(policy);
+        let (mut client, mut events) = SignalFishClient::start(transport1, config);
+
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Connected)
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Authenticated { .. })
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::ProtocolInfo(_))
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Disconnected { .. })
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Reconnecting { attempt: 1, .. })
+        ));
+        // Round 2 never authenticates, so the episode ends in the budget.
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Connected)
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Disconnected { .. })
+        ));
+        match events.recv().await {
+            Some(SignalFishEvent::ReconnectAbandoned {
+                attempts,
+                last_reason,
+            }) => {
+                assert_eq!(attempts, 1);
+                assert_eq!(
+                    last_reason.as_deref(),
+                    Some("closed by server: code=None, reason=None")
+                );
+            }
+            other => panic!("expected ReconnectAbandoned, got {other:?}"),
+        }
+        assert!(events.recv().await.is_none());
+        client.shutdown().await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn terminal_close_skips_the_attempt_budget_entirely() {
+        // `max_attempts(0)` would report `ReconnectAbandoned` for any
+        // retryable close; a terminal-classified close ends before the
+        // budget machinery runs at all.
+        let (transport1, _sent1, _closed1) = MockTransport::new(vec![
+            Some(Ok(authenticated_json())),
+            Some(Ok(protocol_info_v3_json())),
+            Some(Ok(room_joined_json_with_token("tok-1"))),
+            None,
+        ]);
+        let transport1 = transport1.with_peer_close(4007, "kicked");
+        let policy = ReconnectPolicy::new(pool_factory(&transport_pool(Vec::new())))
+            .with_max_attempts(0)
+            .with_terminal_close_codes([4007]);
+        let config = SignalFishConfig::new("mb_reconnect")
+            .enable_v3()
+            .with_reconnect_policy(policy);
+        let (mut client, mut events) = SignalFishClient::start(transport1, config);
+
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Connected)
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Authenticated { .. })
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::ProtocolInfo(_))
+        ));
+        client
+            .join_room(JoinRoomParams::new("test-game", "local"))
+            .unwrap();
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::RoomJoined { .. })
+        ));
+        assert!(matches!(
+            events.recv().await,
+            Some(SignalFishEvent::Disconnected { .. })
+        ));
+        assert!(events.recv().await.is_none());
+        client.shutdown().await;
+    }
+
+    #[test]
+    fn reconnect_policy_terminal_close_codes_are_observable_tuning() {
+        let factory =
+            || -> Box<dyn Transport + Send> { Box::new(MockTransport::new(Vec::new()).0) };
+        let base = SignalFishConfig::new("mb_reconnect")
+            .with_reconnect_policy(ReconnectPolicy::new(factory).with_terminal_close_codes([4007]));
+        let same = SignalFishConfig::new("mb_reconnect")
+            .with_reconnect_policy(ReconnectPolicy::new(factory).with_terminal_close_codes([4007]));
+        let different = SignalFishConfig::new("mb_reconnect")
+            .with_reconnect_policy(ReconnectPolicy::new(factory).with_terminal_close_codes([4000]));
+        let default_codes = SignalFishConfig::new("mb_reconnect")
+            .with_reconnect_policy(ReconnectPolicy::new(factory));
+        assert_eq!(base, same);
+        assert_ne!(base, different);
+        assert_ne!(base, default_codes);
+        // The codes are visible diagnostics, not secrets.
+        let debug = format!(
+            "{:?}",
+            ReconnectPolicy::new(factory).with_terminal_close_codes([4007])
+        );
+        assert!(
+            debug.contains("terminal_close_codes: [4007]"),
+            "unexpected ReconnectPolicy Debug: {debug}"
+        );
     }
 
     /// A hostile backend that never reports readiness yet fails the first

--- a/src/error_codes.rs
+++ b/src/error_codes.rs
@@ -189,8 +189,10 @@ pub enum ErrorCode {
     /// This connection was removed from its room by the room's authority
     /// player. The WebSocket closed with private close code `4007`
     /// (`kicked`); the server never arms reconnection for a kicked seat (a
-    /// configured `ReconnectPolicy` still retries the close like any peer
-    /// close, and on a spec-conformant server the automatic rejoin is
+    /// configured `ReconnectPolicy` retries the close like any peer close
+    /// unless the deployment listed 4007 in
+    /// [`with_terminal_close_codes`](crate::client::ReconnectPolicy::with_terminal_close_codes),
+    /// and on a spec-conformant server the automatic rejoin is
     /// refused in-band).
     Kicked,
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -132,10 +132,13 @@ pub enum SignalFishEvent {
     /// This is a **synthetic event** — it is only emitted when a
     /// [`ReconnectPolicy`](crate::ReconnectPolicy) is configured and its
     /// attempt budget ran out without a successful reconnection. Shutdown,
-    /// a dropped client handle, and
+    /// a dropped client handle, a
     /// [`ProtocolViolationPolicy::Disconnect`](crate::ProtocolViolationPolicy::Disconnect)
-    /// teardowns end the client without attempting reconnection and
-    /// therefore never produce this event.
+    /// teardown, a peer close whose code the policy classifies terminal
+    /// ([`with_terminal_close_codes`](crate::ReconnectPolicy::with_terminal_close_codes)),
+    /// and a teardown whose farewell could not be delivered (the consumer
+    /// wedged past the shutdown budget) all end the client without
+    /// attempting reconnection and therefore never produce this event.
     ReconnectAbandoned {
         /// How many reconnection attempts were made in this episode. `0`
         /// means the policy allowed no attempts at all.

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -964,9 +964,10 @@ pub enum RoomOperationRequest {
     /// seat, broadcasts the usual `PlayerLeft` roster delta to the remaining
     /// members, and closes the target's connection with private close code
     /// 4007 (`kicked`); the server never arms reconnection for a kicked seat
-    /// (a client-side `ReconnectPolicy` still classifies that close as an
-    /// ordinary retryable peer close; on a spec-conformant server the
-    /// automatic rejoin is refused in-band).
+    /// (a client-side `ReconnectPolicy` classifies that close as an ordinary
+    /// retryable peer close unless the deployment listed 4007 in
+    /// [`with_terminal_close_codes`](crate::client::ReconnectPolicy::with_terminal_close_codes);
+    /// on a spec-conformant server the automatic rejoin is refused in-band).
     KickPlayer {
         /// The seated player to remove.
         player_id: PlayerId,

--- a/src/webrtc.rs
+++ b/src/webrtc.rs
@@ -414,7 +414,11 @@ mod controller {
 
         /// Receive the next high-level mesh event. Returns `None` once the
         /// underlying event stream ends (the transport loop exited — client
-        /// shutdown, dropped handle, or an exhausted reconnect policy). At
+        /// shutdown, dropped handle, a `ProtocolViolationPolicy::Disconnect`
+        /// teardown, an exhausted reconnect policy, a peer close classified
+        /// terminal by the policy's `with_terminal_close_codes`, or a
+        /// farewell the consumer never
+        /// drained). At
         /// that boundary the controller clears its session, disconnects every
         /// known driver peer, and becomes fused: later calls also return
         /// `None` without pumping the driver. When this method returns a


### PR DESCRIPTION
## Why

Issue #242: an authority kick (WebSocket close code 4007) is permanent — the server never arms reconnection for a kicked seat — yet a policy-configured client still spent one doomed reconnection round only to be refused in-band. Useful for diagnosing, wasteful for deployments that already know the close is final.

## What changed

- `ReconnectPolicy::with_terminal_close_codes([4007])`: a **peer-initiated close carrying a listed code** now ends the client right after the ordinary `Disconnected` farewell — no `Reconnecting` event, no `ReconnectAbandoned`, attempt budget untouched.
- Matching is deliberately narrow: unlisted codes (notably `4000`, a server going away) keep reconnecting, and a local transport failure can never become a "server verdict". The configured list is normalized (sorted, deduplicated) so config equality reflects the set, not its spelling.
- Default behavior is unchanged: an empty list retries every peer close exactly as before.
- Same-class doc sweep: five other places claimed kicks are "always retried" (`ErrorCode::Kicked` rustdoc, `KickPlayer` rustdoc, the `ReconnectAbandoned` event docs, `docs/events.md`, and the client guide's retryable-edge definition) — all reconciled with the new classifier.

## Verification

- Four paused-clock journey pins (terminal end without retry; 4000 stays retryable with the automatic rejoin still armed; peer-initiation + code gates with the budget path intact; budget skip at `max_attempts(0)`) plus config-equality/normalization/Debug pins.
- Red/green: neutering the classifier fails the end pin; misconfiguring the list fails it too — both probes reverted byte-clean.
- `cargo fmt` + `cargo clippy -D warnings` clean; 1177 tests / 0 failed; rustdoc `-D warnings` clean.
- Round 55 (issue #126): upstream authority drift zero (spec + wire samples byte-identical at the vendored pin); `[Unreleased]` verified truthful against the real v0.12.0→HEAD API diff. Adversarial review loop converged to zero findings.

Closes #242.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes async reconnect teardown classification and public `ReconnectPolicy` surface; misconfigured terminal lists could stop reconnecting when operators expected retries, though default behavior is unchanged.
> 
> **Overview**
> Adds **`ReconnectPolicy::with_terminal_close_codes`** so deployments can treat selected **peer-initiated** WebSocket close codes (e.g. kick **4007**) as **terminal**: after the usual `Disconnected` farewell the async client **stops** instead of emitting `Reconnecting` or spending the attempt budget. **Default is unchanged** — an empty list still retries every peer close.
> 
> Classification is **narrow** (peer-initiated + known code only; unlisted codes like **4000** keep reconnecting). The code list is **normalized** and folded into **`SignalFishConfig` / `ReconnectPolicy` equality and `Debug`**. The transport loop consults close metadata at each retryable teardown edge; transport docs stress recording **`TransportCloseInfo` before `poll_recv` returns `None`** so terminal verdicts are not downgraded to retries.
> 
> Docs, changelog, **`auto_reconnect` example**, and kick-related rustdoc are aligned with the opt-in behavior; **journey tests** cover terminal end, unlisted codes, non-peer closes, and budget skip.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42723d7d8fb133a286a619be8f8f59a24ce85784. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->