### PR TITLE
Round 59: authority/relay wire fixtures; CI cache savings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,6 +251,11 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
       - name: Cache Cargo artifacts
         uses: Swatinem/rust-cache@v2.9.2
+        with:
+          # All 15 cells compile byte-identical inputs and already share the
+          # job-id-keyed restore scope; saving from every cell would upload
+          # 15 near-identical archives. Only the first cell saves.
+          save-if: ${{ strategy.job-index == 0 }}
       - name: Download pinned Signal Fish server
         run: |
           set -euo pipefail

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -4,7 +4,9 @@
 # the report as an artifact for trend tracking.
 #
 # Runs on every push to main and every PR for continuous tracking. Scheduled
-# weekdays at 03:00 UTC — staggered before deep-safety at 04:00.
+# Mondays at 03:00 UTC — staggered before the deep-safety slot; the gate
+# itself already measures every PR and push, so the scheduled run is trend
+# telemetry only and does not need a daily cadence.
 
 name: Coverage
 
@@ -13,8 +15,8 @@ on:
     branches: [main]
   pull_request:
   schedule:
-    # Weekdays at 03:00 UTC — staggered before deep-safety at 04:00
-    - cron: "0 3 * * 1-5"
+    # Mondays at 03:00 UTC — staggered before deep-safety's 04:00 slot
+    - cron: "0 3 * * 1"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/godot-web.yml
+++ b/.github/workflows/godot-web.yml
@@ -67,6 +67,10 @@ jobs:
         uses: emscripten-core/setup-emsdk@v16
         with:
           version: ${{ env.EMSDK_VERSION }}
+          # One emsdk cache shared with wasm.yml (both pin 3.1.74): the
+          # default cache key is per-workflow, so either workflow could
+          # cold-download after its own scope was evicted.
+          cache-key: emsdk-${{ env.EMSDK_VERSION }}-${{ runner.os }}-${{ runner.arch }}
 
       - name: Cache Cargo artifacts
         uses: Swatinem/rust-cache@v2.9.2
@@ -82,7 +86,21 @@ jobs:
             tests/godot-web-smoke/target
             tests/godot-compat-min/target
 
+      - name: Restore pinned Godot editor and templates
+        id: godot-cache
+        uses: actions/cache@v6.1.0
+        with:
+          path: |
+            .godot
+            ~/.local/share/godot/export_templates/${{ env.GODOT_VERSION }}.stable
+          key: godot-editor-${{ runner.os }}-${{ runner.arch }}-${{ env.GODOT_VERSION }}-stable
+        # Trust boundary: identical to the netem tc cache — the restored
+        # editor and export templates are SHA512-SUMS-verified artifacts of a
+        # same-repo branch run (fork PRs cannot write caches). The ~1 GB
+        # download and its checksum verification apply only on cache misses.
+
       - name: Install official Godot editor and templates
+        if: steps.godot-cache.outputs.cache-hit != 'true'
         run: |
           set -euo pipefail
           release="${GODOT_VERSION}-stable"

--- a/.github/workflows/portability.yml
+++ b/.github/workflows/portability.yml
@@ -3,10 +3,13 @@
 # Weekly scheduled `cargo check` lanes for the desktop targets that round 51
 # verified by hand (Windows MSVC and macOS ARM64), so a Windows-only or
 # macOS-only compile break surfaces within seven days instead of at the next
-# cross-platform session audit. Scheduled only, by design: per-PR Windows or
-# macOS runners would contradict the measured CI-cost policy (issue #225) for
-# a regression class that has never failed. Promotion to a required check
-# additionally needs the ruleset plumbing in `.github/required-checks.json`.
+# cross-platform session audit. The lanes also run on manifest-touching PRs
+# (hosted ubuntu cross-checks only — per-PR Windows or macOS runners would
+# contradict the measured CI-cost policy (issue #225)). A rust-cache step
+# keeps each run's dependency builds warm within its branch scope (GitHub
+# isolates PR caches from scheduled main runs). Promotion to a required
+# check additionally needs the ruleset plumbing in
+# `.github/required-checks.json`.
 #
 # The opt-in `tls` feature's `ring` needs the target C toolchain, so lanes
 # run the max NON-crypto feature set and leave `tls` to upstream ring
@@ -74,6 +77,19 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
+
+      - name: Cache Cargo artifacts
+        uses: Swatinem/rust-cache@v2.9.2
+        with:
+          # All four cells share the job-id-keyed restore scope, but only
+          # the first cell (windows-msvc × workspace default) saves, so the
+          # warm archive carries the shared registry plus that cell's
+          # dependency artifacts; every other cell — including the other
+          # target — rebuilds its own feature/target-specific deps. That is
+          # still strictly faster than today's fully cold builds, and a
+          # cold or pruned cache only costs time: cargo fingerprints decide
+          # what rebuilds, never what passes.
+          save-if: ${{ strategy.job-index == 0 }}
 
       - name: Check workspace compiles for target
         run: cargo check ${{ matrix.cell.flags }} --all-targets --locked --target ${{ matrix.target }}

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -46,6 +46,11 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
+  # Matched to the Godot 4.5 web export toolchain (godot-web.yml pins the
+  # same version): the tier-3 wasm32-unknown-emscripten -Zbuild-std link
+  # flags are emsdk-version-sensitive. Upgrade only after a green probe
+  # (issue #201).
+  EMSDK_VERSION: "3.1.74"
 
 jobs:
   wasm:
@@ -98,10 +103,11 @@ jobs:
       - name: Install Emscripten SDK
         uses: emscripten-core/setup-emsdk@v16
         with:
-          # Matched to the Godot 4.5 web export toolchain; the tier-3
-          # wasm32-unknown-emscripten -Zbuild-std link flags are
-          # emsdk-version-sensitive. Upgrade only after a green probe (issue #201).
-          version: 3.1.74
+          version: ${{ env.EMSDK_VERSION }}
+          # One emsdk cache shared with godot-web.yml (both pin the same
+          # version): the default cache key is per-workflow, so either
+          # workflow could cold-download after its own scope was evicted.
+          cache-key: emsdk-${{ env.EMSDK_VERSION }}-${{ runner.os }}-${{ runner.arch }}
       - name: Cache Cargo artifacts
         uses: Swatinem/rust-cache@v2.9.2
       - name: Validate Emscripten FFI safety policy

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -50,8 +50,11 @@ jobs:
           curl --fail --location --retry 5 --retry-all-errors --output "${asset}" "${base}/${asset}"
           printf '%s  %s\n' "${ACTIONLINT_SHA256}" "${asset}" | sha256sum --check
           tar -xzf "${asset}" actionlint
+          mkdir -p "${HOME}/.local/bin"
           install -m 0755 actionlint "${HOME}/.local/bin/actionlint"
-          "${HOME}/.local/bin/actionlint" --version | grep -Fx "${ACTIONLINT_VERSION}"
+          # The installed binary must self-report the pinned version
+          # (substring match: wrong-version installs cannot contain it).
+          "${HOME}/.local/bin/actionlint" --version | grep -F "${ACTIONLINT_VERSION}"
 
       - name: Run actionlint
         run: '"${HOME}/.local/bin/actionlint" -color'

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -36,18 +36,25 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up Go
-        uses: actions/setup-go@v7.0.0
-        with:
-          go-version: stable
-          cache: false
-
-      - name: Install actionlint
-        # Pinned version — bump manually; not covered by Dependabot
-        run: go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.7
+      - name: Download checksum-verified actionlint binary
+        env:
+          # Pinned version + digest — bump manually; go-module installs are
+          # not covered by Dependabot, and a release binary skips the ~1 min
+          # compile-from-source of the previous `go install` step.
+          ACTIONLINT_VERSION: "1.7.7"
+          ACTIONLINT_SHA256: "023070a287cd8cccd71515fedc843f1985bf96c436b7effaecce67290e7e0757"
+        run: |
+          set -euo pipefail
+          asset="actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          base="https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}"
+          curl --fail --location --retry 5 --retry-all-errors --output "${asset}" "${base}/${asset}"
+          printf '%s  %s\n' "${ACTIONLINT_SHA256}" "${asset}" | sha256sum --check
+          tar -xzf "${asset}" actionlint
+          install -m 0755 actionlint "${HOME}/.local/bin/actionlint"
+          "${HOME}/.local/bin/actionlint" --version | grep -Fx "${ACTIONLINT_VERSION}"
 
       - name: Run actionlint
-        run: actionlint -color
+        run: '"${HOME}/.local/bin/actionlint" -color'
 
   # ──────────────────────────────────────────────────────────────
   # yamllint — validate YAML style and syntax of workflow files

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -757,17 +757,36 @@ mod godot_issue_61_policy {
     fn wasm_lanes_share_one_pinned_emsdk_version() {
         // Both wasm lanes link against Godot 4.5's emsdk-sensitive export
         // toolchain; a one-sided bump would silently split the toolchains.
+        // Each workflow declares its pin once (env `EMSDK_VERSION`) and the
+        // setup-emsdk step references it.
         let godot_web = read_project_file(".github/workflows/godot-web.yml");
         let wasm = read_project_file(".github/workflows/wasm.yml");
         let godot_version = godot_web
             .lines()
             .find_map(|line| line.trim().strip_prefix("EMSDK_VERSION: \""))
             .and_then(|rest| rest.split('"').next())
-            .expect("godot-web.yml must pin EMSDK_VERSION");
-        assert!(
-            wasm.contains(&format!("version: {godot_version}")),
-            "wasm.yml must pin the same emsdk version as godot-web.yml ({godot_version})"
-        );
+            .expect("godot-web.yml must pin EMSDK_VERSION")
+            .to_owned();
+        for (name, workflow) in [("godot-web.yml", godot_web), ("wasm.yml", wasm)] {
+            let shared_pin = format!("EMSDK_VERSION: \"{godot_version}\"");
+            assert!(
+                workflow.lines().any(|line| line.trim() == shared_pin),
+                "{name} must declare the shared emsdk pin EMSDK_VERSION: \"{godot_version}\" \
+                 so neither lane can silently split the toolchain"
+            );
+            assert!(
+                workflow.contains("version: ${{ env.EMSDK_VERSION }}"),
+                "{name} must install emsdk from the pinned EMSDK_VERSION env"
+            );
+            assert!(
+                workflow.lines().any(|line| {
+                    line.trim() == "cache-key: emsdk-${{ env.EMSDK_VERSION }}-${{ runner.os }}-${{ runner.arch }}"
+                }),
+                "{name} must share the exact version-pinned emsdk cache key \
+                 with the other wasm lane; a divergent key silently un-shares \
+                 the cache and lets either lane cold-download"
+            );
+        }
     }
 
     #[test]
@@ -1636,6 +1655,68 @@ mod workflow_cache_and_download_hardening {
                     && line.contains("${{ env.IPROUTE2_VERSION }}")),
             "the netem tc cache key must include the pinned IPROUTE2_VERSION"
         );
+        assert!(
+            godot_web
+                .lines()
+                .any(|line| line.contains("key: godot-editor-")
+                    && line.contains("${{ env.GODOT_VERSION }}")),
+            "the Godot editor/templates cache key must include the pinned \
+             GODOT_VERSION so a bump cannot keep restoring the old editor"
+        );
+    }
+
+    /// The 15 e2e cells compile byte-identical inputs inside one job, so
+    /// rust-cache already shares a job-id-keyed restore scope across the
+    /// matrix; saving from every cell would only upload near-identical
+    /// archives. The rust-cache step inside each such shared-scope job must
+    /// therefore save from the first cell only. (The clippy/test matrices
+    /// are deliberately excluded: their cells build different feature sets
+    /// into one shared scope, so first-cell-only saving would drop the
+    /// other cells' artifacts. Portability qualifies because a pruned cache
+    /// only ever costs rebuild time there — cargo fingerprints decide what
+    /// rebuilds, never what passes.)
+    #[test]
+    fn matrix_shared_caches_save_from_one_cell_only() {
+        for (name, path, job_header) in [
+            (
+                "the Server compatibility E2E matrix",
+                ".github/workflows/ci.yml",
+                "  server-mesh-e2e:",
+            ),
+            (
+                "the Portability check matrix",
+                ".github/workflows/portability.yml",
+                "  check:",
+            ),
+        ] {
+            let workflow = read_project_file(path);
+            let lines: Vec<&str> = workflow.lines().collect();
+            let job_start = lines
+                .iter()
+                .position(|line| *line == job_header)
+                .unwrap_or_else(|| panic!("{name}: could not locate its matrix job block"));
+            // Cut the block at the next top-level job header (a line indented
+            // exactly two spaces followed by a non-space character) so a
+            // later job's rust-cache step cannot satisfy this pin.
+            let job_end = lines[job_start + 1..]
+                .iter()
+                .position(|line| {
+                    line.starts_with("  ") && !line.starts_with("   ") && !line.trim().is_empty()
+                })
+                .map(|offset| job_start + 1 + offset)
+                .unwrap_or(lines.len());
+            let job_block = lines[job_start..job_end].join("\n");
+            assert!(
+                job_block.contains("uses: Swatinem/rust-cache@"),
+                "{name}: its matrix job must cache Cargo artifacts with rust-cache"
+            );
+            assert!(
+                job_block.contains("save-if: ${{ strategy.job-index == 0 }}"),
+                "{name}: its rust-cache step must save from the first cell \
+                 only (save-if: ${{{{ strategy.job-index == 0 }}}}); per-cell \
+                 saves race near-identical uploads"
+            );
+        }
     }
 
     /// The #245 hardening: curl exit 35 (TLS handshake) is non-transient to

--- a/tests/wire_golden_tests.rs
+++ b/tests/wire_golden_tests.rs
@@ -394,6 +394,43 @@ fn spectator_server_wire_fixtures_conform() {
     assert_conformance::<ServerMessage>("spectator-server-fixtures", SPECTATOR_SERVER_MESSAGES);
 }
 
+/// Hand-built authority/relay/reconnect server-message wire fixtures.
+///
+/// The upstream server publishes no `AuthorityChanged`, `RelayStats`,
+/// `PlayerReconnected`, `RoomJoinFailed`, or v3 `PlayerLeft` sample lines, so
+/// the vendored `.jsonl` corpus is blind to every one of those frames: a serde
+/// shape drift there could only ever surface on a live server (network-gated)
+/// or through mock frames the test suite built itself from the same types
+/// under test — the exact blindness class the spectator fixtures above closed
+/// for the spectator lifecycle.
+///
+/// These fixtures are hand-built to the **vendored AsyncAPI authority**
+/// (`tests/server-spec/signal-fish-protocol.asyncapi.yaml`, checksum-pinned):
+/// `AuthorityChanged` (peer/you/`null`-vacated authority), `RelayStats`
+/// (cumulative counters), `PlayerReconnected` (v2 epoch-less and v3 `epoch`
+/// faces), `PlayerLeft` (v3 terminal-watermark face), `RoomJoinFailed` (with
+/// and without the schema-optional `error_code`), and the spectator
+/// fan-out-slimming v3 faces (`current_spectators: []` + `spectator_count`).
+/// Every line must deserialize into `ServerMessage` and round-trip to a
+/// semantically identical JSON object, exactly like the complete v3 samples.
+#[test]
+fn authority_relay_reconnect_server_wire_fixtures_conform() {
+    const SERVER_MESSAGES: &str = r#"
+{"type": "AuthorityChanged", "data": {"authority_player": "00000000-0000-0000-0000-00000000000b", "you_are_authority": false}}
+{"type": "AuthorityChanged", "data": {"authority_player": "00000000-0000-0000-0000-00000000000a", "you_are_authority": true}}
+{"type": "AuthorityChanged", "data": {"authority_player": null, "you_are_authority": false}}
+{"type": "RelayStats", "data": {"interval_ms": 5000, "sent_to_you": 1234, "dropped_for_you": 0, "backpressure_events": 2}}
+{"type": "PlayerReconnected", "data": {"player_id": "00000000-0000-0000-0000-00000000000a"}}
+{"type": "PlayerReconnected", "data": {"player_id": "00000000-0000-0000-0000-00000000000a", "epoch": 2}}
+{"type": "PlayerLeft", "data": {"player_id": "00000000-0000-0000-0000-00000000000a", "epoch": 1, "final_seq": 42}}
+{"type": "RoomJoinFailed", "data": {"reason": "room is full", "error_code": "ROOM_FULL"}}
+{"type": "RoomJoinFailed", "data": {"reason": "room not found"}}
+{"type": "NewSpectatorJoined", "data": {"spectator": {"id": "00000000-0000-0000-0000-0000000000c2", "name": "Second", "connected_at": "2024-01-02T03:06:08Z"}, "current_spectators": [], "reason": "joined", "spectator_count": 3}}
+{"type": "SpectatorDisconnected", "data": {"spectator_id": "00000000-0000-0000-0000-0000000000c2", "reason": "disconnected", "current_spectators": [], "spectator_count": 0}}
+"#;
+    assert_conformance::<ServerMessage>("authority-relay-reconnect-fixtures", SERVER_MESSAGES);
+}
+
 /// The `fuzz_binary_game_data` seed corpus must stay decodable.
 ///
 /// The fuzz target keeps two canonical envelopes inline; the seed files under


### PR DESCRIPTION
## Why

Round 59 of the recurring correctness audit (#126), driven by this session's GOAL: CI time must not increase — ideally decrease — without reducing test coverage.

Two real gaps surfaced:

1. **Detection hole.** The vendored wire corpus has no sample lines for `AuthorityChanged`, `RelayStats`, `PlayerReconnected`, `RoomJoinFailed`, or v3 `PlayerLeft` — a serde shape drift in any of those frames could only ever surface on a live server, because every in-repo test fed frames built from the same types under test.
2. **Wasted CI minutes.** The main-push critical path (Godot Web, 12.2 m mean) re-downloads ~1 GB of pinned Godot editor + export templates every run; the 15-cell e2e matrix and 4-cell portability matrix each upload near-identical rust-cache archives from every cell; Workflow Lint compiled actionlint from source on every run.

Upstream check: the server advanced two internal-fix commits past our vendored pin, but the spec and all four wire-sample files re-verified **byte-identical** from a fresh clone — no protocol change, no incorporation.

## How

**Detection (11 new authority-derived fixtures):** a `wire_golden_tests.rs` test pins hand-built lines taken from the checksum-pinned AsyncAPI spec through full deserialize + round-trip conformance — `AuthorityChanged` (peer / you / null-vacated), `RelayStats`, `PlayerReconnected` v2+v3, `PlayerLeft` v3 watermark, `RoomJoinFailed` ± `error_code`, and both spectator fan-out-slimming faces. Red/green-proven against serde-skip and serde-default drifts.

**CI time (all coverage preserved — tests 240→241, wire fixtures 11→12, every matrix cell and required aggregate untouched):**
- Cache the pinned Godot editor + templates (SHA512-verified download only on cache miss) — sits directly on the critical path.
- One shared, version-pinned emsdk cache key across `wasm.yml` + `godot-web.yml`.
- First-cell-only rust-cache saves for the e2e and portability matrices (they already share one restore scope).
- rust-cache for portability's four cross-target cells (the only cargo job without one).
- actionlint 1.7.7 as a digest-pinned release binary instead of a per-run `go install` compile.
- Scheduled Coverage trend runs weekly (the gate still measures every PR and push).

Audit honesty: three tempting cuts were **refused** with evidence — security-job rust-cache is required by the lockfile-verification pin; setup-emsdk already caches by default; the docs job's floating nightly is the faithful docs.rs simulation.

## Verification

- Mandatory workflow green (fmt / clippy `-D warnings` / full test suite).
- Hostile reviewer + convergence verifier converged to zero blocking findings (the reviewer's one MAJOR — a version grep that could never match — was caught and fixed before push).
- ci_config pins extended and red/green-proven; `check-workflows.sh`, actionlint, and the new download step all validated locally with exact CI commands.

Changelog: no entries — all changes are internal (CI + tests) per policy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI workflows and test fixtures; no production runtime or auth/data-path behavior is modified.
> 
> **Overview**
> Adds **11 hand-built server wire golden fixtures** for message types missing from the vendored corpus (`AuthorityChanged`, `RelayStats`, `PlayerReconnected`, v3 `PlayerLeft`, `RoomJoinFailed`, and slim spectator fan-out shapes), with a new conformance test that deserializes and round-trips them like existing spectator pins.
> 
> **CI time reductions** without dropping matrix coverage: caches the pinned Godot editor and export templates (download + SHA512 verify only on miss); shares a version-pinned **emsdk** cache key between `wasm.yml` and `godot-web.yml` (with `EMSDK_VERSION` declared once per workflow); limits **rust-cache** uploads to the first matrix cell for the 15-cell server E2E job and the portability cross-target job, and adds rust-cache to portability; installs **actionlint** from a digest-pinned release binary instead of compiling via `go install`; runs scheduled **Coverage** weekly on Mondays instead of every weekday.
> 
> **Policy tests** in `ci_config_tests.rs` now enforce the shared emsdk pin/cache key, Godot cache key versioning, and first-cell-only rust-cache saves for those matrices.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8372e79fc94eeaa2bed9c687cbf5edd070e67ca2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->