### PR TITLE
ci: retry transient TLS failures on workflow downloads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,7 +256,7 @@ jobs:
           set -euo pipefail
           asset="signal-fish-server-v${SERVER_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
           base="https://github.com/Ambiguous-Interactive/signal-fish-server/releases/download/v${SERVER_VERSION}"
-          curl --fail --location --retry 5 --output "${asset}" "${base}/${asset}"
+          curl --fail --location --retry 5 --retry-all-errors --output "${asset}" "${base}/${asset}"
           printf '%s  %s\n' "${SERVER_SHA256}" "${asset}" | sha256sum --check
           mkdir -p .signal-fish-server
           tar -xzf "${asset}" -C .signal-fish-server

--- a/.github/workflows/godot-web.yml
+++ b/.github/workflows/godot-web.yml
@@ -76,11 +76,11 @@ jobs:
           set -euo pipefail
           release="${GODOT_VERSION}-stable"
           base="https://github.com/godotengine/godot/releases/download/${release}"
-          curl --fail --location --retry 5 --output godot.zip \
+          curl --fail --location --retry 5 --retry-all-errors --output godot.zip \
             "${base}/Godot_v${release}_linux.x86_64.zip"
-          curl --fail --location --retry 5 --output templates.tpz \
+          curl --fail --location --retry 5 --retry-all-errors --output templates.tpz \
             "${base}/Godot_v${release}_export_templates.tpz"
-          curl --fail --location --retry 5 --output SHA512-SUMS.txt \
+          curl --fail --location --retry 5 --retry-all-errors --output SHA512-SUMS.txt \
             "${base}/SHA512-SUMS.txt"
           awk -v editor="Godot_v${release}_linux.x86_64.zip" \
             '$2 == editor { print $1, "godot.zip" }' SHA512-SUMS.txt | sha512sum --check
@@ -111,7 +111,7 @@ jobs:
           set -euo pipefail
           asset="signal-fish-server-v${NATIVE_SERVER_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
           base="https://github.com/Ambiguous-Interactive/signal-fish-server/releases/download/v${NATIVE_SERVER_VERSION}"
-          curl --fail --location --retry 5 --output "${asset}" "${base}/${asset}"
+          curl --fail --location --retry 5 --retry-all-errors --output "${asset}" "${base}/${asset}"
           printf '%s  %s\n' "${SERVER_SHA256_080}" "${asset}" | sha256sum --check
           native_fixture=".godot-native-project"
           mkdir -p .signal-fish-native-server "${native_fixture}"
@@ -394,7 +394,7 @@ jobs:
           fi
           asset="signal-fish-server-v${SERVER_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
           base="https://github.com/Ambiguous-Interactive/signal-fish-server/releases/download/v${SERVER_VERSION}"
-          curl --fail --location --retry 5 --output "${asset}" "${base}/${asset}"
+          curl --fail --location --retry 5 --retry-all-errors --output "${asset}" "${base}/${asset}"
           printf '%s  %s\n' "${server_sha256}" "${asset}" | sha256sum --check
           mkdir -p .signal-fish-server
           tar -xzf "${asset}" -C .signal-fish-server
@@ -462,7 +462,7 @@ jobs:
             if [ ! -x "${built_tc}" ] \
               || ! "${built_tc}" -Version 2>/dev/null | grep -F "iproute2-${IPROUTE2_VERSION}"; then
               sudo apt-get install --yes bison build-essential flex pkg-config
-              curl --fail --location --silent --show-error \
+              curl --fail --location --silent --show-error --retry 5 --retry-all-errors \
                 "https://www.kernel.org/pub/linux/utils/net/iproute2/${archive}" \
                 --output "${archive}"
               echo "${IPROUTE2_SHA256}  ${archive}" | sha256sum --check


### PR DESCRIPTION
## Why

Main's Browser E2E (soak) lane failed 43 seconds in with curl exit 35 (SSL connect error) while downloading the pinned server. `curl --retry` deliberately does not retry TLS handshake errors, so the configured five retries never ran — one transient network blip killed the lane.

## What changed

- `--retry-all-errors` on all seven workflow download sites (Godot editor zip, templates, SHA sums, pinned server releases ×3, iproute2 tarball), so the existing `--retry 5` budget covers the entire transient-error class.
- `protocol-sync.yml`'s raw fetches stay un-retried on purpose: that job is a fail-loud weekly probe.

## Verification

- `scripts/check-workflows.sh` all phases PASS; `ci_config_tests` 237/237.
- RCA evidence: the failing job produced no logs (artifact upload found nothing) and died before the fixture started — pure setup/download failure, not a soak regression.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only curl flag changes with no application code or security logic changes; post-download sha256/sha512 checks still enforce artifact integrity.
> 
> **Overview**
> CI setup steps were failing on **one-shot curl SSL/TLS errors** (e.g. exit 35) even with `--retry 5`, because curl does not retry those failures unless **`--retry-all-errors`** is set.
> 
> This PR adds **`--retry-all-errors`** to pinned-asset downloads in **`ci.yml`** (Signal Fish server tarball for server-mesh E2E) and **`godot-web.yml`** (Godot editor, export templates, SHA512 sums, Signal Fish server tarballs in native smoke and browser scenarios). The **iproute2** tarball fetch in the netem path now also gets **`--retry 5 --retry-all-errors`**, where it previously had no retry budget. **Checksum verification after download is unchanged**, so integrity gates stay the same; only transient network/TLS flakiness during fetch should be absorbed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8798ae56ee1a891bc8460d9e64a7982004c7e750. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->