### PR TITLE
feat!: adopt upstream CONNECT_TOKEN_REQUIRED; release-note truth (round 68)

### DIFF
--- a/.llm/context.md
+++ b/.llm/context.md
@@ -96,7 +96,7 @@ Dependabot uses one root-workspace updater; minimum/latest Godot fixtures stay s
 | `src/protocol/binary.rs` | Strict physical MessagePack envelope decoders for v2/v3 binary game data |
 | `src/accountability.rs` | Server-0.4.0-derived delivery-accountability state machine |
 | `src/signal.rs` | `PeerSignal` — typed, matchbox-compatible WebRTC signal (protocol v3) |
-| `src/error_codes.rs` | `ErrorCode` enum — 61 variants from server (55 in the post-0.7 authority, 6 compatibility-only) |
+| `src/error_codes.rs` | `ErrorCode` enum — 62 variants from server (56 in the post-0.7 authority, 6 compatibility-only) |
 | `src/error.rs` | `SignalFishError` error type |
 | `src/event.rs` | `SignalFishEvent` high-level event stream |
 | `src/client_core.rs` | Shared command construction, decoding, accountability, state, events, and statistics |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `SignalFishConfig` gains a `connect_token` field (`with_connect_token`) that
   rides `Authenticate` on hosted deployments with tenant verification (upstream
   server PR #575); exhaustive struct literals must add it, usually
-  `connect_token: None`. The wire field is omitted when unset, the value is a
-  secret redacted from `Debug`/tracing (presence and byte length only), and
-  rotation guidance lives in the Authentication & Credentials guide.
+  `connect_token: None`, and the same field joined the public
+  `ClientMessage::Authenticate` wire variant. The wire field is omitted when
+  unset, the value is a secret redacted from `Debug`/tracing (presence and byte
+  length only), and rotation guidance lives in the Authentication & Credentials
+  guide.
 - **Breaking:** the exhaustive error-code enum adds `ConnectTokenInvalid`, so
   a refused tenant token (encoding, signature, expiry, TTL ceiling, or app-id
   binding) surfaces as a typed authentication error whose recovery is a fresh
   token plus a new client; add an arm to exhaustive matches.
+- **Breaking:** the exhaustive error-code enum adds `ConnectTokenRequired` for
+  upstream server PR #576's enforcement face of the tenant tier: a deployment
+  that mandates connect tokens refuses a token-less handshake with it, so the
+  refusal surfaces typed instead of failing the frame decode; add an arm to
+  exhaustive matches. Recovery is a control-plane token via
+  `with_connect_token` plus a new client.
 
 - **Breaking:** the wire types gained the upstream room access-control tier —
   exhaustive `ErrorCode` adds `PasswordRequired`, `Banned`, and
@@ -34,8 +42,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Breaking:** `JoinRoomParams::with_password` sets the join password for
   password-protected rooms, serialized into `JoinRoom` (and its negotiated
   form) via the new additive `password` field and omitted when unset, so
-  existing joins keep byte-identical wire behavior; the value is redacted
-  from `Debug` output.
+  existing joins keep byte-identical wire behavior; the value is redacted from
+  `Debug` output. The field also joined `JoinRoomParams` itself plus the
+  `ClientMessage::JoinRoom`, `ClientMessage::JoinAsSpectator`,
+  `RoomOperationRequest::JoinRoom`, and `RoomOperationRequest::JoinAsSpectator`
+  wire variants: exhaustive literals and field-wise matches must add it.
 - **Breaking:** `join_as_spectator_with_password` on both drivers and the
   `SignalFishClientApi` trait (implementors add one method) presents a sealed
   room's join password on `JoinAsSpectator`, so spectator entry into
@@ -44,7 +55,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `SignalFishEvent::SpectatorDisconnected` gain the additive
   `spectator_count: Option<u32>` field, carrying the room's spectator total
   on servers with the v3 spectator fan-out slimming tier (`None` on the
-  full-roster face and older servers).
+  full-roster face and older servers); the same field joined the
+  `ServerMessage::NewSpectatorJoined` and `ServerMessage::SpectatorDisconnected`
+  wire variants, so exhaustive wire literals and field-wise matches must add
+  it.
 - **Breaking:** the wire types gained the upstream authority-moderation
   surface — exhaustive `ErrorCode` adds `NotRoomAuthority`, `KickTargetNotFound`,
   and `Kicked`; `RoomOperationRequest` adds `KickPlayer { player_id }` and

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -29,10 +29,12 @@ Hosted Signal Fish deployments can require a **tenant connect token**: a
 short-lived credential minted by the deployment's control plane as
 `sfct_v1.<base64url(payload)>.<base64url(signature)>` and signed with the
 deployment's Ed25519 public key. The server verifies the token during
-authentication and never logs or echoes it. Self-hosted deployments without
-a verification key keep the public-`app_id` handshake and refuse any
-presented token, so only set one when your deployment documents tenant
-verification.
+authentication and never logs or echoes it. A deployment can also *enforce*
+the credential: a token-less handshake against an enforcing deployment is
+refused with `ConnectTokenRequired` while the socket stays open. Self-hosted
+deployments without a verification key keep the public-`app_id` handshake and
+refuse any presented token, so only set one when your deployment documents
+tenant verification.
 
 ```rust
 let config = SignalFishConfig::new("mb_app_abc123")
@@ -91,7 +93,7 @@ the mTLS fingerprint profile.
 | Secret | Issued | Rotate | On failure |
 |---|---|---|---|
 | Reconnection token | `RoomJoined` | Every `Reconnected` — persist the replacement | `ReconnectionExpired` / `ReconnectionTokenInvalid`: fall back to a normal `join_room` |
-| Tenant connect token | Deployment control plane | Before expiry (upstream TTL: 5 minutes + 60-second skew) | `ConnectTokenInvalid`: issue a fresh token and start a new client |
+| Tenant connect token | Deployment control plane | Before expiry (upstream TTL: 5 minutes + 60-second skew) | `ConnectTokenInvalid` / `ConnectTokenRequired`: issue a fresh token and start a new client |
 | TLS session | Connect | Every new physical connection (fresh handshake, fresh proofs) | Reconnect with a fresh transport |
 | App ID | Deployment | N/A — it is a public label | The server rejects unknown labels at authentication |
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -500,8 +500,8 @@ migration](migration-0.11.md#structured-transport-error-causes).
 
 ### Server-Side: `ErrorCode`
 
-`ErrorCode` is a 61-variant enum that arrives inside events. The post-0.7
-protocol authority declares 55 variants; six compatibility variants remain
+`ErrorCode` is a 62-variant enum that arrives inside events. The post-0.7
+protocol authority declares 56 variants; six compatibility variants remain
 decodable for older servers. The wire uses `SCREAMING_SNAKE_CASE` strings
 (e.g., `"ROOM_NOT_FOUND"`).
 

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -95,9 +95,9 @@ fn try_join(client: &mut SignalFishClient) {
 
 ## `ErrorCode`
 
-`ErrorCode` is a protocol-level enum with **61 variants** representing
+`ErrorCode` is a protocol-level enum with **62 variants** representing
 structured error codes returned by compatible Signal Fish servers. The
-post-0.7 protocol authority declares 55 of them; six variants remain decodable
+post-0.7 protocol authority declares 56 of them; six variants remain decodable
 for older servers and are listed by `ErrorCode::NON_EMITTED`. It derives `Debug`,
 `Clone`, `PartialEq`, `Eq`, `Serialize`, and `Deserialize`.
 
@@ -130,6 +130,7 @@ println!("{}", code.description());
 | `SdkVersionUnsupported` | The SDK version you are using is no longer supported. |
 | `UnsupportedGameDataFormat` | The requested game data format is not supported. |
 | `ConnectTokenInvalid` | The optional tenant connect token failed verification (encoding, signature, expiry, TTL ceiling, or app-id binding). The socket stays open; the configured token is fixed for a client's lifetime, so recovery means issuing a fresh control-plane token and starting a new client. See [Authentication & Credentials](authentication.md#tenant-connect-tokens-optional-hosted-deployments). |
+| `ConnectTokenRequired` | The deployment enforces tenant credentials and the handshake carried no connect token. The socket stays open; recovery means obtaining an `sfct_v1.` token from the deployment's control plane, presenting it via `with_connect_token`, and starting a new client. See [Authentication & Credentials](authentication.md#tenant-connect-tokens-optional-hosted-deployments). |
 
 ### Validation (6)
 

--- a/src/error_codes.rs
+++ b/src/error_codes.rs
@@ -54,6 +54,13 @@ pub enum ErrorCode {
     /// open; since the configured token is fixed for a client's lifetime,
     /// recovery means issuing a fresh token and starting a new client.
     ConnectTokenInvalid,
+    /// The deployment enforces tenant credentials and the handshake carried
+    /// no connect token at all. The socket stays open; recovery means
+    /// obtaining an `sfct_v1.` token from the deployment's control plane,
+    /// presenting it via
+    /// [`with_connect_token`](crate::SignalFishConfig::with_connect_token),
+    /// and starting a new client.
+    ConnectTokenRequired,
 
     // Validation errors
     /// A request parameter was invalid or malformed.
@@ -449,6 +456,9 @@ impl ErrorCode {
             }
             Self::ConnectTokenInvalid => {
                 "The optional tenant connect token failed verification (encoding, signature, expiry, TTL ceiling, or app-id binding). Issue a fresh token from your deployment's control plane and start a new client; the configured token is fixed for this client's lifetime."
+            }
+            Self::ConnectTokenRequired => {
+                "This deployment requires a tenant connect token and the handshake carried none. Obtain an sfct_v1. token from your deployment's control plane, present it via with_connect_token, and start a new client."
             }
         }
     }

--- a/tests/compatibility.toml
+++ b/tests/compatibility.toml
@@ -10,7 +10,7 @@ synced = "2026-09-01"
 # files) without touching the released runtime binding above; any schema,
 # message, or error-code change triggers full type reconciliation.
 [protocol_authority]
-commit = "a6cbbf69dc7356a97ee5847b5a1e8d09a1283b14"
+commit = "018cd0f7656827a7ff6181c9f4a1d87d759d3e42"
 synced = "2026-09-12"
 
 [legacy_server]
@@ -30,4 +30,4 @@ generation = "omitted"
 "v3-server-messages.jsonl" = "5d210777ffe3db0ba36b10be6f40f2354acbbe9c5f4b6b83544eafa95daedbd6"
 
 [server_spec]
-"signal-fish-protocol.asyncapi.yaml" = "55dd84e22ab0580e3d2dec25c3989646eb0a2fc66449682adb4e4d77c7b56684"
+"signal-fish-protocol.asyncapi.yaml" = "70cfd73118014e285f6e166e9e1151b9c787606d39ffd09df8de1f89f7556764"

--- a/tests/compatibility_manifest_tests.rs
+++ b/tests/compatibility_manifest_tests.rs
@@ -95,10 +95,10 @@ fn compatibility_manifest_binds_exact_server_artifacts() {
     // The evidence authority (all vendored protocol artifacts) advances with
     // descriptive drift plus reviewed deliberate schema changes; the released
     // runtime binding above stays at the 0.8.0 release commit. Keep this
-    // literal review-forced. a6cbbf69 is upstream PR #575: the ratified
-    // cloud-auth wire contract (optional `Authenticate.connect_token` +
-    // CONNECT_TOKEN_INVALID), additive-only.
-    assert_eq!(protocol_commit, "a6cbbf69dc7356a97ee5847b5a1e8d09a1283b14");
+    // literal review-forced. 018cd0f7 is upstream PR #576: the optional
+    // tenant connect_token enforcement knob plus the CONNECT_TOKEN_REQUIRED
+    // refusal code (spec enum + prose only; wire samples byte-identical).
+    assert_eq!(protocol_commit, "018cd0f7656827a7ff6181c9f4a1d87d759d3e42");
     assert_eq!(
         wire_provenance["upstream"]["commit"].as_str(),
         Some(protocol_commit)

--- a/tests/error_code_conformance_tests.rs
+++ b/tests/error_code_conformance_tests.rs
@@ -102,6 +102,7 @@ macro_rules! for_each_client_error_code {
             SdkVersionUnsupported,
             UnsupportedGameDataFormat,
             ConnectTokenInvalid,
+            ConnectTokenRequired,
             InvalidInput,
             InvalidGameName,
             InvalidRoomCode,

--- a/tests/protocol_tests.rs
+++ b/tests/protocol_tests.rs
@@ -1672,6 +1672,24 @@ fn connect_token_invalid_error_code_uses_the_upstream_wire_token() {
 }
 
 #[test]
+fn connect_token_required_error_code_uses_the_upstream_wire_token() {
+    // Upstream PR #576: a deployment enforcing tenant credentials refuses a
+    // token-less handshake with this code on the still-open socket.
+    let code = ErrorCode::ConnectTokenRequired;
+    let json = serde_json::to_string(&code).expect("serialize");
+    assert_eq!(json, "\"CONNECT_TOKEN_REQUIRED\"");
+    let parsed: ErrorCode = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(parsed, code);
+    // The full enforced-server refusal frame surfaces typed end to end.
+    let frame = r#"{"type":"AuthenticationError","data":{"error":"tenant connect token required","error_code":"CONNECT_TOKEN_REQUIRED"}}"#;
+    let message: ServerMessage = serde_json::from_str(frame).expect("decode");
+    let ServerMessage::AuthenticationError { error_code, .. } = message else {
+        panic!("AuthenticationError frame must decode");
+    };
+    assert_eq!(error_code, ErrorCode::ConnectTokenRequired);
+}
+
+#[test]
 fn authenticate_mesh_includes_v3_fields_with_exact_strings() {
     let msg = ClientMessage::Authenticate {
         app_id: "mb_app".into(),

--- a/tests/server-spec/PROVENANCE.toml
+++ b/tests/server-spec/PROVENANCE.toml
@@ -7,11 +7,13 @@
 repo = "https://github.com/Ambiguous-Interactive/signal-fish-server"
 path = "spec"
 # Exact server commit the spec bytes were copied from.
-# 2026-09-12 refresh: upstream PR #575 (server issue #517, the ratified cloud
-# auth wire contract) added the optional `Authenticate.connect_token` tenant
-# credential field and the `CONNECT_TOKEN_INVALID` error code. Both are
-# additive: an omitted field is byte-identical to the previous wire on every
-# path, and all four wire samples are byte-identical at the new pin. The
+# 2026-09-12 refresh: upstream PR #576 (server issue #574) added the
+# `CONNECT_TOKEN_REQUIRED` error code (the enforcement face of the #517
+# cloud-auth tier: a deployment that enforces tenant credentials refuses a
+# token-less handshake with it) plus the matching enforcement prose on
+# `Authenticate.connect_token`. The enum addition is a typed-surface change
+# reconciled in lockstep (`ErrorCode::ConnectTokenRequired`); all four wire
+# samples are byte-identical at the new pin. The
 # Server 0.8.0
 # release pin
 # (d79dcdc7549777c8c2bd9fcb2d132641532d8c86) does not declare the
@@ -19,11 +21,11 @@ path = "spec"
 # at that release. This evidence authority advances together with
 # tests/compatibility.toml's [protocol_authority] and the wire-samples
 # PROVENANCE.
-commit = "a6cbbf69dc7356a97ee5847b5a1e8d09a1283b14"
+commit = "018cd0f7656827a7ff6181c9f4a1d87d759d3e42"
 # ISO 8601 date of the last refresh.
 synced = "2026-09-12"
 
 # SHA-256 of each vendored file. A policy test recomputes these, so the spec
 # cannot be edited without also updating this marker (keeps provenance honest).
 [files]
-"signal-fish-protocol.asyncapi.yaml" = "55dd84e22ab0580e3d2dec25c3989646eb0a2fc66449682adb4e4d77c7b56684"
+"signal-fish-protocol.asyncapi.yaml" = "70cfd73118014e285f6e166e9e1151b9c787606d39ffd09df8de1f89f7556764"

--- a/tests/server-spec/signal-fish-protocol.asyncapi.yaml
+++ b/tests/server-spec/signal-fish-protocol.asyncapi.yaml
@@ -607,6 +607,7 @@ components:
         - BANNED
         - TRANSFER_TARGET_NOT_FOUND
         - CONNECT_TOKEN_INVALID
+        - CONNECT_TOKEN_REQUIRED
 
     ReliableDeliveryCounters:
       type: object
@@ -925,10 +926,13 @@ components:
                 `sfct_v1.<base64url(payload)>.<base64url(signature)>` and
                 signed with the Ed25519 key configured on the server under
                 `security.connect_token.public_key`. Absent field keeps the
-                public-app_id semantics. Only meaningful when the server
-                configures a verification key; every verification failure is
-                reported as CONNECT_TOKEN_INVALID. Never logged or echoed by
-                the server.
+                public-app_id semantics unless the deployment enforces the
+                credential (`security.connect_token.required`, or a per-app
+                `require_connect_token` registration), in which case the
+                token-less handshake is refused with CONNECT_TOKEN_REQUIRED.
+                Only meaningful when the server configures a verification
+                key; every verification failure is reported as
+                CONNECT_TOKEN_INVALID. Never logged or echoed by the server.
             sdk_version: { type: string }
             platform: { type: string }
             game_data_format: { $ref: '#/components/schemas/GameDataEncoding' }

--- a/tests/wire-samples/PROVENANCE.toml
+++ b/tests/wire-samples/PROVENANCE.toml
@@ -20,8 +20,10 @@ path = ".llm/code-samples/protocol"
 # the ratified cloud-auth wire contract) added the optional
 # `Authenticate.connect_token` field and the CONNECT_TOKEN_INVALID error code
 # to the spec only — an omitted field is byte-identical, and the four files
-# are byte-identical there as well.)
-commit = "a6cbbf69dc7356a97ee5847b5a1e8d09a1283b14"
+# are byte-identical there as well. The same-day 018cd0f7 follow-up (upstream
+# PR #576) added the CONNECT_TOKEN_REQUIRED spec enum entry; the samples are
+# unchanged there too.)
+commit = "018cd0f7656827a7ff6181c9f4a1d87d759d3e42"
 # Protocol version range these samples exercise.
 protocol_version_min = 2
 protocol_version_max = 3


### PR DESCRIPTION
## Why

Round 68 of the recurring correctness audit (#126), three surfaces:

1. **Upstream moved mid-session** — server PR #576 (`018cd0f7`) added the `CONNECT_TOKEN_REQUIRED` error code (the enforcement face of the #517 tenant tier: an enforcing deployment refuses a token-less handshake with it). Without incorporation, that refusal would surface as an undecodable `DecodeFailed` instead of a typed error.
2. The release notes for the next release never told consumers that **wire variants gained fields**, so exhaustive `ClientMessage`/`ServerMessage` literals and field-wise matches would break without a migration hint.
3. The recurring **measured CI-cost audit** needed fresh data.

## What changed

- **Protocol authority re-synced** at upstream `018cd0f7`: vendored spec byte-exact, all four wire samples re-verified byte-identical, released 0.8.0 binding untouched. Typed surface in lockstep: exhaustive `ErrorCode` adds `ConnectTokenRequired` (breaking) — red/green proven: the conformance suite named `["CONNECT_TOKEN_REQUIRED"]` as undecodable before the variant landed; a new pin decodes the full enforced-server `AuthenticationError` frame.
- **Changelog truth**: three `[Unreleased]` entries now name every wire variant that gained a field (`Authenticate.connect_token`, `JoinRoom`/`JoinAsSpectator.password` on `ClientMessage` and `RoomOperationRequest`, `NewSpectatorJoined`/`SpectatorDisconnected.spectator_count` on `ServerMessage`) with the "must add it" migration imperative. Verified against cargo-semver-checks 0.50.0 vs `v0.12.0` (core + Godot adapter clean). `release-intent` derives 0.12.0 → 0.13.0, major policy.
- **CI-time audit**: no increase (Godot Web steady state 8.5–9.4 m; soak tail is coverage). The last unmeasured step candidate — concurrent fixture builds in build-export — was measured (~10 % warm step saving under 4-core emulation) and **refused**: rustc OOM (os error 12) when both fixtures compiled the godot tree concurrently on a 16 GB box. No workflow changes; coverage unchanged.
- A secret-lifecycle audit of round 67's connect-token code found zero defects; docs now name the enforcement face in the authentication guide.

## Verification

- Mandatory workflow green: 1206 passed / 0 failed (27 suites), fmt + clippy `-D warnings` clean.
- All 18 pre-commit checks passed; adversarial review loop (hostile reviewer + convergence verifier) converged to zero blocking findings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive protocol enum and spec pin with no runtime behavior change beyond decoding a new server refusal; breaking only for exhaustive `ErrorCode` matches.
> 
> **Overview**
> Syncs the SDK with upstream server PR **#576** (`018cd0f7`) so enforcing deployments can refuse token-less handshakes as a typed **`ConnectTokenRequired`** (`CONNECT_TOKEN_REQUIRED`) instead of an undecodable frame.
> 
> **Breaking:** exhaustive **`ErrorCode`** adds **`ConnectTokenRequired`** (with `description()` / docs); conformance and protocol tests pin wire JSON and a full **`AuthenticationError`** decode path. The vendored AsyncAPI spec and **`tests/compatibility.toml`** protocol authority advance together; wire samples stay byte-identical.
> 
> **Docs / release notes:** authentication and errors guides document enforcement vs optional tokens and shared recovery with **`ConnectTokenInvalid`**. **`[Unreleased]`** changelog entries now explicitly list wire variants that gained fields (`Authenticate.connect_token`, join/spectator **`password`**, spectator **`spectator_count`**) so exhaustive literals know what to add.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19c32a5bb0664a01d122d300e99f0e83491e63ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->