### PR TITLE
Round 60: close the GameDataBinary wire-face detection hole

### DIFF
--- a/tests/error_code_conformance_tests.rs
+++ b/tests/error_code_conformance_tests.rs
@@ -256,6 +256,35 @@ fn compatibility_only_error_codes_match_the_public_marker() {
     assert_eq!(public, expected);
 }
 
+/// The compatibility-only tokens must also parse back from their literals.
+///
+/// These tokens are absent from the vendored spec, so the spec-scan
+/// deserialize test never feeds them; the marker test above pins only the
+/// serialize direction. Older deployments can still emit them, so the
+/// retained contract is bidirectional: each literal must deserialize into
+/// exactly its documented variant (a serde rename drift on the parse side
+/// would strand an old server's `Error` frame undecodable).
+#[test]
+fn compatibility_only_error_codes_parse_from_their_wire_tokens() {
+    let pairs: &[(&str, ErrorCode)] = &[
+        ("INVALID_TOKEN", ErrorCode::InvalidToken),
+        ("AUTHENTICATION_REQUIRED", ErrorCode::AuthenticationRequired),
+        ("APP_ID_EXPIRED", ErrorCode::AppIdExpired),
+        ("APP_ID_REVOKED", ErrorCode::AppIdRevoked),
+        ("APP_ID_SUSPENDED", ErrorCode::AppIdSuspended),
+        ("SERVICE_UNAVAILABLE", ErrorCode::ServiceUnavailable),
+    ];
+    assert_eq!(pairs.len(), CLIENT_ONLY_ALLOWLIST.len());
+    for (token, expected) in pairs {
+        let parsed: ErrorCode =
+            serde_json::from_str(&format!("\"{token}\"")).unwrap_or_else(|error| {
+                panic!("compatibility token {token} must deserialize: {error}")
+            });
+        assert_eq!(&parsed, expected, "{token} must parse into its variant");
+        assert_eq!(&wire_token(&parsed), token);
+    }
+}
+
 #[test]
 fn every_server_error_code_token_deserializes_into_a_client_variant() {
     let tokens = extract_spec_error_tokens();

--- a/tests/wire_golden_tests.rs
+++ b/tests/wire_golden_tests.rs
@@ -408,9 +408,12 @@ fn spectator_server_wire_fixtures_conform() {
 /// (`tests/server-spec/signal-fish-protocol.asyncapi.yaml`, checksum-pinned):
 /// `AuthorityChanged` (peer/you/`null`-vacated authority), `RelayStats`
 /// (cumulative counters), `PlayerReconnected` (v2 epoch-less and v3 `epoch`
-/// faces), `PlayerLeft` (v3 terminal-watermark face), `RoomJoinFailed` (with
-/// and without the schema-optional `error_code`), and the spectator
-/// fan-out-slimming v3 faces (`current_spectators: []` + `spectator_count`).
+/// faces), `PlayerLeft` (v3 terminal-watermark face and the bare v2
+/// top-level face), `RoomJoinFailed` (with and without the schema-optional
+/// `error_code`), the spectator fan-out-slimming v3 faces
+/// (`current_spectators: []` + `spectator_count`), the granted
+/// `AuthorityResponse` face (`reason` schema-required, nullable), and the
+/// `GoingAway` advisory with the optional `retry_after_secs` omitted.
 /// Every line must deserialize into `ServerMessage` and round-trip to a
 /// semantically identical JSON object, exactly like the complete v3 samples.
 #[test]
@@ -427,8 +430,151 @@ fn authority_relay_reconnect_server_wire_fixtures_conform() {
 {"type": "RoomJoinFailed", "data": {"reason": "room not found"}}
 {"type": "NewSpectatorJoined", "data": {"spectator": {"id": "00000000-0000-0000-0000-0000000000c2", "name": "Second", "connected_at": "2024-01-02T03:06:08Z"}, "current_spectators": [], "reason": "joined", "spectator_count": 3}}
 {"type": "SpectatorDisconnected", "data": {"spectator_id": "00000000-0000-0000-0000-0000000000c2", "reason": "disconnected", "current_spectators": [], "spectator_count": 0}}
+{"type": "PlayerLeft", "data": {"player_id": "00000000-0000-0000-0000-00000000000a"}}
+{"type": "AuthorityResponse", "data": {"granted": true, "reason": null}}
+{"type": "GoingAway", "data": {"deadline_ms": 1730000000000}}
 "#;
     assert_conformance::<ServerMessage>("authority-relay-reconnect-fixtures", SERVER_MESSAGES);
+}
+
+/// Hand-built `GameDataBinary` JSON wire fixtures.
+///
+/// The vendored `.jsonl` corpus carries **no** `"type": "GameDataBinary"`
+/// line: the AsyncAPI authority models the message's transport face as the
+/// raw MessagePack envelope (`contentType: application/msgpack`), so no
+/// sample exercises the typed variant's serde shape. The only prior
+/// coverage was self-referential `serde_bytes` round-trips — a payload
+/// face, encoding-token, or optional-`seq`/`epoch` drift passed the entire
+/// suite. Both faces the authority's envelope schemas define are pinned: the
+/// v3 face with delivery stamps and the minimal (pre-v3, stamp-less) face.
+/// (The authority's transport face for this message is msgpack-only; these
+/// lines pin the typed variant's JSON serde face, whose field vocabulary
+/// the schemas prescribe.)
+#[test]
+fn binary_game_data_server_wire_fixtures_conform() {
+    const GAME_DATA_BINARY_SERVER_MESSAGES: &str = r#"
+{"type": "GameDataBinary", "data": {"from_player": "00000000-0000-0000-0000-00000000000a", "encoding": "json", "payload": [104, 105], "seq": 42, "epoch": 1}}
+{"type": "GameDataBinary", "data": {"from_player": "00000000-0000-0000-0000-00000000000a", "encoding": "message_pack", "payload": [104, 105]}}
+"#;
+    assert_conformance::<ServerMessage>(
+        "binary-game-data-fixtures",
+        GAME_DATA_BINARY_SERVER_MESSAGES,
+    );
+}
+
+/// The v2-dialect client-message floor must parse from hand-built wire
+/// lines.
+///
+/// The vendored v2 client samples are illustrative placeholders that the
+/// corpus tests only check for JSON validity (`assert_structural`), so
+/// `AuthorityRequest`, `PlayerReady`, `ProvideConnectionInfo`, and `Ping`
+/// had no wire-shaped deserialize coverage — only struct round-trips built
+/// from the types under test. These lines are the authority's complete v2
+/// shapes: the no-payload schemas (`Ping`, `PlayerReady`) require only the
+/// `type` tag (our serializer likewise omits `data`; the tolerant
+/// `"data": null` input face is a serde detail, not the pinned wire form),
+/// and `ProvideConnectionInfo` wraps an internally-tagged `direct` info
+/// object.
+#[test]
+fn v2_client_message_wire_fixtures_conform() {
+    const V2_CLIENT_MESSAGES: &str = r#"
+{"type": "AuthorityRequest", "data": {"become_authority": true}}
+{"type": "PlayerReady"}
+{"type": "Ping"}
+{"type": "ProvideConnectionInfo", "data": {"connection_info": {"type": "direct", "host": "127.0.0.1", "port": 7777}}}
+"#;
+    assert_conformance::<ClientMessage>("v2-client-fixtures", V2_CLIENT_MESSAGES);
+}
+
+/// The binary game-data envelopes must decode from hand-assembled bytes.
+///
+/// The fuzz seed corpus and every prior test built envelopes with this
+/// repository's own encoder, so a decoder/encoder co-drift (both faces
+/// moving together) was invisible. These goldens are assembled by hand from
+/// the checksum-pinned authority's envelope schemas
+/// (`V2BinaryGameDataEnvelope` / `V3BinaryGameDataEnvelope`): fixmap
+/// headers, `bin8` UUID/payload fields, the string encoding tokens, and
+/// minimal-width integer stamps. The third face deliberately uses
+/// non-minimal encodings (`map16`, `bin16`, `uint32`, `uint16`) to pin the
+/// decoder's documented "type-level shape, not minimal-length" tolerance.
+#[test]
+fn binary_game_data_envelopes_decode_from_hand_assembled_bytes() {
+    use signal_fish_client::protocol::{
+        decode_v2_binary_game_data, decode_v3_binary_game_data, GameDataEncoding,
+    };
+
+    fn from_hex(segments: &[&str]) -> Vec<u8> {
+        segments
+            .concat()
+            .as_bytes()
+            .chunks(2)
+            .map(|pair| {
+                assert_eq!(pair.len(), 2, "golden hex must have paired digits");
+                let high = (pair[0] as char).to_digit(16).expect("hex digit");
+                let low = (pair[1] as char).to_digit(16).expect("hex digit");
+                (high * 16 + low) as u8
+            })
+            .collect()
+    }
+
+    let player = "00000000-0000-0000-0000-00000000000a";
+
+    // fixmap(3) { "from_player": bin8(uuid), "encoding": "message_pack",
+    //             "payload": bin8("hi") }
+    let v2 = from_hex(&[
+        "83",                                   // fixmap(3)
+        "AB66726F6D5F706C61796572",             // "from_player"
+        "C4100000000000000000000000000000000A", // bin8 uuid
+        "A8656E636F64696E67",                   // "encoding"
+        "AC6D6573736167655F7061636B",           // "message_pack"
+        "A77061796C6F6164",                     // "payload"
+        "C4026869",                             // bin8("hi")
+    ]);
+    let v2_frame = decode_v2_binary_game_data(&v2).expect("hand-assembled v2 envelope must decode");
+    assert_eq!(v2_frame.from_player.to_string(), player);
+    assert_eq!(v2_frame.encoding, GameDataEncoding::MessagePack);
+    assert_eq!(v2_frame.payload, b"hi");
+
+    // fixmap(5) { "from_player": bin8(uuid), "encoding": "json",
+    //             "payload": bin8("hi"), "seq": 42, "epoch": 1 }
+    let v3 = from_hex(&[
+        "85",                                   // fixmap(5)
+        "AB66726F6D5F706C61796572",             // "from_player"
+        "C4100000000000000000000000000000000A", // bin8 uuid
+        "A8656E636F64696E67",                   // "encoding"
+        "A46A736F6E",                           // "json"
+        "A77061796C6F6164",                     // "payload"
+        "C4026869",                             // bin8("hi")
+        "A3736571",                             // "seq"
+        "2A",                                   // 42
+        "A565706F6368",                         // "epoch"
+        "01",                                   // 1
+    ]);
+    let v3_frame = decode_v3_binary_game_data(&v3).expect("hand-assembled v3 envelope must decode");
+    assert_eq!(v3_frame.from_player.to_string(), player);
+    assert_eq!(v3_frame.encoding, GameDataEncoding::Json);
+    assert_eq!(v3_frame.payload, b"hi");
+    assert_eq!(v3_frame.seq, 42);
+    assert_eq!(v3_frame.epoch, 1);
+
+    // The same v3 envelope in deliberately non-minimal widths:
+    // map16(5), bin16 UUID, uint32 seq, uint16 epoch.
+    let v3_wide = from_hex(&[
+        "DE0005",                                 // map16(5)
+        "AB66726F6D5F706C61796572",               // "from_player"
+        "C500100000000000000000000000000000000A", // bin16 uuid
+        "A8656E636F64696E67",                     // "encoding"
+        "A46A736F6E",                             // "json"
+        "A77061796C6F6164",                       // "payload"
+        "C4026869",                               // bin8("hi")
+        "A3736571",                               // "seq"
+        "CE0000002A",                             // uint32 42
+        "A565706F6368",                           // "epoch"
+        "CD0001",                                 // uint16 1
+    ]);
+    let wide_frame =
+        decode_v3_binary_game_data(&v3_wide).expect("non-minimal-width v3 envelope must decode");
+    assert_eq!(wide_frame, v3_frame);
 }
 
 /// The `fuzz_binary_game_data` seed corpus must stay decodable.


### PR DESCRIPTION
## Summary

Round 60 of the recurring correctness audit (#126). Tests-only diff — zero production changes.

**Why:** a fresh wire-coverage matrix found the last detection hole in the wire corpus: `GameDataBinary` had **no wire-shaped decode input anywhere** (no sample line, no fixture — only round-trips through the types under test, and the msgpack fuzz seeds were produced by the same encoder as the decoder under test). A serde or decoder drift there could only ever surface on a live server.

## What

- **`GameDataBinary` wire faces** (`tests/wire_golden_tests.rs`): hand-built JSON lines (v3 stamped + minimal) under the strict deserialize + semantic round-trip helper, plus **hand-assembled MessagePack goldens** (v2 3-field, v3 5-field, and a deliberately non-minimal-width face pinning the decoder's documented map16/bin16/uint32/uint16 tolerance) decoded through the public strict decoders.
- **Compatibility-only error codes** (`tests/error_code_conformance_tests.rs`): the six tokens older servers may still send now have parse-direction pins (exact variant + token identity); previously serialize-only.
- **Residual authority faces**: bare v2 `PlayerLeft`, granted `AuthorityResponse` (`reason: null`), `GoingAway` with omitted `retry_after_secs`, and the four v2-floor client messages (`AuthorityRequest`, `PlayerReady`, `Ping`, `ProvideConnectionInfo`) moved from structural-sample-only to strict wire-shape pins.

## Evidence

- Upstream authority drift: **zero** — all five vendored files byte-identical at upstream HEAD; pin unchanged; #222 remains blocked upstream.
- CI time (GOAL constraint): **no increase** — tests-only (+178/−3, suite wall +≈0.02s). Step-level API audit of the round-59 changes: the Godot editor cache seeded on main and pays out from the next push; five further reduction candidates measured and refused with mechanism evidence (documented in the session log).
- Red/green probes (all RED → revert → GREEN): encoding-token rename, corrupted msgpack stamp byte, compat-code serde rename.
- Review loop: hostile reviewer independently decoded all hex goldens and verified every doc claim against the vendored authority (0 MAJOR / 0 MINOR / 3 NIT — two fixed); convergence verifier re-probed five fresh angles and re-ran all gates (1192 tests / 0 failed). Converged at zero findings.

No changelog entry (tests are not user-visible, per policy).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only additions; no runtime, auth, or protocol implementation changes.
> 
> **Overview**
> **Tests-only** wire-conformance hardening (no production code changes). The main gap closed is **`GameDataBinary`**: hand-built JSON fixtures now run through strict deserialize + semantic round-trip, and **hand-assembled MessagePack goldens** exercise `decode_v2_binary_game_data` / `decode_v3_binary_game_data` independently of the repo encoder—including a non-minimal-width v3 envelope to pin decoder tolerance.
> 
> Additional pins: the six **client-only / legacy error codes** get **deserialize** coverage (not just serialize via `NON_EMITTED`); authority/relay fixtures gain bare v2 `PlayerLeft`, `AuthorityResponse`, and `GoingAway`; and v2 client messages (`AuthorityRequest`, `PlayerReady`, `Ping`, `ProvideConnectionInfo`) move from structural JSON checks to full wire conformance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e31261f8d9ab9aa5eb5ebd04475c4934f5d7e1c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->