### PR TITLE
Pin banned-reconnect refusal; make lint suppressions self-verifying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added an Authentication & Credentials guide consolidating the public app-ID
   policy, secret reconnection tokens, rotation guidance, and log-hygiene
   rules.
+- Documented that newer upstream servers also refuse a banned seat's
+  reconnection restore with `ErrorCode::Banned` on `ReconnectionFailed`
+  (`ErrorCode::Banned` rustdoc and the errors guide), keeping the pending
+  ban record so a mid-window unban lets the token work again.
 - Added an `auto_reconnect` example: a complete, compiling auto-reconnection
   client showing the `ReconnectPolicy` factory pattern for the built-in
   `WebSocketTransport`, plus the same pattern in the reconnect rustdoc and

--- a/crates/signal-fish-client-godot/src/lib.rs
+++ b/crates/signal-fish-client-godot/src/lib.rs
@@ -808,7 +808,7 @@ impl GodotWebSocketTransport {
 /// is bounded by `8 * (u64::MAX - 1) + u64::MAX`, far below `u128::MAX`, so
 /// neither the multiply-add nor the division can overflow and the only
 /// fallible step is the narrowing conversion handled by `unwrap_or`.
-#[allow(clippy::arithmetic_side_effects)]
+#[expect(clippy::arithmetic_side_effects)]
 fn ewma_one_eighth(previous: u64, sample: u64) -> u64 {
     u64::try_from((u128::from(previous) * 7 + u128::from(sample)) / 8).unwrap_or(u64::MAX)
 }

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -271,7 +271,7 @@ access-control operations itself; `join_room` can present a password with
 | Variant | Description |
 |---------|-------------|
 | `PasswordRequired` | The room requires a join password and the request presented none, the wrong one, or a password for an open room; the server does not distinguish the three cases. |
-| `Banned` | This player id is banned from the room by its authority player and cannot join it (as a player or spectator) while the room lives; the ban is room-scoped and expires with the room. Banning a seated member removes them exactly like a kick: close code 4007 (`kicked`), no reconnection. |
+| `Banned` | This player id is banned from the room by its authority player and cannot join it (as a player or spectator) while the room lives; the ban is room-scoped and expires with the room. Banning a seated member removes them exactly like a kick: close code 4007 (`kicked`), no reconnection. Newer upstream servers also refuse a banned seat's reconnection restore with this code on `ReconnectionFailed`, keeping the pending record so a mid-window unban lets the token work again. |
 | `TransferTargetNotFound` | The player named by `TransferAuthority` is not a seated member of the room. |
 
 !!! note "The v3-era *server* codes vs. `SignalFishError::ProtocolUnsupported`"

--- a/src/client.rs
+++ b/src/client.rs
@@ -3794,7 +3794,7 @@ mod tests {
 
         /// A mock that additionally records outbound binary frames verbatim
         /// instead of refusing them.
-        #[allow(clippy::type_complexity)]
+        #[expect(clippy::type_complexity)]
         fn new_binary_recording(
             incoming: Vec<Option<std::result::Result<String, SignalFishError>>>,
         ) -> (
@@ -3809,7 +3809,6 @@ mod tests {
             (transport, sent, sent_binary, closed)
         }
 
-        #[allow(clippy::type_complexity)]
         fn new_shared(
             incoming: Vec<Option<std::result::Result<String, SignalFishError>>>,
         ) -> (
@@ -3850,7 +3849,7 @@ mod tests {
 
         /// A mock whose outbound sends block on a semaphore after the given
         /// number of initial permits are consumed.
-        #[allow(clippy::type_complexity)]
+        #[expect(clippy::type_complexity)]
         fn new_send_gated(
             incoming: Vec<Option<std::result::Result<String, SignalFishError>>>,
             initial_permits: usize,
@@ -5587,7 +5586,7 @@ mod tests {
     }
 
     impl GatedSendTransport {
-        #[allow(clippy::type_complexity)]
+        #[expect(clippy::type_complexity)]
         fn new(
             initial_permits: usize,
         ) -> (

--- a/src/client_core.rs
+++ b/src/client_core.rs
@@ -2866,7 +2866,7 @@ mod tests {
         // would abort the test thread; leaking this proof-only fixture is
         // the bounded outcome (the same deliberate-leak precedent as the
         // Emscripten close-before-delete policy).
-        #[allow(clippy::mem_forget)]
+        #[expect(clippy::mem_forget)]
         std::mem::forget(pathological);
     }
 
@@ -3781,6 +3781,95 @@ mod tests {
                 "sealed-spectator refusal must carry the code: {code:?}"
             );
             assert_eq!(spectator.pending_room_operation, None);
+        }
+    }
+
+    #[test]
+    fn access_control_reconnection_refusals_surface_codes_and_release_the_fence_in_every_form() {
+        // A banned seat's reconnection restore is refused with
+        // `ReconnectionFailed` (upstream server 0d33961; a banned seat can
+        // still hold an armed reconnection token when the ban lands while it
+        // is disconnected). The access-control codes must ride that frame
+        // exactly like the older `ReconnectionExpired` face: an ordinary
+        // event carrying the code, no violation event, and both the
+        // reconnect-credential queue and the pending room operation released
+        // in the legacy and negotiated admission forms.
+        for code in [crate::ErrorCode::Banned, crate::ErrorCode::PasswordRequired] {
+            let mut legacy = ClientCore::new(
+                Some(GameDataEncoding::Json),
+                ProtocolViolationPolicy::Observe,
+                true,
+            );
+            let _ = process(&mut legacy, authenticated());
+            let _ = process(&mut legacy, protocol_info(Some(3)));
+            legacy.record_admission(ClientCore::admission_for(&ClientOperation::Reconnect(
+                PlayerId::from_u128(LOCAL),
+                RoomId::from_u128(10),
+                "submitted-token".into(),
+            )));
+            let outcome = process(
+                &mut legacy,
+                ServerMessage::ReconnectionFailed {
+                    reason: "banned".into(),
+                    error_code: code.clone(),
+                },
+            );
+            assert!(
+                matches!(
+                    outcome.events.as_slice(),
+                    [SignalFishEvent::ReconnectionFailed { reason, error_code: received, .. }] if *received == code && reason == "banned"
+                ),
+                "legacy reconnect refusal must carry the code: {code:?}"
+            );
+            assert_eq!(legacy.pending_room_operation, None);
+            assert!(legacy.pending_reconnects.is_empty());
+
+            let mut correlated = correlated_outside(ProtocolViolationPolicy::Observe);
+            let (_, id) = prepare_and_admit(
+                &mut correlated,
+                ClientOperation::Reconnect(
+                    PlayerId::from_u128(LOCAL),
+                    RoomId::from_u128(10),
+                    "submitted-token".into(),
+                ),
+            );
+            let outcome = process(
+                &mut correlated,
+                correlated_result(
+                    id,
+                    RoomOperationResult::ReconnectionFailed {
+                        reason: "banned".into(),
+                        error_code: code.clone(),
+                    },
+                ),
+            );
+            assert!(
+                matches!(
+                    outcome.events.as_slice(),
+                    [SignalFishEvent::ReconnectionFailed { reason, error_code: received, .. }] if *received == code && reason == "banned"
+                ),
+                "negotiated reconnect refusal must carry the code: {code:?}"
+            );
+            assert_eq!(correlated.pending_room_operation, None);
+            assert!(correlated.pending_reconnects.is_empty());
+
+            // The released fences admit fresh directed work in both forms.
+            assert!(
+                legacy
+                    .prepare_with_admission(ClientOperation::JoinRoom(JoinRoomParams::new(
+                        "game", "local",
+                    )))
+                    .is_ok(),
+                "legacy fence must admit a fresh join after the refusal: {code:?}"
+            );
+            assert!(
+                correlated
+                    .prepare_with_admission(ClientOperation::JoinRoom(JoinRoomParams::new(
+                        "game", "local",
+                    )))
+                    .is_ok(),
+                "negotiated fence must admit a fresh join after the refusal: {code:?}"
+            );
         }
     }
 

--- a/src/error_codes.rs
+++ b/src/error_codes.rs
@@ -207,7 +207,10 @@ pub enum ErrorCode {
     /// This player id is banned from the room by its authority player and
     /// cannot join it (as a player or spectator) while the room lives. The
     /// ban is room-scoped and expires with the room. Banning a seated member
-    /// removes them exactly like a kick (close code `4007`/`kicked`).
+    /// removes them exactly like a kick (close code `4007`/`kicked`). Newer
+    /// upstream servers also refuse a banned seat's reconnection restore
+    /// with this code on `ReconnectionFailed`, keeping the pending record so
+    /// a mid-window unban lets the token work again.
     Banned,
     /// The player named by `TransferAuthority` is not a seated member of the
     /// room.
@@ -432,7 +435,7 @@ impl ErrorCode {
                 "This room is password-protected, or the join presented a password to an open room. Send the password chosen by the room's authority player, or join without one."
             }
             Self::Banned => {
-                "This player id is banned from the room by its authority player and cannot join it while the room lives."
+                "This player id is banned from the room by its authority player and cannot join it while the room lives. Newer upstream servers also refuse a banned seat's reconnection restore with this code, keeping the pending record so a mid-window unban lets the token work again."
             }
             Self::TransferTargetNotFound => {
                 "The player to transfer authority to is not a current member of this room."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,5 +228,5 @@ pub use webrtc::MeshController;
 
 // Re-export only on the correct target (see transports/mod.rs for rationale).
 #[cfg(all(feature = "transport-websocket-emscripten", target_os = "emscripten"))]
-#[allow(deprecated)]
+#[expect(deprecated)]
 pub use transports::{EmscriptenWebSocketConnectOptions, EmscriptenWebSocketTransport};

--- a/src/protocol/binary.rs
+++ b/src/protocol/binary.rs
@@ -234,7 +234,7 @@ fn require_field<T>(slot: Option<T>, field: &str, version: &str) -> Result<T, St
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, clippy::indexing_slicing)]
+#[expect(clippy::expect_used, clippy::indexing_slicing)]
 mod tests {
     use super::*;
 

--- a/src/terminal_drain.rs
+++ b/src/terminal_drain.rs
@@ -111,7 +111,7 @@ pub(crate) fn peer_close_reason<T: Transport + ?Sized>(transport: &T) -> Option<
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, clippy::indexing_slicing, clippy::panic)]
+#[expect(clippy::panic)]
 mod tests {
     use super::*;
     use crate::transport::TransportCloseInfo;

--- a/src/transports/emscripten_websocket.rs
+++ b/src/transports/emscripten_websocket.rs
@@ -114,17 +114,17 @@ use crate::transport::{
 // ── FFI Bindings ────────────────────────────────────────────────────────────
 
 // These type aliases mirror Emscripten's C naming conventions exactly.
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types)]
 type EMSCRIPTEN_WEBSOCKET_T = c_int;
 
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types)]
 type EM_BOOL = c_int;
 
 // Verified against Emscripten 3.1.74 system/include/emscripten/websocket.h:
 // WebSocket event structs and creation attributes use C `bool` fields. On
 // wasm32-unknown-emscripten that ABI type is one byte. Callback return values
 // remain `EM_BOOL` (`c_int`) in this binding and must not use this field alias.
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types)]
 type C_BOOL = u8;
 
 /// Emscripten result code indicating success.

--- a/src/transports/mod.rs
+++ b/src/transports/mod.rs
@@ -54,5 +54,5 @@ mod emscripten_inbound_queue;
 pub mod emscripten_websocket;
 
 #[cfg(all(feature = "transport-websocket-emscripten", target_os = "emscripten"))]
-#[allow(deprecated)]
+#[expect(deprecated)]
 pub use emscripten_websocket::{EmscriptenWebSocketConnectOptions, EmscriptenWebSocketTransport};

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -2741,7 +2741,6 @@ mod ci_workflow_policy {
     /// as Cargo.toml. Prevents drift where Cargo.toml is bumped but docs or
     /// scripts are left with the old version.
     #[test]
-    #[allow(clippy::indexing_slicing)]
     fn msrv_consistent_across_key_files() {
         let version = cargo_msrv_version();
 

--- a/tests/client_tests.rs
+++ b/tests/client_tests.rs
@@ -49,7 +49,6 @@ use std::time::Duration;
 
 /// Start a client with the given scripted server responses. The first item
 /// is typically `authenticated_json()` so the auth handshake succeeds.
-#[allow(clippy::type_complexity)]
 async fn start_client(incoming: Vec<Option<Result<String, SignalFishError>>>) -> StartedClient {
     start_client_with_config(incoming, SignalFishConfig::new("mb_test_integration")).await
 }

--- a/tests/emscripten-harness/src/main.rs
+++ b/tests/emscripten-harness/src/main.rs
@@ -1094,7 +1094,7 @@ enum Scenario {
 // by the driver's `ccall`, valid for this call); clippy cannot see that
 // cross-language guarantee.
 #[no_mangle]
-#[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[expect(clippy::not_unsafe_ptr_arg_deref)]
 pub extern "C" fn sfh_begin(url: *const c_char, mode: i32) -> i32 {
     // Fresh attribution: an error latched by dropping the previous scenario's
     // transport must fail the next scheduling step, not the previous scenario.

--- a/tests/godot-web-smoke/src/lib.rs
+++ b/tests/godot-web-smoke/src/lib.rs
@@ -934,7 +934,7 @@ impl INode for SignalFishSmoke {
     }
 }
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 fn poll_measured(
     client: &mut Option<Client>,
     poll_timing: &mut PollTimingWindow,
@@ -1241,7 +1241,7 @@ mod tests {
 // Emscripten WebSocket imports into an otherwise valid Godot GDExtension.
 // Official templates cannot resolve those optional JavaScript-library symbols.
 #[cfg(feature = "raw-emscripten-proof")]
-#[allow(deprecated)]
+#[expect(deprecated)]
 fn exercise_raw_emscripten_import() {
     let _ = signal_fish_client::EmscriptenWebSocketTransport::connect(SERVER_URL);
 }

--- a/tools/perf-lab/src/workloads.rs
+++ b/tools/perf-lab/src/workloads.rs
@@ -1480,7 +1480,7 @@ fn reconnect_message(players: usize) -> ServerMessage {
     }))
 }
 
-#[allow(clippy::arithmetic_side_effects)] // `index` starts at 1: subtraction cannot underflow
+#[expect(clippy::arithmetic_side_effects)] // `index` starts at 1: subtraction cannot underflow
 fn players_fixture(players: usize) -> Vec<PlayerInfo> {
     (0..players)
         .map(|index| {

--- a/tools/stateful-campaign/src/main.rs
+++ b/tools/stateful-campaign/src/main.rs
@@ -349,7 +349,7 @@ fn repro(seed: u64, index: usize, policy: ProtocolViolationPolicy, prefix: usize
 /// The scoped `exit` allowance is load-bearing: a hung library call can never
 /// reach a cooperative stop flag, and a CI lane that hangs forever is worse
 /// than one that fails loudly with the stall label and frame count.
-#[allow(clippy::exit)]
+#[expect(clippy::exit)]
 fn spawn_watchdog(budget_secs: u64) {
     std::thread::spawn(move || {
         let started = Instant::now();

--- a/tools/stateful-campaign/src/rng.rs
+++ b/tools/stateful-campaign/src/rng.rs
@@ -49,7 +49,7 @@ impl Rng {
     /// array and `below` returns an index in `0..len`, so the fallback below
     /// is unreachable; the scoped allow carries that proof (repo precedent:
     /// provably-total indexing carries a scoped proof).
-    #[allow(clippy::indexing_slicing)]
+    #[expect(clippy::indexing_slicing)]
     pub fn pick<'a, T>(&mut self, items: &'a [T]) -> &'a T {
         let index = self.below(items.len());
         &items[index.min(items.len().saturating_sub(1))]

--- a/tools/stateful-campaign/src/run.rs
+++ b/tools/stateful-campaign/src/run.rs
@@ -1517,7 +1517,7 @@ impl Oracle {
     /// Close-info attribution: the `Disconnected` reason must agree with the
     /// armed transport face. `transport_peer_closed` mirrors
     /// `Transport::close_info()` at the end of the run.
-    #[allow(clippy::collapsible_match)]
+    #[expect(clippy::collapsible_match)]
     pub(crate) fn verify_close_attribution(
         &self,
         transport_peer_closed: bool,

--- a/tools/stateful-campaign/src/script.rs
+++ b/tools/stateful-campaign/src/script.rs
@@ -139,7 +139,7 @@ pub struct FrameMeta {
     pub bound_breaking: bool,
 }
 
-#[allow(clippy::large_enum_variant)] // scripts own their messages by design
+#[expect(clippy::large_enum_variant)] // scripts own their messages by design
 #[derive(Debug, Clone)]
 pub enum Step {
     /// Deliver a schema-valid `ServerMessage` text frame.


### PR DESCRIPTION
## Why

Round 62 of the #126 correctness/perf audit (#222 re-verified still blocked on the upstream wire contract).

Upstream `signal-fish-server` advanced one commit (`0d33961`) with a client-observable change: a **banned seat's reconnection restore is now refused** with `ReconnectionFailed { error_code: BANNED }` (the pending record is kept, so a mid-window unban lets the token work again). The SDK already passed any typed code through that frame and released both fences — but only `ReconnectionExpired` rode a pin, so a regression in that pass-through or fence release for moderation codes would have gone undetected.

## What

- **Pin the refusal face** (data-driven, shared core): `Banned`/`PasswordRequired` on `ReconnectionFailed` in both the legacy and negotiated admission forms — exact event code + reason, no violation event, both fences released, and a fresh join admitted afterwards. Red/green verified by neutering the fence release.
- **Document the refusal** on `ErrorCode::Banned` (rustdoc + help text) and the errors guide, explicitly qualified as newer-upstream behavior (the vendored spec authority is byte-identical; no protocol change).
- **Make point lint suppressions self-verifying**: 20 `#[allow]` → `#[expect]` conversions so a refactor that makes a suppression unnecessary fails the build instead of suppressing forever. Standing test-module permission tables keep `#[allow]` by design. The migration immediately caught **four genuinely stale suppressions**, now removed.

## Verification

- Mandatory workflow: fmt clean, clippy `-D warnings` clean (all expectations fulfilled), 1194 tests / 0 failed (+1).
- All 7 sparse-feature CI clippy cells clean (no expectation is feature-conditional in firing); emscripten-target harness clippy clean.
- Audits this round (no production defects found): upstream drift zero-wire; CI-time measured — no increase, round-61 warm steady state holding (details in the round report on #126).
- Hostile review + convergence verifier converged to zero findings.

Part of #126 (round 62).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior is documented and tested, not rewritten; remaining changes are lint-attribute migration with no runtime impact.
> 
> **Overview**
> Adds a **regression test** that pins how access-control codes on **`ReconnectionFailed`** behave: **`Banned`** and **`PasswordRequired`** must appear on `SignalFishEvent::ReconnectionFailed` (with reason) in both **legacy** and **negotiated** admission paths, must **not** emit a protocol violation, must **clear** the reconnect queue and pending room operation, and must **allow a fresh join** afterward.
> 
> **Documentation** now states that newer upstream servers refuse a banned seat’s reconnection restore with **`ErrorCode::Banned`** on `ReconnectionFailed` while keeping the pending ban record (so an unban mid-window can still restore). This is reflected in the changelog, errors guide, and `ErrorCode::Banned` rustdoc/help text.
> 
> **Lint hygiene:** point suppressions move from **`#[allow]`** to **`#[expect]`** across the repo so unnecessary allowances fail the build; a few **stale** `allow` attributes are dropped where clippy no longer fires.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5e3c5d85db57c3a4cc652e9ce633c21a2cbdee6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->