### PR TITLE
Round 65: authority-pin enforcement; coverage truthfulness

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -92,8 +92,15 @@ jobs:
 
       - name: Print coverage summary and enforce baseline
         if: always()
-        # Measured at 93.70% after the issue #61 regression expansion. Keep a
-        # little platform/toolchain rounding headroom while preventing drift.
+        # The number is a blended lines-only ratio over the core crate, the
+        # Godot adapter (fake-backend suite), and the stateful-campaign tool;
+        # perf-lab is excluded (its own required job executes every cell), and
+        # doctests plus the target-gated Emscripten FFI transport file are
+        # outside the denominator by construction. `--all-features` also
+        # compiles the doc(hidden) internal-fuzz-facade code, which only the
+        # fuzz lane executes. Measured at 93.70% after the issue #61
+        # regression expansion; keep a little platform/toolchain rounding
+        # headroom while preventing drift.
         run: cargo llvm-cov report --ignore-filename-regex 'tools/perf-lab/' --summary-only --fail-under-lines 93
 
   required:

--- a/.github/workflows/protocol-sync.yml
+++ b/.github/workflows/protocol-sync.yml
@@ -73,6 +73,43 @@ jobs:
           fi
           echo "Vendored wire samples are in sync with upstream."
 
+      - name: Verify vendored bytes match the pinned protocol-authority commit
+        run: |
+          set -euo pipefail
+          # The offline gates prove hash consistency; this step proves the
+          # vendored bytes really are the pinned commit's blobs (fail closed
+          # on an unparseable pin).
+          pin="$(awk '/^\[protocol_authority\]/{pinned=1; next} /^\[/{pinned=0} pinned && /^commit = /{sub(/^commit = "/, ""); sub(/"$/, ""); print; exit}' tests/compatibility.toml)"
+          if ! printf '%s' "$pin" | grep -Eq '^[0-9a-f]{40}$'; then
+            echo "::error::[protocol_authority].commit is not a 40-char hex SHA: '$pin'"
+            exit 1
+          fi
+          drift=0
+          proto_base="https://raw.githubusercontent.com/Ambiguous-Interactive/signal-fish-server/$pin/.llm/code-samples/protocol"
+          for f in v2-client-messages v2-server-messages v3-client-messages v3-server-messages; do
+            curl --fail --silent --show-error --location --retry 5 --retry-all-errors \
+              "$proto_base/$f.jsonl" -o "/tmp/$f.pinned.jsonl"
+            if ! diff -q "tests/wire-samples/$f.jsonl" "/tmp/$f.pinned.jsonl" >/dev/null 2>&1; then
+              echo "::error::vendored $f.jsonl does not match the pinned authority commit $pin"
+              diff "tests/wire-samples/$f.jsonl" "/tmp/$f.pinned.jsonl" || true
+              drift=1
+            fi
+          done
+          spec_base="https://raw.githubusercontent.com/Ambiguous-Interactive/signal-fish-server/$pin/spec"
+          curl --fail --silent --show-error --location --retry 5 --retry-all-errors \
+            "$spec_base/signal-fish-protocol.asyncapi.yaml" -o /tmp/signal-fish-protocol.asyncapi.pinned.yaml
+          if ! diff -q tests/server-spec/signal-fish-protocol.asyncapi.yaml /tmp/signal-fish-protocol.asyncapi.pinned.yaml >/dev/null 2>&1; then
+            echo "::error::vendored AsyncAPI spec does not match the pinned authority commit $pin"
+            diff tests/server-spec/signal-fish-protocol.asyncapi.yaml /tmp/signal-fish-protocol.asyncapi.pinned.yaml || true
+            drift=1
+          fi
+          if [ "$drift" -ne 0 ]; then
+            echo "Vendored evidence diverges from the pinned protocol-authority commit."
+            echo "Refresh per .llm/skills/protocol-wire-conformance/SKILL.md and reconcile any type changes."
+            exit 1
+          fi
+          echo "Vendored evidence byte-matches the pinned protocol-authority commit."
+
       - name: Compare vendored AsyncAPI spec to upstream and fail on drift
         run: |
           set -euo pipefail

--- a/.llm/skills/protocol-wire-conformance/SKILL.md
+++ b/.llm/skills/protocol-wire-conformance/SKILL.md
@@ -34,9 +34,9 @@ the blind spot where a server-side error-code addition passes the wire-sample
 golden tests (they pin message *shapes*, not the error-code value space).
 
 The canonical corpus pins protocol-authority commit
-`af4e6795fac0681e0079b7b5672d141ae91a2e6b`, advanced from the Server 0.8.0
+`ac118f846f26ac55e2fc1f3231dcc9aec86a7275`, advanced from the Server 0.8.0
 release pin `d79dcdc7549777c8c2bd9fcb2d132641532d8c86` by descriptive prose
-plus three deliberate additive changes (the v3 room-member snapshot excludes the
+plus the deliberate additive changes (the v3 room-member snapshot excludes the
 legacy `connection_info` echo — server issue #529; the authority-only
 moderation surface — server issue #525 — added the NOT_ROOM_AUTHORITY /
 KICK_TARGET_NOT_FOUND / KICKED error codes, the KickPlayer / RegenerateRoomCode

--- a/src/client.rs
+++ b/src/client.rs
@@ -6051,6 +6051,46 @@ mod tests {
         client.shutdown().await;
     }
 
+    #[tokio::test]
+    async fn send_game_data_with_delivery_reliable_preserves_delivery_class_on_wire() {
+        // The waiting classified send is a public entry point with no other
+        // test consumer: pin that the caller's delivery class survives the
+        // reliable (queue-capacity-waiting) path onto the v3 wire unchanged.
+        let (transport, sent, _closed) = MockTransport::new(vec![
+            Some(Ok(authenticated_json())),
+            Some(Ok(protocol_info_v3_json())),
+            Some(Ok(finalized_room_v3_json(uuid::Uuid::from_u128(7)))),
+        ]);
+        let config = SignalFishConfig::new("mb_test").enable_v3();
+        let (mut client, mut events) = SignalFishClient::start(transport, config);
+        enter_scripted_player_room(&mut client, &mut events).await;
+
+        client
+            .send_game_data_with_delivery_reliable(
+                serde_json::json!({ "hp": 42 }),
+                GameDataDelivery::Latest { key: 7 },
+            )
+            .await
+            .expect("the reliable classified send must queue and resolve");
+
+        wait_for_sent_len(&sent, 3).await;
+        {
+            let messages = sent.lock().unwrap();
+            let wire: ClientMessage = serde_json::from_str(&messages[2])
+                .expect("third queued frame must be a valid ClientMessage");
+            match wire {
+                ClientMessage::GameData { data, class, key } => {
+                    assert_eq!(data, serde_json::json!({ "hp": 42 }));
+                    assert_eq!(class, Some(crate::protocol::DeliveryClass::Latest));
+                    assert_eq!(key, Some(7));
+                }
+                other => panic!("expected classified GameData on the wire, got {other:?}"),
+            }
+        }
+
+        client.shutdown().await;
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn reliable_send_revalidates_admission_after_reserving_capacity() {
         let (transport, entered_send, permits, _sent) = GatedSendTransport::new(0);
@@ -8908,6 +8948,19 @@ mod tests {
         .await
         .expect("reliable send must resolve promptly after a terminal close");
         assert!(matches!(reliable, Err(SignalFishError::NotConnected)));
+        let reliable_latest = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            client.send_game_data_with_delivery_reliable(
+                serde_json::json!({ "n": 1 }),
+                GameDataDelivery::Latest { key: 2 },
+            ),
+        )
+        .await
+        .expect("reliable classified send must resolve promptly after a terminal close");
+        assert!(matches!(
+            reliable_latest,
+            Err(SignalFishError::NotConnected)
+        ));
 
         // A shutdown after the self-terminated loop stays prompt and
         // idempotent.

--- a/src/polling_client.rs
+++ b/src/polling_client.rs
@@ -5456,6 +5456,58 @@ mod tests {
     }
 
     #[test]
+    fn public_queue_age_peak_reset_matches_the_sampled_clock_twin() {
+        // `reset_queue_age_peak` is the public wrapper around
+        // `reset_queue_age_peak_at(Instant::now())` (its other callers — the
+        // perf-lab tool and the godot-web-smoke fixture — live outside the
+        // coverage denominator): pin that the public entry collapses the
+        // peak onto the freshly sampled current age.
+        let allow = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let transport = TogglePendingSendTransport {
+            allow: std::sync::Arc::clone(&allow),
+            sent: Vec::new(),
+            _sent_binary: Vec::new(),
+        };
+        let mut client = SignalFishPollingClient::new(transport, default_config());
+        let base = Instant::now();
+        client
+            .cmd_queue
+            .front_mut()
+            .expect("Authenticate should be queued")
+            .enqueued_at = base;
+
+        let _ = client.poll_at(base + Duration::from_millis(30));
+        assert_eq!(
+            client.queue_age_stats().peak_oldest_queue_age,
+            Duration::from_millis(30),
+            "the pending frame's age must be sampled at the poll"
+        );
+
+        // Backend acceptance ends client ownership: the sampled current age
+        // collapses to zero, while the peak preserves the last client-owned
+        // sample (the frame was still queued at the acceptance poll's own
+        // sampling point, aged 40 ms).
+        allow.store(true, std::sync::atomic::Ordering::Release);
+        let _ = client.poll_at(base + Duration::from_millis(40));
+        let aged = client.queue_age_stats();
+        assert_eq!(aged.current_oldest_queue_age, Duration::ZERO);
+        assert_eq!(
+            aged.peak_oldest_queue_age,
+            Duration::from_millis(40),
+            "the peak must survive acceptance until an explicit reset"
+        );
+
+        client.reset_queue_age_peak();
+        let reset = client.queue_age_stats();
+        assert_eq!(
+            reset.peak_oldest_queue_age,
+            Duration::ZERO,
+            "the public reset must collapse the peak onto the sampled current age"
+        );
+        assert_eq!(reset.current_oldest_queue_age, Duration::ZERO);
+    }
+
+    #[test]
     fn serialization_failure_cleanup_stops_queue_age_and_preserves_peak() {
         let mut client = SignalFishPollingClient::new(MockTransport::new(), default_config());
         let base = Instant::now();

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -11531,6 +11531,185 @@ mod protocol_wire_conformance_policy {
     }
 
     #[test]
+    fn wire_sample_and_spec_sets_are_pinned_by_every_surface() {
+        // Every vendored protocol-evidence file must be named by every pin
+        // surface — the directory contents, `SAMPLE_FILES`,
+        // `compatibility.toml`, both PROVENANCE `[files]` tables, the
+        // wire-golden `include_str!`s, and the protocol-sync fetch loops — so
+        // a new, renamed, or extra entry cannot escape the hash, golden, or
+        // upstream-truth gates by falling outside a hand-maintained list.
+        let listed: std::collections::BTreeSet<String> = SAMPLE_FILES
+            .iter()
+            .map(|name| (*name).to_string())
+            .collect();
+        let metadata_files: std::collections::BTreeSet<String> = ["README.md", "PROVENANCE.toml"]
+            .into_iter()
+            .map(std::string::ToString::to_string)
+            .collect();
+
+        let mut on_disk = std::collections::BTreeSet::new();
+        collect_vendored_samples(&project_root().join("tests/wire-samples"), &mut on_disk);
+        let mut expected_wire = listed.clone();
+        expected_wire.extend(metadata_files.clone());
+        assert_eq!(
+            on_disk, expected_wire,
+            "tests/wire-samples must hold exactly the pinned sample files plus \
+             README.md and PROVENANCE.toml"
+        );
+
+        let manifest: toml::Value = toml::from_str(&read_project_file("tests/compatibility.toml"))
+            .expect("compatibility.toml must be valid TOML");
+        assert_eq!(
+            toml_table_keys(&manifest, "wire_samples"),
+            listed,
+            "[wire_samples] keys must match the pinned sample set"
+        );
+        assert_eq!(
+            toml_table_keys(&manifest, "server_spec"),
+            spec_entries(),
+            "[server_spec] keys must match the vendored spec files"
+        );
+
+        let wire_provenance: toml::Value =
+            toml::from_str(&read_project_file("tests/wire-samples/PROVENANCE.toml"))
+                .expect("wire-samples PROVENANCE.toml must be valid TOML");
+        assert_eq!(
+            toml_table_keys(&wire_provenance, "files"),
+            listed,
+            "wire-sample PROVENANCE [files] must name exactly the pinned \
+             samples — an extra entry would never be hash-verified"
+        );
+
+        let mut spec_on_disk = std::collections::BTreeSet::new();
+        collect_vendored_samples(&project_root().join("tests/server-spec"), &mut spec_on_disk);
+        let mut expected_spec = spec_entries();
+        expected_spec.extend(metadata_files);
+        assert_eq!(
+            spec_on_disk, expected_spec,
+            "tests/server-spec must hold exactly the pinned spec files plus \
+             README.md and PROVENANCE.toml"
+        );
+        let spec_provenance: toml::Value =
+            toml::from_str(&read_project_file("tests/server-spec/PROVENANCE.toml"))
+                .expect("server-spec PROVENANCE.toml must be valid TOML");
+        assert_eq!(
+            toml_table_keys(&spec_provenance, "files"),
+            spec_entries(),
+            "server-spec PROVENANCE [files] must name exactly the vendored spec files"
+        );
+
+        // Every sample must be consumed by a wire-golden `include_str!` (the
+        // round-trip conformance gate), and no golden may include an unlisted
+        // sample.
+        let golden = read_project_file("tests/wire_golden_tests.rs");
+        let mut golden_samples = std::collections::BTreeSet::new();
+        for (occurrence, _) in golden.match_indices("wire-samples/") {
+            let rest = &golden[occurrence + "wire-samples/".len()..];
+            let name: String = rest
+                .chars()
+                .take_while(|c| *c != '"' && *c != ')' && !c.is_whitespace())
+                .collect();
+            if name.ends_with(".jsonl") {
+                golden_samples.insert(name);
+            }
+        }
+        assert_eq!(
+            golden_samples, listed,
+            "tests/wire_golden_tests.rs include_str!s must pin exactly the \
+             vendored sample set"
+        );
+
+        // The protocol-sync gates must cover exactly the pinned sets so
+        // upstream additions stay visible: every `for f in` fetch loop (the
+        // upstream-`main` comparison and the pinned-commit comparison) must
+        // name every sample, the pinned-commit fetch must exist, and the
+        // vendored spec must be diffed by both comparisons — being named in
+        // the `paths:` trigger alone proves nothing.
+        let sync = read_project_file(".github/workflows/protocol-sync.yml");
+        let loop_lines: Vec<&str> = sync
+            .lines()
+            .filter(|line| line.trim_start().starts_with("for f in "))
+            .collect();
+        assert!(
+            !loop_lines.is_empty(),
+            "protocol-sync must fetch each vendored wire sample"
+        );
+        for line in &loop_lines {
+            for name in SAMPLE_FILES {
+                assert!(
+                    line.contains(name.trim_end_matches(".jsonl")),
+                    "protocol-sync wire-sample fetch loop must cover {name}: {line}"
+                );
+            }
+        }
+        assert!(
+            sync.contains("signal-fish-server/$pin/"),
+            "protocol-sync must fetch evidence at the pinned protocol-authority commit"
+        );
+        let spec_diff_lines = sync
+            .lines()
+            .filter(|line| {
+                line.trim_start().starts_with("diff")
+                    && line.contains("tests/server-spec/signal-fish-protocol.asyncapi.yaml")
+            })
+            .count();
+        assert!(
+            spec_diff_lines >= 2,
+            "protocol-sync must diff the vendored spec against both upstream \
+             main and the pinned protocol-authority commit"
+        );
+    }
+
+    /// Spec authority files vendored under `tests/server-spec/` (README and
+    /// PROVENANCE are pinned separately by the directory-content assertion).
+    fn spec_entries() -> std::collections::BTreeSet<String> {
+        ["signal-fish-protocol.asyncapi.yaml"]
+            .into_iter()
+            .map(std::string::ToString::to_string)
+            .collect()
+    }
+
+    /// Recursively collects every vendored evidence file name relative to the
+    /// vendored directory. Anything that is neither a directory nor a regular
+    /// file (symlinks, devices, ...) fails closed.
+    fn collect_vendored_samples(directory: &Path, names: &mut std::collections::BTreeSet<String>) {
+        for entry in std::fs::read_dir(directory)
+            .unwrap_or_else(|error| panic!("failed to read {}: {error}", directory.display()))
+        {
+            let entry = entry.expect("vendored evidence entry must be readable");
+            let path = entry.path();
+            let file_type = entry
+                .file_type()
+                .expect("vendored evidence entry type must be readable");
+            if file_type.is_dir() {
+                collect_vendored_samples(&path, names);
+            } else if file_type.is_file() {
+                let name = path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .expect("vendored evidence file names must be UTF-8");
+                names.insert(name.to_string());
+            } else {
+                panic!(
+                    "vendored evidence must hold only regular files: {}",
+                    path.display()
+                );
+            }
+        }
+    }
+
+    /// Reads the keys of a top-level `[table]` from a parsed TOML document.
+    fn toml_table_keys(document: &toml::Value, table: &str) -> std::collections::BTreeSet<String> {
+        document
+            .get(table)
+            .and_then(toml::Value::as_table)
+            .expect("[table] required")
+            .keys()
+            .cloned()
+            .collect()
+    }
+
+    #[test]
     fn no_protocol_type_uses_deny_unknown_fields() {
         // Forward-compat: protocol types must tolerate unknown (additive) server
         // fields, so `deny_unknown_fields` must never appear in the protocol layer.

--- a/tests/compatibility_manifest_tests.rs
+++ b/tests/compatibility_manifest_tests.rs
@@ -40,6 +40,15 @@ fn compatibility_manifest_binds_exact_server_artifacts() {
         version_parts.next().is_none(),
         "client_version must be strict X.Y.Z"
     );
+    // The manifest's client version is the released workspace version; the
+    // release tooling rewrites both in the same commit, so a manual bump of
+    // one side must fail here instead of drifting silently until release.
+    assert_eq!(
+        client_version,
+        env!("CARGO_PKG_VERSION"),
+        "tests/compatibility.toml client_version must match the core crate \
+         version (bump both together, as Prepare Release does)"
+    );
     assert_eq!(manifest["server_version"].as_str(), Some("0.8.0"));
     assert_eq!(manifest["server_tag"].as_str(), Some("v0.8.0"));
     let commit = manifest["server_commit"]

--- a/tests/error_code_conformance_tests.rs
+++ b/tests/error_code_conformance_tests.rs
@@ -83,143 +83,106 @@ fn extract_spec_error_tokens() -> Vec<String> {
     tokens
 }
 
+/// One entry per client `ErrorCode` variant. This single list drives both
+/// [`all_client_error_codes`] and [`exhaustiveness_guard`], so adding a
+/// variant extends the runtime inventory and the compile-time guard in one
+/// edit and the inventory cannot go stale.
+macro_rules! for_each_client_error_code {
+    ($mac:ident) => {
+        $mac!(
+            Unauthorized,
+            InvalidToken,
+            AuthenticationRequired,
+            InvalidAppId,
+            AppIdExpired,
+            AppIdRevoked,
+            AppIdSuspended,
+            MissingAppId,
+            AuthenticationTimeout,
+            SdkVersionUnsupported,
+            UnsupportedGameDataFormat,
+            InvalidInput,
+            InvalidGameName,
+            InvalidRoomCode,
+            InvalidPlayerName,
+            InvalidMaxPlayers,
+            MessageTooLarge,
+            RoomNotFound,
+            RoomFull,
+            AlreadyInRoom,
+            NotInRoom,
+            RoomCreationFailed,
+            MaxRoomsPerGameExceeded,
+            InvalidRoomState,
+            AuthorityNotSupported,
+            AuthorityConflict,
+            AuthorityDenied,
+            RateLimitExceeded,
+            TooManyConnections,
+            ReconnectionFailed,
+            ReconnectionTokenInvalid,
+            ReconnectionExpired,
+            PlayerAlreadyConnected,
+            SpectatorNotAllowed,
+            TooManySpectators,
+            NotASpectator,
+            SpectatorJoinFailed,
+            InternalError,
+            StorageError,
+            ServiceUnavailable,
+            GameStartNotReady,
+            GameStartForbidden,
+            RoomSessionIncompatible,
+            CrossRoomSignal,
+            UnsupportedTransport,
+            SignalTargetNotFound,
+            SignalRateLimited,
+            SignalTooLarge,
+            ConnectionIdleTimeout,
+            SlowConsumer,
+            ActivityTimeout,
+            ServerDraining,
+            InvalidDeliveryClass,
+            UnsupportedProtocolVersion,
+            NotRoomAuthority,
+            KickTargetNotFound,
+            Kicked,
+            PasswordRequired,
+            Banned,
+            TransferTargetNotFound,
+        );
+    };
+}
+
 /// Every client `ErrorCode` variant, exactly once.
 ///
-/// Kept honest by [`exhaustiveness_guard`]: adding an enum variant fails to
-/// compile there, forcing an edit to this file — extend BOTH the guard match
-/// and this list.
+/// Mechanically exhaustive: the list lives in [`for_each_client_error_code`],
+/// shared with [`exhaustiveness_guard`].
 fn all_client_error_codes() -> Vec<ErrorCode> {
-    vec![
-        ErrorCode::Unauthorized,
-        ErrorCode::InvalidToken,
-        ErrorCode::AuthenticationRequired,
-        ErrorCode::InvalidAppId,
-        ErrorCode::AppIdExpired,
-        ErrorCode::AppIdRevoked,
-        ErrorCode::AppIdSuspended,
-        ErrorCode::MissingAppId,
-        ErrorCode::AuthenticationTimeout,
-        ErrorCode::SdkVersionUnsupported,
-        ErrorCode::UnsupportedGameDataFormat,
-        ErrorCode::InvalidInput,
-        ErrorCode::InvalidGameName,
-        ErrorCode::InvalidRoomCode,
-        ErrorCode::InvalidPlayerName,
-        ErrorCode::InvalidMaxPlayers,
-        ErrorCode::MessageTooLarge,
-        ErrorCode::RoomNotFound,
-        ErrorCode::RoomFull,
-        ErrorCode::AlreadyInRoom,
-        ErrorCode::NotInRoom,
-        ErrorCode::RoomCreationFailed,
-        ErrorCode::MaxRoomsPerGameExceeded,
-        ErrorCode::InvalidRoomState,
-        ErrorCode::AuthorityNotSupported,
-        ErrorCode::AuthorityConflict,
-        ErrorCode::AuthorityDenied,
-        ErrorCode::RateLimitExceeded,
-        ErrorCode::TooManyConnections,
-        ErrorCode::ReconnectionFailed,
-        ErrorCode::ReconnectionTokenInvalid,
-        ErrorCode::ReconnectionExpired,
-        ErrorCode::PlayerAlreadyConnected,
-        ErrorCode::SpectatorNotAllowed,
-        ErrorCode::TooManySpectators,
-        ErrorCode::NotASpectator,
-        ErrorCode::SpectatorJoinFailed,
-        ErrorCode::InternalError,
-        ErrorCode::StorageError,
-        ErrorCode::ServiceUnavailable,
-        ErrorCode::GameStartNotReady,
-        ErrorCode::GameStartForbidden,
-        ErrorCode::RoomSessionIncompatible,
-        ErrorCode::CrossRoomSignal,
-        ErrorCode::UnsupportedTransport,
-        ErrorCode::SignalTargetNotFound,
-        ErrorCode::SignalRateLimited,
-        ErrorCode::SignalTooLarge,
-        ErrorCode::ConnectionIdleTimeout,
-        ErrorCode::SlowConsumer,
-        ErrorCode::ActivityTimeout,
-        ErrorCode::ServerDraining,
-        ErrorCode::InvalidDeliveryClass,
-        ErrorCode::UnsupportedProtocolVersion,
-        ErrorCode::NotRoomAuthority,
-        ErrorCode::KickTargetNotFound,
-        ErrorCode::Kicked,
-        ErrorCode::PasswordRequired,
-        ErrorCode::Banned,
-        ErrorCode::TransferTargetNotFound,
-    ]
+    let mut codes = Vec::new();
+    macro_rules! push {
+        ($($variant:ident),+ $(,)?) => {
+            $(codes.push(ErrorCode::$variant);)+
+        };
+    }
+    for_each_client_error_code!(push);
+    codes
 }
 
 /// Compile-time exhaustiveness guard: one arm per variant, no wildcard.
 ///
-/// A new `ErrorCode` variant fails compilation here until both this match and
-/// [`all_client_error_codes`] are extended.
+/// A new `ErrorCode` variant fails compilation here until it joins the
+/// shared [`for_each_client_error_code`] list, which extends
+/// [`all_client_error_codes`] in the same edit.
 fn exhaustiveness_guard(code: &ErrorCode) {
-    match code {
-        ErrorCode::Unauthorized
-        | ErrorCode::InvalidToken
-        | ErrorCode::AuthenticationRequired
-        | ErrorCode::InvalidAppId
-        | ErrorCode::AppIdExpired
-        | ErrorCode::AppIdRevoked
-        | ErrorCode::AppIdSuspended
-        | ErrorCode::MissingAppId
-        | ErrorCode::AuthenticationTimeout
-        | ErrorCode::SdkVersionUnsupported
-        | ErrorCode::UnsupportedGameDataFormat
-        | ErrorCode::InvalidInput
-        | ErrorCode::InvalidGameName
-        | ErrorCode::InvalidRoomCode
-        | ErrorCode::InvalidPlayerName
-        | ErrorCode::InvalidMaxPlayers
-        | ErrorCode::MessageTooLarge
-        | ErrorCode::RoomNotFound
-        | ErrorCode::RoomFull
-        | ErrorCode::AlreadyInRoom
-        | ErrorCode::NotInRoom
-        | ErrorCode::RoomCreationFailed
-        | ErrorCode::MaxRoomsPerGameExceeded
-        | ErrorCode::InvalidRoomState
-        | ErrorCode::AuthorityNotSupported
-        | ErrorCode::AuthorityConflict
-        | ErrorCode::AuthorityDenied
-        | ErrorCode::RateLimitExceeded
-        | ErrorCode::TooManyConnections
-        | ErrorCode::ReconnectionFailed
-        | ErrorCode::ReconnectionTokenInvalid
-        | ErrorCode::ReconnectionExpired
-        | ErrorCode::PlayerAlreadyConnected
-        | ErrorCode::SpectatorNotAllowed
-        | ErrorCode::TooManySpectators
-        | ErrorCode::NotASpectator
-        | ErrorCode::SpectatorJoinFailed
-        | ErrorCode::InternalError
-        | ErrorCode::StorageError
-        | ErrorCode::ServiceUnavailable
-        | ErrorCode::GameStartNotReady
-        | ErrorCode::GameStartForbidden
-        | ErrorCode::RoomSessionIncompatible
-        | ErrorCode::CrossRoomSignal
-        | ErrorCode::UnsupportedTransport
-        | ErrorCode::SignalTargetNotFound
-        | ErrorCode::SignalRateLimited
-        | ErrorCode::SignalTooLarge
-        | ErrorCode::ConnectionIdleTimeout
-        | ErrorCode::SlowConsumer
-        | ErrorCode::ActivityTimeout
-        | ErrorCode::ServerDraining
-        | ErrorCode::InvalidDeliveryClass
-        | ErrorCode::UnsupportedProtocolVersion
-        | ErrorCode::NotRoomAuthority
-        | ErrorCode::KickTargetNotFound
-        | ErrorCode::Kicked
-        | ErrorCode::PasswordRequired
-        | ErrorCode::Banned
-        | ErrorCode::TransferTargetNotFound => {}
+    macro_rules! match_arms {
+        ($($variant:ident),+ $(,)?) => {
+            match code {
+                $(ErrorCode::$variant => {})+
+            }
+        };
     }
+    for_each_client_error_code!(match_arms);
 }
 
 fn wire_token(code: &ErrorCode) -> String {


### PR DESCRIPTION
## Why

Paranoid-audit round 65 (issue #126) audited two never-audited surfaces and found that the repository's protocol-authority pins were strong at the four vendored files but open at the edges — and that the coverage number hid two untested public APIs.

## What

**Authority-pin enforcement (no silent protocol rot):**
- New bijection test: vendored evidence files must be named by *every* pin surface (directory contents, `SAMPLE_FILES`, compatibility.toml, both PROVENANCE tables, wire goldens, both protocol-sync fetch loops) — a new, renamed, or extra file can no longer escape the hash/golden/upstream gates.
- Protocol Sync now fetches all five evidence files at the *pinned* authority commit and diffs them against the vendored bytes, so the pin is cryptographically bound, not just conventional.
- `client_version` in compatibility.toml is now asserted equal to the workspace version — one-sided version bumps fail tests instead of drifting to release day.
- The error-code inventory and its compile-time exhaustiveness guard share one list: a new `ErrorCode` variant updates both in one edit or fails to compile.

**Coverage truthfulness (the ~95% number's real holes):**
- `send_game_data_with_delivery_reliable` (public, zero test callers) now pins its delivery class onto the wire and joins the terminal-close refusal matrix.
- `reset_queue_age_peak` gains a wrapper-parity pin (its other callers live outside the coverage denominator).
- The Coverage workflow's stale comment is replaced with an accurate description of what the number does and does not measure.

**Also:** upstream drift check (zero — three server-internal commits; #222 still blocked), CI-time audit (no increase; Godot Web outlier RCA'd as one-off apt slowness), stale skill-doc commit literal fixed.

## Verification

- Mandatory workflow green: fmt, clippy `-D warnings`, 27 suites / 0 failures.
- Red/green probes for every new guard (stray file, extra PROVENANCE entry, version drift, removed variant → E0004, dropped wire class, no-op reset) — all red then green.
- All five pinned-commit blobs byte-match the vendored files today (live check).
- Hostile reviewer + convergence verifier converged to zero functional findings.

No user-visible changes; no changelog entry per policy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are CI guards, workflow checks, and unit tests; no production client logic or wire protocol handling is modified.
> 
> **Overview**
> Tightens **protocol-authority** guarantees and closes a few **coverage holes** without changing runtime behavior.
> 
> **Protocol pins:** Adds a **Protocol Sync** step that downloads wire samples and the AsyncAPI spec at the **`[protocol_authority].commit`** from `tests/compatibility.toml` and diffs them against vendored files, so pins are tied to upstream blobs—not only local hashes. A new **`wire_sample_and_spec_sets_are_pinned_by_every_surface`** test in `ci_config_tests` requires the same file set across on-disk dirs, `SAMPLE_FILES`, manifest tables, PROVENANCE, wire goldens, and both protocol-sync fetch loops. **`compatibility.toml` `client_version`** must match **`CARGO_PKG_VERSION`**. Error-code conformance now uses a shared **`for_each_client_error_code!`** macro so the inventory and compile-time exhaustiveness guard stay in sync. The skill doc’s authority commit literal is updated to **`ac118f846f26ac55e2fc1f3231dcc9aec86a7275`**.
> 
> **Coverage truthfulness:** New tests pin **`send_game_data_with_delivery_reliable`** (delivery class on the wire + **`NotConnected`** after terminal close) and **`reset_queue_age_peak`** on the polling client. The Coverage workflow comment documents what the **93%** line baseline includes and excludes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77405b2f9043a4de8be5a4a2a6c34e824c265169. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->