### PR TITLE
Harden Playwright dep installs against third-party apt repos

### DIFF
--- a/.github/workflows/docs-validation.yml
+++ b/.github/workflows/docs-validation.yml
@@ -112,7 +112,23 @@ jobs:
       - name: Install pinned Chromium automation
         run: |
           npm install --no-save --no-package-lock "playwright@${PLAYWRIGHT_VERSION}"
-          npx playwright install --with-deps chromium
+          # `--with-deps` runs `apt-get update` internally, and the runner
+          # image's third-party Google Chrome repo can be mid-publish (live:
+          # Packages.gz Hash Sum mismatch failed the lane). The automation
+          # deps come only from Ubuntu's own repos, so drop the irrelevant
+          # source first; the retry covers any other third-party repo race.
+          sudo rm -f /etc/apt/sources.list.d/google-chrome*.list
+          for attempt in 1 2 3; do
+            if npx playwright install --with-deps chromium; then
+              break
+            fi
+            if [ "${attempt}" -eq 3 ]; then
+              printf 'playwright install failed after %d attempts\n' "${attempt}" >&2
+              exit 1
+            fi
+            printf 'playwright install attempt %d failed; retrying\n' "${attempt}" >&2
+            sleep 20
+          done
 
       - name: Test responsive documentation accessibility
         run: node scripts/check-docs-accessibility.cjs

--- a/.github/workflows/godot-web.yml
+++ b/.github/workflows/godot-web.yml
@@ -422,7 +422,24 @@ jobs:
       - name: Install pinned Chromium automation
         run: |
           npm install --no-save --no-package-lock "playwright@${PLAYWRIGHT_VERSION}"
-          npx playwright install --with-deps chromium
+          # `--with-deps` runs `apt-get update` internally, and the runner
+          # image's third-party Google Chrome repo can be mid-publish (live:
+          # Packages.gz Hash Sum mismatch failed every browser cell for
+          # hours). The automation deps come only from Ubuntu's own repos,
+          # so drop the irrelevant source first; the retry covers any other
+          # third-party repo race.
+          sudo rm -f /etc/apt/sources.list.d/google-chrome*.list
+          for attempt in 1 2 3; do
+            if npx playwright install --with-deps chromium; then
+              break
+            fi
+            if [ "${attempt}" -eq 3 ]; then
+              printf 'playwright install failed after %d attempts\n' "${attempt}" >&2
+              exit 1
+            fi
+            printf 'playwright install attempt %d failed; retrying\n' "${attempt}" >&2
+            sleep 20
+          done
 
       - name: Download pinned Signal Fish server
         run: |


### PR DESCRIPTION
## Why

Post-merge main CI went red tonight: every Godot Web browser cell and the docs rendering lane failed with `Packages.gz Hash Sum mismatch` from `dl.google.com/linux/chrome-stable/deb` — the runner image's third-party Google Chrome apt repo was mid-publish, and the internal `apt-get update` of `playwright install --with-deps` treats that as fatal. It persisted across two attempts (~10 min), and none of the installed automation dependencies come from that repo.

## How

Both Playwright install sites (godot-web E2E cells, docs-validation rendering check) now drop the irrelevant Chrome apt source before installing, and retry the install three times to ride out any other third-party repo publish race — same spirit as the `--retry-all-errors` curl hardening from PR #245.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow shell changes; no application, auth, or data-path impact beyond how browsers are installed on runners.
> 
> **Overview**
> **Hardens Playwright Chromium setup** in the docs validation rendering job and Godot Web browser E2E matrix so CI stops failing when `playwright install --with-deps` runs `apt-get update` against a flaky Google Chrome apt mirror (`Packages.gz` hash mismatch).
> 
> Before install, both workflows **remove** `/etc/apt/sources.list.d/google-chrome*.list` because Playwright’s system deps come from Ubuntu repos, not that third-party source. They also **retry** `npx playwright install --with-deps chromium` up to three times with a 20s pause, mirroring existing curl `--retry-all-errors` resilience elsewhere in these workflows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7345846b150eb3b06e5543335ceaa7d8792353e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->