### PR TITLE
fix: room snapshots without connected_at still parse (server #539)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Room snapshots without `connected_at` on `PlayerInfo` and `SpectatorInfo`
+  now deserialize instead of failing the whole frame. Protocol-v3 room
+  snapshots may trim the field for privacy (signal-fish-server #539); the
+  SDK reads it back as an empty string, so the timestamp is unknown to this
+  SDK version. The public field type is unchanged.
 - **Breaking:** the core crate's `tokio` dependency no longer enables
   `sync`/`macros` unconditionally — they moved into the `tokio-runtime`
   feature alongside `rt`/`time` — and `futures-util` is now declared without

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -292,7 +292,7 @@ pub struct PlayerInfo {
 | `name` | `String` | Display name chosen at join time. |
 | `is_authority` | `bool` | Whether this player is the room authority. |
 | `is_ready` | `bool` | Whether the player has signaled readiness. |
-| `connected_at` | `String` | ISO 8601 timestamp of when the player connected. |
+| `connected_at` | `String` | ISO 8601 timestamp of when the player connected. Empty when the server omits the field: protocol-v3 room snapshots may trim it for privacy (signal-fish-server #539). |
 | `connection_info` | `Option<ConnectionInfo>` | Legacy self-declared P2P metadata. Protocol-v2 room snapshots may include it; protocol-v3 room snapshots omit it (the authoritative copy reaches peers via `GameStarting`'s `PeerConnectionInfo`). |
 | `epoch` | `Option<u32>` | Protocol v3 only: the player's current incarnation epoch. |
 | `seq` | `Option<u64>` | Protocol v3 only: the player's exact relay baseline; delivery obligations start at `seq + 1`. |
@@ -315,7 +315,7 @@ pub struct SpectatorInfo {
 |-------|------|-------------|
 | `id` | `PlayerId` | The spectator's unique identifier. |
 | `name` | `String` | Display name. |
-| `connected_at` | `String` | ISO 8601 timestamp of when the spectator joined. |
+| `connected_at` | `String` | ISO 8601 timestamp of when the spectator joined. Empty when the server omits the field (see `PlayerInfo`). |
 
 ---
 

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -386,6 +386,11 @@ pub struct PlayerInfo {
     pub name: String,
     pub is_authority: bool,
     pub is_ready: bool,
+    /// ISO 8601 connect timestamp. Defaults to an empty string when the
+    /// server omits it: protocol-v3 room snapshots may trim this field for
+    /// privacy (signal-fish-server #539), and dropping the whole frame over
+    /// a metadata field would break the session.
+    #[serde(default)]
     pub connected_at: String,
     /// Legacy self-declared connection info for P2P establishment. Protocol
     /// v2 room snapshots may include it (when the player provided it);
@@ -406,6 +411,9 @@ pub struct PlayerInfo {
 pub struct SpectatorInfo {
     pub id: PlayerId,
     pub name: String,
+    /// ISO 8601 join timestamp. Defaults to an empty string when the server
+    /// omits it (see [`PlayerInfo::connected_at`]).
+    #[serde(default)]
     pub connected_at: String,
 }
 

--- a/tests/protocol_tests.rs
+++ b/tests/protocol_tests.rs
@@ -2555,6 +2555,37 @@ fn spectator_info_round_trip() {
     assert_eq!(deser.connected_at, "2026-03-01T15:00:00Z");
 }
 
+/// The server may omit `connected_at` from protocol-v3 room snapshots
+/// (signal-fish-server #539 trims it for privacy), so both structs must
+/// deserialize a snapshot payload without the field instead of failing the
+/// whole frame. The value reads back as an empty string: the timestamp is
+/// unknown to this SDK version.
+#[test]
+fn room_snapshot_without_connected_at_still_parses() {
+    let player_json = r#"{
+        "id": "00000000-0000-0000-0000-0000000000c8",
+        "name": "TrimmedV3",
+        "is_authority": true,
+        "is_ready": false
+    }"#;
+    let player: PlayerInfo = serde_json::from_str(player_json).expect("deserialize player");
+    assert_eq!(player.name, "TrimmedV3");
+    assert!(player.is_authority);
+    assert_eq!(player.connected_at, "");
+    assert!(player.connection_info.is_none());
+    assert!(player.epoch.is_none());
+    assert!(player.seq.is_none());
+
+    let spectator_json = r#"{
+        "id": "00000000-0000-0000-0000-000000000190",
+        "name": "TrimmedWatcher"
+    }"#;
+    let spectator: SpectatorInfo =
+        serde_json::from_str(spectator_json).expect("deserialize spectator");
+    assert_eq!(spectator.name, "TrimmedWatcher");
+    assert_eq!(spectator.connected_at, "");
+}
+
 #[test]
 fn peer_connection_info_round_trip() {
     let info = PeerConnectionInfo {


### PR DESCRIPTION
## Summary

Room snapshots without `connected_at` now deserialize. `PlayerInfo` and `SpectatorInfo` read the field with `serde(default)`; the public field type is unchanged.

The Signal Fish server plans to trim `connected_at` from protocol-v3 room snapshots for privacy ([signal-fish-server#539](https://github.com/Ambiguous-Interactive/signal-fish-server/issues/539), owner-ratified 2026-09-11). Released SDKs deserialize the field as required, so a trimmed snapshot fails the whole frame parse and the session stalls. This is the exact failure the server recorded on its fortress fixture in PR #538.

## Changes

- `src/protocol.rs`: `#[serde(default)]` on `PlayerInfo::connected_at` and `SpectatorInfo::connected_at`, with doc comments. A trimmed snapshot reads an empty string (timestamp unknown).
- `tests/protocol_tests.rs`: `room_snapshot_without_connected_at_still_parses` — red-first pin for both structs (failed on the pre-patch code with the required field).
- `docs/protocol.md`: field tables note the empty-string contract.
- `CHANGELOG.md`: `### Changed` entry under `## [Unreleased]`.

## Compatibility

- Older servers: wire behavior byte-identical (the field stays serialized; only the deserializer gained tolerance).
- Newer server with the #539 trim: snapshots parse; `connected_at` reads `""`. Server versions 0.8.0–0.12.0 never omit the field, so behavior there is unchanged too.

## Verification

- `cargo fmt`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — zero warnings
- `cargo nextest run --workspace --all-features` — 1191 passed, 15 skipped

## Follow-ups (tracked in signal-fish-server#539)

1. Release this SDK change.
2. Server repo bumps its fixtures (`clients/fortress` from `=0.8.0`, `clients/fortress-wasm` from `=0.9.0`).
3. Server repo re-lands the v3 `connected_at` trim (the #538 first-cut design: write-layer cohort projection, goldens, spec `V3PlayerInfo`/spectator split).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive deserialization tolerance with unchanged wire types; apps that assume a non-empty ISO timestamp on every snapshot should treat `""` as unknown.
> 
> **Overview**
> **Room snapshots without `connected_at` no longer fail deserialization.** `PlayerInfo` and `SpectatorInfo` use `#[serde(default)]` on `connected_at`, so protocol-v3 snapshots that omit the field (planned server privacy trim, signal-fish-server #539) parse as before instead of breaking the whole frame. The public type stays `String`; a missing field reads as `""` (timestamp unknown).
> 
> Docs (`protocol.md`, `CHANGELOG`) describe the empty-string contract. A new protocol test pins JSON without `connected_at` for both structs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c3a8d62c463ad2c1805f6ea79ef1ced5c593069. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->