### PR TITLE
Round 69: pin the retryable auth-refusal loop; record session pace

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,13 @@ cargo fmt && cargo clippy --workspace --all-targets --all-features -- -D warning
 
 Run this before every commit. All three steps must pass with zero warnings.
 
+## Session Pace
+
+Target **~1 hour per working session** (past sessions ran much longer). Scope
+a session to one coherent deliverable — drift check plus one focused audit
+surface — and record anything left over as an issue or next-round surface
+instead of expanding the session.
+
 ## CI/CD Action Reference Policy
 
 Use version tags in workflow `uses:` references, not commit hashes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `ErrorCode::UnsupportedProtocolVersion` and `ErrorCode::SdkVersionUnsupported`
+  rustdocs and human-readable descriptions now name current server behavior
+  (upstream server PR #577): the handshake refusals arrive on an open socket
+  as retryable, and the deployment — not the client — ends the connection.
+  Documentation only; typed surfaces and wire bytes are unchanged, and a new
+  pin holds the retryable pre-auth refusal loop (including both codes)
+  phase-valid with latest-refusal disconnect attribution.
 - Reduced per-frame allocation churn on both drivers: inbound binary game
   data now reuses the transport's wire buffer for the payload instead of
   copying it into a fresh allocation, and every direct JSON string game

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,12 @@ cargo fmt && cargo clippy --workspace --all-targets --all-features -- -D warning
 
 Run this before every commit. All three steps must pass with zero warnings.
 
+## Session Pace
+
+Target **~1 hour per working session** (past sessions ran much longer). Scope
+a session to one coherent deliverable and record leftovers as issues or
+next-round surfaces instead of expanding the session.
+
 ## GitHub Tool Order
 
 For every GitHub operation, follow

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -127,7 +127,7 @@ println!("{}", code.description());
 | `AppIdSuspended` *(compatibility-only)* | The application ID has been suspended. |
 | `MissingAppId` | Application ID is required but was not provided. |
 | `AuthenticationTimeout` | Authentication took too long to complete. |
-| `SdkVersionUnsupported` | The SDK version you are using is no longer supported. |
+| `SdkVersionUnsupported` | The SDK version you are using is no longer supported. Upgrade the SDK or connect to a compatible deployment; current servers deliver this refusal on an open socket (the deployment, not the client, ends the connection). |
 | `UnsupportedGameDataFormat` | The requested game data format is not supported. |
 | `ConnectTokenInvalid` | The optional tenant connect token failed verification (encoding, signature, expiry, TTL ceiling, or app-id binding). The socket stays open; the configured token is fixed for a client's lifetime, so recovery means issuing a fresh control-plane token and starting a new client. See [Authentication & Credentials](authentication.md#tenant-connect-tokens-optional-hosted-deployments). |
 | `ConnectTokenRequired` | The deployment enforces tenant credentials and the handshake carried no connect token. The socket stays open; recovery means obtaining an `sfct_v1.` token from the deployment's control plane, presenting it via `with_connect_token`, and starting a new client. See [Authentication & Credentials](authentication.md#tenant-connect-tokens-optional-hosted-deployments). |
@@ -247,7 +247,7 @@ that the server could not honor. See the [Mesh Guide](mesh-guide.md).
 
 | Variant | Description |
 |---------|-------------|
-| `UnsupportedProtocolVersion` | The client's highest supported protocol version is below the server's configured minimum, or a pre-v3 connection sent a frame class that requires a newer protocol surface. |
+| `UnsupportedProtocolVersion` | The client's highest supported protocol version is below the server's configured minimum, or a pre-v3 connection sent a frame class that requires a newer protocol surface. Upgrade the client or connect to a compatible deployment; current servers deliver this refusal on an open socket (the deployment, not the client, ends the connection). |
 
 ### Moderation (3)
 

--- a/src/client_core.rs
+++ b/src/client_core.rs
@@ -2814,6 +2814,7 @@ mod tests {
         RateLimitInfo, ReconnectedPayload, ReplayStatus, RoomJoinedPayload, SenderWatermark,
         SessionPeer, SpectatorJoinedPayload, V2BinaryGameDataFrame,
     };
+    use crate::ErrorCode;
 
     /// A chain of `depth` nested arrays around one scalar.
     fn nested_chain(depth: u32) -> serde_json::Value {
@@ -5643,6 +5644,90 @@ mod tests {
             assert_eq!(core.snapshot().quarantined, quarantined, "{policy:?}");
             assert_eq!(core.snapshot().session_generation, generation_before);
             assert!(core.snapshot().authenticated);
+        }
+    }
+
+    #[test]
+    fn pre_auth_retryable_refusal_loop_stays_phase_valid_and_attributes_the_latest_refusal() {
+        // Upstream server PR #577 (906a9e3c): handshake-pending sockets —
+        // allowlist mode or enforced open — receive a *retryable*
+        // AuthenticationError and keep the socket open where legacy behavior
+        // closed them. The client sends exactly one Authenticate per
+        // connection, so the loop is server-driven; the classifier must stay
+        // phase-valid for every refusal in the retryable class, under every
+        // policy, and the eventual disconnect (the server times the silent
+        // socket out) must attribute the latest refusal.
+        let refusal_class = [
+            ErrorCode::ConnectTokenRequired,
+            ErrorCode::ConnectTokenInvalid,
+            ErrorCode::UnsupportedProtocolVersion,
+            ErrorCode::SdkVersionUnsupported,
+        ];
+        for policy in [
+            ProtocolViolationPolicy::Quarantine,
+            ProtocolViolationPolicy::Disconnect,
+            ProtocolViolationPolicy::Observe,
+        ] {
+            for code in &refusal_class {
+                let mut core = ClientCore::new(Some(GameDataEncoding::Json), policy, true);
+                for round in 0..3u8 {
+                    let outcome = process(
+                        &mut core,
+                        ServerMessage::AuthenticationError {
+                            error: format!("refusal {round}"),
+                            error_code: code.clone(),
+                        },
+                    );
+                    assert!(
+                        matches!(
+                            outcome.events.as_slice(),
+                            [SignalFishEvent::AuthenticationError { error_code, .. }]
+                                if error_code == code
+                        ),
+                        "{policy:?} refusal {round}: {:#?}",
+                        outcome.events
+                    );
+                    assert!(!outcome.disconnect, "{policy:?} refusal {round}");
+                    assert!(!core.snapshot().quarantined, "{policy:?} refusal {round}");
+                    assert!(!core.snapshot().authenticated, "{policy:?} refusal {round}");
+                }
+                let SignalFishEvent::Disconnected {
+                    last_server_error, ..
+                } = core.disconnect(None)
+                else {
+                    panic!("disconnect must emit Disconnected");
+                };
+                let attributed = last_server_error.expect("the latest refusal must be attributed");
+                assert_eq!(attributed.error_code.as_ref(), Some(code));
+                assert_eq!(attributed.message, "refusal 2");
+            }
+        }
+
+        // Counter-face: once authentication completes, a refused-handshake
+        // frame is a server bug and fails closed as a lifecycle violation.
+        for policy in [
+            ProtocolViolationPolicy::Quarantine,
+            ProtocolViolationPolicy::Disconnect,
+            ProtocolViolationPolicy::Observe,
+        ] {
+            let mut core = ClientCore::new(Some(GameDataEncoding::Json), policy, true);
+            let _ = process(&mut core, authenticated());
+            let outcome = process(
+                &mut core,
+                ServerMessage::AuthenticationError {
+                    error: "post-auth refusal".into(),
+                    error_code: ErrorCode::ConnectTokenRequired,
+                },
+            );
+            assert_lifecycle_violation(&outcome);
+            assert_eq!(
+                outcome.disconnect,
+                policy == ProtocolViolationPolicy::Disconnect
+            );
+            assert_eq!(
+                core.snapshot().quarantined,
+                policy == ProtocolViolationPolicy::Quarantine
+            );
         }
     }
 

--- a/src/error_codes.rs
+++ b/src/error_codes.rs
@@ -44,7 +44,10 @@ pub enum ErrorCode {
     MissingAppId,
     /// Authentication did not complete within the server's time limit.
     AuthenticationTimeout,
-    /// This SDK version is no longer supported by the server.
+    /// This SDK version is no longer supported by the server. Current
+    /// servers deliver this refusal on an open socket as a retryable
+    /// handshake refusal (upstream PR #577); recovery is upgrading the SDK
+    /// or connecting to a deployment that accepts this version.
     SdkVersionUnsupported,
     /// The requested game-data format is unsupported; the server falls back
     /// to JSON.
@@ -189,7 +192,9 @@ pub enum ErrorCode {
     /// The client's highest supported protocol version is below the server's
     /// configured minimum, or a pre-v3 connection sent a frame class that
     /// requires a newer protocol surface (such as the v3 `RoomOperation`
-    /// envelope).
+    /// envelope). Current servers deliver this on an open socket as a
+    /// retryable handshake refusal (upstream PR #577); the deployment governs
+    /// the socket's fate.
     UnsupportedProtocolVersion,
 
     // Moderation errors (authority-only room operations)
@@ -278,7 +283,7 @@ impl ErrorCode {
                 "Authentication took too long to complete. Please try again."
             }
             Self::SdkVersionUnsupported => {
-                "The SDK version you are using is no longer supported. Please upgrade to the latest version."
+                "This SDK version is no longer supported by the server. Upgrade the SDK or connect to a compatible deployment; current servers deliver this refusal on an open socket (the deployment, not the client, ends the connection)."
             }
             Self::UnsupportedGameDataFormat => {
                 "The requested game data format is not supported by this server. Falling back to JSON encoding."
@@ -432,7 +437,7 @@ impl ErrorCode {
                 "The requested game-data delivery class and key combination is invalid. Latest requires a key; reliable and volatile forbid one."
             }
             Self::UnsupportedProtocolVersion => {
-                "The client's highest supported protocol version is below this server's configured minimum, or a pre-v3 connection sent a frame class that requires a newer protocol surface. Upgrade the client or connect to a compatible deployment."
+                "The client's highest supported protocol version is below this server's configured minimum, or a pre-v3 connection sent a frame class that requires a newer protocol surface. Upgrade the client or connect to a compatible deployment; current servers deliver this refusal on an open socket (the deployment, not the client, ends the connection)."
             }
 
             // Moderation errors (authority-only room operations)


### PR DESCRIPTION
## Why

Round 69 of the recurring correctness audit (#126), first session under the new ~1-hour timebox.

Upstream server PR #577 changed negotiation behavior: handshake-pending sockets now receive a **retryable** `AuthenticationError` and the server keeps the socket open, where legacy behavior closed it. This PR verifies the client face of that change and pins it.

## What

- **New pin**: repeated pre-auth authentication refusals (`ConnectTokenRequired`, `ConnectTokenInvalid`, `UnsupportedProtocolVersion`, `SdkVersionUnsupported`) stay phase-valid under every violation policy, and the eventual disconnect attributes the latest refusal. Post-authentication refusals still fail closed as lifecycle violations. Verified red/green with two mutation probes.
- **Doc accuracy**: `UnsupportedProtocolVersion` and `SdkVersionUnsupported` now state that current servers deliver these refusals on an open socket — the deployment, not the client, ends the connection.
- **Zero upstream drift**: the vendored spec and all four wire samples are byte-identical to upstream HEAD (`906a9e3c`); no reconciliation needed.
- **CI time unchanged**: fresh main-run data matches the round-68 steady-state table exactly.
- **Session pace**: the new ~1-hour session target is recorded in `AGENTS.md`/`CLAUDE.md`.

## Verification

- Mandatory workflow green: fmt, clippy `-D warnings`, 1207 tests passed / 0 failed.
- Docs validation and admonition checks clean; error-code conformance 9/9.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are a regression test plus documentation and agent workflow notes; no production logic or wire behavior changes.
> 
> **Overview**
> Pins **correctness audit round 69** behavior for upstream server PR #577: while the handshake is still pending, repeated retryable `AuthenticationError` frames (`ConnectTokenRequired`, `ConnectTokenInvalid`, `UnsupportedProtocolVersion`, `SdkVersionUnsupported`) must stay phase-valid under every `ProtocolViolationPolicy`, and client disconnect must attribute **`last_server_error`** to the latest refusal. Post-auth refusals remain lifecycle violations.
> 
> **Documentation only** (wire/types unchanged): `SdkVersionUnsupported` and `UnsupportedProtocolVersion` rustdocs, `ErrorCode::description()`, `docs/errors.md`, and `CHANGELOG` now state that current servers deliver these refusals on an **open socket** and the deployment—not the client—ends the connection.
> 
> Agent guidance in **`AGENTS.md`** / **`CLAUDE.md`** adds a **~1 hour session pace** target (one deliverable per session; defer leftovers to issues).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 511d085430091442e2510d6e2e295648263a5669. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->