### PR TITLE
Round 61: stop per-run std rebuilds; complete outbound wire pins

### DIFF
--- a/.github/workflows/deep-safety.yml
+++ b/.github/workflows/deep-safety.yml
@@ -73,7 +73,10 @@ jobs:
       - name: Install Rust nightly with Miri
         uses: dtolnay/rust-toolchain@nightly
         with:
-          components: miri
+          # cargo-miri would install rust-src lazily while preparing its
+          # source-built sysroot; declaring it here lets the mtime pin below
+          # run before that sysroot build instead of after it.
+          components: miri, rust-src
 
       # cargo-miri builds its std sysroot from source and hashes every std
       # source file's mtime into the sysroot cache check, so the fresh

--- a/.github/workflows/deep-safety.yml
+++ b/.github/workflows/deep-safety.yml
@@ -75,6 +75,17 @@ jobs:
         with:
           components: miri
 
+      # cargo-miri builds its std sysroot from source and hashes every std
+      # source file's mtime into the sysroot cache check, so the fresh
+      # toolchain install every run invalidates the restored sysroot in the
+      # cache and forces a full rebuild. Pinning the sources to a fixed epoch
+      # keeps the restored sysroot fresh.
+      - name: Pin std source mtimes for build-std cache reuse
+        run: |
+          set -euo pipefail
+          find "$(rustc +nightly --print sysroot)/lib/rustlib/src/rust" \
+            -type f -exec touch -d '@0' {} +
+
       - name: Cache Cargo artifacts
         uses: Swatinem/rust-cache@v2.9.2
 
@@ -114,6 +125,17 @@ jobs:
         uses: dtolnay/rust-toolchain@nightly
         with:
           components: rust-src
+
+      # cargo fingerprints -Zbuild-std std sources by mtime; the fresh
+      # toolchain install every run stamps them newer than any restored
+      # artifact, forcing a full std + dependent rebuild despite the warm
+      # cache. Pinning the sources to a fixed epoch keeps restored artifacts
+      # fresh.
+      - name: Pin std source mtimes for build-std cache reuse
+        run: |
+          set -euo pipefail
+          find "$(rustc +nightly --print sysroot)/lib/rustlib/src/rust" \
+            -type f -exec touch -d '@0' {} +
 
       - name: Cache Cargo artifacts
         uses: Swatinem/rust-cache@v2.9.2

--- a/.github/workflows/godot-web.yml
+++ b/.github/workflows/godot-web.yml
@@ -58,6 +58,17 @@ jobs:
           toolchain: ${{ env.RUST_NIGHTLY }}
           components: rust-src
 
+      # cargo fingerprints -Zbuild-std std sources by mtime; the fresh
+      # toolchain install every run stamps them newer than any restored
+      # artifact, forcing a full std + dependent rebuild despite the warm
+      # cache (~2 min per fixture build, measured). Pinning the sources to a
+      # fixed epoch keeps restored artifacts fresh.
+      - name: Pin std source mtimes for build-std cache reuse
+        run: |
+          set -euo pipefail
+          find "$(rustc +"${RUST_NIGHTLY}" --print sysroot)/lib/rustlib/src/rust" \
+            -type f -exec touch -d '@0' {} +
+
       - name: Install Rust stable with Clippy
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -100,6 +100,18 @@ jobs:
         uses: dtolnay/rust-toolchain@nightly
         with:
           components: rust-src, clippy
+      # cargo fingerprints -Zbuild-std std sources by mtime; the fresh
+      # toolchain install every run stamps them newer than any restored
+      # artifact, forcing a full std + dependent rebuild despite the warm
+      # cache. Pinning the sources to a fixed epoch keeps restored artifacts
+      # fresh while the rust-cache key (which includes the nightly's rustc
+      # commit hash) is unchanged; an upstream nightly bump still keys a new
+      # scope and seeds it.
+      - name: Pin std source mtimes for build-std cache reuse
+        run: |
+          set -euo pipefail
+          find "$(rustc +nightly --print sysroot)/lib/rustlib/src/rust" \
+            -type f -exec touch -d '@0' {} +
       - name: Install Emscripten SDK
         uses: emscripten-core/setup-emsdk@v16
         with:

--- a/tests/wire_golden_tests.rs
+++ b/tests/wire_golden_tests.rs
@@ -29,6 +29,15 @@
 use serde::{de::DeserializeOwned, Serialize};
 use signal_fish_client::protocol::{ClientMessage, RoomOperationRequest, ServerMessage};
 
+/// Fixed identifier for the pin inventory (a wire token, not a semantic value).
+fn probe_player_id() -> signal_fish_client::protocol::PlayerId {
+    uuid::Uuid::from_u128(0x0b0b)
+}
+
+fn probe_operation_id() -> signal_fish_client::protocol::RoomOperationId {
+    uuid::Uuid::from_u128(0x0d0d)
+}
+
 const V2_CLIENT: &str = include_str!("wire-samples/v2-client-messages.jsonl");
 const V2_SERVER: &str = include_str!("wire-samples/v2-server-messages.jsonl");
 const V3_CLIENT: &str = include_str!("wire-samples/v3-client-messages.jsonl");
@@ -467,23 +476,162 @@ fn binary_game_data_server_wire_fixtures_conform() {
 ///
 /// The vendored v2 client samples are illustrative placeholders that the
 /// corpus tests only check for JSON validity (`assert_structural`), so
-/// `AuthorityRequest`, `PlayerReady`, `ProvideConnectionInfo`, and `Ping`
-/// had no wire-shaped deserialize coverage — only struct round-trips built
-/// from the types under test. These lines are the authority's complete v2
-/// shapes: the no-payload schemas (`Ping`, `PlayerReady`) require only the
-/// `type` tag (our serializer likewise omits `data`; the tolerant
+/// `AuthorityRequest`, `PlayerReady`, `Ping`, `LeaveRoom`, `LeaveSpectator`,
+/// `JoinAsSpectator`, and `ProvideConnectionInfo` had no wire-shaped
+/// deserialize coverage — only struct round-trips built from the types under
+/// test. These lines are the authority's complete v2 shapes: the no-payload
+/// schemas (`Ping`, `PlayerReady`, `LeaveRoom`, `LeaveSpectator`) require
+/// only the `type` tag (our serializer likewise omits `data`; the tolerant
 /// `"data": null` input face is a serde detail, not the pinned wire form),
-/// and `ProvideConnectionInfo` wraps an internally-tagged `direct` info
-/// object.
+/// the `JoinAsSpectator` line pins the full open-room spectator face, and
+/// `ProvideConnectionInfo` wraps an internally-tagged `direct` info object.
 #[test]
 fn v2_client_message_wire_fixtures_conform() {
     const V2_CLIENT_MESSAGES: &str = r#"
 {"type": "AuthorityRequest", "data": {"become_authority": true}}
 {"type": "PlayerReady"}
 {"type": "Ping"}
+{"type": "LeaveRoom"}
+{"type": "LeaveSpectator"}
+{"type": "JoinAsSpectator", "data": {"game_name": "my-game", "room_code": "ABC123", "spectator_name": "Watcher"}}
 {"type": "ProvideConnectionInfo", "data": {"connection_info": {"type": "direct", "host": "127.0.0.1", "port": 7777}}}
 "#;
     assert_conformance::<ClientMessage>("v2-client-fixtures", V2_CLIENT_MESSAGES);
+}
+
+/// Every outbound wire face must be pinned by a non-co-drifting fixture or
+/// sample pin.
+///
+/// Round-trip tests are self-referential (a serde-attribute rename moves both
+/// faces together), and perf-lab ledger digests only fail on byte drift until
+/// deliberately refreshed, so the pins named here are the durable nets for
+/// each outbound face: hand-built, authority-derived fixtures that fail on a
+/// one-sided outbound drift, or byte-exact ledgers checked on every CI run.
+/// Both matches below are deliberately exhaustive and wildcard-free:
+/// adding a `ClientMessage` or `RoomOperationRequest` variant fails to
+/// compile until this inventory (and a real wire pin) covers its outbound
+/// face.
+fn client_message_outbound_pin(message: &ClientMessage) -> &'static str {
+    match message {
+        ClientMessage::Authenticate { .. } => {
+            "v3-client corpus `Authenticate` line (both faces) plus the perf-lab lobby ledgers"
+        }
+        ClientMessage::JoinRoom { .. } => {
+            "`quick_match_join_room_omits_every_unset_optional_member` (omission and \
+             password faces, both forms) plus the perf-lab lobby ledgers"
+        }
+        ClientMessage::LeaveRoom => "`v2_client_message_wire_fixtures_conform` (`LeaveRoom` line)",
+        ClientMessage::GameData { .. } => {
+            "the perf-lab json/out ledgers (plain face, byte-exact) plus the v3-client \
+             corpus `GameData` lines (classified faces, both directions)"
+        }
+        ClientMessage::AuthorityRequest { .. } => {
+            "`v2_client_message_wire_fixtures_conform` (`AuthorityRequest` line)"
+        }
+        ClientMessage::PlayerReady => {
+            "`v2_client_message_wire_fixtures_conform` (`PlayerReady` line)"
+        }
+        ClientMessage::ProvideConnectionInfo { .. } => {
+            "`v2_client_message_wire_fixtures_conform` (`ProvideConnectionInfo` line)"
+        }
+        ClientMessage::Ping => "`v2_client_message_wire_fixtures_conform` (`Ping` line)",
+        ClientMessage::Reconnect { .. } => {
+            "the perf-lab reconnect ledgers (byte-exact, checked on every CI run)"
+        }
+        ClientMessage::JoinAsSpectator { .. } => {
+            "`v2_client_message_wire_fixtures_conform` (`JoinAsSpectator` line, full \
+             shape) plus `sealed_spectator_join_serializes_password_in_both_forms` \
+             (password faces)"
+        }
+        ClientMessage::LeaveSpectator => {
+            "`v2_client_message_wire_fixtures_conform` (`LeaveSpectator` line)"
+        }
+        ClientMessage::RoomOperation { operation, .. } => room_operation_outbound_pin(operation),
+        ClientMessage::StartGame => "`client_message_start_game_unit_variant_has_no_data`",
+        ClientMessage::Signal { .. } => "v3-client corpus `Signal` lines (both faces)",
+        ClientMessage::TransportStatus { .. } => {
+            "v3-client corpus `TransportStatus` line (both faces)"
+        }
+    }
+}
+
+fn room_operation_outbound_pin(operation: &RoomOperationRequest) -> &'static str {
+    match operation {
+        RoomOperationRequest::JoinRoom { .. } => {
+            "`correlated_client_operations_have_exact_nested_shapes` (join_room case)"
+        }
+        RoomOperationRequest::LeaveRoom => {
+            "`correlated_client_operations_have_exact_nested_shapes` (leave_room case)"
+        }
+        RoomOperationRequest::Reconnect { .. } => {
+            "`correlated_client_operations_have_exact_nested_shapes` (reconnect case)"
+        }
+        RoomOperationRequest::JoinAsSpectator { .. } => {
+            "`correlated_client_operations_have_exact_nested_shapes` (open and sealed cases)"
+        }
+        RoomOperationRequest::LeaveSpectator => {
+            "`correlated_client_operations_have_exact_nested_shapes` (leave_spectator case)"
+        }
+        RoomOperationRequest::KickPlayer { .. } => {
+            "v3-client corpus `RoomOperation`/`KickPlayer` line (both faces)"
+        }
+        RoomOperationRequest::RegenerateRoomCode => {
+            "v3-client corpus `RoomOperation`/`RegenerateRoomCode` line (both faces)"
+        }
+        RoomOperationRequest::SetRoomAccess { .. } => {
+            "`access_control_surface_round_trips_with_exact_wire_tokens` (SetRoomAccess cases)"
+        }
+        RoomOperationRequest::BanPlayer { .. } => {
+            "`access_control_surface_round_trips_with_exact_wire_tokens` (BanPlayer case)"
+        }
+        RoomOperationRequest::UnbanPlayer { .. } => {
+            "`access_control_surface_round_trips_with_exact_wire_tokens` (UnbanPlayer case)"
+        }
+        RoomOperationRequest::TransferAuthority { .. } => {
+            "`access_control_surface_round_trips_with_exact_wire_tokens` (TransferAuthority case)"
+        }
+    }
+}
+
+#[test]
+fn every_outbound_wire_face_has_a_named_pin() {
+    // The enforcement is the wildcard-free matches above (a new variant fails
+    // to compile until it names a pin); exercising representative arms here
+    // keeps both functions live and documents the inventory in runnable form.
+    let kick_player_id = probe_player_id();
+    let messages = [
+        ClientMessage::Ping,
+        ClientMessage::LeaveRoom,
+        ClientMessage::LeaveSpectator,
+        ClientMessage::PlayerReady,
+        ClientMessage::StartGame,
+        ClientMessage::RoomOperation {
+            operation_id: probe_operation_id(),
+            operation: Box::new(RoomOperationRequest::LeaveRoom),
+        },
+        ClientMessage::RoomOperation {
+            operation_id: probe_operation_id(),
+            operation: Box::new(RoomOperationRequest::KickPlayer {
+                player_id: kick_player_id,
+            }),
+        },
+        ClientMessage::RoomOperation {
+            operation_id: probe_operation_id(),
+            operation: Box::new(RoomOperationRequest::RegenerateRoomCode),
+        },
+    ];
+    for message in &messages {
+        let _ = client_message_outbound_pin(message);
+    }
+
+    let operations = [
+        RoomOperationRequest::LeaveRoom,
+        RoomOperationRequest::LeaveSpectator,
+        RoomOperationRequest::RegenerateRoomCode,
+    ];
+    for operation in &operations {
+        let _ = room_operation_outbound_pin(operation);
+    }
 }
 
 /// The binary game-data envelopes must decode from hand-assembled bytes.


### PR DESCRIPTION
## Why

Every CI run of the Godot Web workflow's web-GDExtension build — the repository's critical path (~11 m) — fully recompiled std and every dependency despite a warm 814 MB cache. Root cause: cargo fingerprints `-Zbuild-std` std sources by mtime, and the fresh nightly install each run stamps those sources newer than every restored artifact (rustup has not preserved archive mtimes since 1.18.3). Measured locally: 1 m 57 s full rebuild → 4 s warm once the sources' mtimes are pinned to a fixed epoch.

## How

- One sub-second step pins the nightly toolchain's std source mtimes to epoch 0 in the four `-Zbuild-std` jobs (godot-web build-export, wasm emscripten, deep-safety TSan — and the Miri job, whose `rustc_build_sysroot` cache hashes std source mtimes). Verified against rust-cache v2.9.2 source that cache keys contain no mtime component. Expected: Godot Web ≈ 11 m → ≈ 9 m per run once the first post-merge run seeds the steady state; no coverage change.
- Completes the outbound (client→server) wire-face detection matrix: hand-built `LeaveRoom`/`LeaveSpectator`/`JoinAsSpectator` fixture lines replace the last faces whose only coverage was co-drifting serde round-trips, and a wildcard-free exhaustive inventory over all 15 `ClientMessage` and 11 `RoomOperationRequest` variants makes a new variant fail to compile until its outbound face has a real wire pin.

Upstream authority drift: zero (all five vendored files byte-identical at upstream HEAD `fb5e431`); no changelog entry (tests + CI automation only). Two-round adversarial review converged to zero findings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to GitHub Actions caching behavior and test-only wire pinning; no production runtime or protocol authority updates in the diff.
> 
> **Overview**
> **CI** jobs that use `-Zbuild-std` (Miri, TSan, wasm, Godot web) now run a short step that sets nightly **std source file mtimes to epoch 0** right after toolchain install, so restored `rust-cache` artifacts stay valid instead of forcing a full std rebuild every run. The Miri lane also installs **`rust-src` up front** so that pin runs before cargo-miri’s sysroot build.
> 
> **Wire conformance tests** add hand-built v2 JSONL lines for **`LeaveRoom`**, **`LeaveSpectator`**, and **`JoinAsSpectator`**, plus wildcard-free **`client_message_outbound_pin` / `room_operation_outbound_pin`** inventories over every `ClientMessage` and `RoomOperationRequest` variant so a new variant fails to compile until it names a real outbound pin; **`every_outbound_wire_face_has_a_named_pin`** keeps those matchers exercised.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db3b7bfe3e61028ccf1616e952af84e474adf4ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->